### PR TITLE
Report in MASK form for supported codec(s)

### DIFF
--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -144,8 +144,8 @@ static int qsv_implementation_is_hardware(mfxIMPL implementation)
 
 int hb_qsv_available()
 {
-    return (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ||
-            hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265));
+    return (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0 |
+            hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0);
 }
 
 int hb_qsv_video_encoder_is_enabled(int encoder)

--- a/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
+++ b/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="SystemInfo.cs" company="HandBrake Project (http://handbrake.fr)">
 //   This file is part of the HandBrake source code - It may be used under the terms of the GNU General Public License.
 // </copyright>
@@ -71,7 +71,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return HBFunctions.hb_qsv_available() == 1;
+                    return HBFunctions.hb_qsv_available() != 0;
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
this change will help to distinguish H264 and HEVC via MASK form usage and help to update UI for HEVC support
