### PR TITLE
Added missing NULL pointer check in encx265Close

### DIFF
--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -347,6 +347,7 @@ void encx265Close(hb_work_object_t *w)
 {
     hb_work_private_t *pv = w->private_data;
 
+    if (pv == NULL) return;
     if (pv->delayed_chapters != NULL)
     {
         struct chapter_s *item;


### PR DESCRIPTION
pv was never checked to be NULL, which would lead to a NULL pointer
dereference in the pv->delayed_chapters != NULL check, when
w->private_data is NULL.
