### PR TITLE
Add numa to x265 libraries

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -33,7 +33,7 @@ endif
 X265.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265.EXTRACT.dir/)source/)"
 
 ## optional static libs need to be marked
-X265.OSL.libs  = x265
+X265.OSL.libs  = x265 numa
 X265.OSL.files = $(foreach i,$(X265.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build/)lib/lib$(i).a))
 
 

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -181,7 +181,7 @@ if test "x$use_fdk_aac" = "xyes" ; then
 fi
 
 if test "x$use_x265" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lx265"
+    HB_LIBS="$HB_LIBS -lx265 -lnuma"
 fi
 
 if test "x$use_qsv" = "xyes" ; then


### PR DESCRIPTION
When trying to build the current git version on my ubuntu 15.10, I run into the following errors

```
/bin/bash ../libtool  --tag=CXX   --mode=link g++  -g -O2 -Wl,--export-dynamic -Wl,--exclude-libs,ALL -Wl,-S -g0 -O3 -L/opt/source/HandBrake.bug/build//libhb -L/opt/source/HandBrake.bug/build//contrib/lib -o ghb callbacks.o queuehandler.o videohandler.o audiohandler.o subtitlehandler.o x264handler.o main.o settings.o resources.o presets.o preview.o data_res.o ui_res.o icon_res.o icons.o values.o appcast.o plist.o hb-backend.o renderer_button.o ghbcellrenderertext.o ghb-dvd.o marshalers.o -lhandbrake -lavresample -lavformat -lavcodec -lavfilter -lavutil -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -ldl -lpthread -lfdk-aac -lx265 -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgthread-2.0 -pthread -lnotify -lgdk_pixbuf-2.0 -lgio-2.0 -ldbus-glib-1 -ldbus-1 -Wl,--export-dynamic -lgmodule-2.0 -pthread -lgudev-1.0 -lgobject-2.0 -lglib-2.0  
libtool: link: g++ -g -O2 -Wl,--export-dynamic -Wl,--exclude-libs -Wl,ALL -Wl,-S -g0 -O3 -o ghb callbacks.o queuehandler.o videohandler.o audiohandler.o subtitlehandler.o x264handler.o main.o settings.o resources.o presets.o preview.o data_res.o ui_res.o icon_res.o icons.o values.o appcast.o plist.o hb-backend.o renderer_button.o ghbcellrenderertext.o ghb-dvd.o marshalers.o -pthread -Wl,--export-dynamic -pthread  -L/opt/source/HandBrake.bug/build//libhb -L/opt/source/HandBrake.bug/build//contrib/lib -lhandbrake -lavresample -lavformat -lavcodec -lavfilter -lavutil /opt/source/HandBrake.bug/build/contrib/lib/libdvdnav.a -L/opt/source/HandBrake.bug/build/contrib/lib /opt/source/HandBrake.bug/build/contrib/lib/libdvdread.a -lmp3lame /usr/lib/x86_64-linux-gnu/libvorbis.so /usr/lib/x86_64-linux-gnu/libvorbisenc.so -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 /opt/source/HandBrake.bug/build/contrib/lib/libbluray.a -lass -lfontconfig /usr/lib/x86_64-linux-gnu/libfreetype.so -lxml2 -ljansson -ldl -lpthread /opt/source/HandBrake.bug/build/contrib/lib/libfdk-aac.a -lm -lx265 -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lgthread-2.0 -lnotify -lgdk_pixbuf-2.0 -lgio-2.0 -ldbus-glib-1 -ldbus-1 -lgmodule-2.0 -lgudev-1.0 -lgobject-2.0 -lglib-2.0 -pthread
/opt/source/HandBrake.bug/build//contrib/lib/libx265.a(threadpool.cpp.o): In function `x265::ThreadPool::setThreadNodeAffinity(int)':
threadpool.cpp:(.text+0x534): undefined reference to `numa_available'
threadpool.cpp:(.text+0x53f): undefined reference to `numa_run_on_node'
threadpool.cpp:(.text+0x546): undefined reference to `numa_set_preferred'
/opt/source/HandBrake.bug/build//contrib/lib/libx265.a(threadpool.cpp.o): In function `x265::ThreadPool::getNumaNodeCount()':
threadpool.cpp:(.text+0x7c5): undefined reference to `numa_available'
threadpool.cpp:(.text+0x7d3): undefined reference to `numa_max_node'
/opt/source/HandBrake.bug/build//contrib/lib/libx265.a(threadpool.cpp.o): In function `x265::ThreadPool::allocThreadPools(x265_param*, int&)':
threadpool.cpp:(.text+0x86a): undefined reference to `numa_available'
threadpool.cpp:(.text+0x895): undefined reference to `numa_node_of_cpu'
threadpool.cpp:(.text+0x8a7): undefined reference to `numa_node_of_cpu'
/opt/source/HandBrake.bug/build//contrib/lib/libx265.a(threadpool.cpp.o): In function `x265::ThreadPool::setThreadNodeAffinity(int)':
threadpool.cpp:(.text+0x54c): undefined reference to `numa_set_localalloc'
collect2: error: ld returned 1 exit status
Makefile:539: recept voor doel 'ghb' is mislukt
make[3]: *** [ghb] Fout 1
make[3]: Map '/opt/source/HandBrake.bug/build/gtk/src' wordt verlaten
Makefile:444: recept voor doel 'all-recursive' is mislukt
make[2]: *** [all-recursive] Fout 1
make[2]: Map '/opt/source/HandBrake.bug/build/gtk' wordt verlaten
Makefile:376: recept voor doel 'all' is mislukt
make[1]: *** [all] Fout 2
make[1]: Map '/opt/source/HandBrake.bug/build/gtk' wordt verlaten
../gtk/module.rules:27: recept voor doel 'gtk.build' is mislukt
make: *** [gtk.build] Fout 2
```

This branch solves this by also linking to the NUMA library.
