### PR TITLE
better usage of MASK for feature detection, OR fix

### DIFF
--- a/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
+++ b/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
@@ -90,7 +90,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H264);
+                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H264) != 0;
                 }
                 catch (Exception)
                 {
@@ -109,7 +109,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H265);
+                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H265) != 0;
                 }
                 catch (Exception)
                 {

--- a/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
+++ b/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
@@ -90,7 +90,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return HBFunctions.hb_qsv_available() == NativeConstants.HB_VCODEC_QSV_H264;
+                    return (HBFunctions.hb_qsv_available() && NativeConstants.HB_VCODEC_QSV_H264);
                 }
                 catch (Exception)
                 {
@@ -109,7 +109,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return HBFunctions.hb_qsv_available() == (NativeConstants.HB_VCODEC_QSV_H264 | NativeConstants.HB_VCODEC_QSV_H265);
+                    return (HBFunctions.hb_qsv_available() && NativeConstants.HB_VCODEC_QSV_H265);
                 }
                 catch (Exception)
                 {

--- a/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
+++ b/win/CS/HandBrake.ApplicationServices/Utilities/SystemInfo.cs
@@ -90,7 +90,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return (HBFunctions.hb_qsv_available() && NativeConstants.HB_VCODEC_QSV_H264);
+                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H264);
                 }
                 catch (Exception)
                 {
@@ -109,7 +109,7 @@ namespace HandBrake.ApplicationServices.Utilities
             {
                 try
                 {
-                    return (HBFunctions.hb_qsv_available() && NativeConstants.HB_VCODEC_QSV_H265);
+                    return (HBFunctions.hb_qsv_available() & NativeConstants.HB_VCODEC_QSV_H265);
                 }
                 catch (Exception)
                 {


### PR DESCRIPTION
I have some strange .NET 4.6 issues on Win10 and MSVC 2013 to try it out but should be fine

Win10 should have pre-installed .NET 4.6 but MSVC asks me to install again
where .NET 4.6 standalone installation fails
