### PR TITLE
Add opus audio encoding support

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := YASM BZIP2 ZLIB FDKAAC LIBVPX LAME
+__deps__ := YASM BZIP2 ZLIB FDKAAC LIBVPX LAME LIBOPUS
 ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
 __deps__ += PTHREADW32
 endif
@@ -43,6 +43,8 @@ FFMPEG.CONFIGURE.extra = \
     --enable-encoder=mpeg2video \
     --enable-encoder=mpeg4 \
     --enable-encoder=libmp3lame \
+    --enable-libopus \
+    --enable-encoder=libopus \
     --enable-libvpx \
     --enable-encoder=libvpx_vp8 \
     --disable-decoder=libvpx_vp8 \

--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBOPUS,libopus))
 $(eval $(call import.CONTRIB.defs,LIBOPUS))
 
-LIBOPUS.FETCH.url = http://download.handbrake.fr/contrib/opus-1.1.tar.gz
-LIBOPUS.FETCH.url += http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
-LIBOPUS.FETCH.md5 = c5a8cf7c0b066759542bc4ca46817ac6
+LIBOPUS.FETCH.url = http://download.handbrake.fr/contrib/opus-1.1.3.tar.gz
+LIBOPUS.FETCH.url += http://downloads.xiph.org/releases/opus/opus-1.1.3.tar.gz
+LIBOPUS.FETCH.md5 = 32bbb6b557fe1b6066adc0ae1f08b629
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs

--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,0 +1,11 @@
+$(eval $(call import.MODULE.defs,LIBOPUS,libopus))
+$(eval $(call import.CONTRIB.defs,LIBOPUS))
+
+LIBOPUS.FETCH.url = http://download.handbrake.fr/contrib/opus-1.1.tar.gz
+LIBOPUS.FETCH.url += http://downloads.xiph.org/releases/opus/opus-1.1.tar.gz
+LIBOPUS.FETCH.md5 = c5a8cf7c0b066759542bc4ca46817ac6
+
+LIBOPUS.CONFIGURE.shared = --enable-shared=no
+LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs
+
+LIBOPUS.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;

--- a/contrib/libopus/module.rules
+++ b/contrib/libopus/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBOPUS))
+$(eval $(call import.CONTRIB.rules,LIBOPUS))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -157,7 +157,7 @@ PKG_CHECK_MODULES(GHB, [$GHB_PACKAGES])
 
 GHB_CFLAGS="$HBINC $GHB_CFLAGS"
 
-HB_LIBS="-lhandbrake -lavresample -lavformat -lavcodec -lavfilter -lavutil -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson"
+HB_LIBS="-lhandbrake -lavresample -lavformat -lavcodec -lavfilter -lavutil -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus"
 
 case $host in
   *-*-mingw*)

--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -199,6 +199,10 @@ ghb_adjust_audio_rate_combos(signal_user_data_t *ud, GhbValue *asettings)
 
         GtkWidget *w = GHB_WIDGET(ud->builder, "AudioBitrate");
         ghb_audio_bitrate_opts_filter(GTK_COMBO_BOX(w), low, high);
+        w = GHB_WIDGET(ud->builder, "AudioMixdown");
+        ghb_mix_opts_filter(GTK_COMBO_BOX(w), acodec);
+        w = GHB_WIDGET(ud->builder, "AudioSamplerate");
+        ghb_audio_samplerate_opts_filter(GTK_COMBO_BOX(w), acodec);
 
         ghb_ui_update(ud, "AudioEncoder",
                       ghb_dict_get_value(asettings, "Encoder"));
@@ -2138,6 +2142,8 @@ void audio_def_set_limits(signal_user_data_t *ud, GtkWidget *widget, gboolean se
     ghb_audio_bitrate_opts_filter(GTK_COMBO_BOX(w), low, high);
     w = find_widget(GTK_WIDGET(row), "AudioMixdown");
     ghb_mix_opts_filter(GTK_COMBO_BOX(w), enc);
+    w = find_widget(GTK_WIDGET(row), "AudioSamplerate");
+    ghb_audio_samplerate_opts_filter(GTK_COMBO_BOX(w), enc);
 }
 
 void audio_def_set_all_limits_cb(GtkWidget *widget, gpointer data)

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1011,20 +1011,7 @@ lookup_param_option(const hb_filter_param_t *param, const GhbValue *gval)
 gint
 ghb_find_closest_audio_samplerate(gint irate)
 {
-    gint result;
-    const hb_rate_t *rate;
-
-    result = 0;
-    for (rate = hb_audio_samplerate_get_next(NULL); rate != NULL;
-         rate = hb_audio_samplerate_get_next(rate))
-    {
-        if (irate <= rate->rate)
-        {
-            result = rate->rate;
-            break;
-        }
-    }
-    return result;
+    return hb_audio_samplerate_find_closest(irate, HB_ACODEC_INVALID);
 }
 
 const iso639_lang_t* ghb_iso639_lookup_by_int(int idx)

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1355,6 +1355,28 @@ audio_samplerate_opts_set(signal_user_data_t *ud, const gchar *name,
     ghb_audio_samplerate_opts_set(combo);
 }
 
+void
+ghb_audio_samplerate_opts_filter(GtkComboBox *combo, gint acodec)
+{
+    GtkTreeIter iter;
+    GtkListStore *store;
+    gdouble irate;
+
+    store = GTK_LIST_STORE(gtk_combo_box_get_model(combo));
+    if (!gtk_tree_model_get_iter_first( GTK_TREE_MODEL(store), &iter))
+        return;
+
+    do
+    {
+        gtk_tree_model_get(GTK_TREE_MODEL(store), &iter, 3, &irate, -1);
+        // If irate == 0.0, the item is the "Same as Source" item,
+        // so set to TRUE. Otherwise, ask libhb
+        gtk_list_store_set(store, &iter, 1, irate == 0.0 ? TRUE :
+                hb_audio_samplerate_is_supported(irate, acodec), -1);
+    } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter));
+}
+
+
 const hb_rate_t sas_rate =
 {
     .name = N_("Same as source"),

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -172,6 +172,7 @@ void ghb_audio_bitrate_opts_filter(GtkComboBox *combo, gint first_rate, gint las
 void ghb_mix_opts_set(GtkComboBox *combo);
 void ghb_mix_opts_filter(GtkComboBox *combo, gint acodec);
 void ghb_audio_samplerate_opts_set(GtkComboBox *combo);
+void ghb_audio_samplerate_opts_filter(GtkComboBox *combo, gint acodec);
 
 int ghb_lookup_lang(const GhbValue *glang);
 const iso639_lang_t* ghb_iso639_lookup_by_int(int idx);

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -341,10 +341,16 @@ const hb_rate_t* hb_video_framerate_get_next(const hb_rate_t *last);
 int              hb_video_framerate_get_close(hb_rational_t *framerate,
                                               double thresh);
 
-int              hb_audio_samplerate_get_best(uint32_t codec, int samplerate, int *sr_shift);
+int              hb_audio_samplerate_is_supported(int samplerate,
+                                                  uint32_t codec);
+int              hb_audio_samplerate_find_closest(int samplerate,
+                                                  uint32_t codec);
+int              hb_audio_samplerate_get_sr_shift(int samplerate);
 int              hb_audio_samplerate_get_from_name(const char *name);
 const char*      hb_audio_samplerate_get_name(int samplerate);
 const hb_rate_t* hb_audio_samplerate_get_next(const hb_rate_t *last);
+const hb_rate_t* hb_audio_samplerate_get_next_for_codec(const hb_rate_t *last,
+                                                        uint32_t codec);
 
 int              hb_audio_bitrate_get_best(uint32_t codec, int bitrate, int samplerate, int mixdown);
 int              hb_audio_bitrate_get_default(uint32_t codec, int samplerate, int mixdown);
@@ -659,7 +665,7 @@ struct hb_job_s
 /* Audio starts here */
 /* Audio Codecs: Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/NativeConstants.cs when changing these consts */
 #define HB_ACODEC_INVALID   0x00000000
-#define HB_ACODEC_MASK      0x03FFFF00
+#define HB_ACODEC_MASK      0x07FFFF00
 #define HB_ACODEC_LAME      0x00000200
 #define HB_ACODEC_VORBIS    0x00000400
 #define HB_ACODEC_AC3       0x00000800
@@ -677,7 +683,8 @@ struct hb_job_s
 #define HB_ACODEC_FDK_HAAC  0x00800000
 #define HB_ACODEC_FFEAC3    0x01000000
 #define HB_ACODEC_FFTRUEHD  0x02000000
-#define HB_ACODEC_FF_MASK   0x03FF2800
+#define HB_ACODEC_OPUS      0x04000000
+#define HB_ACODEC_FF_MASK   0x07FF2800
 #define HB_ACODEC_PASS_FLAG 0x40000000
 #define HB_ACODEC_PASS_MASK   (HB_ACODEC_AC3 | HB_ACODEC_DCA | HB_ACODEC_DCA_HD | HB_ACODEC_FFAAC | HB_ACODEC_FFEAC3 | HB_ACODEC_FFFLAC | HB_ACODEC_MP3 | HB_ACODEC_FFTRUEHD)
 #define HB_ACODEC_AUTO_PASS   (HB_ACODEC_PASS_FLAG | HB_ACODEC_PASS_MASK)

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -125,6 +125,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             codec_name = "libmp3lame";
             break;
 
+        case HB_ACODEC_OPUS:
+            codec_name = "libopus";
+            break;
+
         default:
             hb_error("encavcodecaInit: unsupported codec (0x%x)",
                      audio->config.out.codec);

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,7 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX FFMPEG FONTCONFIG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBSAMPLERATE LIBTHEORA LIBVORBIS LIBOGG \
     LIBXML2 PTHREADW32 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON \
-    HARFBUZZ
+    HARFBUZZ LIBOPUS
 
 $(eval $(call import.MODULE.defs,LIBHB,libhb,$(__deps__)))
 $(eval $(call import.GCC,LIBHB))
@@ -124,7 +124,7 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 LIBHB.dll.libs = $(foreach n, \
         ass avcodec avformat avfilter avutil avresample dvdnav dvdread fontconfig \
         freetype mp3lame samplerate swscale vpx theora vorbis vorbisenc ogg \
-        x264 xml2 bluray jansson harfbuzz, \
+        x264 xml2 bluray jansson harfbuzz opus, \
         $(CONTRIB.build/)lib/lib$(n).a )
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -485,6 +485,23 @@ static int avformatInit( hb_mux_object_t * m )
                     size += ogg_headers[jj]->bytes;
                 }
             } break;
+            case HB_ACODEC_OPUS:
+                track->st->codec->codec_id = AV_CODEC_ID_OPUS;
+
+                if (audio->priv.config.extradata.length)
+                {
+                    priv_size = audio->priv.config.extradata.length;
+                    priv_data = av_malloc(priv_size + FF_INPUT_BUFFER_PADDING_SIZE);
+                    if (priv_data == NULL)
+                    {
+                        hb_error("OPUS extradata: malloc failure");
+                        goto error;
+                    }
+                    memcpy(priv_data,
+                           audio->priv.config.extradata.bytes,
+                           audio->priv.config.extradata.length);
+                }
+                break;
             case HB_ACODEC_FFFLAC:
             case HB_ACODEC_FFFLAC24:
                 track->st->codec->codec_id = AV_CODEC_ID_FLAC;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -967,9 +967,8 @@ static int sanitize_audio(hb_job_t *job)
             audio->config.out.samplerate = audio->config.in.samplerate;
         }
         best_samplerate =
-            hb_audio_samplerate_get_best(audio->config.out.codec,
-                                         audio->config.out.samplerate,
-                                         NULL);
+            hb_audio_samplerate_find_closest(audio->config.out.samplerate,
+                                             audio->config.out.codec);
         if (best_samplerate != audio->config.out.samplerate)
         {
             hb_log("work: sanitizing track %d unsupported samplerate %d Hz to %s kHz",

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -50,6 +50,7 @@ ifneq (,$(filter $(BUILD.system),darwin cygwin mingw))
     MODULES += contrib/libass
     MODULES += contrib/libogg
     MODULES += contrib/libvorbis
+    MODULES += contrib/libopus
     MODULES += contrib/libtheora
     MODULES += contrib/libsamplerate
     MODULES += contrib/lame

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avresample avformat avcodec avfilter avutil mp3lame dvdnav \
         dvdread fontconfig fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
-        bluray freetype xml2 bz2 z jansson harfbuzz
+        bluray freetype xml2 bz2 z jansson harfbuzz opus
 
 ifeq (1,$(FEATURE.qsv))
     TEST.GCC.D += USE_QSV HAVE_THREADS=1


### PR DESCRIPTION
This isn't quite finished and only lightly tested.  But I'm going to be out of touch for another week, so I thought I would post this so that others can do some testing and prepare any UI work that needs to be done.

CLI and Linux and OSX UIs should have basic support.  Some work needs to be done in the UIs to limit the samplerates available when opus is the encoder.
