### PR TITLE
Interop log and const fixes

### DIFF
--- a/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeUtils.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeUtils.cs
@@ -145,10 +145,10 @@ namespace HandBrake.ApplicationServices.Interop
         /// </param>
         public static void LoggingHandler(string message)
         {
-	        message = message.TrimEnd();
+            message = message.TrimEnd();
             if (!string.IsNullOrEmpty(message))
             {
-	            SendMessageEvent(message);
+                SendMessageEvent(message);
             }
         }
 

--- a/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeUtils.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeUtils.cs
@@ -145,15 +145,10 @@ namespace HandBrake.ApplicationServices.Interop
         /// </param>
         public static void LoggingHandler(string message)
         {
+	        message = message.TrimEnd();
             if (!string.IsNullOrEmpty(message))
             {
-                string[] messageParts = message.Split(new[] { "\n" }, StringSplitOptions.RemoveEmptyEntries);
-
-                if (messageParts.Length > 0)
-                {
-                    message = messageParts[0];
-                    SendMessageEvent(message);
-                }
+	            SendMessageEvent(message);
             }
         }
 

--- a/win/CS/HandBrake.ApplicationServices/Interop/HbLib/NativeConstants.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/HbLib/NativeConstants.cs
@@ -13,7 +13,7 @@ namespace HandBrake.ApplicationServices.Interop.HbLib
     public class NativeConstants
     {
         // Audio encoders
-        public const uint HB_ACODEC_MASK = 0x00FFFF00;
+        public const uint HB_ACODEC_MASK = 0x03FFFF00;
         public const uint HB_ACODEC_LAME = 0x00000200;
         public const uint HB_ACODEC_VORBIS = 0x00000400;
         public const uint HB_ACODEC_AC3 = 0x00000800;
@@ -58,5 +58,10 @@ namespace HandBrake.ApplicationServices.Interop.HbLib
         public const int HB_STATE_PAUSED = 16;
         public const int HB_STATE_WORKDONE = 32;
         public const int HB_STATE_MUXING = 64;
-    }
+
+        // Keep aspect ratio values
+        public const int HB_KEEP_WIDTH = 0x01;
+        public const int HB_KEEP_HEIGHT = 0x02;
+        public const int HB_KEEP_DISPLAY_ASPECT = 0x04;
+	}
 }


### PR DESCRIPTION
Fixed the double-line logging on multi-line log messages from core. (notably the JSON object logging)
Updated audio codec mask.
Added some keep aspect ratio consts.
