### PR TITLE
New NLMeans tunes

### DIFF
--- a/libhb/param.c
+++ b/libhb/param.c
@@ -35,6 +35,7 @@ static hb_filter_param_t nlmeans_tunes[] =
     { 3, "High Motion", "highmotion", NULL              },
     { 4, "Animation",   "animation",  NULL              },
     { 5, "Tape",        "tape",       NULL              },
+    { 6, "Sprite",      "sprite",     NULL              },
     { 0, NULL,          NULL,         NULL              }
 };
 
@@ -345,6 +346,31 @@ static hb_dict_t * generate_nlmeans_settings(const char *preset,
                 strength[0]    = 3.5; strength[1]    = 8;
                 origin_tune[0] = 0.6; origin_tune[1] = 0.6;
                 patch_size[0]  = 5;   patch_size[1]  = 5;
+            }
+        }
+        else if (!strcasecmp(tune, "sprite"))
+        {
+            strength[0]    = 3;    strength[1]    = 4;
+            origin_tune[0] = 0.15; origin_tune[1] = 0.5;
+            patch_size[0]  = 5;    patch_size[1]  = 5;
+            range[0]       = 5;    range[1]       = 9;
+            frames[0]      = 2;    frames[1]      = 4;
+            prefilter[0]   = 0;    prefilter[1]   = 0;
+            if (!strcasecmp(preset, "ultralight"))
+            {
+                strength[0]    = 1.5; strength[1]    = 3;
+                range[0]       = 5;   range[1]       = 7;
+                frames[0]      = 1;   frames[1]      = 2;
+            }
+            else if (!strcasecmp(preset, "light"))
+            {
+                strength[0]    = 2; strength[1]    = 4;
+                frames[0]      = 2; frames[1]      = 2;
+            }
+            else if (!strcasecmp(preset, "strong"))
+            {
+                strength[0]    = 3; strength[1]    = 4;
+                range[0]       = 7; range[1]       = 11;
             }
         }
         else

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -180,6 +180,8 @@ void hb_param_configure_qsv(void)
  * grain      - like film but preserves luma grain
  * highmotion - like film but avoids color smearing with stronger settings
  * animation  - cel animation such as cartoons, anime
+ * tape       - analog tape sources such as VHS
+ * sprite     - 1-/4-/8-/16-bit 2-dimensional games
  */
 static hb_dict_t * generate_nlmeans_settings(const char *preset,
                                              const char *tune,

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -34,6 +34,7 @@ static hb_filter_param_t nlmeans_tunes[] =
     { 2, "Grain",       "grain",      NULL              },
     { 3, "High Motion", "highmotion", NULL              },
     { 4, "Animation",   "animation",  NULL              },
+    { 5, "Tape",        "tape",       NULL              },
     { 0, NULL,          NULL,         NULL              }
 };
 
@@ -318,6 +319,32 @@ static hb_dict_t * generate_nlmeans_settings(const char *preset,
             else if (!strcasecmp(preset, "strong"))
             {
                 strength[0] = 10; strength[1] = 8;
+            }
+        }
+        else if (!strcasecmp(tune, "tape"))
+        {
+            strength[0]    = 3;   strength[1]    = 6;
+            origin_tune[0] = 0.8; origin_tune[1] = 0.8;
+            patch_size[0]  = 3;   patch_size[1]  = 5;
+            range[0]       = 5;   range[1]       = 5;
+            frames[0]      = 2;   frames[1]      = 2;
+            prefilter[0]   = 0;   prefilter[1]   = 0;
+            if (!strcasecmp(preset, "ultralight"))
+            {
+                strength[0]    = 1.5; strength[1]    = 5;
+                origin_tune[0] = 0.9; origin_tune[1] = 0.9;
+                frames[0]      = 1;   frames[1]      = 1;
+            }
+            else if (!strcasecmp(preset, "light"))
+            {
+                strength[0]    = 2;   strength[1]    = 6;
+                origin_tune[0] = 0.9; origin_tune[1] = 0.9;
+            }
+            else if (!strcasecmp(preset, "strong"))
+            {
+                strength[0]    = 3.5; strength[1]    = 8;
+                origin_tune[0] = 0.6; origin_tune[1] = 0.6;
+                patch_size[0]  = 5;   patch_size[1]  = 5;
             }
         }
         else


### PR DESCRIPTION
Tape for (wait for it) analog tape sources including VHS, and Sprite for most 1-/4-/8-/16-bit 2D games. Don't use Sprite on high definition sources unless you have a lot of time on your hands.

Testing and comments appreciated.
