### PR TITLE
contrib: Update to libass 0.13.2 and add HarfBuzz 1.2.6.

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -1,0 +1,25 @@
+__deps__ := FONTCONFIG FREETYPE
+$(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
+$(eval $(call import.CONTRIB.defs,HARFBUZZ))
+
+HARFBUZZ.FETCH.url = http://download.handbrake.fr/handbrake/contrib/harfbuzz-1.2.6.tar.bz2
+HARFBUZZ.FETCH.url += https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.2.6.tar.bz2
+HARFBUZZ.FETCH.md5 = 9f4b6831c86135faef011e991f59f77f
+
+# Tell configure where to find our versions of freetype and fontconfig
+HARFBUZZ.CONFIGURE.extra = \
+    --with-fontconfig=yes --with-freetype=yes \
+    FREETYPE_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfreetype" \
+    FREETYPE_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2" \
+    FONTCONFIG_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfontconfig" \
+    FONTCONFIG_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include"
+
+ifeq ($(BUILD.system),darwin)
+    HARFBUZZ.CONFIGURE.extra += --with-coretext=no --with-glib=no
+endif
+
+ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
+    HARFBUZZ.CONFIGURE.extra += --with-directwrite=no --with-glib=no \
+        --with-gobject=no --with-cairo=no --with-icu=no --with-graphite=no \
+        --with-uniscribe=no
+endif

--- a/contrib/harfbuzz/module.rules
+++ b/contrib/harfbuzz/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,HARFBUZZ))
+$(eval $(call import.CONTRIB.rules,HARFBUZZ))

--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -1,19 +1,14 @@
-__deps__ := FONTCONFIG FREETYPE FRIBIDI
+__deps__ := YASM FONTCONFIG FREETYPE FRIBIDI HARFBUZZ
 $(eval $(call import.MODULE.defs,LIBASS,libass,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBASS))
 
-LIBASS.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libass-0.12.3.tar.gz
-LIBASS.FETCH.url += https://github.com/libass/libass/releases/download/0.12.3/libass-0.12.3.tar.gz
-LIBASS.FETCH.md5 =  648ee785f966c69d4b5d50948e509d93
+LIBASS.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libass-0.13.2.tar.gz
+LIBASS.FETCH.url += https://github.com/libass/libass/releases/download/0.13.2/libass-0.13.2.tar.gz
+LIBASS.FETCH.md5 = b4d82616bb18e8e954b18746a105a3b8
 
-# TODO: libass >= 0.13.0
-#LIBASS.FETCH.url = https://github.com/libass/libass/releases/download/0.13.0/libass-0.13.0.tar.gz
-#LIBASS.FETCH.md5 = 44290519105b3779b8b25813a25a9914
-
-# Disable as many external dependencies as I can get away with
-# and tell configure where to find our version of freetype
+# Tell configure where to find our versions of freetype and fontconfig
 LIBASS.CONFIGURE.extra = \
-    --disable-png --disable-enca --disable-harfbuzz \
+    --enable-asm --enable-fontconfig --enable-harfbuzz \
     FREETYPE_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfreetype" \
     FREETYPE_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2" \
     FONTCONFIG_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfontconfig" \
@@ -23,4 +18,12 @@ ifneq ($(BUILD.system),linux)
 LIBASS.CONFIGURE.extra += \
     FRIBIDI_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfribidi" \
     FRIBIDI_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include"
+endif
+
+ifeq ($(BUILD.system),darwin)
+    LIBASS.CONFIGURE.extra += --disable-coretext
+endif
+
+ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
+    LIBASS.CONFIGURE.extra += --disable-directwrite
 endif

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,6 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX FFMPEG FONTCONFIG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBOGG LIBSAMPLERATE LIBTHEORA LIBVORBIS \
-    LIBXML2 PTHREADW32 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON
+    LIBXML2 PTHREADW32 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON \
+    HARFBUZZ
 
 $(eval $(call import.MODULE.defs,LIBHB,libhb,$(__deps__)))
 $(eval $(call import.GCC,LIBHB))
@@ -119,7 +120,7 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 LIBHB.dll.libs = $(foreach n, \
         ass avcodec avformat avfilter avutil avresample dvdnav dvdread fontconfig \
         freetype mp3lame ogg samplerate swscale vpx theora vorbis vorbisenc \
-        x264 xml2 bluray jansson, \
+        x264 xml2 bluray jansson harfbuzz, \
         $(CONTRIB.build/)lib/lib$(n).a )
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1C6D76551CD7733300F5B943 /* libharfbuzz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C15C82B1CD7722500368223 /* libharfbuzz.a */; };
+		1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C15C82B1CD7722500368223 /* libharfbuzz.a */; };
 		226268E11572CC7300477B4E /* libavresample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 226268DF1572CC7300477B4E /* libavresample.a */; };
 		22DD2C4B177B95DA00EF50D3 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
@@ -293,6 +295,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1C15C82B1CD7722500368223 /* libharfbuzz.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libharfbuzz.a; path = external/contrib/lib/libharfbuzz.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		226268DF1572CC7300477B4E /* libavresample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libavresample.a; path = external/contrib/lib/libavresample.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22CC9E74191EBEA500C69D81 /* libx265.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libx265.a; path = external/contrib/lib/libx265.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DD2C49177B94DB00EF50D3 /* libvpx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvpx.a; path = external/contrib/lib/libvpx.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -593,6 +596,7 @@
 				27D6C77114B102DA00B785E4 /* libx264.a in Frameworks */,
 				27D6C77314B102DA00B785E4 /* libxml2.a in Frameworks */,
 				A955128B1A320B02001BFC6F /* libjansson.a in Frameworks */,
+				1C6D76551CD7733300F5B943 /* libharfbuzz.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -630,6 +634,7 @@
 				A91CE2B91C7DABBC0068F46F /* libbluray.a in Frameworks */,
 				A91CE2BA1C7DABBC0068F46F /* libdvdnav.a in Frameworks */,
 				A91CE2BB1C7DABBC0068F46F /* libdvdread.a in Frameworks */,
+				1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */,
 				A91CE2BC1C7DABBC0068F46F /* libfontconfig.a in Frameworks */,
 				A91CE2BD1C7DABBC0068F46F /* libfreetype.a in Frameworks */,
 				A91CE2BE1C7DABBC0068F46F /* libfribidi.a in Frameworks */,
@@ -687,6 +692,7 @@
 				27D6C74014B102DA00B785E4 /* libxml2.a */,
 				A95512881A320A12001BFC6F /* libjansson.a */,
 				A9E165511C523016003EF30E /* libavfilter.a */,
+				1C15C82B1CD7722500368223 /* libharfbuzz.a */,
 			);
 			name = "Static Libraries";
 			sourceTree = "<group>";

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -45,6 +45,7 @@ ifneq (,$(filter $(BUILD.system),darwin cygwin mingw))
     MODULES += contrib/fontconfig
     MODULES += contrib/freetype
     MODULES += contrib/fribidi
+    MODULES += contrib/harfbuzz
     MODULES += contrib/libxml2
     MODULES += contrib/libass
     MODULES += contrib/libogg

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avresample avformat avcodec avfilter avutil mp3lame dvdnav \
         dvdread fontconfig fribidi ogg \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc x264 \
-        bluray freetype xml2 bz2 z jansson
+        bluray freetype xml2 bz2 z jansson harfbuzz
 
 ifeq (1,$(FEATURE.qsv))
     TEST.GCC.D += USE_QSV HAVE_THREADS=1


### PR DESCRIPTION
HarfBuzz is now enabled when building libass.

Resolves #162.

Additional libass notes:
- Add yasm dependency for better performance.
- Remove no longer valid configure params.
- Disable new coretext and directwrite font selection backends pending additional testing (coretext did not build properly).
