### PR TITLE
contrib: Update to x265 2.1-1 hotfix.

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,10 +2,12 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url =  http://download.handbrake.fr/contrib/x265_2.1.tar.gz
+X265.FETCH.url =  http://download.handbrake.fr/contrib/x265_2.1-1.tar.gz
 X265.FETCH.url += https://bitbucket.org/multicoreware/x265/downloads/x265_2.1.tar.gz
 X265.FETCH.url += https://download.videolan.org/pub/videolan/x265/x265_2.1.tar.gz
-X265.FETCH.md5 =  c2657ab0925bee1fe7f3675b3f199ac0
+X265.FETCH.md5 =  2d9cb183d2675dfb325abdedd2424bfa
+X265.FETCH.basename  = x265_2.1-1.tar.gz
+X265.EXTRACT.tarbase = x265_2.1
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
The existing x265 2.1 archive **_should not**_ be replaced on the VM.

Please:
1. Download the new archive: https://bitbucket.org/multicoreware/x265/downloads/x265_2.1.tar.gz
2. Verify MD5 == 2d9cb183d2675dfb325abdedd2424bfa
3. Rename to x265_2.1-1.tar.gz
4. Upload to the VM

🎉 
