### PR TITLE
contrib: Update to M4 1.4.17.

### DIFF
--- a/contrib/m4/module.defs
+++ b/contrib/m4/module.defs
@@ -1,6 +1,6 @@
 $(eval $(call import.MODULE.defs,M4,m4))
 $(eval $(call import.CONTRIB.defs,M4))
 
-M4.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/m4-1.4.16.tar.bz2
-M4.FETCH.url += http://ftp.gnu.org/gnu/m4/m4-1.4.16.tar.bz2
-M4.FETCH.md5 =  8a7cef47fecab6272eb86a6be6363b2f
+M4.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/m4-1.4.17.tar.bz2
+M4.FETCH.url += https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.bz2
+M4.FETCH.md5 =  8a1787edcba75ae5cd1dc40d7d8ed03a


### PR DESCRIPTION
Currently shipping version fails to build in many scenarios, due to operating system warnings. M4 1.4.17 seems to fix these issues.

Please place https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.bz2 on the VM and verify MD5 == 8a1787edcba75ae5cd1dc40d7d8ed03a
