### PR TITLE
x265: update to version 1.8

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,7 +2,7 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url = http://download.handbrake.fr/contrib/x265_1.7.tar.gz
+X265.FETCH.url = http://download.handbrake.fr/contrib/x265_1.8.tar.gz
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
Speed improvements and bug fixes.

New limit-refs
    This feature limits the references analysed for individual CUS.
    Provides a nice tradeoff between efficiency and performance.

New aq-mode 3
    A new aq-mode that provides additional biasing for low-light
    conditions.

Improved scene cut detection logic that allows ratecontrol to manage
visual quality at fade-ins and fade-outs better.

modified tune grain
        Increases psyRdoq strength to 10.0, and rdoq-level to 2.
