### PR TITLE
mux: flush cached buffers when closing

### DIFF
--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -459,26 +459,19 @@ static int muxWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
 
 static void muxFlush(hb_mux_t * mux)
 {
-    int ii;
+    int ii, done = 0;
 
-    while (1)
+    while (!done)
     {
+        done = 1;
         for (ii = 0; ii < mux->ntracks; ii++)
         {
             OutputTrackChunk(mux, ii, mux->m);
-        }
-
-        for (ii = 0; ii < mux->ntracks; ii++)
-        {
             if (mux->track[ii]->mf.out != mux->track[ii]->mf.in)
             {
                 // track buffer is not empty
-                break;
+                done = 0;
             }
-        }
-        if (ii >= mux->ntracks)
-        {
-            break;
         }
         mux->pts += mux->interleave;
     }

--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -457,7 +457,34 @@ static int muxWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
     return HB_WORK_OK;
 }
 
-void muxClose( hb_work_object_t * w )
+static void muxFlush(hb_mux_t * mux)
+{
+    int ii;
+
+    while (1)
+    {
+        for (ii = 0; ii < mux->ntracks; ii++)
+        {
+            OutputTrackChunk(mux, ii, mux->m);
+        }
+
+        for (ii = 0; ii < mux->ntracks; ii++)
+        {
+            if (mux->track[ii]->mf.out != mux->track[ii]->mf.in)
+            {
+                // track buffer is not empty
+                break;
+            }
+        }
+        if (ii >= mux->ntracks)
+        {
+            break;
+        }
+        mux->pts += mux->interleave;
+    }
+}
+
+static void muxClose( hb_work_object_t * w )
 {
     hb_work_private_t * pv = w->private_data;
     hb_mux_t    * mux = pv->mux;
@@ -468,6 +495,8 @@ void muxClose( hb_work_object_t * w )
     hb_lock( mux->mutex );
     if ( --mux->ref == 0 )
     {
+        muxFlush(mux);
+
         // Update state before closing muxer.  Closing the muxer
         // may initiate optimization which can take a while and
         // we want the muxing state to be visible while this is


### PR DESCRIPTION
When an encode is cancelled, cached mux buffers are not currently
written to the output file.  Since we don't start writing output till
50MB of data has been cached, this can result in no data being written
when an encode is cancelled early.
