### PR TITLE
QSV: better compatibility with recent SW lib

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1404,7 +1404,8 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     }
 
     // AsyncDepth has now been set and/or modified by Media SDK
-    pv->max_async_depth = videoParam.AsyncDepth;
+    // fall back to default if zero
+    pv->max_async_depth = videoParam.AsyncDepth ? videoParam.AsyncDepth : AV_QSV_ASYNC_DEPTH_DEFAULT;
     pv->async_depth     = 0;
 
     return 0;


### PR DESCRIPTION
To avoid having max_async_depth == 0 with recent MSDK SW library,
this would help to allocate properly internal resources and to avoid crash during encode
