### PR TITLE
contrib: Update to Yasm version 1.3.0.

### DIFF
--- a/contrib/yasm/module.defs
+++ b/contrib/yasm/module.defs
@@ -1,6 +1,6 @@
 $(eval $(call import.MODULE.defs,YASM,yasm))
 $(eval $(call import.CONTRIB.defs,YASM))
 
-YASM.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/yasm-1.2.0.tar.gz
-YASM.FETCH.url += https://www.tortall.net/projects/yasm/releases/yasm-1.2.0.tar.gz
-YASM.FETCH.md5 =  4cfc0686cf5350dd1305c4d905eb55a6
+YASM.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/yasm-1.3.0.tar.gz
+YASM.FETCH.url += https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
+YASM.FETCH.md5 =  fc9e586751ff789b34b1f21d572d96af


### PR DESCRIPTION
Remarkably faster compilation, in parallel.

Note that this does not increase the required Yasm version, only provides version 1.3.0 when downloading from us.
