### PR TITLE
Fix bizarre custom anamorphic behavior

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1873,7 +1873,7 @@ set_title_settings(signal_user_data_t *ud, GhbValue *settings)
         if (!(keep_aspect || pic_par) || pic_par == 3)
         {
             ghb_dict_set_int(settings, "scale_height",
-                             title->geometry.width - title->crop[0] - title->crop[1]);
+                             title->geometry.height - title->crop[0] - title->crop[1]);
         }
 
         ghb_set_scale_settings(settings, GHB_PIC_KEEP_PAR|GHB_PIC_USE_MAX);
@@ -2501,7 +2501,7 @@ scale_width_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_check_dependency(ud, widget, NULL);
     ghb_clear_presets_selection(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, GHB_PIC_KEEP_WIDTH);
+        ghb_set_scale(ud, GHB_PIC_KEEP_WIDTH|GHB_PIC_KEEP_PAR);
     update_preview = TRUE;
     ghb_live_reset(ud);
 
@@ -2516,7 +2516,7 @@ scale_height_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_check_dependency(ud, widget, NULL);
     ghb_clear_presets_selection(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, GHB_PIC_KEEP_HEIGHT);
+        ghb_set_scale(ud, GHB_PIC_KEEP_HEIGHT|GHB_PIC_KEEP_PAR);
 
     update_preview = TRUE;
     ghb_live_reset(ud);
@@ -2532,7 +2532,7 @@ crop_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_check_dependency(ud, widget, NULL);
     ghb_clear_presets_selection(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, 0);
+        ghb_set_scale(ud, GHB_PIC_KEEP_PAR);
     update_preview = TRUE;
     ghb_live_reset(ud);
 
@@ -2562,7 +2562,7 @@ display_height_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, GHB_PIC_KEEP_DISPLAY_HEIGHT);
+        ghb_set_scale(ud, GHB_PIC_KEEP_DISPLAY_HEIGHT|GHB_PIC_KEEP_PAR);
 
     update_preview = TRUE;
 }
@@ -2590,7 +2590,7 @@ scale_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, 0);
+        ghb_set_scale(ud, GHB_PIC_KEEP_PAR);
     update_preview = TRUE;
 
     update_aspect_info(ud);
@@ -2604,7 +2604,7 @@ show_crop_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_check_dependency(ud, widget, NULL);
     ghb_live_reset(ud);
     if (gtk_widget_is_sensitive(widget))
-        ghb_set_scale(ud, 0);
+        ghb_set_scale(ud, GHB_PIC_KEEP_PAR);
     ghb_pref_save(ud->prefs, "preview_show_crop");
     update_preview = TRUE;
 }

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3746,6 +3746,8 @@ ghb_set_scale_settings(GhbValue *settings, gint mode)
                 uiGeo.geometry.par.num =
                         ghb_dict_get_int(settings, "PictureDisplayWidth");
                 uiGeo.geometry.par.den = width;
+                hb_reduce(&uiGeo.geometry.par.num, &uiGeo.geometry.par.den,
+                           uiGeo.geometry.par.num,  uiGeo.geometry.par.den);
             }
         }
         else

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -4517,6 +4517,33 @@ ghb_get_preview_image(
     uiGeo.geometry.par.num = 1;
     uiGeo.geometry.par.den = 1;
 
+    GdkScreen *ss;
+    gint s_w, s_h;
+
+    ss = gdk_screen_get_default();
+    s_w = gdk_screen_get_width(ss);
+    s_h = gdk_screen_get_height(ss);
+
+    if (uiGeo.geometry.width > s_w * 2 ||
+        uiGeo.geometry.height > s_h * 2)
+    {
+        double factor = 1.;
+
+        // Image is of extreme size > twice the screen dimensions.
+        // In some extreme cases (very lopsided PAR), this can cause
+        // hb_get_preview2 to crash or hang.
+        if (uiGeo.geometry.width > s_w)
+        {
+            factor = (double)s_w / uiGeo.geometry.width;
+        }
+        if (uiGeo.geometry.height * factor > s_h)
+        {
+            factor = (double)s_h / uiGeo.geometry.height;
+        }
+        uiGeo.geometry.width  *= factor;
+        uiGeo.geometry.height *= factor;
+    }
+
     GdkPixbuf *preview;
     hb_image_t *image;
     image = hb_get_preview2(h_scan, title->index, index, &uiGeo, deinterlace);
@@ -4581,17 +4608,12 @@ ghb_get_preview_image(
     // If the preview is too large to fit the screen, reduce it's size.
     if (ghb_dict_get_bool(ud->prefs, "reduce_hd_preview"))
     {
-        GdkScreen *ss;
-        gint s_w, s_h;
         gint factor = 80;
 
         if (ghb_dict_get_bool(ud->prefs, "preview_fullscreen"))
         {
             factor = 100;
         }
-        ss = gdk_screen_get_default();
-        s_w = gdk_screen_get_width(ss);
-        s_h = gdk_screen_get_height(ss);
 
         if (previewWidth > s_w * factor / 100 ||
             previewHeight > s_h * factor / 100)

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -72,6 +72,11 @@
 
 #define HB_DVD_READ_BUFFER_SIZE 2048
 
+#define HB_MIN_WIDTH    32
+#define HB_MIN_HEIGHT   32
+#define HB_MAX_WIDTH    10240
+#define HB_MAX_HEIGHT   10240
+
 typedef struct hb_handle_s hb_handle_t;
 typedef struct hb_hwd_s hb_hwd_t;
 typedef struct hb_list_s hb_list_t;

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -74,8 +74,8 @@
 
 #define HB_MIN_WIDTH    32
 #define HB_MIN_HEIGHT   32
-#define HB_MAX_WIDTH    10240
-#define HB_MAX_HEIGHT   10240
+#define HB_MAX_WIDTH    20480
+#define HB_MAX_HEIGHT   20480
 
 typedef struct hb_handle_s hb_handle_t;
 typedef struct hb_hwd_s hb_hwd_t;

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1155,9 +1155,6 @@ void hb_set_anamorphic_size2(hb_geometry_t *src_geo,
             /* Anamorphic 3: Power User Jamboree
                - Set everything based on specified values */
 
-            /* Use specified storage dimensions */
-            storage_aspect = (double)geo->geometry.width / geo->geometry.height;
-
             /* Time to get picture dimensions that divide cleanly.*/
             width  = MULTIPLE_MOD_UP(geo->geometry.width, mod);
             height = MULTIPLE_MOD_UP(geo->geometry.height, mod);
@@ -1166,31 +1163,10 @@ void hb_set_anamorphic_size2(hb_geometry_t *src_geo,
             if (maxWidth && width > maxWidth)
             {
                 width = maxWidth;
-                // If we are keeping the display aspect, then we are going
-                // to be modifying the PAR anyway.  So it's preferred
-                // to let the width/height stray some from the original
-                // requested storage aspect.
-                //
-                // But otherwise, PAR and DAR will change the least
-                // if we stay as close as possible to the requested
-                // storage aspect.
-                if (!keep_display_aspect &&
-                    (maxHeight == 0 || height < maxHeight))
-                {
-                    height = width / storage_aspect + 0.5;
-                    height = MULTIPLE_MOD(height, mod);
-                }
             }
             if (maxHeight && height > maxHeight)
             {
                 height = maxHeight;
-                // Ditto, see comment above
-                if (!keep_display_aspect &&
-                    (maxWidth == 0 || width < maxWidth))
-                {
-                    width = height * storage_aspect + 0.5;
-                    width  = MULTIPLE_MOD(width, mod);
-                }
             }
             if (keep_display_aspect)
             {
@@ -1202,19 +1178,6 @@ void hb_set_anamorphic_size2(hb_geometry_t *src_geo,
                                        src_par.num;
                 dst_par_den = (int64_t)width  * cropped_height *
                                        src_par.den;
-            }
-            else
-            {
-                /* If the dimensions were changed by the modulus
-                 * or by maxWidth/maxHeight, we also change the
-                 * output PAR so that the DAR is unchanged.
-                 *
-                 * PAR is the requested output display width / storage width
-                 * requested output display width is the original
-                 * requested width * original requested PAR
-                 */
-                dst_par_num = geo->geometry.width * dst_par_num;
-                dst_par_den = width * dst_par_den;
             }
         } break;
     }


### PR DESCRIPTION
When "keep aspect" is unset in custom anamorphic, it was making very
uintuitive changes to PAR.  This simplifies the code and makes the
behavior more sane.
