### PR TITLE
libhb: Expand default frame rates to include 72, 75, 90, 100, 120.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -102,6 +102,11 @@ hb_rate_internal_t hb_video_rates[]  =
     { { "50",                   540000, }, NULL, 1, },
     { { "59.94",                450450, }, NULL, 1, },
     { { "60",                   450000, }, NULL, 1, },
+    { { "72",                   375000, }, NULL, 1, },
+    { { "75",                   360000, }, NULL, 1, },
+    { { "90",                   300000, }, NULL, 1, },
+    { { "100",                  270000, }, NULL, 1, },
+    { { "120",                  225000, }, NULL, 1, },
 };
 int hb_video_rates_count = sizeof(hb_video_rates) / sizeof(hb_video_rates[0]);
 


### PR DESCRIPTION
Most are HFR variations on 24/30 fps. 75, 90, and 120 are in production or planned for VR (see https://forum.handbrake.fr/viewtopic.php?t=34295).

Lower frame rates (5..20) are mostly used for making low bitrate web videos. Definitely a dying breed, yet I would rather not kick these users to the CLI, especially since we recently added some of these frame rates. We can easily drop everything below 23.976 from the default list once we allow custom fps input in the GUIs, effectively retaining all standard frame rates between film and 120 fps and allowing people to specify whatever else they want.
