### PR TITLE
fix(de.po): Minor typo causing a nasty warning

### DIFF
--- a/gtk/po/de.po
+++ b/gtk/po/de.po
@@ -387,7 +387,7 @@ msgid ""
 msgstr ""
 
 msgid "<b>Forced Only</b>"
-msgstr "<b>Nur Erzwungene>"
+msgstr "<b>Nur Erzwungene</b>"
 
 msgid ""
 "Add (or subtract) an offset (in milliseconds)\n"


### PR DESCRIPTION
Fixes `Gtk: Failed to set text '<b>Nur Erzwungene>' from markup due to error parsing markup: Fehler in Zeile 1, Zeichen 35: Element »markup« wurde geschlossen, aber das derzeit offene Element ist »b«`
