### PR TITLE
Update x264 and x265.

### DIFF
--- a/contrib/x264/A00-version-string.patch
+++ b/contrib/x264/A00-version-string.patch
@@ -1,8 +1,8 @@
 diff --git a/x264.h b/x264.h
-index 2e4a98d..2065222 100644
+index 2b59b92..6211a64 100644
 --- a/x264.h
 +++ b/x264.h
-@@ -41,7 +41,17 @@
+@@ -45,7 +45,17 @@ extern "C" {
  
  #include "x264_config.h"
  
@@ -17,7 +17,7 @@ index 2e4a98d..2065222 100644
 +#undef  X264_VERSION
 +#endif
 +#define X264_BUILD       148
-+#define X264_VERSION " r2665 a01e339"
++#define X264_VERSION " r2705 3f5ed56"
  
  /* Application developers planning to link against a shared library version of
   * libx264 from a Microsoft Visual Studio or similar development environment

--- a/contrib/x264/module.defs
+++ b/contrib/x264/module.defs
@@ -1,10 +1,9 @@
 $(eval $(call import.MODULE.defs,X264,x264,YASM PTHREADW32))
 $(eval $(call import.CONTRIB.defs,X264))
 
-# TODO: Unknown upstream url
-X264.FETCH.url = http://download.handbrake.fr/handbrake/contrib/x264-r2665-a01e339.tar.gz
-X264.FETCH.md5 = 4ffeac9157c5a7119b5b6ff36a5d96b7
-X264.EXTRACT.tarbase = x264
+X264.FETCH.url  = http://download.handbrake.fr/handbrake/contrib/x264-snapshot-20160809-2245-stable.tar.bz2
+X264.FETCH.url += https://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20160809-2245-stable.tar.bz2
+X264.FETCH.md5  = 7ca36de9a2c57c1711ecb517e60d815d
 
 X264.GCC.args.c_std =
 

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,9 +2,9 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url = http://download.handbrake.fr/contrib/x265_1.9.tar.gz
-X265.FETCH.url += https://download.videolan.org/pub/videolan/x265/x265_1.9.tar.gz
-X265.FETCH.md5 = f34a1c4c660ff07511365cb0983cf164
+X265.FETCH.url =  http://download.handbrake.fr/contrib/x265_2.0.tar.gz
+X265.FETCH.url += https://download.videolan.org/pub/videolan/x265/x265_2.0.tar.gz
+X265.FETCH.md5 =  a4f16c0f054f002d6d8c9c6f7fb03026
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
Bug fixes and improvements. Assembly optimizations in x264 improve performance on faster presets by 5-10%. Notable improvements to x265 tune grain.

Compiles on all officially supported platforms. Tested basic encoding on Mac.
