### PR TITLE
presets: Add ghb_override_user_config_dir function

### DIFF
--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -661,6 +661,7 @@ typedef struct
 static gchar *dvd_device = NULL;
 static gchar *arg_preset = NULL;
 static gboolean ghb_debug = FALSE;
+static gchar *arg_config_dir = NULL;
 #if defined(_WIN32)
 static gboolean win32_console = FALSE;
 #endif
@@ -670,6 +671,7 @@ static GOptionEntry entries[] =
     { "device", 'd', 0, G_OPTION_ARG_FILENAME, &dvd_device, N_("The device or file to encode"), NULL },
     { "preset", 'p', 0, G_OPTION_ARG_STRING, &arg_preset, N_("The preset values to use for encoding"), NULL },
     { "debug",  'x', 0, G_OPTION_ARG_NONE, &ghb_debug, N_("Spam a lot"), NULL },
+    { "config", 'o', 0, G_OPTION_ARG_STRING, &arg_config_dir, N_("The path to override user config dir"), NULL },
 #if defined(_WIN32)
     { "console",'c', 0, G_OPTION_ARG_NONE, &win32_console, N_("Open a console for debug output"), NULL },
 #endif
@@ -910,6 +912,12 @@ main(int argc, char *argv[])
     dbus_g_thread_init();
 #endif
     ghb_udev_init();
+
+    // Override user config dir
+    if (arg_config_dir != NULL)
+    {
+        ghb_override_user_config_dir(arg_config_dir);
+    }
 
     ghb_write_pid_file();
     ud = g_malloc0(sizeof(signal_user_data_t));

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -54,6 +54,7 @@ enum
 
 static GhbValue *prefsDict = NULL;
 static gboolean prefs_modified = FALSE;
+static gchar *override_user_config_dir = NULL;
 
 static void store_prefs(void);
 static void store_presets(void);
@@ -596,7 +597,14 @@ ghb_get_user_config_dir(gchar *subdir)
     const gchar *dir;
     gchar       *config;
 
-    dir = g_get_user_config_dir();
+    if (override_user_config_dir != NULL)
+    {
+        dir = override_user_config_dir;
+    }
+    else
+    {
+        dir = g_get_user_config_dir();
+    }
     if (!g_file_test(dir, G_FILE_TEST_IS_DIR))
     {
         dir    = g_get_home_dir();
@@ -629,6 +637,12 @@ ghb_get_user_config_dir(gchar *subdir)
         g_strfreev(split);
     }
     return config;
+}
+
+void
+ghb_override_user_config_dir(char *dir)
+{
+    override_user_config_dir = dir;
 }
 
 static void

--- a/gtk/src/presets.h
+++ b/gtk/src/presets.h
@@ -39,6 +39,7 @@ void ghb_save_queue(GhbValue *queue);
 GhbValue* ghb_load_old_queue(int pid);
 void ghb_remove_old_queue_file(int pid);
 gchar* ghb_get_user_config_dir(gchar *subdir);
+void ghb_override_user_config_dir(char *dir);
 void ghb_settings_to_ui(signal_user_data_t *ud, GhbValue *dict);
 void ghb_clear_presets_selection(signal_user_data_t *ud);
 void ghb_select_preset(GtkBuilder *builder, const char *name);


### PR DESCRIPTION
I've made a function to override the default location of the ghb directory via command line options.

It's w.i.p. just tell me what you think.
