### PR TITLE
Improving support for importing Chapter names via CSV file (take 2)

### DIFF
--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -87,10 +87,8 @@
     <Reference Include="GongSolutions.Wpf.DragDrop">
       <HintPath>..\libraries\WPFDragDrop\GongSolutions.Wpf.DragDrop.dll</HintPath>
     </Reference>
-    <Reference Include="LumenWorks.Framework.IO">
-      <HintPath>..\libraries\CsvReader\LumenWorks.Framework.IO.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Newtonsoft.Json, Version=4.5.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\libraries\json\Newtonsoft.Json.dll</HintPath>
@@ -234,6 +232,7 @@
     <Compile Include="Utilities\GeneralUtilities.cs" />
     <Compile Include="Utilities\HandBrakeApp.cs" />
     <Compile Include="Utilities\Interfaces\INotifyPropertyChangedEx.cs" />
+    <Compile Include="Utilities\Output\CsvHelper.cs" />
     <Compile Include="Utilities\PropertyChangedBase.cs" />
     <Compile Include="Utilities\Win7.cs" />
     <Compile Include="ViewModels\CountdownAlertViewModel.cs" />

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -448,11 +448,47 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Unable to save Chapter Makrers file! .
+        ///   Looks up a localized string similar to Unable to save Chapter Markers file! .
         /// </summary>
         public static string ChaptersViewModel_UnableToExportChaptersWarning {
             get {
                 return ResourceManager.GetString("ChaptersViewModel_UnableToExportChaptersWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to First column in chapters file must only contain a integer number value higher than zero (0).
+        /// </summary>
+        public static string ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to All lines in chapters file must have at least 2 columns of data.
+        /// </summary>
+        public static string ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Line {0} is invalid. Nothing will be imported..
+        /// </summary>
+        public static string ChaptersViewModel_UnableToImportChaptersMalformedLineMsg {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnableToImportChaptersMalformedLineMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to import chapter file.
+        /// </summary>
+        public static string ChaptersViewModel_UnableToImportChaptersWarning {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnableToImportChaptersWarning", resourceCulture);
             }
         }
         

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -584,7 +584,7 @@ The Activity log may have further information.</value>
     <value>Switch Back To Tracks</value>
   </data>
   <data name="ChaptersViewModel_UnableToExportChaptersWarning" xml:space="preserve">
-    <value>Unable to save Chapter Makrers file! </value>
+    <value>Unable to save Chapter Markers file! </value>
   </data>
   <data name="ChaptersViewModel_UnableToExportChaptersMsg" xml:space="preserve">
     <value>Chapter marker names will NOT be saved in your encode.</value>
@@ -738,5 +738,17 @@ Your old presets file was archived to:</value>
   </data>
   <data name="MainViewModel_LowDiskSpaceWarning" xml:space="preserve">
     <value>Warning, you are running low on disk space. HandBrake will not be able to complete this encode if you run out of space. </value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersMalformedLineMsg" xml:space="preserve">
+    <value>Line {0} is invalid. Nothing will be imported.</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersWarning" xml:space="preserve">
+    <value>Unable to import chapter file</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns" xml:space="preserve">
+    <value>All lines in chapters file must have at least 2 columns of data</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber" xml:space="preserve">
+    <value>First column in chapters file must only contain a integer number value higher than zero (0)</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Utilities/Output/CsvHelper.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Output/CsvHelper.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandBrakeWPF.Utilities.Output
+{
+    /// <summary>
+    /// Utilitiy functions for writing CSV files
+    /// </summary>
+    internal sealed class CsvHelper
+    {
+        private const string QUOTE = "\"";
+        private const string ESCAPED_QUOTE = "\"\"";
+        private static readonly char[] CHARACTERS_THAT_MUST_BE_QUOTED = { ',', '"', '\n' };
+
+        /// <summary>
+        /// Properly escapes a string value containing reserved characters with double quotes "..." before it is written to a CSV file.
+        /// </summary>
+        /// <param name="value">Value to be escaped</param>
+        /// <returns>Fully escaped value</returns>
+        public static string Escape(string value)
+        {
+            if (value.Contains(QUOTE))
+                value = value.Replace(QUOTE, ESCAPED_QUOTE);
+
+            if (value.IndexOfAny(CHARACTERS_THAT_MUST_BE_QUOTED) > -1)
+                value = QUOTE + value + QUOTE;
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
_Edit: Moved changes to feature branch as I should have done_

Reference: https://forum.handbrake.fr/viewtopic.php?f=26&t=33546

Decided to break my changes into two parts.

This is the first part which deals only with bug fixes to the existing CSV import.

Changes:
- Better handling of escape characters both when importing and exporting
- Better handling of most common alternative value separators (e.g. semicolon, tab)
- Fixing resource leakage via undisposed FileDialogs.
- Changing dependency on Microsoft.Win32 for FileDialogs to the System.Windows.Forms ones (they're preferable)
- Removed dependency on LumenWorks.Framework.IO.dll and instead use the built in CSV reader in the .NET framework
- Fixing spelling mistake in resource file
- Minor refactorings to improve readability and performance.
