### PR TITLE
warnings-related patchset

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -302,7 +302,11 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             fseek( pv->file, 0, SEEK_SET );
             log = malloc( size + 1 );
             log[size] = '\0';
-            fread( log, size, 1, pv->file );
+            if (size > 0 &&
+                fread( log, size, 1, pv->file ) < size)
+            {
+                hb_log( "encavcodecInit: Failed to read %s" , filename);
+            }
             fclose( pv->file );
             pv->file = NULL;
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -696,7 +696,13 @@ hb_buffer_t * hb_read_preview(hb_handle_t * h, hb_title_t *title, int preview)
 
         for (hh = 0; hh < h; hh++)
         {
-            fread(data, w, 1, file);
+            if (fread(data, w, 1, file) < w)
+            {
+                hb_error( "hb_read_preview: Failed to read line %d from %s" , hh, filename );
+                hb_buffer_close(&buf);
+                break;
+            }
+
             data += stride;
         }
     }

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1938,7 +1938,8 @@ static void thread_func( void * _h )
 static void redirect_thread_func(void * _data)
 {
     int pfd[2];
-    pipe(pfd);
+    if (pipe(pfd))
+       return;
 #if defined( SYS_MINGW )
     // dup2 doesn't work on windows for some stupid reason
     stderr->_file = pfd[1];

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -36,6 +36,7 @@ static void         preset_clean(hb_value_t *preset, hb_value_t *template);
 static int          preset_import(hb_value_t *preset, int major, int minor,
                                   int micro);
 static hb_value_t * presets_package(const hb_value_t *presets);
+static int hb_presets_add_internal(hb_value_t *);
 
 enum
 {
@@ -3109,7 +3110,7 @@ void hb_presets_builtin_update(void)
     hb_value_free(&builtin);
 }
 
-int hb_presets_add_internal(hb_value_t *preset)
+static int hb_presets_add_internal(hb_value_t *preset)
 {
     hb_preset_index_t *path;
     int                added = 0;

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -3280,19 +3280,24 @@ static int hb_ps_read_packet( hb_stream_t * stream, hb_buffer_t *b )
             hb_buffer_realloc( b, b->alloc * 2 );
         }
 
-        // There are at least 8 bytes.  More if this is mpeg2 pack.
-        fread( cp+pos, 1, 8, stream->file_handle );
+        // There are (hopefully) at least 8 bytes.  More if this is mpeg2 pack.
+        if (fread( cp+pos, 1, 8, stream->file_handle ) < 8)
+            goto done;
         int mark = cp[pos] >> 4;
         pos += 8;
 
         if ( mark != 0x02 )
         {
             // mpeg-2 pack,
-            fread( cp+pos, 1, 2, stream->file_handle );
-            pos += 2;
-            int len = cp[start+13] & 0x7;
-            fread( cp+pos, 1, len, stream->file_handle );
-            pos += len;
+            if (fread( cp+pos, 1, 2, stream->file_handle ) == 2)
+            {
+                int len;
+                pos += 2;
+                len = cp[start+13] & 0x7;
+                if (len > 0 &&
+                    fread( cp+pos, 1, len, stream->file_handle ) == len)
+                    pos += len;
+            }
         }
     }
     // Non-video streams can emulate start codes, so we need


### PR DESCRIPTION
Hi HandBrake developers,

Here are a few patches to handle warnings emitted from gcc when building HandBrake.
