### PR TITLE
Chapter import: Adding support for chapterdb.org XML and TXT formats

### DIFF
--- a/win/CS/HandBrakeWPF/Exceptions/GeneralApplicationException.cs
+++ b/win/CS/HandBrakeWPF/Exceptions/GeneralApplicationException.cs
@@ -36,6 +36,18 @@ namespace HandBrakeWPF.Exceptions
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GeneralApplicationException"/> class with no wrapped exception.
+        /// </summary>
+        /// <param name="error">
+        /// The error.
+        /// </param>
+        /// <param name="solution">
+        /// The solution.
+        /// </param>
+        public GeneralApplicationException(string error, string solution) : this(error, solution, null)
+        {}
+
+        /// <summary>
         /// Gets or sets FailureReason.
         /// </summary>
         public string Error { get; set; }

--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -153,6 +153,7 @@
     <Compile Include="EventArgs\SettingChangedEventArgs.cs" />
     <Compile Include="Exceptions\GeneralApplicationException.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Helpers\TimeSpanHelper.cs" />
     <Compile Include="Helpers\Validate.cs" />
     <Compile Include="Model\Audio\AudioTrackDefaultsMode.cs" />
     <Compile Include="Model\Audio\AudioBehaviourModes.cs" />
@@ -231,6 +232,9 @@
     <Compile Include="Utilities\ExtensionMethods.cs" />
     <Compile Include="Utilities\GeneralUtilities.cs" />
     <Compile Include="Utilities\HandBrakeApp.cs" />
+    <Compile Include="Utilities\Input\ChapterImporterCsv.cs" />
+    <Compile Include="Utilities\Input\ChapterImporterTxt.cs" />
+    <Compile Include="Utilities\Input\ChapterImporterXml.cs" />
     <Compile Include="Utilities\Interfaces\INotifyPropertyChangedEx.cs" />
     <Compile Include="Utilities\Output\CsvHelper.cs" />
     <Compile Include="Utilities\PropertyChangedBase.cs" />
@@ -640,6 +644,7 @@
   <ItemGroup>
     <Resource Include="Views\Images\information64.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(ProgramFiles)\MSBuild\StyleCop\v4.*\StyleCop.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/win/CS/HandBrakeWPF/Helpers/TimeSpanHelper.cs
+++ b/win/CS/HandBrakeWPF/Helpers/TimeSpanHelper.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandBrakeWPF.Helpers
+{
+    using System.Globalization;
+
+    /// <summary>
+    /// Helper functions for handling <see cref="TimeSpan"/> structures
+    /// </summary>
+    internal static class TimeSpanHelper
+    {
+        /// <summary>
+        /// Parses chapter time start value from a chapter marker input file. 
+        /// </summary>
+        /// <param name="chapterStartRaw">The raw string value parsed from the input file</param>
+        internal static TimeSpan ParseChapterTimeStart(string chapterStartRaw)
+        {
+            //Format: 02:35:05 and 02:35:05.2957333
+            return TimeSpan.ParseExact(chapterStartRaw,
+                                        new[]
+                                        {
+                                                    @"hh\:mm\:ss",  // Handle whole seconds
+                                                    @"hh\:mm\:ss\.FFFFFFF"  // Handle fraction seconds
+                                        }, CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -493,6 +493,88 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Chapter files of type &apos;{0}&apos; are not currently supported..
+        /// </summary>
+        public static string ChaptersViewModel_UnsupportedFileFormatMsg {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnsupportedFileFormatMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unsupported chapter file type.
+        /// </summary>
+        public static string ChaptersViewModel_UnsupportedFileFormatWarning {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_UnsupportedFileFormatWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of chapters on the source media 
+        ///and the number of chapters in the input file do not match ({0} vs {1}).
+        ///
+        ///Do you still want to import the chapter names?.
+        /// </summary>
+        public static string ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatch {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatch", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The number of chapters on the source media 
+        ///and the number of chapters in the input file do not match ({0} vs {1}).
+        ///
+        ///Do you still want to import the chapter names?.
+        /// </summary>
+        public static string ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chapter count doesn&apos;t match between source and input file.
+        /// </summary>
+        public static string ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The reported duration of the chapters on the source media 
+        ///and the duration of chapters in the input file differ drastically.
+        ///It is very likely that this chapter file was produced from a different source media.
+        ///
+        ///Are you sure you want to import the chapter names?.
+        /// </summary>
+        public static string ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chapter duration doesn&apos;t match between source and input file.
+        /// </summary>
+        public static string ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid chapter information for source media.
+        /// </summary>
+        public static string ChaptersViewModel_ValidationFailedWarning {
+            get {
+                return ResourceManager.GetString("ChaptersViewModel_ValidationFailedWarning", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Confirm.
         /// </summary>
         public static string Confirm {

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -545,7 +545,8 @@ namespace HandBrakeWPF.Properties {
         
         /// <summary>
         ///   Looks up a localized string similar to The reported duration of the chapters on the source media 
-        ///and the duration of chapters in the input file differ drastically.
+        ///and the duration of chapters in the input file differ greatly.
+        ///
         ///It is very likely that this chapter file was produced from a different source media.
         ///
         ///Are you sure you want to import the chapter names?.

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -751,4 +751,38 @@ Your old presets file was archived to:</value>
   <data name="ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber" xml:space="preserve">
     <value>First column in chapters file must only contain a integer number value higher than zero (0)</value>
   </data>
+  <data name="ChaptersViewModel_UnsupportedFileFormatMsg" xml:space="preserve">
+    <value>Chapter files of type '{0}' are not currently supported.</value>
+  </data>
+  <data name="ChaptersViewModel_UnsupportedFileFormatWarning" xml:space="preserve">
+    <value>Unsupported chapter file type</value>
+  </data>
+  <data name="ChaptersViewModel_ValidationFailedWarning" xml:space="preserve">
+    <value>Invalid chapter information for source media</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatch" xml:space="preserve">
+    <value>The number of chapters on the source media 
+and the number of chapters in the input file do not match ({0} vs {1}).
+
+Do you still want to import the chapter names?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg" xml:space="preserve">
+    <value>The number of chapters on the source media 
+and the number of chapters in the input file do not match ({0} vs {1}).
+
+Do you still want to import the chapter names?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning" xml:space="preserve">
+    <value>Chapter count doesn't match between source and input file</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg" xml:space="preserve">
+    <value>The reported duration of the chapters on the source media 
+and the duration of chapters in the input file differ drastically.
+It is very likely that this chapter file was produced from a different source media.
+
+Are you sure you want to import the chapter names?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning" xml:space="preserve">
+    <value>Chapter duration doesn't match between source and input file</value>
+  </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -777,7 +777,8 @@ Do you still want to import the chapter names?</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg" xml:space="preserve">
     <value>The reported duration of the chapters on the source media 
-and the duration of chapters in the input file differ drastically.
+and the duration of chapters in the input file differ greatly.
+
 It is very likely that this chapter file was produced from a different source media.
 
 Are you sure you want to import the chapter names?</value>

--- a/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterCsv.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterCsv.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandBrakeWPF.Utilities.Input
+{
+    using HandBrakeWPF.Exceptions;
+    using HandBrakeWPF.Properties;
+
+    using Microsoft.VisualBasic.FileIO;
+
+    /// <summary>
+    /// Handles the importing of Chapter information from CSV files
+    /// </summary>
+    internal class ChapterImporterCsv
+    {
+        public static string FileFilter => "CSV files (*.csv;*.tsv)|*.csv;*.tsv";
+
+        public static void Import(string filename, ref Dictionary<int, Tuple<string, TimeSpan>> importedChapters)
+        {
+            using (TextFieldParser csv = new TextFieldParser(filename)
+            {
+                CommentTokens = new[] { "#" }, // Comment lines
+                Delimiters = new[] { ",", "\t", ";", ":" }, // Support all of these common delimeter types
+                HasFieldsEnclosedInQuotes = true, // Assume that our data will be properly escaped
+                TextFieldType = FieldType.Delimited,
+                TrimWhiteSpace = true // Remove excess whitespace from ends of imported values
+            })
+            {
+                while (!csv.EndOfData)
+                {
+                    try
+                    {
+                        // Only read the first two columns, anything else will be ignored but will not raise an error
+                        var row = csv.ReadFields();
+                        if (row == null || row.Length < 2) // null condition happens if the file is somehow corrupt during reading
+                            throw new MalformedLineException(Resources.ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns, csv.LineNumber);
+
+                        int chapterNumber;
+                        if (!int.TryParse(row[0], out chapterNumber))
+                            throw new MalformedLineException(Resources.ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber, csv.LineNumber);
+
+                        // Store the chapter name at the correct index
+                        importedChapters[chapterNumber] = new Tuple<string, TimeSpan>(row[1]?.Trim(), TimeSpan.Zero);
+                    }
+                    catch (MalformedLineException mlex)
+                    {
+                        throw new GeneralApplicationException(
+                            Resources.ChaptersViewModel_UnableToImportChaptersWarning,
+                            string.Format(Resources.ChaptersViewModel_UnableToImportChaptersMalformedLineMsg, mlex.LineNumber),
+                            mlex);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterCsv.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterCsv.cs
@@ -16,8 +16,16 @@ namespace HandBrakeWPF.Utilities.Input
     /// </summary>
     internal class ChapterImporterCsv
     {
+        /// <summary>
+        /// The file filter value for the OpenFileDialog
+        /// </summary>
         public static string FileFilter => "CSV files (*.csv;*.tsv)|*.csv;*.tsv";
 
+        /// <summary>
+        /// Imports all chapter information from the given <see cref="filename"/> into the <see cref="chapterMap"/> dictionary.
+        /// </summary>
+        /// <param name="filename">The full path and filename of the chapter marker file to import</param>
+        /// <param name="chapterMap">The dictionary that should be populated with parsed chapter markers</param>
         public static void Import(string filename, ref Dictionary<int, Tuple<string, TimeSpan>> importedChapters)
         {
             using (TextFieldParser csv = new TextFieldParser(filename)

--- a/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterTxt.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterTxt.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandBrakeWPF.Utilities.Input
+{
+    using System.IO;
+
+    using HandBrakeWPF.Helpers;
+
+    public class ChapterImporterTxt
+    {
+        public static string FileFilter => "Text files (*.txt)|*.txt";
+
+        public static void Import(string filename, ref Dictionary<int, Tuple<string, TimeSpan>> chapterMap)
+        {
+            using (var file = new StreamReader(filename))
+            {
+                // Indexing is 1-based
+                int chapterMapIdx = 1;
+                TimeSpan prevChapterStart = TimeSpan.Zero;
+
+                while (!file.EndOfStream)
+                {
+                    // Read the lines in pairs, the duration is always first then the chapter name
+                    var chapterStartRaw = file.ReadLine();
+                    var chapterName = file.ReadLine();
+
+                    // If either of the values is null then the end of the file has been reached and we need to terminate
+                    if (chapterName == null || chapterStartRaw == null)
+                        break;
+
+                    // Split the values on '=' and take the left side
+                    chapterName = chapterName.Split(new []{ '=' }, 2).LastOrDefault();
+                    chapterStartRaw = chapterStartRaw.Split(new[] { '=' }, 2).LastOrDefault();
+
+                    // Parse the time
+                    if(!string.IsNullOrWhiteSpace(chapterStartRaw))
+                    { 
+                        var chapterStart = TimeSpanHelper.ParseChapterTimeStart(chapterStartRaw);
+
+                        // If we're past the first chapter in the file then calculate the duration for the previous chapter
+                        if (chapterMapIdx > 1)
+                        {
+                            var old = chapterMap[chapterMapIdx - 1];
+                            chapterMap[chapterMapIdx - 1] = new Tuple<string, TimeSpan>(old.Item1, chapterStart - prevChapterStart);
+                        }
+
+                        prevChapterStart = chapterStart;
+                    }
+
+                    // Save the chapter info, we calculate the duration in the next iteration (look back)
+                    chapterMap[chapterMapIdx++] = new Tuple<string, TimeSpan>(chapterName, TimeSpan.Zero);
+                }
+            }
+        }
+    }
+}

--- a/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterTxt.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterTxt.cs
@@ -10,10 +10,22 @@ namespace HandBrakeWPF.Utilities.Input
 
     using HandBrakeWPF.Helpers;
 
+    /// <summary>
+    /// Imports chapter markers in the ChaptersDb.org TXT format
+    /// More info: http://www.chapterdb.org/docs
+    /// </summary>
     public class ChapterImporterTxt
     {
+        /// <summary>
+        /// The file filter value for the OpenFileDialog
+        /// </summary>
         public static string FileFilter => "Text files (*.txt)|*.txt";
 
+        /// <summary>
+        /// Imports all chapter information from the given <see cref="filename"/> into the <see cref="chapterMap"/> dictionary.
+        /// </summary>
+        /// <param name="filename">The full path and filename of the chapter marker file to import</param>
+        /// <param name="chapterMap">The dictionary that should be populated with parsed chapter markers</param>
         public static void Import(string filename, ref Dictionary<int, Tuple<string, TimeSpan>> chapterMap)
         {
             using (var file = new StreamReader(filename))

--- a/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterXml.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Input/ChapterImporterXml.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace HandBrakeWPF.Utilities.Input
+{
+    using System.Globalization;
+    using System.IO;
+    using System.Xml;
+    using System.Xml.Linq;
+    using System.Xml.XPath;
+
+    using HandBrakeWPF.Helpers;
+
+    /// <summary>
+    /// Imports chapter markers in the ChaptersDb.org XML format
+    /// More info: http://www.chapterdb.org/docs
+    /// </summary>
+    internal class ChapterImporterXml
+    {
+        /// <summary>
+        /// The file filter value for the OpenFileDialog
+        /// </summary>
+        public static string FileFilter => "XML files (*.xml)|*.xml";
+
+        /// <summary>
+        /// Imports all chapter information from the given <see cref="filename"/> into the <see cref="chapterMap"/> dictionary.
+        /// </summary>
+        /// <param name="filename">The full path and filename of the chapter marker file to import</param>
+        /// <param name="chapterMap">The dictionary that should be populated with parsed chapter markers</param>
+        public static void Import(string filename, ref Dictionary<int, Tuple<string, TimeSpan>> chapterMap)
+        {
+            XDocument xDoc = XDocument.Load(new StreamReader(filename));
+            var xRoot = xDoc.Root;
+            if (xRoot == null)
+                return;
+
+            // Indexing is 1-based
+            int chapterMapIdx = 1;
+
+            // Get all chapters in the document
+            var chapters = xRoot.XPathSelectElements("/Chapters/EditionEntry/ChapterAtom");
+            TimeSpan prevChapterStart = TimeSpan.Zero;
+
+            foreach (XElement chapter in chapters)
+            {
+                // Extract and clean up any special XML escape characters
+                var chapterName = chapter.XPathSelectElement("ChapterDisplay/ChapterString")?.Value;
+                if (!string.IsNullOrWhiteSpace(chapterName))
+                {
+                    chapterName = XmlConvert.DecodeName(chapterName);
+                }
+
+                var chapterStartRaw = chapter.XPathSelectElement("ChapterTimeStart")?.Value;
+                if(!string.IsNullOrWhiteSpace(chapterStartRaw))
+                {
+                    //Format: 02:35:05 and 02:35:05.2957333
+                    var chapterStart = TimeSpanHelper.ParseChapterTimeStart(chapterStartRaw);
+
+                    // If we're past the first chapter in the file then calculate the duration for the previous chapter
+                    if (chapterMapIdx > 1)
+                    {
+                        var old = chapterMap[chapterMapIdx - 1];
+                        chapterMap[chapterMapIdx-1] = new Tuple<string, TimeSpan>(old.Item1, chapterStart - prevChapterStart);
+                    }
+
+                    prevChapterStart = chapterStart;
+                }
+
+                // Save the chapter info, we calculate the duration in the next iteration (look back)
+                chapterMap[chapterMapIdx++] = new Tuple<string, TimeSpan>(chapterName, TimeSpan.Zero);
+            }
+        }
+    }
+}

--- a/win/CS/HandBrakeWPF/Utilities/Output/CsvHelper.cs
+++ b/win/CS/HandBrakeWPF/Utilities/Output/CsvHelper.cs
@@ -13,7 +13,7 @@ namespace HandBrakeWPF.Utilities.Output
     {
         private const string QUOTE = "\"";
         private const string ESCAPED_QUOTE = "\"\"";
-        private static readonly char[] CHARACTERS_THAT_MUST_BE_QUOTED = { ',', '"', '\n' };
+        private static readonly char[] CHARACTERS_THAT_MUST_BE_QUOTED = { ',', '"', '\n', '\t' };
 
         /// <summary>
         /// Properly escapes a string value containing reserved characters with double quotes "..." before it is written to a CSV file.

--- a/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
@@ -16,6 +16,7 @@ namespace HandBrakeWPF.ViewModels
     using System.IO;
     using System.Text;
     using System.Linq;
+    using System.Windows;
     using System.Windows.Forms;
 
     using Caliburn.Micro;
@@ -31,16 +32,23 @@ namespace HandBrakeWPF.ViewModels
     using ChapterMarker = HandBrakeWPF.Services.Encode.Model.Models.ChapterMarker;
     using EncodeTask = HandBrakeWPF.Services.Encode.Model.EncodeTask;
     using GeneralApplicationException = HandBrakeWPF.Exceptions.GeneralApplicationException;
+    using MessageBox = System.Windows.Forms.MessageBox;
 
     /// <summary>
     /// The Chapters View Model
     /// </summary>
     public class ChaptersViewModel : ViewModelBase, IChaptersViewModel
     {
+        #region Constants and Fields
+
+        private readonly IErrorService errorService;
+
         /// <summary>
         /// The source chapters backing field
         /// </summary>
         private List<Chapter> sourceChaptersList;
+
+        #endregion
 
         #region Constructors and Destructors
 
@@ -53,9 +61,13 @@ namespace HandBrakeWPF.ViewModels
         /// <param name="userSettingService">
         /// The user Setting Service.
         /// </param>
-        public ChaptersViewModel(IWindowManager windowManager, IUserSettingService userSettingService)
+        /// <param name="errorService">
+        /// The Error Service 
+        /// </param>
+        public ChaptersViewModel(IWindowManager windowManager, IUserSettingService userSettingService, IErrorService errorService)
         {
             this.Task = new EncodeTask();
+            this.errorService = errorService;
         }
 
         #endregion
@@ -235,13 +247,12 @@ namespace HandBrakeWPF.ViewModels
             // If the number of chapters don't match, prompt for confirmation
             if (importedChapters.Count != this.Task.ChapterNames.Count)
             {
-                if (DialogResult.Yes !=
-                    MessageBox.Show(
+                if (MessageBoxResult.Yes !=
+                    this.errorService.ShowMessageBox(
                         string.Format(Resources.ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg, this.Task.ChapterNames.Count, importedChapters.Count),
                         Resources.ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning,
-                        MessageBoxButtons.YesNo,
-                        MessageBoxIcon.Question,
-                        MessageBoxDefaultButton.Button2))
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Question))
                 {
                     return false;
                 }
@@ -255,13 +266,12 @@ namespace HandBrakeWPF.ViewModels
             var diffs = importedChapters.Zip(this.Task.ChapterNames, (import, source) => source.Duration - import.Value.Item2);
             if (diffs.Count(diff => Math.Abs(diff.TotalSeconds) > 15) > 2)
             {
-                if (DialogResult.Yes !=
-                    MessageBox.Show(
+                if (MessageBoxResult.Yes !=
+                    this.errorService.ShowMessageBox(
                         Resources.ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg,
                         Resources.ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning,
-                        MessageBoxButtons.YesNo,
-                        MessageBoxIcon.Question,
-                        MessageBoxDefaultButton.Button2))
+                        MessageBoxButton.YesNo,
+                        MessageBoxImage.Question))
                 {
                     return false;
                 }

--- a/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/ChaptersViewModel.cs
@@ -28,8 +28,6 @@ namespace HandBrakeWPF.ViewModels
     using HandBrakeWPF.Utilities.Output;
     using HandBrakeWPF.ViewModels.Interfaces;
 
-    using Microsoft.VisualBasic.FileIO;
-
     using ChapterMarker = HandBrakeWPF.Services.Encode.Model.Models.ChapterMarker;
     using EncodeTask = HandBrakeWPF.Services.Encode.Model.EncodeTask;
     using GeneralApplicationException = HandBrakeWPF.Exceptions.GeneralApplicationException;
@@ -174,7 +172,8 @@ namespace HandBrakeWPF.ViewModels
             // Execute the importer based on the file extension
             switch (fileExtension)
             {
-                case ".csv":
+                case ".csv": // comma separated file
+                case ".tsv": // tab separated file
                     ChapterImporterCsv.Import(filename, ref importedChapters);
                     break;
                 case ".xml":
@@ -199,6 +198,9 @@ namespace HandBrakeWPF.ViewModels
             {
                 if( !string.IsNullOrEmpty(validationErrorMessage))
                     throw new GeneralApplicationException(Resources.ChaptersViewModel_ValidationFailedWarning, validationErrorMessage);
+
+                // The user has cancelled the import, so exit
+                return;
             }
 
             // Now iterate over each chatper we have, and set it's name


### PR DESCRIPTION
Adding basic support for chapter name import from XML and TXT files downloaded from chapterdb.org. -Only chapter names will be imported into HandBrake and timings and chapter count originally detected by HandBrake will be left unchanged.

Summary:
- Added basic validation for main import function that validates input data against chapter information retrieved from source media
- Added two new input parsers for XML and TXT formats (parser is chosen based on file extension)
- Added a new convenience constructor to GeneralApplicationException to use when thrown with no inner exception
