### PR TITLE
logging: rename hb_error to hb_spam_log and create new hb_error

### DIFF
--- a/libhb/audio_remap.c
+++ b/libhb/audio_remap.c
@@ -185,7 +185,7 @@ hb_audio_remap_t* hb_audio_remap_init(enum AVSampleFormat sample_fmt,
     hb_audio_remap_t *remap = calloc(1, sizeof(hb_audio_remap_t));
     if (remap == NULL)
     {
-        hb_error("hb_audio_remap_init: failed to allocate remap");
+        hb_spam_log("hb_audio_remap_init: failed to allocate remap");
         goto fail;
     }
 
@@ -221,15 +221,15 @@ hb_audio_remap_t* hb_audio_remap_init(enum AVSampleFormat sample_fmt,
             break;
 
         default:
-            hb_error("hb_audio_remap_init: unsupported sample format '%s'",
-                     av_get_sample_fmt_name(sample_fmt));
+            hb_spam_log("hb_audio_remap_init: unsupported sample format '%s'",
+                        av_get_sample_fmt_name(sample_fmt));
             goto fail;
     }
 
     // input/output channel order
     if (channel_map_in == NULL || channel_map_out == NULL)
     {
-        hb_error("hb_audio_remap_init: invalid channel map(s)");
+        hb_spam_log("hb_audio_remap_init: invalid channel map(s)");
         goto fail;
     }
     remap->channel_map_in  = channel_map_in;

--- a/libhb/audio_resample.c
+++ b/libhb/audio_resample.c
@@ -17,7 +17,7 @@ hb_audio_resample_t* hb_audio_resample_init(enum AVSampleFormat sample_fmt,
     hb_audio_resample_t *resample = calloc(1, sizeof(hb_audio_resample_t));
     if (resample == NULL)
     {
-        hb_error("hb_audio_resample_init: failed to allocate resample");
+        hb_spam_log("hb_audio_resample_init: failed to allocate resample");
         goto fail;
     }
 
@@ -27,8 +27,8 @@ hb_audio_resample_t* hb_audio_resample_init(enum AVSampleFormat sample_fmt,
     // we don't support planar output yet
     if (av_sample_fmt_is_planar(sample_fmt))
     {
-        hb_error("hb_audio_resample_init: planar output not supported ('%s')",
-                 av_get_sample_fmt_name(sample_fmt));
+        hb_spam_log("hb_audio_resample_init: planar output not supported ('%s')",
+                    av_get_sample_fmt_name(sample_fmt));
         goto fail;
     }
 
@@ -115,7 +115,7 @@ int hb_audio_resample_update(hb_audio_resample_t *resample)
 {
     if (resample == NULL)
     {
-        hb_error("hb_audio_resample_update: resample is NULL");
+        hb_spam_log("hb_audio_resample_update: resample is NULL");
         return 1;
     }
 
@@ -141,7 +141,7 @@ int hb_audio_resample_update(hb_audio_resample_t *resample)
             resample->avresample = avresample_alloc_context();
             if (resample->avresample == NULL)
             {
-                hb_error("hb_audio_resample_update: avresample_alloc_context() failed");
+                hb_spam_log("hb_audio_resample_update: avresample_alloc_context() failed");
                 return 1;
             }
 
@@ -174,8 +174,8 @@ int hb_audio_resample_update(hb_audio_resample_t *resample)
         {
             char err_desc[64];
             av_strerror(ret, err_desc, 63);
-            hb_error("hb_audio_resample_update: avresample_open() failed (%s)",
-                     err_desc);
+            hb_spam_log("hb_audio_resample_update: avresample_open() failed (%s)",
+                        err_desc);
             // avresample won't open, start over
             avresample_free(&resample->avresample);
             return ret;
@@ -210,13 +210,13 @@ hb_buffer_t* hb_audio_resample(hb_audio_resample_t *resample,
 {
     if (resample == NULL)
     {
-        hb_error("hb_audio_resample: resample is NULL");
+        hb_spam_log("hb_audio_resample: resample is NULL");
         return NULL;
     }
     if (resample->resample_needed && resample->avresample == NULL)
     {
-        hb_error("hb_audio_resample: resample needed but libavresample context "
-                 "is NULL");
+        hb_spam_log("hb_audio_resample: resample needed but libavresample "
+                    "context is NULL");
         return NULL;
     }
 

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -173,7 +173,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
                                                   filter->settings);
     if (avfilter_settings == NULL)
     {
-        hb_error("avfilter_init: no filter settings specified");
+        hb_log("avfilter_init: no filter settings specified");
         return 1;
     }
 
@@ -184,7 +184,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     pv->graph = avfilter_graph_alloc();
     if (pv->graph == NULL)
     {
-        hb_error("avfilter_init: avfilter_graph_alloc failed");
+        hb_log("avfilter_init: avfilter_graph_alloc failed");
         goto fail;
     }
 
@@ -199,7 +199,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     result = avfilter_graph_parse2(pv->graph, avfilter_settings, &in, &out);
     if (result < 0 || in == NULL || out == NULL)
     {
-        hb_error("avfilter_init: avfilter_graph_parse2 failed (%s)",
+        hb_log("avfilter_init: avfilter_graph_parse2 failed (%s)",
                  avfilter_settings);
         goto fail;
     }
@@ -216,7 +216,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     free(filter_args);
     if (avfilter == NULL)
     {
-        hb_error("avfilter_init: failed to create buffer source filter");
+        hb_log("avfilter_init: failed to create buffer source filter");
         goto fail;
     }
     pv->input = avfilter;
@@ -224,7 +224,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     avfilter = append_filter(pv, "format", "yuv420p");
     if (avfilter == NULL)
     {
-        hb_error("avfilter_init: failed to create pix format filter");
+        hb_log("avfilter_init: failed to create pix format filter");
         goto fail;
     }
 
@@ -240,7 +240,7 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     avfilter = append_filter(pv, "buffersink", NULL);
     if (avfilter == NULL)
     {
-        hb_error("avfilter_init: failed to create buffer output filter");
+        hb_log("avfilter_init: failed to create buffer output filter");
         goto fail;
     }
     pv->output = avfilter;
@@ -248,14 +248,14 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
     result = avfilter_graph_config(pv->graph, NULL);
     if (result < 0)
     {
-        hb_error("avfilter_init: failed to configure filter graph");
+        hb_log("avfilter_init: failed to configure filter graph");
         goto fail;
     }
 
     pv->frame = av_frame_alloc();
     if (pv->frame == NULL)
     {
-        hb_error("avfilter_init: failed to allocate frame filter");
+        hb_log("avfilter_init: failed to allocate frame filter");
         goto fail;
     }
 

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -730,13 +730,13 @@ hb_buffer_t * hb_bd_read( hb_bd_t * d )
         result = next_packet( d->bd, buf );
         if ( result < 0 )
         {
-            hb_error("bd: Read Error");
+            hb_spam_log("bd: Read Error");
             pos = bd_tell( d->bd );
             bd_seek( d->bd, pos + 192 );
             error_count++;
             if (error_count > 10)
             {
-                hb_error("bd: Error, too many consecutive read errors");
+                hb_spam_log("bd: Error, too many consecutive read errors");
                 hb_set_work_error(d->h, HB_ERROR_READ);
                 return NULL;
             }

--- a/libhb/comb_detect.c
+++ b/libhb/comb_detect.c
@@ -1166,7 +1166,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
     if (taskset_init( &pv->decomb_filter_taskset, pv->cpu_count,
                       sizeof( decomb_thread_arg_t ) ) == 0)
     {
-        hb_error( "decomb could not initialize taskset" );
+        hb_log( "decomb could not initialize taskset" );
+        return 1;
     }
 
     decomb_thread_arg_t *decomb_prev_thread_args = NULL;
@@ -1205,7 +1206,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
                                  decomb_filter_thread,
                                  HB_NORMAL_PRIORITY ) == 0)
         {
-            hb_error( "decomb could not spawn thread" );
+            hb_log( "decomb could not spawn thread" );
+            return 1;
         }
 
         decomb_prev_thread_args = thread_args;
@@ -1224,7 +1226,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
     if (taskset_init( &pv->decomb_check_taskset, pv->comb_check_nthreads,
                       sizeof( decomb_thread_arg_t ) ) == 0)
     {
-        hb_error( "decomb check could not initialize taskset" );
+        hb_log( "decomb check could not initialize taskset" );
+        return 1;
     }
 
     decomb_prev_thread_args = NULL;
@@ -1270,7 +1273,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
                                   decomb_check_thread,
                                   HB_NORMAL_PRIORITY ) == 0)
         {
-            hb_error( "decomb check could not spawn thread" );
+            hb_log( "decomb check could not spawn thread" );
+            return 1;
         }
 
         decomb_prev_thread_args = thread_args;
@@ -1281,7 +1285,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
         if (taskset_init( &pv->mask_filter_taskset, pv->cpu_count,
                           sizeof( decomb_thread_arg_t ) ) == 0)
         {
-            hb_error( "maske filter could not initialize taskset" );
+            hb_log( "maske filter could not initialize taskset" );
+            return 1;
         }
 
         decomb_prev_thread_args = NULL;
@@ -1321,7 +1326,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
                                      mask_filter_thread,
                                      HB_NORMAL_PRIORITY ) == 0)
             {
-                hb_error( "mask filter could not spawn thread" );
+                hb_log( "mask filter could not spawn thread" );
+                return 1;
             }
 
             decomb_prev_thread_args = thread_args;
@@ -1332,7 +1338,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
             if (taskset_init( &pv->mask_erode_taskset, pv->cpu_count,
                               sizeof( decomb_thread_arg_t ) ) == 0)
             {
-                hb_error( "mask erode could not initialize taskset" );
+                hb_log( "mask erode could not initialize taskset" );
+                return 1;
             }
 
             decomb_prev_thread_args = NULL;
@@ -1372,7 +1379,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
                                          mask_erode_thread,
                                          HB_NORMAL_PRIORITY ) == 0)
                 {
-                    hb_error( "mask erode could not spawn thread" );
+                    hb_log( "mask erode could not spawn thread" );
+                    return 1;
                 }
 
                 decomb_prev_thread_args = thread_args;
@@ -1381,7 +1389,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
             if (taskset_init( &pv->mask_dilate_taskset, pv->cpu_count,
                               sizeof( decomb_thread_arg_t ) ) == 0)
             {
-                hb_error( "mask dilate could not initialize taskset" );
+                hb_log( "mask dilate could not initialize taskset" );
+                return 1;
             }
 
             decomb_prev_thread_args = NULL;
@@ -1421,7 +1430,8 @@ static int comb_detect_init( hb_filter_object_t * filter,
                                          mask_dilate_thread,
                                          HB_NORMAL_PRIORITY ) == 0)
                 {
-                    hb_error( "mask dilate could not spawn thread" );
+                    hb_log( "mask dilate could not spawn thread" );
+                    return 1;
                 }
 
                 decomb_prev_thread_args = thread_args;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3400,7 +3400,7 @@ void hb_spam_log( char * log, ... )
  * It is meant to be use by the frontends to inform the user of 
  * failures.
  *********************************************************************/
-void hb_error( char * log, ... )
+void hb_error( int error, char * log, ... )
 {
     va_list args;
 
@@ -3412,7 +3412,7 @@ void hb_error( char * log, ... )
         string = hb_strdup_vaprintf(log, args);
         va_end( args );
 
-        error_handler(string);
+        error_handler(error, string);
         free(string);
     }
     else

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -85,11 +85,14 @@
 typedef enum
 {
      HB_ERROR_NONE         = 0,
-     HB_ERROR_CANCELED     = 1,
-     HB_ERROR_WRONG_INPUT  = 2,
-     HB_ERROR_INIT         = 3,
-     HB_ERROR_UNKNOWN      = 4,
-     HB_ERROR_READ         = 5
+     HB_ERROR_CANCELED,
+     HB_ERROR_APP_INIT,
+     HB_ERROR_ENC_INIT,
+     HB_ERROR_ENC_INPUT,
+     HB_ERROR_ENC,
+     HB_ERROR_UNKNOWN,
+     HB_ERROR_READ,
+     HB_ERROR_SCAN
 } hb_error_code;
 
 #include "ports.h"
@@ -1272,7 +1275,7 @@ char               * hb_filter_settings_string(int filter_id,
 char               * hb_filter_settings_string_json(int filter_id,
                                                     const char * json);
 
-typedef void hb_error_handler_t( const char *errmsg );
+typedef void hb_error_handler_t( int error, const char *errmsg );
 
 extern void hb_register_error_handler( hb_error_handler_t * handler );
 

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -190,7 +190,7 @@ static int decavcodecaInit( hb_work_object_t * w, hb_job_t * job )
                                    w->audio->config.out.normalize_mix_level);
         if (pv->resample == NULL)
         {
-            hb_error("decavcodecaInit: hb_audio_resample_init() failed");
+            hb_log("decavcodecaInit: hb_audio_resample_init() failed");
             return 1;
         }
         /*

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -172,7 +172,7 @@ static int declpcmInit( hb_work_object_t * w, hb_job_t * job )
                                w->audio->config.out.normalize_mix_level);
     if (pv->resample == NULL)
     {
-        hb_error("declpcmInit: hb_audio_resample_init() failed");
+        hb_log("declpcmInit: hb_audio_resample_init() failed");
         return 1;
     }
 

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -353,7 +353,7 @@ static void blend_filter_line(filter_param_t *filter,
     }
     else
     {
-        hb_error("Invalid value y %d heigh %d", y, height);
+        hb_spam_log("Invalid value y %d heigh %d", y, height);
         return;
     }
 
@@ -1021,7 +1021,8 @@ static int hb_decomb_init( hb_filter_object_t * filter,
         taskset_init( &pv->yadif_taskset, pv->cpu_count,
                       sizeof( yadif_thread_arg_t ) ) == 0 )
     {
-        hb_error( "yadif could not initialize taskset" );
+        hb_log( "yadif could not initialize taskset" );
+        return 1;
     }
 
     yadif_thread_arg_t *yadif_prev_thread_args = NULL;
@@ -1060,7 +1061,7 @@ static int hb_decomb_init( hb_filter_object_t * filter,
                                  yadif_decomb_filter_thread,
                                  HB_NORMAL_PRIORITY ) == 0 )
         {
-            hb_error( "yadif could not spawn thread" );
+            hb_log( "yadif could not spawn thread" );
         }
         yadif_prev_thread_args = thread_args;
     }
@@ -1073,7 +1074,8 @@ static int hb_decomb_init( hb_filter_object_t * filter,
         if( taskset_init( &pv->eedi2_taskset, /*thread_count*/3,
                           sizeof( eedi2_thread_arg_t ) ) == 0 )
         {
-            hb_error( "eedi2 could not initialize taskset" );
+            hb_log( "eedi2 could not initialize taskset" );
+            return 1;
         }
 
         if( pv->post_processing > 1 )
@@ -1113,7 +1115,8 @@ static int hb_decomb_init( hb_filter_object_t * filter,
                                       eedi2_filter_thread,
                                       HB_NORMAL_PRIORITY ) == 0 )
             {
-                hb_error( "eedi2 could not spawn thread" );
+                hb_log( "eedi2 could not spawn thread" );
+                return 1;
             }
         }
     }

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -668,13 +668,13 @@ static int hb_dvdread_start( hb_dvd_t * e, hb_title_t *title, int chapter )
     d->ttn = d->vmg->tt_srpt->title[t-1].vts_ttn;
     if( !( d->ifo = ifoOpen( d->reader, d->vts ) ) )
     {
-        hb_error( "dvd: ifoOpen failed for VTS %d", d->vts );
+        hb_log( "dvd: ifoOpen failed for VTS %d", d->vts );
         return 0;
     }
     if( !( d->file = DVDOpenFile( d->reader, d->vts,
                                   DVD_READ_TITLE_VOBS ) ) )
     {
-        hb_error( "dvd: DVDOpenFile failed for VTS %d", d->vts );
+        hb_log( "dvd: DVDOpenFile failed for VTS %d", d->vts );
         return 0;
     }
 
@@ -990,7 +990,7 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
             /* Wasn't a valid VOBU, try next block */
             if( ++error > 1024 )
             {
-                hb_error( "dvd: couldn't find a VOBU after 1024 blocks" );
+                hb_spam_log( "dvd: couldn't find a VOBU after 1024 blocks" );
                 hb_buffer_close( &b );
                 hb_set_work_error(d->h, HB_ERROR_READ);
                 return NULL;
@@ -1044,7 +1044,7 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
                 }
                 if( d->in_cell )
                 {
-                    hb_error( "dvd: assuming missed end of cell %d at block %d", d->cell_cur, d->block );
+                    hb_spam_log( "dvd: assuming missed end of cell %d at block %d", d->cell_cur, d->block );
                     d->cell_cur  = d->cell_next;
                     d->next_vobu = d->pgc->cell_playback[d->cell_cur].first_sector;
                     FindNextCell( d );
@@ -1084,8 +1084,8 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
             // this may be a real DVD error or may be DRM. Either way
             // we don't want to quit because of one bad block so set
             // things up so we'll advance to the next vobu and recurse.
-            hb_error( "dvd: DVDReadBlocks failed (%d), skipping to vobu %u",
-                      d->block, d->next_vobu );
+            hb_spam_log("dvd: DVDReadBlocks failed (%d), skipping to vobu %u",
+                        d->block, d->next_vobu);
             d->pack_len = 0;
             goto top;  /* XXX need to restructure this routine & avoid goto */
         }

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -116,7 +116,7 @@ static int hb_dvdnav_reset( hb_dvdnav_t * d )
     if (dvdnav_set_readahead_flag(d->dvdnav, DVD_READ_CACHE) !=
         DVDNAV_STATUS_OK)
     {
-        hb_error("Error: dvdnav_set_readahead_flag: %s\n",
+        hb_spam_log("Error: dvdnav_set_readahead_flag: %s\n",
                  dvdnav_err_to_string(d->dvdnav));
         goto fail;
     }
@@ -128,7 +128,7 @@ static int hb_dvdnav_reset( hb_dvdnav_t * d )
      **/
     if (dvdnav_set_PGC_positioning_flag(d->dvdnav, 1) != DVDNAV_STATUS_OK)
     {
-        hb_error("Error: dvdnav_set_PGC_positioning_flag: %s\n",
+        hb_spam_log("Error: dvdnav_set_PGC_positioning_flag: %s\n",
                  dvdnav_err_to_string(d->dvdnav));
         goto fail;
     }
@@ -189,8 +189,8 @@ static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, char * path )
     if (dvdnav_set_readahead_flag(d->dvdnav, DVD_READ_CACHE) !=
         DVDNAV_STATUS_OK)
     {
-        hb_error("Error: dvdnav_set_readahead_flag: %s\n",
-                 dvdnav_err_to_string(d->dvdnav));
+        hb_log("Error: dvdnav_set_readahead_flag: %s\n",
+               dvdnav_err_to_string(d->dvdnav));
         goto fail;
     }
 
@@ -201,8 +201,8 @@ static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, char * path )
      **/
     if (dvdnav_set_PGC_positioning_flag(d->dvdnav, 1) != DVDNAV_STATUS_OK)
     {
-        hb_error("Error: dvdnav_set_PGC_positioning_flag: %s\n",
-                 dvdnav_err_to_string(d->dvdnav));
+        hb_log("Error: dvdnav_set_PGC_positioning_flag: %s\n",
+               dvdnav_err_to_string(d->dvdnav));
         goto fail;
     }
 
@@ -219,7 +219,7 @@ static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, char * path )
     /* Open main IFO */
     if( !( d->vmg = ifoOpen( d->reader, 0 ) ) )
     {
-        hb_error( "dvd: ifoOpen failed" );
+        hb_log( "dvd: ifoOpen failed" );
         goto fail;
     }
 
@@ -871,7 +871,7 @@ static int skip_to_menu( dvdnav_t * dvdnav, int blocks )
         result = dvdnav_get_next_block( dvdnav, buf, &event, &len );
         if ( result == DVDNAV_STATUS_ERR )
         {
-            hb_error("dvdnav: Read Error, %s", dvdnav_err_to_string(dvdnav));
+            hb_spam_log("dvdnav: Read Error, %s", dvdnav_err_to_string(dvdnav));
             return 0;
         }
         switch ( event )
@@ -995,7 +995,7 @@ static int try_button( dvdnav_t * dvdnav, int button, hb_list_t * list_title )
             result = dvdnav_get_next_block( dvdnav, buf, &event, &len );
             if ( result == DVDNAV_STATUS_ERR )
             {
-                hb_error("dvdnav: Read Error, %s", dvdnav_err_to_string(dvdnav));
+                hb_spam_log("dvdnav: Read Error, %s", dvdnav_err_to_string(dvdnav));
                 goto done;
             }
             switch ( event )
@@ -1146,7 +1146,7 @@ static int try_menu(
             result = dvdnav_menu_call( d->dvdnav, menu );
             if ( result != DVDNAV_STATUS_OK )
             {
-                hb_error("dvdnav: Can not set dvd menu, %s", dvdnav_err_to_string(d->dvdnav));
+                hb_spam_log("dvdnav: Can not set dvd menu, %s", dvdnav_err_to_string(d->dvdnav));
                 goto done;
             }
         }
@@ -1165,7 +1165,7 @@ static int try_menu(
             result = dvdnav_get_next_block( d->dvdnav, buf, &event, &len );
             if ( result == DVDNAV_STATUS_ERR )
             {
-                hb_error("dvdnav: Read Error, %s", dvdnav_err_to_string(d->dvdnav));
+                hb_spam_log("dvdnav: Read Error, %s", dvdnav_err_to_string(d->dvdnav));
                 goto done;
             }
             switch ( event )
@@ -1460,8 +1460,8 @@ static int hb_dvdnav_start( hb_dvd_t * e, hb_title_t *title, int c )
         result = dvdnav_part_play(d->dvdnav, t, 1);
     if (result != DVDNAV_STATUS_OK)
     {
-        hb_error( "dvd: dvdnav_*_play failed - %s", 
-                  dvdnav_err_to_string(d->dvdnav) );
+        hb_log("dvd: dvdnav_*_play failed - %s", 
+               dvdnav_err_to_string(d->dvdnav));
         return 0;
     }
     d->title = t;
@@ -1552,7 +1552,7 @@ static int hb_dvdnav_seek( hb_dvd_t * e, float f )
         result = dvdnav_get_next_block( d->dvdnav, buf, &event, &len );
         if ( result == DVDNAV_STATUS_ERR )
         {
-            hb_error("dvdnav: Read Error, %s", dvdnav_err_to_string(d->dvdnav));
+            hb_spam_log("dvdnav: Read Error, %s", dvdnav_err_to_string(d->dvdnav));
             return 0;
         }
         switch ( event )
@@ -1590,8 +1590,8 @@ static int hb_dvdnav_seek( hb_dvd_t * e, float f )
 
     if (dvdnav_sector_search(d->dvdnav, sector, SEEK_SET) != DVDNAV_STATUS_OK)
     {
-        hb_error( "dvd: dvdnav_sector_search failed - %s", 
-                  dvdnav_err_to_string(d->dvdnav) );
+        hb_spam_log("dvd: dvdnav_sector_search failed - %s", 
+                    dvdnav_err_to_string(d->dvdnav));
         return 0;
     }
     d->chapter = 0;
@@ -1622,11 +1622,12 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
         result = dvdnav_get_next_block( d->dvdnav, b->data, &event, &len );
         if ( result == DVDNAV_STATUS_ERR )
         {
-            hb_error("dvdnav: Read Error, %s", dvdnav_err_to_string(d->dvdnav));
+            hb_spam_log("dvdnav: Read Error, %s",
+                        dvdnav_err_to_string(d->dvdnav));
             if (dvdnav_sector_search(d->dvdnav, 1, SEEK_CUR) != DVDNAV_STATUS_OK)
             {
-                hb_error( "dvd: dvdnav_sector_search failed - %s",
-                        dvdnav_err_to_string(d->dvdnav) );
+                hb_spam_log("dvd: dvdnav_sector_search failed - %s",
+                            dvdnav_err_to_string(d->dvdnav));
                 hb_buffer_close( &b );
                 hb_set_work_error(d->h, HB_ERROR_READ);
                 return NULL;
@@ -1634,7 +1635,7 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             error_count++;
             if (error_count > 500)
             {
-                hb_error("dvdnav: Error, too many consecutive read errors");
+                hb_spam_log("dvdnav: Error, too many consecutive read errors");
                 hb_buffer_close( &b );
                 hb_set_work_error(d->h, HB_ERROR_READ);
                 return NULL;

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -460,7 +460,7 @@ int qsv_enc_init(hb_work_private_t *pv)
     {
         if (!pv->is_sys_mem)
         {
-            hb_error("qsv_enc_init: decode enabled but no context!");
+            hb_log("qsv_enc_init: decode enabled but no context!");
             return 3;
         }
         job->qsv.ctx = qsv = av_mallocz(sizeof(av_qsv_context));
@@ -549,7 +549,7 @@ int qsv_enc_init(hb_work_private_t *pv)
     {
         if (MFXQueryVersion(qsv->mfx_session, &version) != MFX_ERR_NONE)
         {
-            hb_error("qsv_enc_init: MFXQueryVersion failed");
+            hb_log("qsv_enc_init: MFXQueryVersion failed");
             *job->done_error = HB_ERROR_INIT;
             *job->die = 1;
             return -1;
@@ -557,7 +557,7 @@ int qsv_enc_init(hb_work_private_t *pv)
         pv->loaded_plugins = hb_qsv_load_plugins(pv->qsv_info, qsv->mfx_session, version);
         if (pv->loaded_plugins == NULL)
         {
-            hb_error("qsv_enc_init: hb_qsv_load_plugins failed");
+            hb_log("qsv_enc_init: hb_qsv_load_plugins failed");
             *job->done_error = HB_ERROR_INIT;
             *job->die = 1;
             return -1;
@@ -574,7 +574,7 @@ int qsv_enc_init(hb_work_private_t *pv)
                                      &qsv_encode->request[0]);
     if (sts < MFX_ERR_NONE) // ignore warnings
     {
-        hb_error("qsv_enc_init: MFXVideoENCODE_QueryIOSurf failed (%d)", sts);
+        hb_log("qsv_enc_init: MFXVideoENCODE_QueryIOSurf failed (%d)", sts);
         *job->done_error = HB_ERROR_INIT;
         *job->die = 1;
         return -1;
@@ -635,7 +635,7 @@ int qsv_enc_init(hb_work_private_t *pv)
     sts = MFXVideoENCODE_Init(qsv->mfx_session, pv->param.videoParam);
     if (sts < MFX_ERR_NONE) // ignore warnings
     {
-        hb_error("qsv_enc_init: MFXVideoENCODE_Init failed (%d)", sts);
+        hb_log("qsv_enc_init: MFXVideoENCODE_Init failed (%d)", sts);
         *job->done_error = HB_ERROR_INIT;
         *job->die = 1;
         return -1;
@@ -681,7 +681,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     if (hb_qsv_param_default_preset(&pv->param, &pv->enc_space.m_mfxVideoParam,
                                      pv->qsv_info, job->encoder_preset))
     {
-        hb_error("encqsvInit: hb_qsv_param_default_preset failed");
+        hb_log("encqsvInit: hb_qsv_param_default_preset failed");
         return -1;
     }
 
@@ -838,12 +838,12 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     // parse user-specified codec profile and level
     if (hb_qsv_profile_parse(&pv->param, pv->qsv_info, job->encoder_profile))
     {
-        hb_error("encqsvInit: bad profile %s", job->encoder_profile);
+        hb_log("encqsvInit: bad profile %s", job->encoder_profile);
         return -1;
     }
     if (hb_qsv_level_parse(&pv->param, pv->qsv_info, job->encoder_level))
     {
-        hb_error("encqsvInit: bad level %s", job->encoder_level);
+        hb_log("encqsvInit: bad level %s", job->encoder_level);
         return -1;
     }
 
@@ -855,7 +855,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
             pv->param.videoParam->mfx.CodecProfile == MFX_PROFILE_AVC_BASELINE             ||
             pv->param.videoParam->mfx.CodecProfile == MFX_PROFILE_AVC_PROGRESSIVE_HIGH)
         {
-            hb_error("encqsvInit: profile %s doesn't support interlaced encoding",
+            hb_log("encqsvInit: profile %s doesn't support interlaced encoding",
                      hb_qsv_profile_name(MFX_CODEC_AVC,
                                          pv->param.videoParam->mfx.CodecProfile));
             return -1;
@@ -864,7 +864,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
              pv->param.videoParam->mfx.CodecLevel <= MFX_LEVEL_AVC_2) ||
             (pv->param.videoParam->mfx.CodecLevel >= MFX_LEVEL_AVC_42))
         {
-            hb_error("encqsvInit: level %s doesn't support interlaced encoding",
+            hb_log("encqsvInit: level %s doesn't support interlaced encoding",
                      hb_qsv_level_name(MFX_CODEC_AVC,
                                        pv->param.videoParam->mfx.CodecLevel));
             return -1;
@@ -975,7 +975,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     }
     else
     {
-        hb_error("encqsvInit: invalid rate control (%f, %d)",
+        hb_log("encqsvInit: invalid rate control (%f, %d)",
                  job->vquality, job->vbitrate);
         return -1;
     }
@@ -1076,7 +1076,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     err = MFXInit(pv->qsv_info->implementation, &version, &session);
     if (err != MFX_ERR_NONE)
     {
-        hb_error("encqsvInit: MFXInit failed (%d)", err);
+        hb_log("encqsvInit: MFXInit failed (%d)", err);
         return -1;
     }
 
@@ -1084,7 +1084,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     err = MFXQueryVersion(session, &version);
     if (err != MFX_ERR_NONE)
     {
-        hb_error("encqsvInit: MFXQueryVersion failed (%d)", err);
+        hb_log("encqsvInit: MFXQueryVersion failed (%d)", err);
         MFXClose(session);
         return -1;
     }
@@ -1093,7 +1093,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     pv->loaded_plugins = hb_qsv_load_plugins(pv->qsv_info, session, version);
     if (pv->loaded_plugins == NULL)
     {
-        hb_error("encqsvInit: hb_qsv_load_plugins failed");
+        hb_log("encqsvInit: hb_qsv_load_plugins failed");
         MFXClose(session);
         return -1;
     }
@@ -1113,7 +1113,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
 #endif
     if (err < MFX_ERR_NONE) // ignore warnings
     {
-        hb_error("encqsvInit: MFXVideoENCODE_Init failed (%d)", err);
+        hb_log("encqsvInit: MFXVideoENCODE_Init failed (%d)", err);
         hb_qsv_unload_plugins(&pv->loaded_plugins, session, version);
         MFXClose(session);
         return -1;
@@ -1154,7 +1154,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     err = MFXVideoENCODE_GetVideoParam(session, &videoParam);
     if (err != MFX_ERR_NONE)
     {
-        hb_error("encqsvInit: MFXVideoENCODE_GetVideoParam failed (%d)", err);
+        hb_log("encqsvInit: MFXVideoENCODE_GetVideoParam failed (%d)", err);
         hb_qsv_unload_plugins(&pv->loaded_plugins, session, version);
         MFXClose(session);
         return -1;
@@ -1175,7 +1175,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     {
         if (qsv_hevc_make_header(w, session) < 0)
         {
-            hb_error("encqsvInit: qsv_hevc_make_header failed");
+            hb_log("encqsvInit: qsv_hevc_make_header failed");
             hb_qsv_unload_plugins(&pv->loaded_plugins, session, version);
             MFXVideoENCODE_Close(session);
             MFXClose(session);
@@ -1343,7 +1343,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
             hb_log("encqsvInit: PicStruct bottom field first");
             break;
         default:
-            hb_error("encqsvInit: invalid PicStruct value 0x%"PRIx16"",
+            hb_log("encqsvInit: invalid PicStruct value 0x%"PRIx16"",
                      videoParam.mfx.FrameInfo.PicStruct);
             return -1;
     }
@@ -1615,7 +1615,7 @@ static void qsv_bitstream_slurp(hb_work_private_t *pv, mfxBitstream *bs)
         if ((buf = hb_nal_bitstream_annexb_to_mp4(bs->Data + bs->DataOffset,
                                                   bs->DataLength)) == NULL)
         {
-            hb_error("encqsv: hb_nal_bitstream_annexb_to_mp4 failed");
+            hb_spam_log("encqsv: hb_nal_bitstream_annexb_to_mp4 failed");
             goto fail;
         }
     }
@@ -1624,7 +1624,7 @@ static void qsv_bitstream_slurp(hb_work_private_t *pv, mfxBitstream *bs)
         /* Both extradata and bitstream are in Annex B format. */
         if ((buf = hb_buffer_init(bs->DataLength)) == NULL)
         {
-            hb_error("encqsv: hb_buffer_init failed");
+            hb_spam_log("encqsv: hb_buffer_init failed");
             goto fail;
         }
         memcpy(buf->data, bs->Data + bs->DataOffset, bs->DataLength);
@@ -1713,7 +1713,7 @@ static int qsv_enc_work(hb_work_private_t *pv,
         int sync_idx = av_qsv_get_free_sync(qsv_enc_space, qsv_ctx);
         if (sync_idx == -1)
         {
-            hb_error("encqsv: av_qsv_get_free_sync failed");
+            hb_log("encqsv: av_qsv_get_free_sync failed");
             return -1;
         }
         av_qsv_task *task = av_qsv_list_item(qsv_enc_space->tasks,
@@ -1745,7 +1745,7 @@ static int qsv_enc_work(hb_work_private_t *pv,
             }
             else if (sts < MFX_ERR_NONE)
             {
-                hb_error("encqsv: MFXVideoENCODE_EncodeFrameAsync failed (%d)", sts);
+                hb_log("encqsv: MFXVideoENCODE_EncodeFrameAsync failed (%d)", sts);
                 return -1;
             }
             else if (sts == MFX_WRN_DEVICE_BUSY)
@@ -1874,7 +1874,7 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
                                                      QSV_PART_ANY);
         if (surface_index == -1)
         {
-            hb_error("encqsv: av_qsv_get_free_surface failed");
+            hb_log("encqsv: av_qsv_get_free_surface failed");
             goto fail;
         }
 
@@ -1947,14 +1947,14 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         sts = MFXVideoENCODE_Close(qsv_ctx->mfx_session);
         if (sts != MFX_ERR_NONE)
         {
-            hb_error("encqsv: MFXVideoENCODE_Close failed (%d)", sts);
+            hb_log("encqsv: MFXVideoENCODE_Close failed (%d)", sts);
             goto fail;
         }
 
         sts = MFXVideoENCODE_Init(qsv_ctx->mfx_session, pv->param.videoParam);
         if (sts < MFX_ERR_NONE)
         {
-            hb_error("encqsv: MFXVideoENCODE_Init failed (%d)", sts);
+            hb_log("encqsv: MFXVideoENCODE_Init failed (%d)", sts);
             goto fail;
         }
 

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -101,7 +101,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         } break;
         default:
         {
-            hb_error("encavcodecInit: unsupported encoder!");
+            hb_log("encavcodecInit: unsupported encoder!");
             return 1;
         }
     }
@@ -629,7 +629,7 @@ int encavcodecWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
     }
     else
     {
-        hb_error( "encavcodec: codec context has uninitialized codec; skipping frame" );
+        hb_spam_log( "encavcodec: codec context has uninitialized codec; skipping frame" );
     }
 
     av_frame_free( &frame );

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -126,7 +126,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             break;
 
         default:
-            hb_error("encavcodecaInit: unsupported codec (0x%x)",
+            hb_log("encavcodecaInit: unsupported codec (0x%x)",
                      audio->config.out.codec);
             return 1;
     }
@@ -135,7 +135,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         codec = avcodec_find_encoder_by_name(codec_name);
         if (codec == NULL)
         {
-            hb_error("encavcodecaInit: avcodec_find_encoder_by_name(%s) failed",
+            hb_log("encavcodecaInit: avcodec_find_encoder_by_name(%s) failed",
                      codec_name);
             return 1;
         }
@@ -145,7 +145,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         codec = avcodec_find_encoder(codec_id);
         if (codec == NULL)
         {
-            hb_error("encavcodecaInit: avcodec_find_encoder(%d) failed",
+            hb_log("encavcodecaInit: avcodec_find_encoder(%d) failed",
                      codec_id);
             return 1;
         }
@@ -189,7 +189,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     if (hb_avcodec_open(context, codec, &av_opts, 0))
     {
-        hb_error("encavcodecaInit: hb_avcodec_open() failed");
+        hb_log("encavcodecaInit: hb_avcodec_open() failed");
         return 1;
     }
     // avcodec_open populates the opts dictionary with the
@@ -219,7 +219,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         pv->avresample = avresample_alloc_context();
         if (pv->avresample == NULL)
         {
-            hb_error("encavcodecaInit: avresample_alloc_context() failed");
+            hb_log("encavcodecaInit: avresample_alloc_context() failed");
             return 1;
         }
         av_opt_set_int(pv->avresample, "in_sample_fmt",
@@ -242,7 +242,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         }
         if (avresample_open(pv->avresample))
         {
-            hb_error("encavcodecaInit: avresample_open() failed");
+            hb_log("encavcodecaInit: avresample_open() failed");
             avresample_free(&pv->avresample);
             return 1;
         }

--- a/libhb/enctheora.c
+++ b/libhb/enctheora.c
@@ -135,13 +135,13 @@ int enctheoraInit( hb_work_object_t * w, hb_job_t * job )
         bytes = th_encode_ctl(pv->ctx, TH_ENCCTL_2PASS_OUT, &buffer, sizeof(buffer));
         if( bytes < 0 )
         {
-            hb_error("Could not set up the first pass of two-pass mode.\n");
-            hb_error("Did you remember to specify an estimated bitrate?\n");
+            hb_log("Could not set up the first pass of two-pass mode.\n");
+            hb_log("Did you remember to specify an estimated bitrate?\n");
             return 1;
         }
         if( fwrite( buffer, 1, bytes, pv->file ) < bytes )
         {
-            hb_error("Unable to write to two-pass data file.\n");
+            hb_log("Unable to write to two-pass data file.\n");
             return 1;
         }
         fflush( pv->file );
@@ -258,7 +258,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             bytes = th_encode_ctl( pv->ctx, TH_ENCCTL_2PASS_IN, NULL, 0 );
             if( bytes < 0 )
             {
-                hb_error("Error requesting stats size in second pass.");
+                hb_log("Error requesting stats size in second pass.");
                 *job->done_error = HB_ERROR_UNKNOWN;
                 *job->die = 1;
                 return HB_WORK_DONE;
@@ -277,7 +277,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             if( size > 0 &&
                 fread( pv->stat_buf+pv->stat_fill, 1, size, pv->file ) < size )
             {
-                hb_error("Could not read frame data from two-pass data file!");
+                hb_log("Could not read frame data from two-pass data file!");
                 *job->done_error = HB_ERROR_UNKNOWN;
                 *job->die = 1;
                 return HB_WORK_DONE;
@@ -291,7 +291,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
                                  pv->stat_buf+pv->stat_read, bytes);
             if( ret < 0 )
             {
-                hb_error("Error submitting pass data in second pass.");
+                hb_log("Error submitting pass data in second pass.");
                 *job->done_error = HB_ERROR_UNKNOWN;
                 *job->die = 1;
                 return HB_WORK_DONE;

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -76,7 +76,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
                                         audio->config.out.samplerate, -1,
                                         audio->config.out.bitrate * 1000, -1))
         {
-            hb_error("encvorbis: vorbis_encode_setup_managed() failed");
+            hb_log("encvorbis: vorbis_encode_setup_managed() failed");
             *job->done_error = HB_ERROR_INIT;
             *job->die = 1;
             return -1;
@@ -89,7 +89,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
                                     audio->config.out.samplerate,
                                     audio->config.out.quality / 10))
         {
-            hb_error("encvorbis: vorbis_encode_setup_vbr() failed");
+            hb_log("encvorbis: vorbis_encode_setup_vbr() failed");
             *job->done_error = HB_ERROR_INIT;
             *job->die = 1;
             return -1;
@@ -99,7 +99,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
     if (vorbis_encode_ctl(&pv->vi, OV_ECTL_RATEMANAGE2_SET, NULL) ||
         vorbis_encode_setup_init(&pv->vi))
     {
-        hb_error("encvorbis: vorbis_encode_ctl(ratemanage2_set) OR vorbis_encode_setup_init() failed");
+        hb_log("encvorbis: vorbis_encode_ctl(ratemanage2_set) OR vorbis_encode_setup_init() failed");
         *job->done_error = HB_ERROR_INIT;
         *job->die = 1;
         return -1;

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -77,7 +77,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
                                         audio->config.out.bitrate * 1000, -1))
         {
             hb_log("encvorbis: vorbis_encode_setup_managed() failed");
-            *job->done_error = HB_ERROR_INIT;
+            *job->done_error = HB_ERROR_ENC_INIT;
             *job->die = 1;
             return -1;
         }
@@ -90,7 +90,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
                                     audio->config.out.quality / 10))
         {
             hb_log("encvorbis: vorbis_encode_setup_vbr() failed");
-            *job->done_error = HB_ERROR_INIT;
+            *job->done_error = HB_ERROR_ENC_INIT;
             *job->die = 1;
             return -1;
         }
@@ -100,7 +100,7 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
         vorbis_encode_setup_init(&pv->vi))
     {
         hb_log("encvorbis: vorbis_encode_ctl(ratemanage2_set) OR vorbis_encode_setup_init() failed");
-        *job->done_error = HB_ERROR_INIT;
+        *job->done_error = HB_ERROR_ENC_INIT;
         *job->die = 1;
         return -1;
     }

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -305,7 +305,7 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
     pv->api   = hb_x264_api_get(bit_depth);
     if (pv->api == NULL)
     {
-        hb_error("encx264: hb_x264_api_get failed, bit-depth %d", bit_depth);
+        hb_log("encx264: hb_x264_api_get failed, bit-depth %d", bit_depth);
         return 1;
     }
 
@@ -569,7 +569,7 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
     pv->x264 = pv->api->encoder_open( &param );
     if ( pv->x264 == NULL )
     {
-        hb_error("encx264: x264_encoder_open failed.");
+        hb_log("encx264: x264_encoder_open failed.");
         free( pv );
         w->private_data = NULL;
         return 1;
@@ -946,7 +946,7 @@ static int apply_h264_profile(const x264_api_t *api, x264_param_t *param,
     else
     {
         // error (profile not a string), abort
-        hb_error("apply_h264_profile: no profile specified");
+        hb_log("apply_h264_profile: no profile specified");
         return -1;
     }
 }
@@ -1001,7 +1001,7 @@ int apply_h264_level(const x264_api_t *api, x264_param_t *param,
         if (x264_level == NULL)
         {
             // error (invalid or unsupported level), abort
-            hb_error("apply_h264_level: invalid level %s", h264_level);
+            hb_log("apply_h264_level: invalid level %s", h264_level);
             return -1;
         }
     }
@@ -1013,7 +1013,7 @@ int apply_h264_level(const x264_api_t *api, x264_param_t *param,
     else
     {
         // error (level not a string), abort
-        hb_error("apply_h264_level: no level specified");
+        hb_log("apply_h264_level: no level specified");
         return -1;
     }
 
@@ -1091,8 +1091,8 @@ int apply_h264_level(const x264_api_t *api, x264_param_t *param,
     if (param->i_width <= 0 || param->i_height <= 0)
     {
         // error (invalid width or height), abort
-        hb_error("apply_h264_level: invalid resolution (width: %d, height: %d)",
-                 param->i_width, param->i_height);
+        hb_log("apply_h264_level: invalid resolution (width: %d, height: %d)",
+               param->i_width, param->i_height);
         return -1;
     }
 

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -102,7 +102,7 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
 
     if (pv->api == NULL)
     {
-        hb_error("encx265: x265_api_query failed, bit depth %d.", depth);
+        hb_log("encx265: x265_api_query failed, bit depth %d.", depth);
         goto fail;
     }
 
@@ -111,7 +111,7 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     if (pv->api->param_default_preset(param, job->encoder_preset,
                                       job->encoder_tune) < 0)
     {
-        hb_error("encx265: x265_param_default_preset failed. Preset (%s) Tune (%s)", job->encoder_preset, job->encoder_tune);
+        hb_log("encx265: x265_param_default_preset failed. Preset (%s) Tune (%s)", job->encoder_preset, job->encoder_tune);
         goto fail;
     }
 
@@ -301,7 +301,7 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     pv->x265 = pv->api->encoder_open(param);
     if (pv->x265 == NULL)
     {
-        hb_error("encx265: x265_encoder_open failed.");
+        hb_log("encx265: x265_encoder_open failed.");
         goto fail;
     }
 
@@ -314,12 +314,12 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     ret = pv->api->encoder_headers(pv->x265, &nal, &nnal);
     if (ret < 0)
     {
-        hb_error("encx265: x265_encoder_headers failed (%d)", ret);
+        hb_log("encx265: x265_encoder_headers failed (%d)", ret);
         goto fail;
     }
     if (ret > sizeof(w->config->h265.headers))
     {
-        hb_error("encx265: bitstream headers too large (%d)", ret);
+        hb_log("encx265: bitstream headers too large (%d)", ret);
         goto fail;
     }
     memcpy(w->config->h265.headers, nal->payload, ret);

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -439,7 +439,7 @@ hb_buffer_t * hb_buffer_init_internal( int size , int needsMapped )
             int status = hb_cl_create_mapped_buffer(&b->cl.buffer, &b->data, b->alloc);
             if (!status)
             {
-                hb_error("Failed to map CL buffer");
+                hb_spam_log("Failed to map CL buffer");
                 free(b);
                 return NULL;
             }
@@ -759,7 +759,7 @@ void hb_buffer_close( hb_buffer_t ** _b )
 #if defined(HB_BUFFER_DEBUG)
             if (hb_fifo_contains(buffer_pool, b))
             {
-                hb_error("hb_buffer_close: buffer %p already freed", b);
+                hb_log("hb_buffer_close: buffer %p already freed", b);
                 assert(0);
             }
 #endif

--- a/libhb/grayscale.c
+++ b/libhb/grayscale.c
@@ -94,7 +94,7 @@ void grayscale_filter_thread( void *thread_args_v )
         grayscale_work = &pv->grayscale_arguments[segment];
         if (grayscale_work->src == NULL)
         {
-            hb_error( "Thread started when no work available" );
+            hb_spam_log( "Thread started when no work available" );
             hb_snooze(500);
             goto report_completion;
         }
@@ -180,7 +180,7 @@ static int hb_grayscale_init( hb_filter_object_t * filter,
         taskset_init( &pv->grayscale_taskset, pv->cpu_count,
                       sizeof( grayscale_thread_arg_t ) ) == 0)
     {
-        hb_error( "grayscale could not initialize taskset" );
+        hb_spam_log( "grayscale could not initialize taskset" );
     }
 
     int ii;
@@ -199,7 +199,7 @@ static int hb_grayscale_init( hb_filter_object_t * filter,
                                  grayscale_filter_thread,
                                  HB_NORMAL_PRIORITY ) == 0)
         {
-            hb_error( "grayscale could not spawn thread" );
+            hb_spam_log( "grayscale could not spawn thread" );
         }
     }
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -163,8 +163,8 @@ int hb_picture_fill(uint8_t *data[], int stride[], hb_buffer_t *buf)
                                  buf->data, stride);
     if (ret != buf->size)
     {
-        hb_error("Internal error hb_picture_fill expected %d, got %d",
-                 buf->size, ret);
+        hb_spam_log("Internal error hb_picture_fill expected %d, got %d",
+                    buf->size, ret);
     }
     return ret;
 }
@@ -244,7 +244,7 @@ hb_sws_get_context(int srcW, int srcH, enum AVPixelFormat srcFormat,
                       1 << 16 ); // saturation
 
         if (sws_init_context(ctx, NULL, NULL) < 0) {
-            hb_error("Cannot initialize resampling context");
+            hb_spam_log("Cannot initialize resampling context");
             sws_freeContext(ctx);
             ctx = NULL;
         }
@@ -645,7 +645,7 @@ int hb_save_preview( hb_handle_t * h, int title, int preview, hb_buffer_t *buf )
     file = hb_fopen(filename, "wb");
     if( !file )
     {
-        hb_error( "hb_save_preview: fopen failed (%s)", filename );
+        hb_spam_log( "hb_save_preview: fopen failed (%s)", filename );
         return -1;
     }
 
@@ -678,7 +678,7 @@ hb_buffer_t * hb_read_preview(hb_handle_t * h, hb_title_t *title, int preview)
     file = hb_fopen(filename, "rb");
     if (!file)
     {
-        hb_error( "hb_read_preview: fopen failed (%s)", filename );
+        hb_spam_log( "hb_read_preview: fopen failed (%s)", filename );
         return NULL;
     }
 
@@ -742,7 +742,7 @@ hb_image_t* hb_get_preview2(hb_handle_t * h, int title_idx, int picture,
     title = hb_find_title_by_index(h, title_idx);
     if (title == NULL)
     {
-        hb_error( "hb_get_preview2: invalid title (%d)", title_idx );
+        hb_spam_log( "hb_get_preview2: invalid title (%d)", title_idx );
         goto fail;
     }
 
@@ -1263,7 +1263,7 @@ void hb_add_filter2( hb_value_array_t * list, hb_dict_t * filter_dict )
     hb_filter_object_t * filter = hb_filter_get(new_id);
     if (filter == NULL)
     {
-        hb_error("hb_add_filter2: Invalid filter ID %d", new_id);
+        hb_spam_log("hb_add_filter2: Invalid filter ID %d", new_id);
         hb_value_free(&filter_dict);
         return;
     }

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1718,7 +1718,7 @@ int hb_global_init()
     result = hb_platform_init();
     if (result < 0)
     {
-        hb_error("Platform specific initialization failed!");
+        hb_error(HB_ERROR_APP_INIT, "Platform specific initialization failed!");
         return -1;
     }
 
@@ -1726,7 +1726,7 @@ int hb_global_init()
     result = hb_qsv_info_init();
     if (result < 0)
     {
-        hb_error("hb_qsv_info_init failed!");
+        hb_error(HB_ERROR_APP_INIT, "hb_qsv_info_init failed!");
         return -1;
     }
     hb_param_configure_qsv();

--- a/libhb/hb_dict.c
+++ b/libhb/hb_dict.c
@@ -85,7 +85,7 @@ hb_value_t * hb_value_json(const char *json)
     hb_value_t *val = json_loads(json, 0, &error);
     if (val == NULL)
     {
-        hb_error("hb_value_json: Failed, error %s", error.text);
+        hb_spam_log("hb_value_json: Failed, error %s", error.text);
     }
     return val;
 }
@@ -727,8 +727,8 @@ hb_value_array_set(hb_value_array_t *array, int index, hb_value_t *value)
 {
     if (index < 0 || index >= json_array_size(array))
     {
-        hb_error("hb_value_array_set: invalid index %d size %zu",
-                 index, json_array_size(array));
+        hb_spam_log("hb_value_array_set: invalid index %d size %zu",
+                    index, json_array_size(array));
         return;
     }
     json_array_set_new(array, index, value);

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -72,12 +72,12 @@ hb_dict_t* hb_state_to_dict( hb_state_t * state)
                 "Progress", hb_value_double(state->param.muxing.progress));
         break;
     default:
-        hb_error("hb_state_to_json: unrecognized state %d", state->state);
+        hb_spam_log("hb_state_to_json: unrecognized state %d", state->state);
         break;
     }
     if (dict == NULL)
     {
-        hb_error("json pack failure: %s", error.text);
+        hb_spam_log("json pack failure: %s", error.text);
     }
     return dict;
 }
@@ -161,7 +161,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
     );
     if (dict == NULL)
     {
-        hb_error("json pack failure: %s", error.text);
+        hb_spam_log("json pack failure: %s", error.text);
         return NULL;
     }
 
@@ -243,7 +243,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
         );
         if (chapter_dict == NULL)
         {
-            hb_error("json pack failure: %s", error.text);
+            hb_spam_log("json pack failure: %s", error.text);
             return NULL;
         }
         hb_value_array_append(chapter_list, chapter_dict);
@@ -268,7 +268,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
             "ChannelLayout",    hb_value_int(audio->config.in.channel_layout));
         if (audio_dict == NULL)
         {
-            hb_error("json pack failure: %s", error.text);
+            hb_spam_log("json pack failure: %s", error.text);
             return NULL;
         }
         hb_value_array_append(audio_list, audio_dict);
@@ -290,7 +290,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
             "LanguageCode", hb_value_string(subtitle->iso639_2));
         if (subtitle_dict == NULL)
         {
-            hb_error("json pack failure: %s", error.text);
+            hb_spam_log("json pack failure: %s", error.text);
             return NULL;
         }
         hb_value_array_append(subtitle_list, subtitle_dict);
@@ -441,7 +441,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     );
     if (dict == NULL)
     {
-        hb_error("json pack failure: %s", error.text);
+        hb_spam_log("json pack failure: %s", error.text);
         return NULL;
     }
     hb_dict_t *dest_dict = hb_dict_get(dict, "Destination");
@@ -739,7 +739,7 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
                            );
     if (result < 0)
     {
-        hb_error("json unpack failure, failed to find title: %s", error.text);
+        hb_spam_log("json unpack failure, failed to find title: %s", error.text);
         hb_value_free(&dict);
         return;
     }
@@ -766,9 +766,9 @@ static int validate_audio_codec_mux(int codec, int mux, int track)
     {
         if ((enc->codec == codec) && (enc->muxers & mux) == 0)
         {
-            hb_error("track %d: incompatible encoder '%s' for muxer '%s'",
-                     track + 1, enc->short_name,
-                     hb_container_get_short_name(mux));
+            hb_log("track %d: incompatible encoder '%s' for muxer '%s'",
+                   track + 1, enc->short_name,
+                   hb_container_get_short_name(mux));
             return -1;
         }
     }
@@ -795,14 +795,14 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                             "Source", "Title", unpack_i(&titleindex));
     if (result < 0)
     {
-        hb_error("hb_dict_to_job: failed to find title: %s", error.text);
+        hb_spam_log("hb_dict_to_job: failed to find title: %s", error.text);
         return NULL;
     }
 
     job = hb_job_init_by_index(h, titleindex);
     if (job == NULL)
     {
-        hb_error("hb_dict_to_job: Title %d doesn't exist", titleindex);
+        hb_spam_log("hb_dict_to_job: Title %d doesn't exist", titleindex);
         return NULL;
     }
 
@@ -915,7 +915,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     );
     if (result < 0)
     {
-        hb_error("hb_dict_to_job: failed to parse dict: %s", error.text);
+        hb_spam_log("hb_dict_to_job: failed to parse dict: %s", error.text);
         goto fail;
     }
 
@@ -1059,8 +1059,8 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                                     "{s:s}", "Name", unpack_s(&name));
             if (result < 0)
             {
-                hb_error("hb_dict_to_job: failed to find chapter name: %s",
-                         error.text);
+                hb_spam_log("hb_dict_to_job: failed to find chapter name: %s",
+                            error.text);
                 goto fail;
             }
             if (name != NULL && name[0] != 0)
@@ -1092,8 +1092,8 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                                     "Settings", unpack_o(&filter_settings));
             if (result < 0)
             {
-                hb_error("hb_dict_to_job: failed to find filter settings: %s",
-                         error.text);
+                hb_spam_log("hb_dict_to_job: failed to find filter settings: %s",
+                            error.text);
                 goto fail;
             }
             if (filter_id >= HB_FILTER_FIRST && filter_id <= HB_FILTER_LAST)
@@ -1190,8 +1190,8 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                 "CompressionLevel",     unpack_f(&audio.out.compression_level));
             if (result < 0)
             {
-                hb_error("hb_dict_to_job: failed to find audio settings: %s",
-                         error.text);
+                hb_spam_log("hb_dict_to_job: failed to find audio settings: %s",
+                            error.text);
                 goto fail;
             }
             if (acodec != NULL)
@@ -1288,7 +1288,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                                         "Filename", unpack_s(&srtfile));
             if (result < 0)
             {
-                hb_error("json unpack failure: %s", error.text);
+                hb_spam_log("json unpack failure: %s", error.text);
                 hb_job_close(&job);
                 return NULL;
             }
@@ -1308,7 +1308,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                         "Offset",   unpack_I(&offset));
                     if (result < 0)
                     {
-                        hb_error("json unpack failure: %s", error.text);
+                        hb_spam_log("json unpack failure: %s", error.text);
                         hb_job_close(&job);
                         return NULL;
                     }
@@ -1336,7 +1336,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                         "Codeset",  unpack_s(&srtcodeset));
                     if (result < 0)
                     {
-                        hb_error("json unpack failure: %s", error.text);
+                        hb_spam_log("json unpack failure: %s", error.text);
                         hb_job_close(&job);
                         return NULL;
                     }
@@ -1458,7 +1458,7 @@ char* hb_set_anamorphic_size_json(const char * json_param)
 
     if (json_result < 0)
     {
-        hb_error("json unpack failure: %s", error.text);
+        hb_spam_log("json unpack failure: %s", error.text);
         return NULL;
     }
 
@@ -1473,7 +1473,7 @@ char* hb_set_anamorphic_size_json(const char * json_param)
                 "Den",      hb_value_int(geo_result.par.den));
     if (dict == NULL)
     {
-        hb_error("hb_set_anamorphic_size_json: pack failure: %s", error.text);
+        hb_spam_log("hb_set_anamorphic_size_json: pack failure: %s", error.text);
         return NULL;
     }
     char *result = hb_value_get_json(dict);
@@ -1535,7 +1535,7 @@ char* hb_get_preview_json(hb_handle_t * h, const char *json_param)
 
     if (json_result < 0)
     {
-        hb_error("preview params: json unpack failure: %s", error.text);
+        hb_spam_log("preview params: json unpack failure: %s", error.text);
         return NULL;
     }
 
@@ -1552,7 +1552,7 @@ char* hb_get_preview_json(hb_handle_t * h, const char *json_param)
             "Height",       hb_value_int(image->height));
     if (dict == NULL)
     {
-        hb_error("hb_get_preview_json: pack failure: %s", error.text);
+        hb_spam_log("hb_get_preview_json: pack failure: %s", error.text);
         return NULL;
     }
 
@@ -1580,7 +1580,7 @@ char* hb_get_preview_json(hb_handle_t * h, const char *json_param)
         );
         if (plane_dict == NULL)
         {
-            hb_error("plane_dict: json pack failure: %s", error.text);
+            hb_spam_log("plane_dict: json pack failure: %s", error.text);
             return NULL;
         }
         hb_value_array_append(planes, plane_dict);
@@ -1632,7 +1632,7 @@ char* hb_get_preview_params_json(int title_idx, int preview_idx,
     );
     if (dict == NULL)
     {
-        hb_error("hb_get_preview_params_json: pack failure: %s", error.text);
+        hb_spam_log("hb_get_preview_params_json: pack failure: %s", error.text);
         return NULL;
     }
 
@@ -1660,7 +1660,7 @@ hb_image_t* hb_json_to_image(char *json_image)
     );
     if (json_result < 0)
     {
-        hb_error("image: json unpack failure: %s", error.text);
+        hb_spam_log("image: json unpack failure: %s", error.text);
         hb_value_free(&dict);
         return NULL;
     }
@@ -1677,7 +1677,7 @@ hb_image_t* hb_json_to_image(char *json_image)
                                  "{s:o}", "Planes", unpack_o(&planes));
     if (json_result < 0)
     {
-        hb_error("image::planes: json unpack failure: %s", error.text);
+        hb_spam_log("image::planes: json unpack failure: %s", error.text);
         hb_value_free(&dict);
         return image;
     }
@@ -1697,7 +1697,7 @@ hb_image_t* hb_json_to_image(char *json_image)
                                          "Data", unpack_s(&data));
             if (json_result < 0)
             {
-                hb_error("image::plane::data: json unpack failure: %s", error.text);
+                hb_spam_log("image::plane::data: json unpack failure: %s", error.text);
                 hb_value_free(&dict);
                 return image;
             }

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -27,7 +27,7 @@ typedef enum hb_debug_level_s
 void hb_valog( hb_debug_level_t level, const char * prefix, const char * log, va_list args) HB_WPRINTF(3,0);
 void hb_deep_log( hb_debug_level_t level, char * log, ... ) HB_WPRINTF(2,3);
 void hb_spam_log( char * fmt, ...) HB_WPRINTF(1,2);
-void hb_error( char * fmt, ...) HB_WPRINTF(1,2);
+void hb_error( int error, char * fmt, ...) HB_WPRINTF(2,3);
 void hb_hexdump( hb_debug_level_t level, const char * label, const uint8_t * data, int len );
 
 int  hb_list_bytes( hb_list_t * );

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -26,6 +26,7 @@ typedef enum hb_debug_level_s
 } hb_debug_level_t;
 void hb_valog( hb_debug_level_t level, const char * prefix, const char * log, va_list args) HB_WPRINTF(3,0);
 void hb_deep_log( hb_debug_level_t level, char * log, ... ) HB_WPRINTF(2,3);
+void hb_spam_log( char * fmt, ...) HB_WPRINTF(1,2);
 void hb_error( char * fmt, ...) HB_WPRINTF(1,2);
 void hb_hexdump( hb_debug_level_t level, const char * label, const uint8_t * data, int len );
 

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -996,7 +996,7 @@ error:
     free(job->mux_data);
     job->mux_data = NULL;
     avformat_free_context(m->oc);
-    *job->done_error = HB_ERROR_INIT;
+    *job->done_error = HB_ERROR_ENC_INIT;
     *job->die = 1;
     return -1;
 }
@@ -1222,7 +1222,7 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
                         av_strerror(ret, errstr, sizeof(errstr));
                         hb_log("avformatMux: track %d, av_interleaved_write_frame failed with error '%s' (empty_pkt)",
                                track->st->index, errstr);
-                        hb_error("Failure to mux output packet");
+                        hb_error(HB_ERROR_ENC, "Failure to mux output packet");
                         *job->done_error = HB_ERROR_UNKNOWN;
                         *job->die = 1;
                         return -1;
@@ -1302,7 +1302,7 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
             {
                 // Memory allocation failure!
                 hb_log("avformatMux: subtitle memory allocation failure");
-                hb_error("Failure to mux output packet");
+                hb_error(HB_ERROR_ENC, "Failure to mux output packet");
                 *job->done_error = HB_ERROR_UNKNOWN;
                 *job->die = 1;
                 return -1;
@@ -1335,7 +1335,7 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
         av_strerror(ret < 0 ? ret : m->oc->pb->error, errstr, sizeof(errstr));
         hb_log("avformatMux: track %d, av_interleaved_write_frame failed with error '%s'",
                track->st->index, errstr);
-        hb_error("Failure to mux output packet");
+        hb_error(HB_ERROR_ENC, "Failure to mux output packet");
         *job->done_error = HB_ERROR_UNKNOWN;
         *job->die = 1;
         return -1;

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -139,7 +139,7 @@ static int avformatInit( hb_mux_object_t * m )
     m->oc = avformat_alloc_context();
     if (m->oc == NULL)
     {
-        hb_error( "Could not initialize avformat context." );
+        hb_log( "Could not initialize avformat context." );
         goto error;
     }
 
@@ -173,14 +173,14 @@ static int avformatInit( hb_mux_object_t * m )
 
         default:
         {
-            hb_error("Invalid Mux %x", job->mux);
+            hb_log("Invalid Mux %x", job->mux);
             goto error;
         }
     }
     m->oc->oformat = av_guess_format(muxer_name, NULL, NULL);
     if(m->oc->oformat == NULL)
     {
-        hb_error("Could not guess output format %s", muxer_name);
+        hb_log("Could not guess output format %s", muxer_name);
         goto error;
     }
     av_strlcpy(m->oc->filename, job->file, sizeof(m->oc->filename));
@@ -188,7 +188,7 @@ static int avformatInit( hb_mux_object_t * m )
                      &m->oc->interrupt_callback, NULL);
     if( ret < 0 )
     {
-        hb_error( "avio_open2 failed, errno %d", ret);
+        hb_log( "avio_open2 failed, errno %d", ret);
         goto error;
     }
 
@@ -201,7 +201,7 @@ static int avformatInit( hb_mux_object_t * m )
     track->st = avformat_new_stream(m->oc, NULL);
     if (track->st == NULL)
     {
-        hb_error("Could not initialize video stream");
+        hb_log("Could not initialize video stream");
         goto error;
     }
     track->st->time_base = m->time_base;
@@ -225,7 +225,7 @@ static int avformatInit( hb_mux_object_t * m )
             priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
             if (priv_data == NULL)
             {
-                hb_error("H.264 extradata: malloc failure");
+                hb_log("H.264 extradata: malloc failure");
                 goto error;
             }
 
@@ -261,7 +261,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("MPEG4 extradata: malloc failure");
+                    hb_log("MPEG4 extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data, job->config.mpeg4.bytes, priv_size);
@@ -277,7 +277,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("MPEG2 extradata: malloc failure");
+                    hb_log("MPEG2 extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data, job->config.mpeg4.bytes, priv_size);
@@ -313,7 +313,7 @@ static int avformatInit( hb_mux_object_t * m )
             priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
             if (priv_data == NULL)
             {
-                hb_error("Theora extradata: malloc failure");
+                hb_log("Theora extradata: malloc failure");
                 goto error;
             }
 
@@ -341,7 +341,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("H.265 extradata: malloc failure");
+                    hb_log("H.265 extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data, job->config.h265.headers, priv_size);
@@ -349,7 +349,7 @@ static int avformatInit( hb_mux_object_t * m )
             break;
 
         default:
-            hb_error("muxavformat: Unknown video codec: %x", job->vcodec);
+            hb_log("muxavformat: Unknown video codec: %x", job->vcodec);
             goto error;
     }
     track->st->codec->extradata = priv_data;
@@ -413,7 +413,7 @@ static int avformatInit( hb_mux_object_t * m )
         track->st = avformat_new_stream(m->oc, NULL);
         if (track->st == NULL)
         {
-            hb_error("Could not initialize audio stream");
+            hb_log("Could not initialize audio stream");
             goto error;
         }
         avcodec_get_context_defaults3(track->st->codec, NULL);
@@ -471,7 +471,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("Vorbis extradata: malloc failure");
+                    hb_log("Vorbis extradata: malloc failure");
                     goto error;
                 }
 
@@ -495,7 +495,7 @@ static int avformatInit( hb_mux_object_t * m )
                     priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                     if (priv_data == NULL)
                     {
-                        hb_error("FLAC extradata: malloc failure");
+                        hb_log("FLAC extradata: malloc failure");
                         goto error;
                     }
                     memcpy(priv_data,
@@ -521,7 +521,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("AAC extradata: malloc failure");
+                    hb_log("AAC extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data,
@@ -538,8 +538,8 @@ static int avformatInit( hb_mux_object_t * m )
                 }
                 break;
             default:
-                hb_error("muxavformat: Unknown audio codec: %x",
-                         audio->config.out.codec);
+                hb_log("muxavformat: Unknown audio codec: %x",
+                       audio->config.out.codec);
                 goto error;
         }
         track->st->codec->extradata = priv_data;
@@ -704,7 +704,7 @@ static int avformatInit( hb_mux_object_t * m )
         track->st = avformat_new_stream(m->oc, NULL);
         if (track->st == NULL)
         {
-            hb_error("Could not initialize subtitle stream");
+            hb_log("Could not initialize subtitle stream");
             goto error;
         }
         avcodec_get_context_defaults3(track->st->codec, NULL);
@@ -739,7 +739,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("VOBSUB extradata: malloc failure");
+                    hb_log("VOBSUB extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data, subidx, priv_size);
@@ -772,7 +772,7 @@ static int avformatInit( hb_mux_object_t * m )
                         priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                         if (priv_data == NULL)
                         {
-                            hb_error("SSA extradata: malloc failure");
+                            hb_log("SSA extradata: malloc failure");
                             goto error;
                         }
                         memcpy(priv_data, subtitle->extradata, priv_size);
@@ -822,7 +822,7 @@ static int avformatInit( hb_mux_object_t * m )
             priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
             if (priv_data == NULL)
             {
-                hb_error("TX3G extradata: malloc failure");
+                hb_log("TX3G extradata: malloc failure");
                 goto error;
             }
             memcpy(priv_data, properties, priv_size);
@@ -860,7 +860,7 @@ static int avformatInit( hb_mux_object_t * m )
                 AVStream *st = avformat_new_stream(m->oc, NULL);
                 if (st == NULL)
                 {
-                    hb_error("Could not initialize attachment stream");
+                    hb_log("Could not initialize attachment stream");
                     goto error;
                 }
                 avcodec_get_context_defaults3(st->codec, NULL);
@@ -880,7 +880,7 @@ static int avformatInit( hb_mux_object_t * m )
                 priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
                 if (priv_data == NULL)
                 {
-                    hb_error("Font extradata: malloc failure");
+                    hb_log("Font extradata: malloc failure");
                     goto error;
                 }
                 memcpy(priv_data, attachment->data, priv_size);
@@ -979,7 +979,7 @@ static int avformatInit( hb_mux_object_t * m )
     if( ret < 0 )
     {
         av_dict_free( &av_opts );
-        hb_error( "muxavformat: avformat_write_header failed!");
+        hb_log( "muxavformat: avformat_write_header failed!");
         goto error;
     }
 
@@ -1011,14 +1011,14 @@ static int add_chapter(hb_mux_object_t *m, int64_t start, int64_t end, char * ti
     chapters = av_realloc(m->oc->chapters, nchap * sizeof(AVChapter*));
     if (chapters == NULL)
     {
-        hb_error("chapter array: malloc failure");
+        hb_log("chapter array: malloc failure");
         return -1;
     }
 
     chap = av_mallocz(sizeof(AVChapter));
     if (chap == NULL)
     {
-        hb_error("chapter: malloc failure");
+        hb_log("chapter: malloc failure");
         return -1;
     }
 
@@ -1220,8 +1220,9 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
                     {
                         char errstr[64];
                         av_strerror(ret, errstr, sizeof(errstr));
-                        hb_error("avformatMux: track %d, av_interleaved_write_frame failed with error '%s' (empty_pkt)",
-                                 track->st->index, errstr);
+                        hb_log("avformatMux: track %d, av_interleaved_write_frame failed with error '%s' (empty_pkt)",
+                               track->st->index, errstr);
+                        hb_error("Failure to mux output packet");
                         *job->done_error = HB_ERROR_UNKNOWN;
                         *job->die = 1;
                         return -1;
@@ -1300,7 +1301,8 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
             if (pkt.data == NULL)
             {
                 // Memory allocation failure!
-                hb_error("avformatMux: subtitle memory allocation failure");
+                hb_log("avformatMux: subtitle memory allocation failure");
+                hb_error("Failure to mux output packet");
                 *job->done_error = HB_ERROR_UNKNOWN;
                 *job->die = 1;
                 return -1;
@@ -1331,8 +1333,9 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
     {
         char errstr[64];
         av_strerror(ret < 0 ? ret : m->oc->pb->error, errstr, sizeof(errstr));
-        hb_error("avformatMux: track %d, av_interleaved_write_frame failed with error '%s'",
-                 track->st->index, errstr);
+        hb_log("avformatMux: track %d, av_interleaved_write_frame failed with error '%s'",
+               track->st->index, errstr);
+        hb_error("Failure to mux output packet");
         *job->done_error = HB_ERROR_UNKNOWN;
         *job->die = 1;
         return -1;

--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -652,7 +652,7 @@ static int muxInit( hb_work_object_t * muxer, hb_job_t * job )
             break;
         default:
             hb_log( "No muxer selected, exiting" );
-            *job->done_error = HB_ERROR_INIT;
+            *job->done_error = HB_ERROR_ENC_INIT;
             *job->die = 1;
             return -1;
         }
@@ -662,7 +662,7 @@ static int muxInit( hb_work_object_t * muxer, hb_job_t * job )
             int result = mux->m->init( mux->m );
             if (result < 0)
             {
-                *job->done_error = HB_ERROR_INIT;
+                *job->done_error = HB_ERROR_ENC_INIT;
                 *job->die = 1;
                 return -1;
             }

--- a/libhb/nal_units.c
+++ b/libhb/nal_units.c
@@ -114,7 +114,7 @@ hb_buffer_t* hb_nal_bitstream_annexb_to_mp4(const uint8_t *data,
     out = hb_buffer_init(out_size);
     if (out == NULL)
     {
-        hb_error("hb_nal_bitstream_annexb_to_mp4: hb_buffer_init failed");
+        hb_spam_log("hb_nal_bitstream_annexb_to_mp4: hb_buffer_init failed");
         return NULL;
     }
 
@@ -176,7 +176,7 @@ hb_buffer_t* hb_nal_bitstream_mp4_to_annexb(const uint8_t *data,
     out = hb_buffer_init(out_size);
     if (out == NULL)
     {
-        hb_error("hb_nal_bitstream_mp4_to_annexb: hb_buffer_init failed");
+        hb_spam_log("hb_nal_bitstream_mp4_to_annexb: hb_buffer_init failed");
         return NULL;
     }
 

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -893,7 +893,7 @@ static int nlmeans_init(hb_filter_object_t *filter,
     if (taskset_init(&pv->taskset, pv->thread_count,
                      sizeof(nlmeans_thread_arg_t)) == 0)
     {
-        hb_error("NLMeans could not initialize taskset");
+        hb_log("NLMeans could not initialize taskset");
         goto fail;
     }
 
@@ -902,7 +902,7 @@ static int nlmeans_init(hb_filter_object_t *filter,
         pv->thread_data[ii] = taskset_thread_args(&pv->taskset, ii);
         if (pv->thread_data[ii] == NULL)
         {
-            hb_error("NLMeans could not create thread args");
+            hb_log("NLMeans could not create thread args");
             goto fail;
         }
         pv->thread_data[ii]->pv = pv;
@@ -910,7 +910,7 @@ static int nlmeans_init(hb_filter_object_t *filter,
         if (taskset_thread_spawn(&pv->taskset, ii, "nlmeans_filter",
                                  nlmeans_filter_thread, HB_NORMAL_PRIORITY) == 0)
         {
-            hb_error("NLMeans could not spawn thread");
+            hb_log("NLMeans could not spawn thread");
             goto fail;
         }
     }

--- a/libhb/oclscale.c
+++ b/libhb/oclscale.c
@@ -81,7 +81,7 @@ int hb_ocl_scale_func( void **data, KernelEnv *kenv )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_ocl_scale_func: OpenCL support not available");
+        hb_log("hb_ocl_scale_func: OpenCL support not available");
         return 0;
     }
 
@@ -212,7 +212,7 @@ int setupScaleWeights(cl_float xscale, cl_float yscale, int width, int height, h
 
     if (hb_ocl == NULL)
     {
-        hb_error("setupScaleWeights: OpenCL support not available");
+        hb_log("setupScaleWeights: OpenCL support not available");
         return 1;
     }
 

--- a/libhb/opencl.c
+++ b/libhb/opencl.c
@@ -50,7 +50,7 @@ hb_opencl_library_t* hb_opencl_library_init()
     hb_opencl_library_t *opencl;
     if ((opencl = calloc(1, sizeof(hb_opencl_library_t))) == NULL)
     {
-        hb_error("hb_opencl_library_init: memory allocation failure");
+        hb_log("hb_opencl_library_init: memory allocation failure");
         goto fail;
     }
 
@@ -155,19 +155,19 @@ static hb_opencl_device_t* hb_opencl_device_get(hb_opencl_library_t *opencl,
 {
     if (opencl == NULL || opencl->clGetDeviceInfo == NULL)
     {
-        hb_error("hb_opencl_device_get: OpenCL support not available");
+        hb_log("hb_opencl_device_get: OpenCL support not available");
         return NULL;
     }
     else if (device_id == NULL)
     {
-        hb_error("hb_opencl_device_get: invalid device ID");
+        hb_log("hb_opencl_device_get: invalid device ID");
         return NULL;
     }
 
     hb_opencl_device_t *device = calloc(1, sizeof(hb_opencl_device_t));
     if (device == NULL)
     {
-        hb_error("hb_opencl_device_get: memory allocation failure");
+        hb_log("hb_opencl_device_get: memory allocation failure");
         return NULL;
     }
 
@@ -240,14 +240,14 @@ static hb_list_t* hb_opencl_devices_list_get(hb_opencl_library_t *opencl,
         opencl->clGetDeviceInfo  == NULL ||
         opencl->clGetPlatformIDs == NULL)
     {
-        hb_error("hb_opencl_devices_list_get: OpenCL support not available");
+        hb_log("hb_opencl_devices_list_get: OpenCL support not available");
         return NULL;
     }
 
     hb_list_t *list = hb_list_init();
     if (list == NULL)
     {
-        hb_error("hb_opencl_devices_list_get: memory allocation failure");
+        hb_log("hb_opencl_devices_list_get: memory allocation failure");
         return NULL;
     }
 
@@ -262,7 +262,7 @@ static hb_list_t* hb_opencl_devices_list_get(hb_opencl_library_t *opencl,
     }
     if ((platform_ids = malloc(sizeof(cl_platform_id) * num_platforms)) == NULL)
     {
-        hb_error("hb_opencl_devices_list_get: memory allocation failure");
+        hb_log("hb_opencl_devices_list_get: memory allocation failure");
         goto fail;
     }
     if (opencl->clGetPlatformIDs(num_platforms, platform_ids, NULL) != CL_SUCCESS)
@@ -278,7 +278,7 @@ static hb_list_t* hb_opencl_devices_list_get(hb_opencl_library_t *opencl,
         }
         if ((device_ids = malloc(sizeof(cl_device_id) * num_devices)) == NULL)
         {
-            hb_error("hb_opencl_devices_list_get: memory allocation failure");
+            hb_log("hb_opencl_devices_list_get: memory allocation failure");
             goto fail;
         }
         if (opencl->clGetDeviceIDs(platform_ids[i], device_type, num_devices, device_ids, NULL) != CL_SUCCESS)

--- a/libhb/opencl.h
+++ b/libhb/opencl.h
@@ -741,7 +741,7 @@ int hb_ocl_scale(hb_buffer_t *in, hb_buffer_t *out, int *crop,
     status = method(__VA_ARGS__);                                               \
     if (status != CL_SUCCESS)                                                   \
     {                                                                           \
-        hb_error("%s:%d (%s) error: %d\n",__FUNCTION__,__LINE__,#method,status);\
+        hb_log("%s:%d (%s) error: %d\n",__FUNCTION__,__LINE__,#method,status);\
         return status;                                                          \
     }                                                                           \
 }

--- a/libhb/openclwrapper.c
+++ b/libhb/openclwrapper.c
@@ -163,7 +163,7 @@ int hb_binary_generated( cl_context context, const char * cl_file_name, FILE ** 
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_binary_generated: OpenCL support not available");
+        hb_log("hb_binary_generated: OpenCL support not available");
         return 0;
     }
 
@@ -256,7 +256,7 @@ int hb_generat_bin_from_kernel_source( cl_program program, const char * cl_file_
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_generat_bin_from_kernel_source: OpenCL support not available");
+        hb_log("hb_generat_bin_from_kernel_source: OpenCL support not available");
         return 0;
     }
 
@@ -417,7 +417,7 @@ int hb_create_kernel( char * kernelname, KernelEnv * env )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_create_kernel: OpenCL support not available");
+        hb_log("hb_create_kernel: OpenCL support not available");
         return 0;
     }
 
@@ -435,7 +435,7 @@ int hb_release_kernel( KernelEnv * env )
 {
     if (hb_ocl == NULL)
     {
-        hb_error("hb_release_kernel: OpenCL support not available");
+        hb_log("hb_release_kernel: OpenCL support not available");
         return 0;
     }
 
@@ -467,7 +467,7 @@ int hb_init_opencl_env( GPUEnv *gpu_info )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_init_opencl_env: OpenCL support not available");
+        hb_log("hb_init_opencl_env: OpenCL support not available");
         return 1;
     }
 
@@ -642,7 +642,7 @@ int hb_release_opencl_env( GPUEnv *gpu_info )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_release_opencl_env: OpenCL support not available");
+        hb_log("hb_release_opencl_env: OpenCL support not available");
         return 0;
     }
 
@@ -766,7 +766,7 @@ int hb_compile_kernel_file( const char *filename, GPUEnv *gpu_info,
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_compile_kernel_file: OpenCL support not available");
+        hb_log("hb_compile_kernel_file: OpenCL support not available");
         return 0;
     }
 
@@ -1045,7 +1045,7 @@ int hb_create_buffer( cl_mem *cl_Buf, int flags, int size )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_create_buffer: OpenCL support not available");
+        hb_log("hb_create_buffer: OpenCL support not available");
         return 0;
     }
 
@@ -1073,7 +1073,7 @@ int hb_read_opencl_buffer( cl_mem cl_inBuf, unsigned char *outbuf, int size )
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_read_opencl_suffer: OpenCL support not available");
+        hb_log("hb_read_opencl_suffer: OpenCL support not available");
         return 0;
     }
 
@@ -1095,7 +1095,7 @@ int hb_cl_create_mapped_buffer(cl_mem *mem, unsigned char **addr, int size)
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_cl_create_mapped_buffer: OpenCL support not available");
+        hb_log("hb_cl_create_mapped_buffer: OpenCL support not available");
         return 0;
     }
 
@@ -1116,7 +1116,7 @@ int hb_cl_free_mapped_buffer(cl_mem mem, unsigned char *addr)
 
     if (hb_ocl == NULL)
     {
-        hb_error("hb_cl_free_mapped_buffer: OpenCL support not available");
+        hb_log("hb_cl_free_mapped_buffer: OpenCL support not available");
         return 0;
     }
 
@@ -1143,7 +1143,7 @@ int hb_copy_buffer(cl_mem src_buffer,cl_mem dst_buffer,size_t src_offset,size_t 
 {
     if (hb_ocl == NULL)
     {
-        hb_error("hb_copy_buffer: OpenCL support not available");
+        hb_log("hb_copy_buffer: OpenCL support not available");
         return 0;
     }
 
@@ -1180,7 +1180,7 @@ int hb_write_opencl_frame_buffer(cl_mem cl_inBuf,unsigned char *Ybuf,unsigned ch
 {
     if (hb_ocl == NULL)
     {
-        hb_error("hb_write_opencl_frame_buffer: OpenCL support not available");
+        hb_log("hb_write_opencl_frame_buffer: OpenCL support not available");
         return 0;
     }
 

--- a/libhb/plist.c
+++ b/libhb/plist.c
@@ -242,7 +242,7 @@ start_element(
     }
     if (ii == TAG_MAP_SZ)
     {
-        hb_error("Unrecognized start tag (%s)", name);
+        hb_spam_log("Unrecognized start tag (%s)", name);
         return;
     }
     if (pd->value)
@@ -313,7 +313,7 @@ start_element(
         {
             if (pd->key == NULL)
             {
-                hb_error("No key for dictionary item");
+                hb_spam_log("No key for dictionary item");
                 hb_value_free(&gval);
             }
             else
@@ -323,7 +323,7 @@ start_element(
         }
         else
         {
-            hb_error("Invalid container type. This shouldn't happen");
+            hb_spam_log("Invalid container type. This shouldn't happen");
         }
     }
 }
@@ -358,12 +358,12 @@ end_element(
     }
     if (ii == TAG_MAP_SZ)
     {
-        hb_error("Unrecognized start tag (%s)", name);
+        hb_spam_log("Unrecognized start tag (%s)", name);
         return;
     }
     start_id.pid = queue_pop_head(pd->tag_stack);
     if (start_id.id != id)
-        hb_error("start tag != end tag: (%s %d) %d", name, id, id);
+        hb_spam_log("start tag != end tag: (%s %d) %d", name, id, id);
 
     hb_value_t *gval = NULL;
     hb_value_t *current = queue_peek_head(pd->stack);
@@ -416,7 +416,7 @@ end_element(
         } break;
         default:
         {
-            hb_error("Unhandled plist type %d", id);
+            hb_spam_log("Unhandled plist type %d", id);
         } break;
     }
     if (gval)
@@ -438,7 +438,7 @@ end_element(
         {
             if (pd->key == NULL)
             {
-                hb_error("No key for dictionary item");
+                hb_spam_log("No key for dictionary item");
                 hb_value_free(&gval);
             }
             else
@@ -448,7 +448,7 @@ end_element(
         }
         else
         {
-            hb_error("Invalid container type. This shouldn't happen");
+            hb_spam_log("Invalid container type. This shouldn't happen");
         }
     }
     if (queue_is_empty(pd->stack))
@@ -520,7 +520,7 @@ hb_plist_parse(const char *buf, size_t len)
     int result = xmlSAXUserParseMemory(&parser, &pd, buf, len);
     if (result != 0)
     {
-        hb_error("Plist parse failed");
+        hb_spam_log("Plist parse failed");
         return NULL;
     }
     xmlCleanupParser();
@@ -651,7 +651,7 @@ gval_write(FILE *file, hb_value_t *gval)
     else
     {
         // Try to make anything thats unrecognized into a string
-        hb_error("Unhandled data type %d", gtype);
+        hb_spam_log("Unhandled data type %d", gtype);
     }
 }
 

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -475,7 +475,7 @@ int hb_platform_init()
     result = !pthread_win32_process_attach_np();
     if (result)
     {
-        hb_error("pthread_win32_process_attach_np() failed!");
+        hb_log("pthread_win32_process_attach_np() failed!");
         return -1;
     }
 #endif
@@ -488,13 +488,13 @@ int hb_platform_init()
     result = setvbuf(stdout, NULL, _IONBF, 0);
     if (result)
     {
-        hb_error("setvbuf(stdout, NULL, _IONBF, 0) failed!");
+        hb_log("setvbuf(stdout, NULL, _IONBF, 0) failed!");
         return -1;
     }
     result = setvbuf(stderr, NULL, _IONBF, 0);
     if (result)
     {
-        hb_error("setvbuf(stderr, NULL, _IONBF, 0) failed!");
+        hb_log("setvbuf(stderr, NULL, _IONBF, 0) failed!");
         return -1;
     }
 #endif
@@ -567,7 +567,7 @@ void hb_get_user_config_directory( char path[512] )
     }
 #endif
 
-    hb_error("Failed to lookup user config directory!");
+    hb_log("Failed to lookup user config directory!");
     path[0] = 0;
 }
 
@@ -1275,7 +1275,7 @@ void* hb_system_sleep_opaque_init()
     opaque = calloc(sizeof(IOPMAssertionID), 1);
     if (opaque == NULL)
     {
-        hb_error("hb_system_sleep: failed to allocate opaque");
+        hb_log("hb_system_sleep: failed to allocate opaque");
         return NULL;
     }
 
@@ -1306,7 +1306,7 @@ void hb_system_sleep_private_enable(void *opaque)
 #ifdef __APPLE__
     if (opaque == NULL)
     {
-        hb_error("hb_system_sleep: opaque is NULL");
+        hb_log("hb_system_sleep: opaque is NULL");
     }
 
     IOPMAssertionID *assertionID = (IOPMAssertionID*)opaque;
@@ -1336,7 +1336,7 @@ void hb_system_sleep_private_disable(void *opaque)
 #ifdef __APPLE__
     if (opaque == NULL)
     {
-        hb_error("hb_system_sleep: opaque is NULL");
+        hb_log("hb_system_sleep: opaque is NULL");
     }
     
     IOPMAssertionID *assertionID = (IOPMAssertionID*)opaque;

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -303,7 +303,7 @@ static int get_job_mux(hb_dict_t *job_dict)
     if (container == NULL)
     {
         char *str = hb_value_get_string_xform(mux_value);
-        hb_error("Invalid container (%s)", str);
+        hb_log("Invalid container (%s)", str);
         free(str);
         return HB_MUX_INVALID;
     }
@@ -340,7 +340,7 @@ static hb_value_t* get_audio_copy_mask(const hb_dict_t * preset, int *mask)
                 codec = hb_audio_encoder_get_from_name(s);
                 if (codec == 0)
                 {
-                    hb_error(
+                    hb_log(
                         "Invalid audio codec in autopassthru copy mask (%s)\n"
                         "Codec name is invalid or can not be copied", s);
                     free(tmp);
@@ -422,7 +422,7 @@ static int validate_audio_encoders(const hb_dict_t *preset)
         if (hb_audio_encoder_get_from_codec(codec) == NULL)
         {
             char *str = hb_value_get_string_xform(value);
-            hb_error("Invalid audio encoder (%s)", str);
+            hb_log("Invalid audio encoder (%s)", str);
             free(str);
             return -1;
         }
@@ -439,7 +439,7 @@ static int validate_audio_encoders(const hb_dict_t *preset)
         if (hb_mixdown_get_from_mixdown(mix) == NULL)
         {
             char *str = hb_value_get_string_xform(value);
-            hb_error("Invalid audio mixdown (%s)", str);
+            hb_log("Invalid audio mixdown (%s)", str);
             free(str);
             return -1;
         }
@@ -466,7 +466,7 @@ static int validate_audio_encoders(const hb_dict_t *preset)
         if (sr != 0 && hb_audio_samplerate_get_name(sr) == NULL)
         {
             char *str = hb_value_get_string_xform(value);
-            hb_error("Invalid audio samplerate (%s)", str);
+            hb_log("Invalid audio samplerate (%s)", str);
             free(str);
             return -1;
         }
@@ -633,7 +633,7 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
     if (title == NULL)
     {
         // Can't create audio track list without knowing source audio tracks
-        hb_error("Invalid title index (%d)", title_index);
+        hb_log("Invalid title index (%d)", title_index);
         return -1;
     }
     if (hb_list_count(title->list_audio) <= 0)
@@ -673,7 +673,7 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
             fallback = hb_audio_encoder_get_from_name(s);
             if (fallback == 0)
             {
-                hb_error("Invalid fallback audio codec (%s)", s);
+                hb_log("Invalid fallback audio codec (%s)", s);
                 return -1;
             }
         }
@@ -835,7 +835,7 @@ int hb_preset_job_add_subtitles(hb_handle_t *h, int title_index,
     if (title == NULL)
     {
         // Can't create subtitle track list without knowing source
-        hb_error("Invalid title index (%d)", title_index);
+        hb_log("Invalid title index (%d)", title_index);
         return -1;
     }
 
@@ -1122,7 +1122,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
         if (filter_settings == NULL)
         {
             char *s = hb_value_get_string_xform(detel_val);
-            hb_error("Invalid detelecine filter settings (%s)", s);
+            hb_log("Invalid detelecine filter settings (%s)", s);
             free(s);
             return -1;
         }
@@ -1151,7 +1151,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
                                                 comb_preset, NULL, comb_custom);
         if (filter_settings == NULL)
         {
-            hb_error("Invalid comb detect filter preset (%s)", comb_preset);
+            hb_log("Invalid comb detect filter preset (%s)", comb_preset);
             return -1;
         }
         else if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1189,14 +1189,14 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
         }
         else
         {
-            hb_error("Invalid deinterlace filter (%s)", deint_filter);
+            hb_log("Invalid deinterlace filter (%s)", deint_filter);
             return -1;
         }
         filter_settings = hb_generate_filter_settings(
                         filter_id, deint_preset, NULL, deint_custom);
         if (filter_settings == NULL)
         {
-            hb_error("Invalid deinterlace filter preset (%s)", deint_preset);
+            hb_log("Invalid deinterlace filter preset (%s)", deint_preset);
             return -1;
         }
         if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1237,10 +1237,10 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
                                 denoise_preset, denoise_tune, denoise_custom);
             if (filter_settings == NULL)
             {
-                hb_error("Invalid denoise filter settings (%s%s%s)",
-                         denoise_preset,
-                         denoise_tune ? "," : "",
-                         denoise_tune ? denoise_tune : "");
+                hb_log("Invalid denoise filter settings (%s%s%s)",
+                       denoise_preset,
+                       denoise_tune ? "," : "",
+                       denoise_tune ? denoise_tune : "");
                 return -1;
             }
             else if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1268,7 +1268,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
                                               deblock, NULL, deblock_custom);
         if (filter_settings == NULL)
         {
-            hb_error("Invalid deblock filter settings (%s)", deblock);
+            hb_log("Invalid deblock filter settings (%s)", deblock);
             return -1;
         }
         else if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1294,7 +1294,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
                                                       NULL, NULL, rotate);
         if (filter_settings == NULL)
         {
-            hb_error("Invalid rotate filter settings (%s)", rotate);
+            hb_log("Invalid rotate filter settings (%s)", rotate);
             return -1;
         }
         else if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1327,7 +1327,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
                                                       NULL, NULL, pad);
         if (filter_settings == NULL)
         {
-            hb_error("Invalid pad filter settings (%s)", pad);
+            hb_log("Invalid pad filter settings (%s)", pad);
             return -1;
         }
         else if (!hb_dict_get_bool(filter_settings, "disable"))
@@ -1349,7 +1349,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
     if (vrate_den < 0)
     {
         char *str = hb_value_get_string_xform(fr_value);
-        hb_error("Invalid video framerate (%s)", str);
+        hb_log("Invalid video framerate (%s)", str);
         free(str);
         return -1;
     }
@@ -1375,7 +1375,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
     }
     if (hb_validate_filter_settings(HB_FILTER_VFR, filter_settings))
     {
-        hb_error("Invalid VFR filter settings");
+        hb_log("Invalid VFR filter settings");
         hb_value_free(&filter_settings);
         return -1;
     }
@@ -1412,15 +1412,15 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
     if (encoder == NULL)
     {
         char *str = hb_value_get_string_xform(vcodec_value);
-        hb_error("Invalid video encoder (%s)", str);
+        hb_log("Invalid video encoder (%s)", str);
         free(str);
         return -1;
     }
     if (!(encoder->muxers & mux))
     {
-        hb_error("Incompatible video encoder (%s) for muxer (%s)",
-                  hb_video_encoder_get_name(vcodec),
-                  hb_container_get_name(mux));
+        hb_log("Incompatible video encoder (%s) for muxer (%s)",
+               hb_video_encoder_get_name(vcodec),
+               hb_container_get_name(mux));
         return -1;
     }
 
@@ -1543,7 +1543,7 @@ int hb_preset_apply_mux(const hb_dict_t *preset, hb_dict_t *job_dict)
     if (container == NULL)
     {
         char *str = hb_value_get_string_xform(mux_value);
-        hb_error("Invalid container (%s)", str);
+        hb_log("Invalid container (%s)", str);
         free(str);
         return -1;
     }
@@ -1705,7 +1705,7 @@ int hb_preset_apply_title(hb_handle_t *h, int title_index,
     hb_dict_set(filter_settings, "crop-right", hb_value_int(geo.crop[3]));
     if (hb_validate_filter_settings(HB_FILTER_CROP_SCALE, filter_settings))
     {
-        hb_error("Invalid crop/scale filter settings");
+        hb_log("Invalid crop/scale filter settings");
         hb_value_free(&filter_settings);
         goto fail;
     }
@@ -1748,7 +1748,7 @@ hb_dict_t* hb_preset_job_init(hb_handle_t *h, int title_index,
     hb_title_t *title = hb_find_title_by_index(h, title_index);
     if (title == NULL)
     {
-        hb_error("Invalid title index (%d)", title_index);
+        hb_log("Invalid title index (%d)", title_index);
         return NULL;
     }
 
@@ -2932,7 +2932,7 @@ int hb_presets_gui_init(void)
 #endif
     if (dict == NULL)
     {
-        hb_error("Failed to load GUI presets file\n"
+        hb_log("Failed to load GUI presets file\n"
 #if defined(HB_PRESET_JSON_FILE)
         "Attempted: %s\n"
 #endif

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -248,7 +248,7 @@ static int presets_do(preset_do_f do_func, hb_value_t *preset,
     }
     else
     {
-        hb_error("Error: invalid preset format in presets_do()");
+        hb_spam_log("Error: invalid preset format in presets_do()");
         return PRESET_DO_DELETE;
     }
     return PRESET_DO_DONE;
@@ -340,8 +340,9 @@ static hb_value_t* get_audio_copy_mask(const hb_dict_t * preset, int *mask)
                 codec = hb_audio_encoder_get_from_name(s);
                 if (codec == 0)
                 {
-                    hb_error("Invalid audio codec in autopassthru copy mask (%s)", s);
-                    hb_error("Codec name is invalid or can not be copied");
+                    hb_error(
+                        "Invalid audio codec in autopassthru copy mask (%s)\n"
+                        "Codec name is invalid or can not be copied", s);
                     free(tmp);
                     hb_value_free(&out_copy_mask);
                     return NULL;
@@ -1374,7 +1375,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
     }
     if (hb_validate_filter_settings(HB_FILTER_VFR, filter_settings))
     {
-        hb_error("hb_preset_apply_filters: Internal error, invalid VFR");
+        hb_error("Invalid VFR filter settings");
         hb_value_free(&filter_settings);
         return -1;
     }
@@ -1704,7 +1705,7 @@ int hb_preset_apply_title(hb_handle_t *h, int title_index,
     hb_dict_set(filter_settings, "crop-right", hb_value_int(geo.crop[3]));
     if (hb_validate_filter_settings(HB_FILTER_CROP_SCALE, filter_settings))
     {
-        hb_error("hb_preset_apply_title: Internal error, invalid CROP_SCALE");
+        hb_error("Invalid crop/scale filter settings");
         hb_value_free(&filter_settings);
         goto fail;
     }
@@ -1816,8 +1817,8 @@ dict_clean(hb_value_t *dict, hb_value_t *template)
                 template_type == HB_VALUE_TYPE_DICT  ||
                 template_type == HB_VALUE_TYPE_ARRAY)
             {
-                hb_error("Preset %s: Incompatible value types for key %s. "
-                         "Dropping.", preset_name, key);
+                hb_log("Preset %s: Incompatible value types for key %s. "
+                       "Dropping.", preset_name, key);
                 hb_dict_remove(dict, key);
             }
             else if (hb_value_is_number(val) &&
@@ -1831,8 +1832,8 @@ dict_clean(hb_value_t *dict, hb_value_t *template)
             else
             {
                 hb_value_t *v;
-                hb_error("Preset %s: Incorrect value type for key %s. "
-                         "Converting.", preset_name, key);
+                hb_log("Preset %s: Incorrect value type for key %s. "
+                       "Converting.", preset_name, key);
                 v = hb_value_xform(val, template_type);
                 hb_dict_set(dict, key, v);
             }
@@ -1909,7 +1910,7 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
         {
             const hb_container_t *c = hb_container_get_next(NULL);
             muxer = c->format;
-            hb_error("Preset %s: Invalid container (%s)", preset_name, s);
+            hb_log("Preset %s: Invalid container (%s)", preset_name, s);
         }
         mux = hb_container_get_short_name(muxer);
         val = hb_value_string(mux);
@@ -1930,7 +1931,7 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
         if (vcodec == HB_VCODEC_INVALID)
         {
             vcodec = hb_video_encoder_get_default(muxer);
-            hb_error("Preset %s: Invalid video encoder (%s)", preset_name, s);
+            hb_log("Preset %s: Invalid video encoder (%s)", preset_name, s);
         }
         enc = hb_video_encoder_get_short_name(vcodec);
         val = hb_value_string(enc);
@@ -1948,8 +1949,8 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
             {
                 if (strcasecmp(s, "same as source"))
                 {
-                    hb_error("Preset %s: Invalid video framerate (%s)",
-                             preset_name, s);
+                    hb_log("Preset %s: Invalid video framerate (%s)",
+                           preset_name, s);
                 }
                 val = hb_value_string("auto");
                 hb_dict_set(preset, "VideoFramerate", val);
@@ -1966,8 +1967,8 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
         if (acodec == HB_ACODEC_INVALID)
         {
             acodec = hb_audio_encoder_get_default(muxer);
-            hb_error("Preset %s: Invalid audio fallback encoder (%s)",
-                     preset_name, s);
+            hb_log("Preset %s: Invalid audio fallback encoder (%s)",
+                   preset_name, s);
         }
         enc = hb_audio_encoder_get_short_name(acodec);
         val = hb_value_string(enc);
@@ -1989,8 +1990,8 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
             if (acodec == HB_ACODEC_INVALID)
             {
                 acodec = hb_audio_encoder_get_default(muxer);
-                hb_error("Preset %s: Invalid audio encoder (%s)",
-                         preset_name, s);
+                hb_log("Preset %s: Invalid audio encoder (%s)",
+                       preset_name, s);
             }
             enc = hb_audio_encoder_get_short_name(acodec);
             val = hb_value_string(enc);
@@ -2006,8 +2007,8 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
                 int sr = hb_audio_samplerate_get_from_name(s);
                 if (sr < 0)
                 {
-                    hb_error("Preset %s: Invalid audio samplerate (%s)",
-                             preset_name, s);
+                    hb_log("Preset %s: Invalid audio samplerate (%s)",
+                           preset_name, s);
                     val = hb_value_string("auto");
                     hb_dict_set(adict, "AudioSamplerate", val);
                 }
@@ -2023,8 +2024,8 @@ static void preset_clean(hb_value_t *preset, hb_value_t *template)
             {
                 // work.c do_job() sanitizes NONE to default mixdown
                 mixdown = HB_AMIXDOWN_NONE;
-                hb_error("Preset %s: Invalid audio mixdown (%s)",
-                         preset_name, s);
+                hb_log("Preset %s: Invalid audio mixdown (%s)",
+                       preset_name, s);
             }
             mix = hb_mixdown_get_short_name(mixdown);
             val = hb_value_string(mix);
@@ -2414,7 +2415,7 @@ static void import_deint_0_0_0(hb_value_t *preset)
         }
         else
         {
-            hb_error("Invalid decomb index %d", index);
+            hb_log("Invalid decomb index %d", index);
             hb_dict_set(preset, "PictureDecomb", hb_value_string("off"));
         }
     }
@@ -2431,7 +2432,7 @@ static void import_deint_0_0_0(hb_value_t *preset)
         }
         else
         {
-            hb_error("Invalid deinterlace index %d", index);
+            hb_log("Invalid deinterlace index %d", index);
             hb_dict_set(preset, "PictureDeinterlace", hb_value_string("off"));
         }
     }
@@ -2451,7 +2452,7 @@ static void import_detel_0_0_0(hb_value_t *preset)
         }
         else
         {
-            hb_error("Invalid detelecine index %d", index);
+            hb_log("Invalid detelecine index %d", index);
             hb_dict_set(preset, "PictureDetelecine", hb_value_string("off"));
         }
     }
@@ -2474,7 +2475,7 @@ static void import_denoise_0_0_0(hb_value_t *preset)
         else
         {
             if (index != 0)
-                hb_error("Invalid denoise index %d", index);
+                hb_log("Invalid denoise index %d", index);
             hb_dict_set(preset, "PictureDenoiseFilter", hb_value_string("off"));
         }
     }
@@ -2931,13 +2932,21 @@ int hb_presets_gui_init(void)
 #endif
     if (dict == NULL)
     {
-        hb_error("Failed to load GUI presets file");
+        hb_error("Failed to load GUI presets file\n"
 #if defined(HB_PRESET_JSON_FILE)
-        hb_error("Attempted: %s", HB_PRESET_JSON_FILE);
+        "Attempted: %s\n"
 #endif
 #if defined(HB_PRESET_PLIST_FILE)
-        hb_error("Attempted: %s", HB_PRESET_PLIST_FILE);
+        "Attempted: %s\n"
 #endif
+#if defined(HB_PRESET_JSON_FILE)
+        , HB_PRESET_JSON_FILE
+#endif
+#if defined(HB_PRESET_PLIST_FILE)
+        , HB_PRESET_PLIST_FILE
+#endif
+                );
+
         return -1;
     }
     else
@@ -3391,7 +3400,7 @@ hb_preset_get(const hb_preset_index_t *path)
     {
         if (hb_value_array_len(folder) <= path->index[path->depth-1])
         {
-            hb_error("hb_preset_get: not found");
+            hb_log("hb_preset_get: not found");
         }
         else
         {
@@ -3400,7 +3409,7 @@ hb_preset_get(const hb_preset_index_t *path)
     }
     else
     {
-        hb_error("hb_preset_get: not found");
+        hb_log("hb_preset_get: not found");
     }
     return NULL;
 }
@@ -3420,7 +3429,7 @@ hb_preset_set(const hb_preset_index_t *path, const hb_value_t *dict)
     {
         if (hb_value_array_len(folder) <= path->index[path->depth-1])
         {
-            hb_error("hb_preset_replace: not found");
+            hb_log("hb_preset_replace: not found");
             return -1;
         }
         else
@@ -3432,7 +3441,7 @@ hb_preset_set(const hb_preset_index_t *path, const hb_value_t *dict)
     }
     else
     {
-        hb_error("hb_preset_replace: not found");
+        hb_log("hb_preset_replace: not found");
         return -1;
     }
     return 0;
@@ -3465,7 +3474,7 @@ int hb_preset_insert(const hb_preset_index_t *path, const hb_value_t *dict)
     }
     else
     {
-        hb_error("hb_preset_insert: not found");
+        hb_log("hb_preset_insert: not found");
         return -1;
     }
     return index;
@@ -3490,7 +3499,7 @@ int hb_preset_append(const hb_preset_index_t *path, const hb_value_t *dict)
     }
     else
     {
-        hb_error("hb_preset_append: not found");
+        hb_log("hb_preset_append: not found");
         return -1;
     }
     return 0;
@@ -3511,7 +3520,7 @@ hb_preset_delete(const hb_preset_index_t *path)
     {
         if (hb_value_array_len(folder) <= path->index[path->depth-1])
         {
-            hb_error("hb_preset_delete: not found");
+            hb_log("hb_preset_delete: not found");
             return -1;
         }
         else
@@ -3521,7 +3530,7 @@ hb_preset_delete(const hb_preset_index_t *path)
     }
     else
     {
-        hb_error("hb_preset_delete: not found");
+        hb_log("hb_preset_delete: not found");
         return -1;
     }
     return 0;
@@ -3541,7 +3550,7 @@ int hb_preset_move(const hb_preset_index_t *src_path,
     dst_folder = hb_presets_get_folder_children(&dst_folder_path);
     if (src_folder == NULL || dst_folder == NULL)
     {
-        hb_error("hb_preset_move: not found");
+        hb_log("hb_preset_move: not found");
         return -1;
     }
 

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1684,7 +1684,7 @@ int hb_qsv_param_default_preset(hb_qsv_param_t *param,
     }
     else
     {
-        hb_error("hb_qsv_param_default_preset: invalid pointer(s)");
+        hb_spam_log("hb_qsv_param_default_preset: invalid pointer(s)");
         return -1;
     }
     if (preset != NULL && preset[0] != '\0')
@@ -1782,7 +1782,7 @@ int hb_qsv_param_default_preset(hb_qsv_param_t *param,
         }
         else
         {
-            hb_error("hb_qsv_param_default_preset: invalid preset '%s'", preset);
+            hb_spam_log("hb_qsv_param_default_preset: invalid preset '%s'", preset);
             return -1;
         }
     }
@@ -1915,7 +1915,7 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
     }
     else
     {
-        hb_error("hb_qsv_param_default: invalid pointer(s)");
+        hb_spam_log("hb_qsv_param_default: invalid pointer(s)");
         return -1;
     }
     return 0;

--- a/libhb/qsv_filter.c
+++ b/libhb/qsv_filter.c
@@ -489,14 +489,14 @@ int process_frame(av_qsv_list* received_item, av_qsv_context* qsv, hb_filter_pri
     {
             if (sync_idx == -1)
             {
-                hb_error("qsv: Not enough resources allocated for QSV filter");
+                hb_spam_log("qsv: Not enough resources allocated for QSV filter");
                 ret = 0;
                 break;
             }
             if( sts == MFX_ERR_MORE_SURFACE || sts == MFX_ERR_NONE )
                surface_idx = av_qsv_get_free_surface(qsv_vpp, qsv,  &(qsv_vpp->m_mfxVideoParam.vpp.Out), QSV_PART_ANY);
             if (surface_idx == -1) {
-                hb_error("qsv: Not enough resources allocated for QSV filter");
+                hb_spam_log("qsv: Not enough resources allocated for QSV filter");
                 ret = 0;
                 break;
             }

--- a/libhb/qsv_filter_pp.c
+++ b/libhb/qsv_filter_pp.c
@@ -323,7 +323,7 @@ int pre_process_frame(hb_buffer_t *in, av_qsv_context* qsv, hb_filter_private_t 
     {
             if (sync_idx == -1)
             {
-                hb_error("qsv: Not enough resources allocated for the preprocessing filter");
+                hb_spam_log("qsv: Not enough resources allocated for the preprocessing filter");
                 ret = 0;
                 break;
             }
@@ -331,7 +331,7 @@ int pre_process_frame(hb_buffer_t *in, av_qsv_context* qsv, hb_filter_private_t 
             if (sts == MFX_ERR_MORE_SURFACE || sts == MFX_ERR_NONE)
                surface_idx = av_qsv_get_free_surface(qsv_vpp, qsv,  &(qsv_vpp->m_mfxVideoParam.vpp.Out), QSV_PART_ANY);
             if (surface_idx == -1) {
-                hb_error("qsv: Not enough resources allocated for the preprocessing filter");
+                hb_spam_log("qsv: Not enough resources allocated for the preprocessing filter");
                 ret = 0;
                 break;
             }

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -529,7 +529,7 @@ static int ssa_post_init( hb_filter_object_t * filter, hb_job_t * job )
 
     pv->ssa = ass_library_init();
     if ( !pv->ssa ) {
-        hb_error( "decssasub: libass initialization failed\n" );
+        hb_log( "decssasub: libass initialization failed\n" );
         return 1;
     }
 
@@ -1039,7 +1039,7 @@ static int hb_rendersub_work( hb_filter_object_t * filter,
 
         default:
         {
-            hb_error("rendersub: unsupported subtitle format %d", pv->type );
+            hb_spam_log("rendersub: unsupported subtitle format %d", pv->type );
             return 1;
         } break;
     }
@@ -1080,7 +1080,7 @@ static void hb_rendersub_close( hb_filter_object_t * filter )
 
         default:
         {
-            hb_error("rendersub: unsupported subtitle format %d", pv->type );
+            hb_log("rendersub: unsupported subtitle format %d", pv->type );
         } break;
     }
 }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -568,7 +568,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
 
     if (title->video_codec == WORK_NONE)
     {
-        hb_error("No video decoder set!");
+        hb_log("No video decoder set!");
         free(info_list);
         crop_record_free(crops);
         return 0;
@@ -579,7 +579,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
 
     if (vid_decoder->init(vid_decoder, NULL))
     {
-        hb_error("Decoder init failed!");
+        hb_log("Decoder init failed!");
         free(info_list);
         crop_record_free(crops);
         return 0;
@@ -719,7 +719,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
             {
                 // Silence compiler warning
                 buf = NULL;
-                hb_error( "Error: This can't happen!" );
+                hb_log( "Error: This can't happen!" );
                 abort = 1;
                 goto skip_preview;
             }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -199,7 +199,7 @@ static void ScanFunc( void * _data )
         else
         {
             hb_title_close( &title );
-            hb_log( "scan: unrecognized file type" );
+            hb_error(HB_ERROR_SCAN, "Unrecognized file type" );
             return;
         }
     }

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -931,7 +931,7 @@ hb_stream_t * hb_bd_stream_open( hb_handle_t *h, hb_title_t *title )
     hb_stream_t *d = calloc( sizeof( hb_stream_t ), 1 );
     if ( d == NULL )
     {
-        hb_error( "hb_bd_stream_open: can't allocate space for stream state" );
+        hb_log( "hb_bd_stream_open: can't allocate space for stream state" );
         return NULL;
     }
 
@@ -1128,7 +1128,7 @@ static const uint8_t *next_packet( hb_stream_t *stream )
             int err;
             if ((err = ferror(stream->file_handle)) != 0)
             {
-                hb_error("next_packet: error (%d)", err);
+                hb_spam_log("next_packet: error (%d)", err);
                 hb_set_work_error(stream->h, HB_ERROR_READ);
             }
             return NULL;
@@ -2427,7 +2427,7 @@ static off_t align_to_next_packet(hb_stream_t *stream)
             int err;
             if ((err = ferror(stream->file_handle)) != 0)
             {
-                hb_error("align_to_next_packet: error (%d)", err);
+                hb_log("align_to_next_packet: error (%d)", err);
                 hb_set_work_error(stream->h, HB_ERROR_READ);
             }
             return 0;
@@ -3382,7 +3382,7 @@ done:
     int err;
     if ((err = ferror(stream->file_handle)) != 0)
     {
-        hb_error("hb_ps_read_packet: error (%d)", err);
+        hb_spam_log("hb_ps_read_packet: error (%d)", err);
         hb_set_work_error(stream->h, HB_ERROR_READ);
     }
 
@@ -3804,7 +3804,7 @@ static void hb_ps_stream_find_streams(hb_stream_t *stream)
                 }
                 else
                 {
-                    hb_error("Error parsing program stream map");
+                    hb_log("Error parsing program stream map");
                 }
             }
             else if ( ( pes_info.stream_id & 0xe0 ) == 0xc0 )
@@ -5693,7 +5693,7 @@ hb_buffer_t * hb_ffmpeg_read( hb_stream_t *stream )
             {
                 char errstr[80];
                 av_strerror(err, errstr, 80);
-                hb_error("av_read_frame error (%d): %s", err, errstr);
+                hb_spam_log("av_read_frame error (%d): %s", err, errstr);
                 hb_set_work_error(stream->h, HB_ERROR_READ);
             }
             return NULL;
@@ -5871,7 +5871,7 @@ static int ffmpeg_seek( hb_stream_t *stream, float frac )
         res = avformat_seek_file( ic, -1, 0, pos, pos, AVSEEK_FLAG_BACKWARD);
         if (res < 0)
         {
-            hb_error("avformat_seek_file failed");
+            hb_log("avformat_seek_file failed");
         }
     }
     else
@@ -5880,7 +5880,7 @@ static int ffmpeg_seek( hb_stream_t *stream, float frac )
         res = avformat_seek_file( ic, -1, 0, pos, pos, AVSEEK_FLAG_BACKWARD);
         if (res < 0)
         {
-            hb_error("avformat_seek_file failed");
+            hb_log("avformat_seek_file failed");
         }
     }
     stream->need_keyframe = 1;

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -392,7 +392,7 @@ static void checkFirstPts( sync_common_t * common )
     else
     {
         // This should never happen
-        hb_error("checkFirstPts: No initial PTS found!\n");
+        hb_log("checkFirstPts: No initial PTS found!\n");
     }
 }
 
@@ -2741,7 +2741,7 @@ static hb_buffer_t * FilterAudioFrame( sync_stream_t * stream,
             if (src_process(stream->audio.src.ctx, &stream->audio.src.pkt))
             {
                 /* XXX If this happens, we're screwed */
-                hb_error("sync: audio 0x%x src_process failed", audio->id);
+                hb_spam_log("sync: audio 0x%x src_process failed", audio->id);
             }
             hb_buffer_close(&buf_raw);
 

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1534,7 +1534,8 @@ static void do_job(hb_job_t *job)
             w = hb_audio_decoder(job->h, audio->config.in.codec);
             if (w == NULL)
             {
-                hb_error("Invalid input codec: %d", audio->config.in.codec);
+                hb_error("Invalid audio input codec: %d",
+                         audio->config.in.codec);
                 *job->done_error = HB_ERROR_WRONG_INPUT;
                 *job->die = 1;
                 goto cleanup;
@@ -1620,7 +1621,8 @@ static void do_job(hb_job_t *job)
                 w = hb_audio_encoder( job->h, audio->config.out.codec);
                 if (w == NULL)
                 {
-                    hb_error("Invalid audio codec: %#x", audio->config.out.codec);
+                    hb_error("Invalid audio encoder: %#x",
+                             audio->config.out.codec);
                     w = NULL;
                     *job->done_error = HB_ERROR_WRONG_INPUT;
                     *job->die = 1;
@@ -1703,7 +1705,7 @@ static void do_job(hb_job_t *job)
         w->done = &job->done;
         if (w->init( w, job ))
         {
-            hb_error( "Failure to initialise thread '%s'", w->name );
+            hb_error( "Failure to initialise '%s'", w->name );
             *job->done_error = HB_ERROR_INIT;
             *job->die = 1;
             goto cleanup;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -110,9 +110,10 @@ static void work_func( void * _work )
             hb_job_t *new_job = hb_json_to_job(job->h, job->json);
             if (new_job == NULL)
             {
+                hb_error(HB_ERROR_ENC_INIT, "Failed to parse job description");
                 hb_job_close(&job);
                 hb_list_close(&passes);
-                *work->error = HB_ERROR_INIT;
+                *work->error = HB_ERROR_ENC_INIT;
                 *work->die = 1;
                 break;
             }
@@ -189,7 +190,8 @@ hb_work_object_t* hb_video_decoder(hb_handle_t *h, int vcodec, int param)
     w = hb_get_work(h, vcodec);
     if (w == NULL)
     {
-        hb_error("Invalid video decoder: codec %d, param %d", vcodec, param);
+        hb_error(HB_ERROR_ENC_INPUT,
+                 "Invalid video decoder: codec %d, param %d", vcodec, param);
         return NULL;
     }
     w->codec_param = param;
@@ -239,7 +241,8 @@ hb_work_object_t* hb_video_encoder(hb_handle_t *h, int vcodec)
             break;
 #endif
         default:
-            hb_error("Unknown video codec (0x%x)", vcodec );
+            hb_error(HB_ERROR_ENC_INPUT,
+                     "Unknown video encoder (0x%x)", vcodec );
     }
 
     return w;
@@ -1391,7 +1394,7 @@ static void do_job(hb_job_t *job)
     result = sanitize_subtitles(job);
     if (result)
     {
-        *job->done_error = HB_ERROR_WRONG_INPUT;
+        *job->done_error = HB_ERROR_ENC_INPUT;
         *job->die = 1;
         goto cleanup;
     }
@@ -1401,7 +1404,7 @@ static void do_job(hb_job_t *job)
     result = sanitize_qsv(job);
     if (result)
     {
-        *job->done_error = HB_ERROR_WRONG_INPUT;
+        *job->done_error = HB_ERROR_ENC_INPUT;
         *job->die = 1;
         goto cleanup;
     }
@@ -1511,7 +1514,7 @@ static void do_job(hb_job_t *job)
     result = sanitize_audio(job);
     if (result)
     {
-        *job->done_error = HB_ERROR_WRONG_INPUT;
+        *job->done_error = HB_ERROR_ENC_INPUT;
         *job->die = 1;
         goto cleanup;
     }
@@ -1534,9 +1537,10 @@ static void do_job(hb_job_t *job)
             w = hb_audio_decoder(job->h, audio->config.in.codec);
             if (w == NULL)
             {
-                hb_error("Invalid audio input codec: %d",
+                hb_error(HB_ERROR_ENC_INPUT,
+                         "Invalid audio input codec: %d",
                          audio->config.in.codec);
-                *job->done_error = HB_ERROR_WRONG_INPUT;
+                *job->done_error = HB_ERROR_ENC_INPUT;
                 *job->die = 1;
                 goto cleanup;
             }
@@ -1592,7 +1596,7 @@ static void do_job(hb_job_t *job)
     w = hb_video_decoder(job->h, title->video_codec, title->video_codec_param);
     if (w == NULL)
     {
-        *job->done_error = HB_ERROR_WRONG_INPUT;
+        *job->done_error = HB_ERROR_ENC_INPUT;
         *job->die = 1;
         goto cleanup;
     }
@@ -1621,10 +1625,11 @@ static void do_job(hb_job_t *job)
                 w = hb_audio_encoder( job->h, audio->config.out.codec);
                 if (w == NULL)
                 {
-                    hb_error("Invalid audio encoder: %#x",
+                    hb_error(HB_ERROR_ENC_INPUT,
+                             "Invalid audio encoder: %#x",
                              audio->config.out.codec);
                     w = NULL;
-                    *job->done_error = HB_ERROR_WRONG_INPUT;
+                    *job->done_error = HB_ERROR_ENC_INPUT;
                     *job->die = 1;
                     goto cleanup;
                 }
@@ -1660,7 +1665,7 @@ static void do_job(hb_job_t *job)
         w = hb_video_encoder(job->h, job->vcodec);
         if (w == NULL)
         {
-            *job->done_error = HB_ERROR_INIT;
+            *job->done_error = HB_ERROR_ENC_INPUT;
             *job->die = 1;
             goto cleanup;
         }
@@ -1705,8 +1710,8 @@ static void do_job(hb_job_t *job)
         w->done = &job->done;
         if (w->init( w, job ))
         {
-            hb_error( "Failure to initialise '%s'", w->name );
-            *job->done_error = HB_ERROR_INIT;
+            hb_error(HB_ERROR_ENC_INIT, "Failure to initialise '%s'", w->name);
+            *job->done_error = HB_ERROR_ENC_INIT;
             *job->die = 1;
             goto cleanup;
         }

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -18,7 +18,7 @@
 static BOOL globalInitialized = NO;
 
 static void (^errorHandler)(NSString *error) = NULL;
-static void hb_error_handler(const char *errmsg)
+static void hb_error_handler(int error, const char *errmsg)
 {
     NSString *error = @(errmsg);
     if (error)

--- a/test/test.c
+++ b/test/test.c
@@ -212,7 +212,7 @@ static int show_mux_warning = 1;
  * When using the CLI just display using hb_log as we always did in the past
  * make sure that we prefix with a nice ERROR message to catch peoples eyes.
  ****************************************************************************/
-static void hb_cli_error_handler ( const char *errmsg )
+static void hb_cli_error_handler ( int error, const char *errmsg )
 {
     fprintf( stderr, "ERROR: %s\n", errmsg );
 }
@@ -794,7 +794,7 @@ static int HandleEvents(hb_handle_t * h, hb_dict_t *preset_dict)
             {
                 /* No valid title, stop right there */
                 fprintf( stderr, "No title found.\n" );
-                done_error = HB_ERROR_WRONG_INPUT;
+                done_error = HB_ERROR_SCAN;
                 die = 1;
                 break;
             }
@@ -830,7 +830,7 @@ static int HandleEvents(hb_handle_t * h, hb_dict_t *preset_dict)
                 if( main_feature_pos == -1 )
                 {
                     fprintf( stderr, "No main feature title found.\n" );
-                    done_error = HB_ERROR_WRONG_INPUT;
+                    done_error = HB_ERROR_ENC_INPUT;
                     die = 1;
                     break;
                 }


### PR DESCRIPTION
hb_error was originally written to consolidate spammy log messages by checking for duplicates and only showing first occurance plus last occurance and count.  It also had a callback interface that the frontend could use to capture these messages.  But the spam isn't really useful to the frontend. So I've simplified it to only do message deduplication.

The new hb_error is connected to the callback and is used more frugally so should be more appropriate for frontend error feedback.
