### PR TITLE
libhb: don't use deprecated AVPicture

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -920,8 +920,9 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
             h != context->height)
         {
             // have to convert to our internal color space and/or rescale
-            AVPicture dstpic;
-            hb_avpicture_fill(&dstpic, buf);
+            uint8_t * data[4];
+            int       stride[4];
+            hb_picture_fill(data, stride, buf);
 
             if (pv->sws_context == NULL            ||
                 pv->sws_width   != context->width  ||
@@ -941,8 +942,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
             }
             sws_scale(pv->sws_context,
                       (const uint8_t* const *)pv->frame->data,
-                      pv->frame->linesize,
-                      0, context->height, dstpic.data, dstpic.linesize);
+                      pv->frame->linesize, 0, context->height, data, stride);
         }
         else
         {

--- a/libhb/hbffmpeg.h
+++ b/libhb/hbffmpeg.h
@@ -32,4 +32,3 @@ struct SwsContext*
 hb_sws_get_context(int srcW, int srcH, enum AVPixelFormat srcFormat,
                    int dstW, int dstH, enum AVPixelFormat dstFormat,
                    int flags);
-int hb_avpicture_fill(AVPicture *pic, hb_buffer_t *buf);

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -183,6 +183,9 @@ int           hb_buffer_copy( hb_buffer_t * dst, const hb_buffer_t * src );
 void          hb_buffer_swap_copy( hb_buffer_t *src, hb_buffer_t *dst );
 hb_image_t  * hb_image_init(int pix_fmt, int width, int height);
 hb_image_t  * hb_buffer_to_image(hb_buffer_t *buf);
+int           hb_picture_fill(uint8_t *data[], int stride[], hb_buffer_t *b);
+int           hb_picture_crop(uint8_t *data[], int stride[], hb_buffer_t *b,
+                              int top, int left);
 
 hb_fifo_t   * hb_fifo_init( int capacity, int thresh );
 void          hb_fifo_register_full_cond( hb_fifo_t * f, hb_cond_t * c );

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -218,8 +218,9 @@ static hb_buffer_t * ScaleSubtitle(hb_filter_private_t *pv,
     }
     if (ABS(xfactor - 1) > 0.01 || ABS(yfactor - 1) > 0.01)
     {
-        AVPicture pic_in, pic_out;
-        int width, height;
+        uint8_t * in_data[4], * out_data[4];
+        int       in_stride[4], out_stride[4];
+        int       width, height;
 
         width       = sub->f.width  * xfactor;
         height      = sub->f.height * yfactor;
@@ -227,8 +228,8 @@ static hb_buffer_t * ScaleSubtitle(hb_filter_private_t *pv,
         scaled->f.x = sub->f.x * xfactor;
         scaled->f.y = sub->f.y * yfactor;
 
-        hb_avpicture_fill(&pic_in,  sub);
-        hb_avpicture_fill(&pic_out, scaled);
+        hb_picture_fill(in_data,  in_stride,  sub);
+        hb_picture_fill(out_data, out_stride, scaled);
 
         if (pv->sws        == NULL   ||
             pv->sws_width  != width  ||
@@ -243,9 +244,8 @@ static hb_buffer_t * ScaleSubtitle(hb_filter_private_t *pv,
             pv->sws_width   = width;
             pv->sws_height  = height;
         }
-        sws_scale(pv->sws,
-                  (const uint8_t* const *)pic_in.data, pic_in.linesize,
-                  0, sub->f.height, pic_out.data, pic_out.linesize);
+        sws_scale(pv->sws, (const uint8_t* const *)in_data, in_stride,
+                  0, sub->f.height, out_data, out_stride);
     }
     else
     {


### PR DESCRIPTION
libav just deprecated AVPicture and all av_picture__/avpicture__
functions.
