### PR TITLE
sync: correct timestamp discontinuities in sync instead of reader

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -105,7 +105,7 @@ struct hb_work_private_s
     int                    chap_scr;
     int                    new_chap;        // output chapter mark pending
     int64_t                last_pts;
-    int64_t                next_pts;
+    double                 next_pts;
     uint32_t               nframes;
     uint32_t               decode_errors;
     packet_info_t          packet_info;

--- a/libhb/deccc608sub.h
+++ b/libhb/deccc608sub.h
@@ -70,6 +70,7 @@ struct eia608
     int ssa_counter; // Number of subs currently written
     int screenfuls_counter; // Number of meaningful screenfuls written
     int64_t current_visible_start_ms; // At what time did the current visible buffer became so?
+    int64_t current_visible_scr_sequence; // At what time did the current visible buffer became so?
     enum cc_modes mode;
     unsigned char last_c1, last_c2;
     int channel; // Currently selected channel
@@ -89,6 +90,7 @@ struct s_write {
     hb_buffer_t *hb_buffer;
     hb_buffer_t *hb_last_buffer;
     int64_t last_pts;
+    int      last_scr_sequence;
     unsigned char *enc_buffer; // Generic general purpose buffer
     unsigned enc_buffer_used;
     unsigned enc_buffer_capacity;

--- a/libhb/deccc608sub.h
+++ b/libhb/deccc608sub.h
@@ -70,7 +70,7 @@ struct eia608
     int ssa_counter; // Number of subs currently written
     int screenfuls_counter; // Number of meaningful screenfuls written
     int64_t current_visible_start_ms; // At what time did the current visible buffer became so?
-    int64_t current_visible_scr_sequence; // At what time did the current visible buffer became so?
+    int64_t current_visible_scr_sequence; // At what SCR did the current visible buffer became so?
     enum cc_modes mode;
     unsigned char last_c1, last_c2;
     int channel; // Currently selected channel

--- a/libhb/decpgssub.c
+++ b/libhb/decpgssub.c
@@ -410,6 +410,7 @@ static int decsubWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
                     out->s.start         = pts;
                     out->s.stop          = AV_NOPTS_VALUE;
                     out->s.renderOffset  = AV_NOPTS_VALUE;
+                    out->s.scr_sequence  = in->s.scr_sequence;
                     out->f.x             = x0;
                     out->f.y             = y0;
                     out->f.window_width  = pv->context->width;
@@ -474,6 +475,7 @@ static int decsubWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
                     out->s.start        = pts;
                     out->s.stop         = pts;
                     out->s.renderOffset = AV_NOPTS_VALUE;
+                    out->s.scr_sequence = in->s.scr_sequence;
                     out->f.x            = 0;
                     out->f.y            = 0;
                     out->f.width        = 0;

--- a/libhb/decssasub.c
+++ b/libhb/decssasub.c
@@ -226,7 +226,9 @@ void hb_ssa_style_init(hb_subtitle_style_t *style)
     style->bg_alpha  = 0xFF;
 }
 
-static hb_buffer_t *ssa_decode_line_to_mkv_ssa( hb_work_object_t * w, uint8_t *in_data, int in_size );
+static hb_buffer_t *
+ssa_decode_line_to_mkv_ssa( hb_work_object_t * w, int scr_sequence,
+                            uint8_t *in_data, int in_size );
 
 /*
  * Decodes a single SSA packet to one or more TEXTSUB or PICTURESUB subtitle packets.
@@ -256,35 +258,9 @@ static hb_buffer_t *ssa_decode_packet( hb_work_object_t * w, hb_buffer_t *in )
             continue;
 
         // Decode an individual SSA line
-        buf = ssa_decode_line_to_mkv_ssa(w, (uint8_t *)curLine,
-                                         strlen(curLine));
+        buf = ssa_decode_line_to_mkv_ssa(w, in->s.scr_sequence,
+                                         (uint8_t *)curLine, strlen(curLine));
         hb_buffer_list_append(&list, buf);
-    }
-
-    // For point-to-point encoding, when the start time of the stream
-    // may be offset, the timestamps of the subtitles must be offset as well.
-    //
-    // HACK: Here we are making the assumption that, under normal circumstances,
-    //       the output display time of the first output packet is equal to the
-    //       display time of the input packet.
-    //
-    //       During point-to-point encoding, the display time of the input
-    //       packet will be offset to compensate.
-    //
-    //       Therefore we offset all of the output packets by a slip amount
-    //       such that first output packet's display time aligns with the
-    //       input packet's display time. This should give the correct time
-    //       when point-to-point encoding is in effect.
-    buf = hb_buffer_list_head(&list);
-    if (buf && buf->s.start > in->s.start)
-    {
-        int64_t slip = buf->s.start - in->s.start;
-        while (buf != NULL)
-        {
-            buf->s.start -= slip;
-            buf->s.stop -= slip;
-            buf = buf->next;
-        }
     }
 
     return hb_buffer_list_clear(&list);
@@ -346,7 +322,9 @@ static uint8_t *find_field( uint8_t *pos, uint8_t *end, int fieldNum )
  *   ReadOrder,Marked,          Style,Name,MarginL,MarginR,MarginV,Effect,Text '\0'
  *   1         2                3     4    5       6       7       8      9
  */
-static hb_buffer_t *ssa_decode_line_to_mkv_ssa( hb_work_object_t * w, uint8_t *in_data, int in_size )
+static hb_buffer_t *
+ssa_decode_line_to_mkv_ssa( hb_work_object_t * w, int scr_sequence,
+                            uint8_t *in_data, int in_size )
 {
     hb_work_private_t * pv = w->private_data;
     hb_buffer_t * out;
@@ -393,10 +371,11 @@ static hb_buffer_t *ssa_decode_line_to_mkv_ssa( hb_work_object_t * w, uint8_t *i
     strcat( mkvIn, "," );
     strcat( mkvIn, (char *)styleToTextFields );
 
-    out->size = strlen(mkvIn) + 1;
-    out->s.frametype = HB_FRAME_SUBTITLE;
-    out->s.start = in_start;
-    out->s.stop = in_stop;
+    out->size           = strlen(mkvIn) + 1;
+    out->s.frametype    = HB_FRAME_SUBTITLE;
+    out->s.start        = in_start;
+    out->s.stop         = in_stop;
+    out->s.scr_sequence = scr_sequence;
 
     if( out->size == 0 )
     {

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -216,9 +216,10 @@ static hb_buffer_t *tx3g_decode_to_ssa(hb_work_private_t *pv, hb_buffer_t *in)
     out->size = dst - out->data;
 
     // Copy metadata from the input packet to the output packet
-    out->s.frametype = HB_FRAME_SUBTITLE;
-    out->s.start = in->s.start;
-    out->s.stop = in->s.stop;
+    out->s.frametype    = HB_FRAME_SUBTITLE;
+    out->s.start        = in->s.start;
+    out->s.stop         = in->s.stop;
+    out->s.scr_sequence = in->s.scr_sequence;
 
 fail:
     free(styleRecords);

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -393,12 +393,13 @@ hb_buffer_t * hb_buffer_init_internal( int size , int needsMapped )
             int loc             = b->cl.buffer_location;
 
             memset( b, 0, sizeof(hb_buffer_t) );
-            b->alloc = buffer_pool->buffer_size;
-            b->size = size;
-            b->data = data;
-            b->s.start = AV_NOPTS_VALUE;
-            b->s.stop = AV_NOPTS_VALUE;
+            b->alloc          = buffer_pool->buffer_size;
+            b->size           = size;
+            b->data           = data;
+            b->s.start        = AV_NOPTS_VALUE;
+            b->s.stop         = AV_NOPTS_VALUE;
             b->s.renderOffset = AV_NOPTS_VALUE;
+            b->s.scr_sequence = -1;
 
             /* OpenCL */
             b->cl.buffer          = buffer;
@@ -470,9 +471,10 @@ hb_buffer_t * hb_buffer_init_internal( int size , int needsMapped )
         buffers.allocated += b->alloc;
         hb_unlock(buffers.lock);
     }
-    b->s.start = AV_NOPTS_VALUE;
-    b->s.stop = AV_NOPTS_VALUE;
+    b->s.start        = AV_NOPTS_VALUE;
+    b->s.stop         = AV_NOPTS_VALUE;
     b->s.renderOffset = AV_NOPTS_VALUE;
+    b->s.scr_sequence = -1;
 #if defined(HB_BUFFER_DEBUG)
     hb_lock(buffers.lock);
     hb_list_add(buffers.alloc_list, b);

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -66,6 +66,8 @@ struct hb_buffer_settings_s
     int64_t       stop;         // stop time of frame
     int64_t       renderOffset; // DTS used by b-frame offsets in muxmp4
     int64_t       pcr;
+    int           scr_sequence; // The SCR sequence that this buffer's 
+                                // timestamps are referenced to
     int           split;
     uint8_t       discontinuity;
     int           new_chap;     // Video packets: if non-zero, is the index of the chapter whose boundary was crossed

--- a/libhb/reader.c
+++ b/libhb/reader.c
@@ -27,17 +27,6 @@ hb_work_object_t hb_reader =
 
 typedef struct
 {
-    int    startup;
-    double average; // average time between packets
-    double filtered_average; // average time between packets
-    int64_t last;   // last timestamp seen on this stream
-    int id;         // stream id
-    int is_audio;   // != 0 if this is an audio stream
-    int valid;      // Stream timing is not valid until next scr.
-} stream_timing_t;
-
-typedef struct
-{
     int              id;
     hb_buffer_list_t list;
 } buffer_splice_list_t;
@@ -53,20 +42,18 @@ struct hb_work_private_s
     hb_dvd_t     * dvd;
     hb_stream_t  * stream;
 
-    stream_timing_t *stream_timing;
-    int64_t        scr_offset;
-    int            sub_scr_set;
     hb_psdemux_t   demux;
     int            scr_changes;
-    uint8_t        st_slots;        // size (in slots) of stream_timing array
-    uint8_t        saw_video;       // != 0 if we've seen video
-    uint8_t        saw_audio;       // != 0 if we've seen audio
+    int64_t        scr_offset;
+    int64_t        last_pts;
 
     int            start_found;     // found pts_to_start point
     int64_t        pts_to_start;
     int            chapter_end;
+
     uint64_t       st_first;
-    uint64_t       duration;
+    int64_t        duration;
+
     hb_fifo_t   ** fifos;
 
     buffer_splice_list_t * splice_list;
@@ -77,14 +64,29 @@ struct hb_work_private_s
  * Local prototypes
  **********************************************************************/
 static hb_fifo_t ** GetFifoForId( hb_work_private_t * r, int id );
-static void UpdateState( hb_work_private_t  * r, int64_t start);
 static hb_buffer_list_t * get_splice_list(hb_work_private_t * r, int id);
+static void UpdateState( hb_work_private_t  * r );
 
 /***********************************************************************
  * reader_init
  ***********************************************************************
  *
  **********************************************************************/
+static int64_t chapter_end_pts(hb_title_t * title, int chapter_end )
+{
+    hb_chapter_t * chapter;
+    int64_t        duration;
+    int            ii;
+
+    duration = 0;
+    for (ii = 0; ii < chapter_end; ii++)
+    {
+        chapter = hb_list_item(title->list_chapter, ii);
+        duration += chapter->duration;
+    }
+    return duration;
+}
+
 static int hb_reader_open( hb_work_private_t * r )
 {
     if ( r->title->type == HB_BD_TYPE )
@@ -119,6 +121,8 @@ static int hb_reader_open( hb_work_private_t * r )
         else
         {
             hb_bd_seek_chapter(r->bd, r->job->chapter_start);
+            r->duration -= chapter_end_pts(r->job->title,
+                                           r->job->chapter_start - 1);
         }
     }
     else if (r->title->type == HB_DVD_TYPE)
@@ -130,6 +134,8 @@ static int hb_reader_open( hb_work_private_t * r )
             hb_dvd_close(&r->dvd);
             return 1;
         }
+        r->duration -= chapter_end_pts(r->job->title,
+                                       r->job->chapter_start - 1);
         if (r->job->angle)
         {
             hb_dvd_set_angle(r->dvd, r->job->angle);
@@ -141,6 +147,10 @@ static int hb_reader_open( hb_work_private_t * r )
                         (r->job->seek_points ? (r->job->seek_points + 1.0)
                                              : 11.0));
         }
+        // libdvdnav doesn't have a seek to timestamp function.
+        // So we will have to decode frames until we find the correct time
+        // in sync.c
+        r->start_found = 1;
     }
     else if (r->title->type == HB_STREAM_TYPE ||
              r->title->type == HB_FF_STREAM_TYPE)
@@ -161,11 +171,17 @@ static int hb_reader_open( hb_work_private_t * r )
                 // that we want.  So we will retrieve the start time of the
                 // first packet we get, subtract that from pts_to_start, and
                 // inspect the reset of the frames in sync.
-                r->start_found = 2;
                 r->duration -= r->job->pts_to_start;
             }
-            // hb_stream_seek_ts does nothing for TS streams and will return
-            // an error.
+            else
+            {
+                // hb_stream_seek_ts does nothing for TS streams and will
+                // return an error.
+                //
+                // So we will decode frames until we find the correct time
+                // in sync.c
+                r->start_found = 1;
+            }
         }
         else
         {
@@ -187,6 +203,8 @@ static int hb_reader_open( hb_work_private_t * r )
              * Seek to the start chapter.
              */
             hb_stream_seek_chapter(r->stream, start);
+            r->duration -= chapter_end_pts(r->job->title,
+                                           r->job->chapter_start - 1);
         }
     }
     else
@@ -210,22 +228,14 @@ static int reader_init( hb_work_object_t * w, hb_job_t * job )
     r->title = job->title;
     r->die   = job->die;
 
-    r->st_slots = 4;
-    r->stream_timing = calloc( sizeof(stream_timing_t), r->st_slots );
-    r->stream_timing[0].id = r->title->video_id;
-    r->stream_timing[0].average = 90000. * (double)job->vrate.den /
-                                           job->vrate.num;
-    r->stream_timing[0].filtered_average = r->stream_timing[0].average;
-    r->stream_timing[0].last = -r->stream_timing[0].average;
-    r->stream_timing[0].valid = 1;
-    r->stream_timing[0].startup = 10;
-    r->stream_timing[1].id = -1;
-
     r->demux.last_scr = AV_NOPTS_VALUE;
+    r->last_pts       = AV_NOPTS_VALUE;
 
     r->chapter_end = job->chapter_end;
-    if ( !job->pts_to_start )
+    if (!job->pts_to_start)
+    {
         r->start_found = 1;
+    }
     else
     {
         // The frame at the actual start time may not be an i-frame
@@ -235,7 +245,7 @@ static int reader_init( hb_work_object_t * w, hb_job_t * job )
         r->pts_to_start = MAX(0, job->pts_to_start - 1000000);
     }
 
-    if (job->pts_to_stop)
+    if (job->pts_to_stop > 0)
     {
         r->duration = job->pts_to_start + job->pts_to_stop;
     }
@@ -243,18 +253,18 @@ static int reader_init( hb_work_object_t * w, hb_job_t * job )
     {
         int frames = job->frame_to_start + job->frame_to_stop;
         r->duration = (int64_t)frames * job->title->vrate.den * 90000 /
-                               job->title->vrate.num;
+                                        job->title->vrate.num;
     }
     else
     {
-        hb_chapter_t *chapter;
-        int ii;
-
-        r->duration = 0;
-        for (ii = job->chapter_start; ii < job->chapter_end; ii++)
+        int count = hb_list_count(job->title->list_chapter);
+        if (count == 0 || count <= job->chapter_end)
         {
-            chapter = hb_list_item( job->title->list_chapter, ii - 1);
-            r->duration += chapter->duration;
+            r->duration = job->title->duration;
+        }
+        else
+        {
+            r->duration = chapter_end_pts(job->title, job->chapter_end);
         }
     }
 
@@ -289,7 +299,6 @@ static int reader_init( hb_work_object_t * w, hb_job_t * job )
     // with the reader. Specifically avcodec needs this.
     if ( hb_reader_open( r ) )
     {
-        free( r->stream_timing );
         free( r );
         return 1;
     }
@@ -318,11 +327,6 @@ static void reader_close( hb_work_object_t * w )
     else if (r->stream)
     {
         hb_stream_close(&r->stream);
-    }
-
-    if ( r->stream_timing )
-    {
-        free( r->stream_timing );
     }
 
     int ii;
@@ -389,150 +393,6 @@ static void push_buf( hb_work_private_t *r, hb_fifo_t *fifo, hb_buffer_t *buf )
     {
         hb_buffer_close( &buf );
     }
-}
-
-static int is_audio( hb_work_private_t *r, int id )
-{
-    int i;
-    hb_audio_t *audio;
-
-    for( i = 0; ( audio = hb_list_item( r->title->list_audio, i ) ); ++i )
-    {
-        if ( audio->id == id )
-        {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-static int is_subtitle( hb_work_private_t *r, int id )
-{
-    int i;
-    hb_subtitle_t *sub;
-
-    for( i = 0; ( sub = hb_list_item( r->title->list_subtitle, i ) ); ++i )
-    {
-        if ( sub->id == id )
-        {
-            return 1;
-        }
-    }
-    return 0;
-}
-
-// The MPEG STD (Standard Target Decoder) essentially requires that we keep
-// per-stream timing so that when there's a timing discontinuity we can
-// seemlessly join packets on either side of the discontinuity. This join
-// requires that we know the timestamp of the previous packet and the
-// average inter-packet time (since we position the new packet at the end
-// of the previous packet). The next four routines keep track of this
-// per-stream timing.
-
-// find or create the per-stream timing state for 'buf'
-
-static stream_timing_t *id_to_st( hb_work_private_t *r, const hb_buffer_t *buf, int valid )
-{
-    stream_timing_t *st = r->stream_timing;
-    while ( st->id != buf->s.id && st->id != -1)
-    {
-        ++st;
-    }
-    // if we haven't seen this stream add it.
-    if ( st->id == -1 )
-    {
-        // we keep the steam timing info in an array with some power-of-two
-        // number of slots. If we don't have two slots left (one for our new
-        // entry plus one for the "-1" eol) we need to expand the array.
-        int slot = st - r->stream_timing;
-        if ( slot + 1 >= r->st_slots )
-        {
-            r->st_slots *= 2;
-            r->stream_timing = realloc( r->stream_timing, r->st_slots *
-                                        sizeof(*r->stream_timing) );
-            st = r->stream_timing + slot;
-        }
-        st->id = buf->s.id;
-        st->average = 30.*90.;
-        st->filtered_average = st->average;
-        st->startup = 10;
-        st->last = -st->average;
-        if ( ( st->is_audio = is_audio( r, buf->s.id ) ) != 0 )
-        {
-            r->saw_audio = 1;
-        }
-        st[1].id = -1;
-        st->valid = valid;
-    }
-    return st;
-}
-
-// update the average inter-packet time of the stream associated with 'buf'
-// using a recursive low-pass filter with a 16 packet time constant.
-
-static void update_ipt( hb_work_private_t *r, const hb_buffer_t *buf )
-{
-    stream_timing_t *st = id_to_st( r, buf, 1 );
-
-    if (buf->s.renderOffset == AV_NOPTS_VALUE)
-    {
-        st->last += st->filtered_average;
-        return;
-    }
-
-    double dt = buf->s.renderOffset - st->last;
-
-    // Protect against spurious bad timestamps
-    // timestamps should only move forward and by reasonable increments
-    if ( dt > 0 && dt < 5 * 90000LL )
-    {
-        if( st->startup )
-        {
-            st->average += ( dt - st->average ) * (1./4.);
-            st->startup--;
-        }
-        else
-        {
-            st->average += ( dt - st->average ) * (1./32.);
-        }
-        // Ignore outliers
-        if (dt < 1.5 * st->average)
-        {
-            st->filtered_average += ( dt - st->filtered_average ) * (1./32.);
-        }
-    }
-    st->last = buf->s.renderOffset;
-    st->valid = 1;
-}
-
-// use the per-stream state associated with 'buf' to compute a new scr_offset
-// such that 'buf' will follow the previous packet of this stream separated
-// by the average packet time of the stream.
-
-static void new_scr_offset( hb_work_private_t *r, hb_buffer_t *buf )
-{
-    stream_timing_t *st = id_to_st( r, buf, 1 );
-    int64_t last;
-    if ( !st->valid )
-    {
-        // !valid means we've not received any previous data
-        // for this stream.  There is no 'last' packet time.
-        // So approximate it with video's last time.
-        last = r->stream_timing[0].last;
-        st->valid = 1;
-    }
-    else
-    {
-        last = st->last;
-    }
-    int64_t nxt = last + st->filtered_average;
-    r->scr_offset = buf->s.renderOffset - nxt;
-    // This log is handy when you need to debug timing problems...
-    //hb_log("id %x last %"PRId64" avg %g nxt %"PRId64" renderOffset %"PRId64
-    //       " scr_offset %"PRId64"",
-    //    buf->s.id, last, st->filtered_average, nxt,
-    //    buf->s.renderOffset, r->scr_offset);
-    r->scr_changes = r->demux.scr_changes;
 }
 
 static void reader_send_eof( hb_work_private_t * r )
@@ -619,10 +479,57 @@ static int reader_work( hb_work_object_t * w, hb_buffer_t ** buf_in,
 
     while ((buf = hb_buffer_list_rem_head(&list)) != NULL)
     {
-        fifos = GetFifoForId( r, buf->s.id );
-
-        if (fifos && r->stream && r->start_found == 2 )
+        if (buf->s.start   != AV_NOPTS_VALUE &&
+            r->scr_changes != r->demux.scr_changes)
         {
+            // First valid timestamp after an SCR change.  Update
+            // the per-stream scr sequence number
+            r->scr_changes = r->demux.scr_changes;
+
+            // libav tries to be too smart with timestamps and
+            // enforces unnecessary conditions.  One such condition
+            // is that subtitle timestamps must be monotonically
+            // increasing.  To encure this is the case, we calculate
+            // an offset upon each SCR change that will guarantee this.
+            // This is just a very rough SCR offset.  A fine grained
+            // offset that maintains proper sync is calculated in sync.c
+            if (r->last_pts != AV_NOPTS_VALUE)
+            {
+                r->scr_offset  = r->last_pts + 90000 - buf->s.start;
+            }
+            else
+            {
+                r->scr_offset  = -buf->s.start;
+            }
+        }
+        // Set the scr sequence that this buffer's timestamps are
+        // referenced to.
+        buf->s.scr_sequence = r->scr_changes;
+        if (buf->s.start != AV_NOPTS_VALUE)
+        {
+            buf->s.start += r->scr_offset;
+        }
+        if (buf->s.renderOffset != AV_NOPTS_VALUE)
+        {
+            buf->s.renderOffset += r->scr_offset;
+        }
+        if (buf->s.start > r->last_pts)
+        {
+            r->last_pts = buf->s.start;
+            UpdateState(r);
+        }
+
+        fifos = GetFifoForId( r, buf->s.id );
+        if (fifos && r->stream && !r->start_found)
+        {
+            // libav is allowing SSA subtitles to leak through that are
+            // prior to the seek point.  So only make the adjustment to
+            // pts_to_start after we see the next video buffer.
+            if (buf->s.id != r->job->title->video_id)
+            {
+                hb_buffer_close(&buf);
+                continue;
+            }
             // We will inspect the timestamps of each frame in sync
             // to skip from this seek point to the timestamp we
             // want to start at.
@@ -638,176 +545,9 @@ static int reader_work( hb_work_object_t * w, hb_buffer_t ** buf_in,
             r->start_found = 1;
         }
 
-        if ( fifos && ! r->saw_video && !r->job->indepth_scan )
-        {
-            // The first data packet with a PTS from an audio or video stream
-            // that we're decoding defines 'time zero'. Discard packets until
-            // we get one.
-            if (buf->s.start != AV_NOPTS_VALUE &&
-                buf->s.renderOffset != AV_NOPTS_VALUE &&
-                 (buf->s.id == r->title->video_id ||
-                  is_audio( r, buf->s.id)))
-            {
-                // force a new scr offset computation
-                r->scr_changes = r->demux.scr_changes - 1;
-                // create a stream state if we don't have one so the
-                // offset will get computed correctly.
-                id_to_st( r, buf, 1 );
-                r->saw_video = 1;
-                hb_log( "reader: first SCR %"PRId64" id 0x%x DTS %"PRId64,
-                        r->demux.last_scr, buf->s.id, buf->s.renderOffset );
-            }
-            else
-            {
-                fifos = NULL;
-            }
-        }
-
-        if ( r->job->indepth_scan || fifos )
-        {
-            if ( buf->s.renderOffset != AV_NOPTS_VALUE )
-            {
-                if ( r->scr_changes != r->demux.scr_changes )
-                {
-                    // This is the first audio or video packet after an SCR
-                    // change. Compute a new scr offset that would make this
-                    // packet follow the last of this stream with the
-                    // correct average spacing.
-                    stream_timing_t *st = id_to_st( r, buf, 0 );
-
-                    // if this is the video stream and we don't have
-                    // audio yet or this is an audio stream
-                    // generate a new scr
-                    if ( st->is_audio ||
-                         ( st == r->stream_timing && !r->saw_audio ) )
-                    {
-                        new_scr_offset( r, buf );
-                        r->sub_scr_set = 0;
-                    }
-                    else
-                    {
-                        // defer the scr change until we get some
-                        // audio since audio has a timestamp per
-                        // frame but video & subtitles don't. Clear
-                        // the timestamps so the decoder will generate
-                        // them from the frame durations.
-                        if (is_subtitle(r, buf->s.id) &&
-                            buf->s.start != AV_NOPTS_VALUE)
-                        {
-                            if (!r->sub_scr_set)
-                            {
-                                // We can't generate timestamps in the
-                                // subtitle decoder as we can for
-                                // audio & video.  So we need to make
-                                // the closest guess that we can
-                                // for the subtitles start time here.
-                                int64_t last = r->stream_timing[0].last;
-                                r->scr_offset = buf->s.start - last;
-                                r->sub_scr_set = 1;
-                            }
-                        }
-                        else
-                        {
-                            buf->s.start = AV_NOPTS_VALUE;
-                            buf->s.renderOffset = AV_NOPTS_VALUE;
-                        }
-                    }
-                }
-            }
-            if ( buf->s.start != AV_NOPTS_VALUE )
-            {
-                int64_t start = buf->s.start - r->scr_offset;
-
-                if (!r->start_found || r->job->indepth_scan)
-                {
-                    UpdateState( r, start );
-                }
-
-                if (r->job->indepth_scan && r->job->pts_to_stop &&
-                    start >= r->pts_to_start + r->job->pts_to_stop)
-                {
-                    // sync normally would terminate p-to-p
-                    // but sync doesn't run during indepth scan
-                    hb_log("reader: reached pts %"PRId64", exiting early", start);
-                    reader_send_eof(r);
-                    hb_buffer_list_close(&list);
-                    return HB_WORK_DONE;
-                }
-
-                if (!r->start_found && start >= r->pts_to_start)
-                {
-                    // pts_to_start point found
-                    // Note that this code path only gets executed for
-                    // medai where we have not performed an initial seek
-                    // to get close to the start time. So the 'start' time
-                    // is the time since the first frame.
-
-                    if (r->stream)
-                    {
-                        // libav multi-threaded decoders can get into
-                        // a bad state if the initial data is not
-                        // decodable.  So try to improve the chances of
-                        // a good start by waiting for an initial iframe
-                        hb_stream_set_need_keyframe(r->stream, 1);
-                        hb_buffer_close( &buf );
-                        continue;
-                    }
-                    r->start_found = 1;
-                    // sync.c also pays attention to job->pts_to_start
-                    // It eats up the 10 second slack that we build in
-                    // to the start time here in reader (so that video
-                    // decode is clean at the start time).
-                    // sync.c expects pts_to_start to be relative to the
-                    // first timestamp it sees.
-                    if (r->job->pts_to_start > start)
-                    {
-                        r->job->pts_to_start -= start;
-                    }
-                    else
-                    {
-                        r->job->pts_to_start = 0;
-                    }
-                }
-                // This log is handy when you need to debug timing problems
-                //hb_log("id %x scr_offset %"PRId64
-                //       " start %"PRId64" --> %"PRId64"",
-                //        buf->s.id, r->scr_offset, buf->s.start,
-                //        buf->s.start - r->scr_offset);
-                buf->s.start -= r->scr_offset;
-                if ( buf->s.stop != AV_NOPTS_VALUE )
-                {
-                    buf->s.stop -= r->scr_offset;
-                }
-            }
-            if ( buf->s.renderOffset != AV_NOPTS_VALUE )
-            {
-                // This packet is referenced to the same SCR as the last.
-                // Adjust timestamp to remove the System Clock Reference
-                // offset then update the average inter-packet time
-                // for this stream.
-                buf->s.renderOffset -= r->scr_offset;
-                update_ipt( r, buf );
-            }
-#if 0
-            // JAS: This was added to fix a rare "audio time went backward"
-            // sync error I found in one sample.  But it has a bad side
-            // effect on DVDs, causing frequent "adding silence" sync
-            // errors. So I am disabling it.
-            else
-            {
-                update_ipt( r, buf );
-            }
-#endif
-        }
         buf = splice_discontinuity(r, buf);
-        if( fifos && buf != NULL )
+        if (fifos && buf != NULL)
         {
-            if ( !r->start_found )
-            {
-                hb_buffer_close( &buf );
-                continue;
-            }
-
             /* if there are mutiple output fifos, send a copy of the
              * buffer down all but the first (we have to not ship the
              * original buffer or we'll race with the thread that's
@@ -832,11 +572,17 @@ static int reader_work( hb_work_object_t * w, hb_buffer_t ** buf_in,
     return HB_WORK_OK;
 }
 
-static void UpdateState( hb_work_private_t  * r, int64_t start)
+static void UpdateState( hb_work_private_t  * r )
 {
     hb_state_t state;
     uint64_t now;
     double avg;
+
+    if (!r->job->indepth_scan || !r->start_found)
+    {
+        // Only update state when sync.c is not handling state updates
+        return;
+    }
 
     now = hb_get_date();
     if( !r->st_first )
@@ -846,16 +592,8 @@ static void UpdateState( hb_work_private_t  * r, int64_t start)
 
     hb_get_state2(r->job->h, &state);
 #define p state.param.working
-    if ( !r->job->indepth_scan )
-    {
-        state.state = HB_STATE_SEARCHING;
-        p.progress  = (float) start / (float) r->job->pts_to_start;
-    }
-    else
-    {
-        state.state = HB_STATE_WORKING;
-        p.progress  = (float) start / (float) r->duration;
-    }
+    state.state = HB_STATE_WORKING;
+    p.progress  = (float) r->last_pts / (float) r->duration;
     if( p.progress > 1.0 )
     {
         p.progress = 1.0;
@@ -866,11 +604,12 @@ static void UpdateState( hb_work_private_t  * r, int64_t start)
     {
         int eta;
 
-        avg = 1000.0 * (double)start / (now - r->st_first);
-        if ( !r->job->indepth_scan )
-            eta = ( r->job->pts_to_start - start ) / avg;
-        else
-            eta = ( r->duration - start ) / avg;
+        avg = 1000.0 * (double)r->last_pts / (now - r->st_first);
+        eta = (r->duration - r->last_pts) / avg;
+        if (eta < 0)
+        {
+            eta = 0;
+        }
         p.hours   = eta / 3600;
         p.minutes = ( eta % 3600 ) / 60;
         p.seconds = eta % 60;
@@ -885,6 +624,7 @@ static void UpdateState( hb_work_private_t  * r, int64_t start)
 
     hb_set_state( r->job->h, &state );
 }
+
 /***********************************************************************
  * GetFifoForId
  ***********************************************************************
@@ -898,9 +638,9 @@ static hb_fifo_t ** GetFifoForId( hb_work_private_t * r, int id )
     hb_subtitle_t * subtitle;
     int             i, n;
 
-    if( id == title->video_id )
+    if (id == title->video_id)
     {
-        if (job->indepth_scan && !job->frame_to_stop)
+        if (job->indepth_scan && r->start_found)
         {
             /*
              * Ditch the video here during the indepth scan until
@@ -919,7 +659,7 @@ static hb_fifo_t ** GetFifoForId( hb_work_private_t * r, int id )
         }
     }
 
-    for( i = n = 0; i < hb_list_count( job->list_subtitle ); i++ )
+    for (i = n = 0; i < hb_list_count( job->list_subtitle ); i++)
     {
         subtitle =  hb_list_item( job->list_subtitle, i );
         if (id == subtitle->id)
@@ -928,24 +668,24 @@ static hb_fifo_t ** GetFifoForId( hb_work_private_t * r, int id )
             r->fifos[n++] = subtitle->fifo_in;
         }
     }
-    if ( n != 0 )
+    if (n != 0)
     {
         r->fifos[n] = NULL;
         return r->fifos;
     }
 
-    if( !job->indepth_scan )
+    if (!job->indepth_scan)
     {
-        for( i = n = 0; i < hb_list_count( job->list_audio ); i++ )
+        for (i = n = 0; i < hb_list_count( job->list_audio ); i++)
         {
             audio = hb_list_item( job->list_audio, i );
-            if( id == audio->id )
+            if (id == audio->id)
             {
                 r->fifos[n++] = audio->priv.fifo_in;
             }
         }
 
-        if( n != 0 )
+        if (n != 0)
         {
             r->fifos[n] = NULL;
             return r->fifos;

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -17,7 +17,7 @@
 
 // Audio is small, buffer a lot.  It helps to ensure that we see
 // the initial PTS from all input streams before setting the 'zero' point.
-#define SYNC_MAX_AUDIO_QUEUE_LEN    100
+#define SYNC_MAX_AUDIO_QUEUE_LEN    200
 #define SYNC_MIN_AUDIO_QUEUE_LEN    30
 
 // We do not place a limit on the number of subtitle frames

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -57,12 +57,22 @@ typedef struct
 
 typedef struct sync_common_s sync_common_t;
 
+#define SCR_HASH_SZ   (2 << 3)
+#define SCR_HASH_MASK (SCR_HASH_SZ - 1)
+
+typedef struct
+{
+    int                 scr_sequence;
+    int64_t             scr_offset;
+} scr_t;
+
 typedef struct
 {
     sync_common_t     * common;
 
     // Stream I/O control
     hb_list_t         * in_queue;
+    hb_list_t         * scr_delay_queue;
     int                 max_len;
     int                 min_len;
     hb_cond_t         * cond_full;
@@ -73,6 +83,10 @@ typedef struct
     int64_t             pts_slip;
     double              next_pts;
     double              last_pts;
+
+    // SCR recovery
+    double              last_scr_pts;
+    double              last_duration;
 
     // frame statistics
     int64_t             first_pts;
@@ -127,13 +141,17 @@ typedef struct
 
 struct sync_common_s
 {
-    /* Audio/Video sync thread synchronization */
+    // Audio/Video sync thread synchronization
     hb_job_t      * job;
     hb_lock_t     * mutex;
     int             stream_count;
     sync_stream_t * streams;
     int             found_first_pts;
     int             done;
+
+    // SCR adjustments
+    scr_t           scr[SCR_HASH_SZ];
+    int             first_scr;
 
     // point-to-point support
     int             start_found;
@@ -163,8 +181,10 @@ struct hb_work_private_s
 static void UpdateState( sync_common_t * common, int frame_count );
 static void UpdateSearchState( sync_common_t * common, int64_t start,
                                int frame_count );
+static int  UpdateSCR( sync_stream_t * stream, hb_buffer_t * buf );
 static hb_buffer_t * FilterAudioFrame( sync_stream_t * stream,
                                        hb_buffer_t *buf );
+static void SortedQueueBuffer( sync_stream_t * stream, hb_buffer_t * buf );
 static hb_buffer_t * sanitizeSubtitle(sync_stream_t        * stream,
                                       hb_buffer_t          * sub);
 
@@ -223,16 +243,12 @@ static void signalBuffer( sync_stream_t * stream )
     }
 }
 
-static void allSlip( sync_common_t * common, int64_t delta )
+static void scrSlip( sync_common_t * common, int64_t delta )
 {
     int ii;
-    for (ii = 0; ii < common->stream_count; ii++)
+    for (ii = 0; ii < SCR_HASH_SZ; ii++)
     {
-        common->streams[ii].pts_slip += delta;
-        if (common->streams[ii].next_pts != (int64_t)AV_NOPTS_VALUE)
-        {
-            common->streams[ii].next_pts -= delta;
-        }
+        common->scr[ii].scr_offset += delta;
     }
 }
 
@@ -240,27 +256,105 @@ static void shiftTS( sync_common_t * common, int64_t delta )
 {
     int ii, jj;
 
-    allSlip(common, delta);
+    scrSlip(common, delta);
     for (ii = 0; ii < common->stream_count; ii++)
     {
+        hb_buffer_t   * buf = NULL;
         sync_stream_t * stream = &common->streams[ii];
-        int count = hb_list_count(stream->in_queue);
+        int             count = hb_list_count(stream->in_queue);
+
         for (jj = 0; jj < count; jj++)
         {
-            hb_buffer_t * buf = hb_list_item(stream->in_queue, jj);
-            buf->s.start -= delta;
+            buf = hb_list_item(stream->in_queue, jj);
+            if (buf->s.start != AV_NOPTS_VALUE)
+            {
+                buf->s.start -= delta;
+            }
             if (buf->s.stop != AV_NOPTS_VALUE)
             {
                 buf->s.stop  -= delta;
             }
+        }
+        if (buf != NULL && buf->s.start != AV_NOPTS_VALUE)
+        {
+            stream->last_scr_pts = buf->s.start + buf->s.duration;
+        }
+        else
+        {
+            stream->last_scr_pts = (int64_t)AV_NOPTS_VALUE;
+        }
+    }
+}
+
+static void computeInitialTS( sync_common_t * common,
+                              sync_stream_t * first_stream )
+{
+    int           ii, count;
+    hb_buffer_t * prev;
+
+    // Process first_stream first since it has the initial PTS
+    prev = NULL;
+    count = hb_list_count(first_stream->in_queue);
+    for (ii = 0; ii < count; ii++)
+    {
+        hb_buffer_t * buf = hb_list_item(first_stream->in_queue, ii);
+        if (UpdateSCR(first_stream, buf))
+        {
+            if (first_stream->type == SYNC_TYPE_VIDEO && prev != NULL)
+            {
+                double duration = buf->s.start - prev->s.start;
+                if (duration > 0)
+                {
+                    prev->s.duration = duration;
+                    prev->s.stop = buf->s.start;
+                }
+            }
+        }
+        prev = buf;
+    }
+    for (ii = 0; ii < common->stream_count; ii++)
+    {
+        sync_stream_t * stream = &common->streams[ii];
+
+        if (stream == first_stream)
+        {
+            // skip first_stream, already done
+            continue;
+        }
+
+        int jj;
+        prev = NULL;
+        for (jj = 0; jj < hb_list_count(stream->in_queue);)
+        {
+            hb_buffer_t * buf = hb_list_item(stream->in_queue, jj);
+            if (!UpdateSCR(stream, buf))
+            {
+                // Subtitle put into delay queue, remove it from in_queue
+                hb_list_rem(stream->in_queue, buf);
+            }
+            else
+            {
+                jj++;
+                if (stream->type == SYNC_TYPE_VIDEO && prev != NULL)
+                {
+                    double duration = buf->s.start - prev->s.start;
+                    if (duration > 0)
+                    {
+                        prev->s.duration = duration;
+                        prev->s.stop = buf->s.start;
+                    }
+                }
+            }
+            prev = buf;
         }
     }
 }
 
 static void checkFirstPts( sync_common_t * common )
 {
-    int ii;
-    int64_t first_pts = INT64_MAX;
+    int             ii;
+    int64_t         first_pts = INT64_MAX;
+    sync_stream_t * first_stream = NULL;
 
     for (ii = 0; ii < common->stream_count; ii++)
     {
@@ -275,22 +369,30 @@ static void checkFirstPts( sync_common_t * common )
         if (hb_list_count(stream->in_queue) > 0)
         {
             hb_buffer_t * buf = hb_list_item(stream->in_queue, 0);
-            if (first_pts > buf->s.start)
+            if (buf->s.start != AV_NOPTS_VALUE && buf->s.start < first_pts)
             {
                 first_pts = buf->s.start;
+                first_stream = stream;
             }
         }
     }
+    // We should *always* find a first pts because we let the queues
+    // fill before performing this test.
     if (first_pts != INT64_MAX)
     {
-        // Add a fudge factor to first pts to prevent negative
-        // timestamps from leaking through.  The pipeline can
-        // handle a positive offset, but some things choke on
-        // negative offsets
-        //first_pts -= 500000;
-        shiftTS(common, first_pts);
+        common->found_first_pts = 1;
+        // We may have buffers that have no timestamps (i.e. AV_NOPTS_VALUE).
+        // Compute these timestamps based on previous buffer's timestamp
+        // and duration.
+        computeInitialTS(common, first_stream);
+        // After this initialization, all AV_NOPTS_VALUE timestamps
+        // will be filled in by UpdateSCR()
     }
-    common->found_first_pts = 1;
+    else
+    {
+        // This should never happen
+        hb_error("checkFirstPts: No initial PTS found!\n");
+    }
 }
 
 static void addDelta( sync_common_t * common, int64_t start, int64_t delta)
@@ -1305,27 +1407,218 @@ static void Synchronize( sync_stream_t * stream )
     hb_unlock(common->mutex);
 }
 
-static void updateDuration( sync_stream_t * stream, int64_t start )
+static void updateDuration( sync_stream_t * stream )
 {
-    // The video decoder does not set an initial duration for frames.
-    // So set it here.
+    // The video decoder sets a nominal duration for frames.  But the
+    // actual duration needs to be computed from timestamps.
     if (stream->type == SYNC_TYPE_VIDEO)
     {
         int count = hb_list_count(stream->in_queue);
-        if (count > 0)
+        if (count >= 2)
         {
-            hb_buffer_t * buf = hb_list_item(stream->in_queue, count - 1);
-            double duration = start - buf->s.start;
+            hb_buffer_t * buf1 = hb_list_item(stream->in_queue, count - 1);
+            hb_buffer_t * buf2 = hb_list_item(stream->in_queue, count - 2);
+            double duration = buf1->s.start - buf2->s.start;
             if (duration > 0)
             {
-                buf->s.duration = duration;
-                buf->s.stop = start;
+                buf2->s.duration = duration;
+                buf2->s.stop = buf1->s.start;
             }
             else
             {
-                buf->s.duration = 0.;
-                buf->s.stop = buf->s.start;
+                buf2->s.duration = 0.;
+                buf2->s.start = buf2->s.stop = buf1->s.start;
             }
+        }
+    }
+}
+
+static void ProcessSCRDelayQueue( sync_common_t * common )
+{
+    int ii, jj;
+
+    for (ii = 0; ii < common->stream_count; ii++)
+    {
+        sync_stream_t * stream = &common->streams[ii];
+        for (jj = 0; jj < hb_list_count(stream->scr_delay_queue);)
+        {
+            hb_buffer_t * buf = hb_list_item(stream->scr_delay_queue, jj);
+            int           hash = buf->s.scr_sequence & SCR_HASH_MASK;
+            if (buf->s.scr_sequence < 0)
+            {
+                // Unset scr_sequence inidicates an external stream
+                // (e.g. SRT subtitle) that is not on the same timebase
+                // as the source tracks. Do not adjust timestamps for
+                // scr_offset in this case.
+                hb_list_rem(stream->scr_delay_queue, buf);
+                SortedQueueBuffer(stream, buf);
+            }
+            else if (buf->s.scr_sequence == common->scr[hash].scr_sequence)
+            {
+                if (buf->s.start != AV_NOPTS_VALUE)
+                {
+                    buf->s.start -= common->scr[hash].scr_offset;
+                    buf->s.start -= stream->pts_slip;
+                }
+                if (buf->s.stop != AV_NOPTS_VALUE)
+                {
+                    buf->s.stop -= common->scr[hash].scr_offset;
+                    buf->s.stop -= stream->pts_slip;
+                }
+                hb_list_rem(stream->scr_delay_queue, buf);
+                SortedQueueBuffer(stream, buf);
+            }
+            else
+            {
+                jj++;
+            }
+        }
+    }
+}
+
+static int UpdateSCR( sync_stream_t * stream, hb_buffer_t * buf )
+{
+    int             hash = buf->s.scr_sequence & SCR_HASH_MASK;
+    sync_common_t * common = stream->common;
+    double          last_scr_pts, last_duration;
+    int64_t         scr_offset = 0;
+
+    if (buf->s.scr_sequence >= 0)
+    {
+        if (buf->s.scr_sequence != common->scr[hash].scr_sequence)
+        {
+            if (stream->type == SYNC_TYPE_SUBTITLE ||
+                (stream->last_scr_pts == (int64_t)AV_NOPTS_VALUE &&
+                 common->first_scr))
+            {
+                // We got a new scr, but we have no last_scr_pts to base it
+                // off of. Delay till we can compute the scr offset from a
+                // different stream.
+                hb_list_add(stream->scr_delay_queue, buf);
+                return 0;
+            }
+            if (buf->s.start != AV_NOPTS_VALUE)
+            {
+                last_scr_pts  = stream->last_scr_pts;
+                last_duration = stream->last_duration;
+                if (last_scr_pts == (int64_t)AV_NOPTS_VALUE)
+                {
+                    last_scr_pts      = 0.;
+                    last_duration     = 0.;
+                    common->first_scr = 1;
+                }
+                // New SCR.  Compute SCR offset
+                common->scr[hash].scr_sequence = buf->s.scr_sequence;
+                common->scr[hash].scr_offset   = buf->s.start -
+                                                 (last_scr_pts + last_duration);
+                ProcessSCRDelayQueue(common);
+            }
+        }
+        scr_offset = common->scr[hash].scr_offset;
+    }
+
+    // Adjust buffer timestamps for SCR offset
+    if (buf->s.start != AV_NOPTS_VALUE)
+    {
+        buf->s.start -= scr_offset;
+        last_scr_pts  = buf->s.start;
+    }
+    else if (stream->last_scr_pts != (int64_t)AV_NOPTS_VALUE)
+    {
+        last_scr_pts = stream->last_scr_pts + stream->last_duration;
+        buf->s.start = last_scr_pts;
+    }
+    else
+    {
+        // This should happen extremely rarely if ever.
+        // But if we get here, this is the first buffer received for
+        // this stream.  Normally, some buffers will be queued for
+        // every stream before we ever call UpdateSCR.
+        // We don't really know what it's timestamp should be,
+        // but 0 is a good guess.
+        buf->s.start = 0;
+        last_scr_pts = buf->s.start;
+    }
+    if (buf->s.stop != AV_NOPTS_VALUE)
+    {
+        buf->s.stop -= scr_offset;
+    }
+    if (last_scr_pts > stream->last_scr_pts)
+    {
+        stream->last_scr_pts = last_scr_pts;
+    }
+    stream->last_duration = buf->s.duration;
+
+    return 1;
+}
+
+// Handle broken timestamps that are out of order
+// These are usually due to a broken decoder (e.g. QSV and libav AVI packed
+// b-frame support).  But sometimes can come from a severely broken or
+// corrupted source file.
+//
+// We can pretty reliably fix out of order timestamps *if* every frame
+// has a timestamp.  But some container formats allow frames with no
+// timestamp (e.g. TS and PS).  When there is no timestamp, we will
+// compute one based on the last frames timestamp.  If the missing
+// timestamp is out of order and really belonged on an earlier frame (A),
+// this will result in the frame before (A) being long and the frame
+// after the current will overlap current.
+//
+// The condition above of one long frame and one overlap will most likely
+// get fixed by dejitterVideo. dejitterVideo finds sequences where the
+// sum of the durations of frames 1..N == (1/fps) * N. When it finds such
+// a sequence, it adjusts the frame durations to all be 1/fps. Since the
+// vast majority of video is constant framerate, this will fix the above
+// problem most of the time.
+static void SortedQueueBuffer( sync_stream_t * stream, hb_buffer_t * buf )
+{
+    int64_t start;
+    int     ii, count;
+
+    start = buf->s.start;
+    hb_list_add(stream->in_queue, buf);
+
+    // Search for the first earlier timestamp that is < this one.
+    // Under normal circumstances where the timestamps are not broken,
+    // this will only check the next to last buffer in the queue
+    // before aborting.
+    count = hb_list_count(stream->in_queue);
+    for (ii = count - 2; ii >= 0; ii--)
+    {
+        buf = hb_list_item(stream->in_queue, ii);
+        if (buf->s.start < start || start == AV_NOPTS_VALUE)
+        {
+            break;
+        }
+    }
+    if (ii < count - 2)
+    {
+        hb_buffer_t * prev = NULL;
+        int           jj;
+
+        // The timestamp was out of order.
+        // The timestamp belongs at position ii + 1
+        // Every timestamp from ii + 2 to count - 1 needs to be shifted up.
+        if (ii >= 0)
+        {
+            prev = hb_list_item(stream->in_queue, ii);
+        }
+        for (jj = ii + 1; jj < count; jj++)
+        {
+            int64_t tmp_start;
+
+            buf = hb_list_item(stream->in_queue, jj);
+            tmp_start = buf->s.start;
+            buf->s.start = start;
+            start = tmp_start;
+            if (stream->type == SYNC_TYPE_VIDEO && prev != NULL)
+            {
+                // recompute video buffer duration
+                prev->s.duration = buf->s.start - prev->s.start;
+                prev->s.stop     = buf->s.start;
+            }
+            prev = buf;
         }
     }
 }
@@ -1374,17 +1667,42 @@ static void QueueBuffer( sync_stream_t * stream, hb_buffer_t * buf )
     buf->s.renderOffset = AV_NOPTS_VALUE;
 
     hb_deep_log(11,
-        "type %8s id %x start %"PRId64" stop %"PRId64" dur %f",
-        getStreamType(stream), getStreamId(stream),
+        "type %8s id %x scr seq %d start %"PRId64" stop %"PRId64" dur %f",
+        getStreamType(stream), getStreamId(stream), buf->s.scr_sequence,
         buf->s.start, buf->s.stop, buf->s.duration);
 
-    buf->s.start -= stream->pts_slip;
-    if (buf->s.stop != AV_NOPTS_VALUE)
+    if (stream->common->found_first_pts)
     {
-        buf->s.stop -= stream->pts_slip;
+        if (UpdateSCR(stream, buf))
+        {
+            // Apply any stream slips.
+            // Stream slips will only temporarily differ between
+            // the streams.  The slips get updated in applyDeltas.  When
+            // all the deltas are absorbed, the stream slips will all
+            // be equal.
+            buf->s.start -= stream->pts_slip;
+            if (buf->s.stop != AV_NOPTS_VALUE)
+            {
+                buf->s.stop -= stream->pts_slip;
+            }
+
+            SortedQueueBuffer(stream, buf);
+            updateDuration(stream);
+        }
     }
-    updateDuration(stream, buf->s.start);
-    hb_list_add(stream->in_queue, buf);
+    else
+    {
+        if (buf->s.start == AV_NOPTS_VALUE &&
+            hb_list_count(stream->in_queue) == 0)
+        {
+            // We require an initial pts to start synchronization
+            saveChap(stream, buf);
+            hb_buffer_close(&buf);
+            hb_unlock(stream->common->mutex);
+            return;
+        }
+        SortedQueueBuffer(stream, buf);
+    }
 
     // Make adjustments for gaps found in other streams
     applyDeltas(stream->common);
@@ -1426,6 +1744,7 @@ static int InitAudio( sync_common_t * common, int index )
     pv->stream->cond_full       = hb_cond_init();
     if (pv->stream->cond_full == NULL) goto fail;
     pv->stream->in_queue        = hb_list_init();
+    pv->stream->scr_delay_queue = hb_list_init();
     pv->stream->max_len         = SYNC_MAX_AUDIO_QUEUE_LEN;
     pv->stream->min_len         = SYNC_MIN_AUDIO_QUEUE_LEN;
     if (pv->stream->in_queue == NULL) goto fail;
@@ -1435,6 +1754,8 @@ static int InitAudio( sync_common_t * common, int index )
     pv->stream->first_pts       = AV_NOPTS_VALUE;
     pv->stream->next_pts        = (int64_t)AV_NOPTS_VALUE;
     pv->stream->last_pts        = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_scr_pts    = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_duration   = (int64_t)AV_NOPTS_VALUE;
     pv->stream->audio.audio     = audio;
     pv->stream->fifo_out        = w->fifo_out;
 
@@ -1498,6 +1819,7 @@ static int InitSubtitle( sync_common_t * common, int index )
     pv->stream->cond_full         = hb_cond_init();
     if (pv->stream->cond_full == NULL) goto fail;
     pv->stream->in_queue          = hb_list_init();
+    pv->stream->scr_delay_queue   = hb_list_init();
     pv->stream->max_len           = SYNC_MAX_SUBTITLE_QUEUE_LEN;
     pv->stream->min_len           = SYNC_MIN_SUBTITLE_QUEUE_LEN;
     if (pv->stream->in_queue == NULL) goto fail;
@@ -1507,6 +1829,8 @@ static int InitSubtitle( sync_common_t * common, int index )
     pv->stream->first_pts         = AV_NOPTS_VALUE;
     pv->stream->next_pts          = (int64_t)AV_NOPTS_VALUE;
     pv->stream->last_pts          = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_scr_pts      = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_duration     = (int64_t)AV_NOPTS_VALUE;
     pv->stream->subtitle.subtitle = subtitle;
     pv->stream->fifo_out          = subtitle->fifo_out;
 
@@ -1594,6 +1918,7 @@ static int syncVideoInit( hb_work_object_t * w, hb_job_t * job)
     pv->stream->cond_full       = hb_cond_init();
     if (pv->stream->cond_full == NULL) goto fail;
     pv->stream->in_queue        = hb_list_init();
+    pv->stream->scr_delay_queue = hb_list_init();
     pv->stream->max_len         = SYNC_MAX_VIDEO_QUEUE_LEN;
     pv->stream->min_len         = SYNC_MIN_VIDEO_QUEUE_LEN;
     if (pv->stream->in_queue == NULL) goto fail;
@@ -1603,6 +1928,8 @@ static int syncVideoInit( hb_work_object_t * w, hb_job_t * job)
     pv->stream->first_pts       = AV_NOPTS_VALUE;
     pv->stream->next_pts        = (int64_t)AV_NOPTS_VALUE;
     pv->stream->last_pts        = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_scr_pts    = (int64_t)AV_NOPTS_VALUE;
+    pv->stream->last_duration   = (int64_t)AV_NOPTS_VALUE;
     pv->stream->fifo_out        = job->fifo_sync;
     pv->stream->video.id        = job->title->video_id;
 


### PR DESCRIPTION
This patch passes discontinuity information through the pipeline till it
reaches sync.c.  The timestamps are passed through the pipeline as read
and unmodified to sync.c (instead of attempting to correct
discontinuities in reader).  In sync, when we see a discontinuity,
we know where the next timestamp should be based on the timestamp
and duration of the previous buffer (before the discontinuity). So
we calculate an "SCR" offset based on the timestamp after the
discontinuity and what we calculate it should be.

The old discontinuity handling code was broken due to the following.

The MPEG STD timing model relies heavily on the decoder having an STC
that is phase lock looped to the PCRs in the stream.  When decoding a
broadcast stream, the decoder can count on the time measure between PCRs
using the STC to match to a high degree of accuracy.
I.e. STC - lastSTC  == PCR - lastPCR.  When a discontinuity occurs, the
decoder calculates a new PCR offset = PCR - STC.  I.e. the offset is the
new PCR value minus what it would have been if there had been no
discontinuity.

The above does not work without a reliable STC, which we do not have.
We have been attempting to approximate one by avereraging the duration
of received packets and extrapolating an "STC" based on the last PTS and
the average packet duration.  But this is highly variable and
unreliable.
