### PR TITLE
fix to prevent lazy compiler assumption and avoid full computation

### DIFF
--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -144,8 +144,9 @@ static int qsv_implementation_is_hardware(mfxIMPL implementation)
 
 int hb_qsv_available()
 {
-    return (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0 |
-            hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0);
+    int is_qsv_available =  hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0;
+    is_qsv_available     |= hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0;
+    return is_qsv_available;
 }
 
 int hb_qsv_video_encoder_is_enabled(int encoder)

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -144,9 +144,8 @@ static int qsv_implementation_is_hardware(mfxIMPL implementation)
 
 int hb_qsv_available()
 {
-    int is_qsv_available =  hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0;
-    is_qsv_available     |= hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0;
-    return is_qsv_available;
+    return ((hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0) |
+            (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0)); 
 }
 
 int hb_qsv_video_encoder_is_enabled(int encoder)


### PR DESCRIPTION
it looks that current version leaves out from computation 
| hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0)

therefore result is not always correct, this patch should fix it.
