### PR TITLE
git: Tidy up .gitignore layout/comments and restore configure script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,17 @@
-# Ignore output created by Visual Studio
-build/
-build.*/
-download/
+# Visual Studio
 win/CS/*/bin
 win/CS/*/obj
 win/CS/*.suo
 
-# Ignore Xcode user data
+# Xcode user data
 xcuserdata
 
-# Ignore autoconf spam
+# Build system
+build/
+build.*/
+download/
+
+# autoconf spam
 Makefile.in
 aclocal.m4
 autom4te.cache
@@ -17,7 +19,6 @@ compile
 config.guess
 config.h.in
 config.sub
-configure
 depcomp
 install-sh
 ltmain.sh

--- a/.gitignore
+++ b/.gitignore
@@ -11,15 +11,16 @@ build/
 build.*/
 download/
 
-# autoconf spam
-Makefile.in
-aclocal.m4
-autom4te.cache
-compile
-config.guess
-config.h.in
-config.sub
-depcomp
-install-sh
-ltmain.sh
-missing
+# Gtk autoconf spam
+gtk/Makefile.in*
+gtk/*/Makefile.in*
+gtk/aclocal.m4
+gtk/autom4te.cache
+gtk/compile
+gtk/config.*
+gtk/configure
+gtk/depcomp
+gtk/install-sh
+gtk/ltmain.sh
+gtk/missing
+


### PR DESCRIPTION
I accidentally placed `build/` and `download/` under the VS comment in HandBrake/HandBrake@0b26f9f and John accidentally ignored `configure` in HandBrake/HandBrake@04b44e7.
