### PR TITLE
configure: use gm4 as a synonym for GNU m4

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -1458,7 +1458,7 @@ try:
         else:
             gmake = ToolProbe( 'GMAKE.exe', 'gmake', 'make' )
 
-        m4       = ToolProbe( 'M4.exe',       'm4' )
+        m4       = ToolProbe( 'M4.exe',       'gm4', 'm4' )
         mkdir    = ToolProbe( 'MKDIR.exe',    'mkdir' )
         patch    = ToolProbe( 'PATCH.exe',    'gpatch', 'patch' )
         rm       = ToolProbe( 'RM.exe',       'rm' )


### PR DESCRIPTION
On Solaris, there are several m4 executables -- gm4 is always the GNU version.
