### PR TITLE
Change checksumming in build process from md5 to sha256

### DIFF
--- a/contrib/autoconf/module.defs
+++ b/contrib/autoconf/module.defs
@@ -1,6 +1,6 @@
 $(eval $(call import.MODULE.defs,AUTOCONF,autoconf,M4))
 $(eval $(call import.CONTRIB.defs,AUTOCONF))
 
-AUTOCONF.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/autoconf-2.69.tar.gz
-AUTOCONF.FETCH.url += http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
-AUTOCONF.FETCH.md5 =  82d05e03b93e45f5a39b828dc9c6c29b
+AUTOCONF.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/autoconf-2.69.tar.gz
+AUTOCONF.FETCH.url    += http://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz
+AUTOCONF.FETCH.sha256 =  954bd69b391edc12d6a4a51a2dd1476543da5c6bbf05a95b59dc0dd6fd4c2969

--- a/contrib/automake/module.defs
+++ b/contrib/automake/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,AUTOMAKE,automake,AUTOCONF))
 $(eval $(call import.CONTRIB.defs,AUTOMAKE))
 
-AUTOMAKE.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/automake-1.13.1.tar.gz
-AUTOMAKE.FETCH.url += http://ftp.gnu.org/gnu/automake/automake-1.13.1.tar.gz
-AUTOMAKE.FETCH.md5 =  78a0ef8216b0556b44508e7b5b0c0847
+AUTOMAKE.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/automake-1.13.1.tar.gz
+AUTOMAKE.FETCH.url    += http://ftp.gnu.org/gnu/automake/automake-1.13.1.tar.gz
+AUTOMAKE.FETCH.sha256 =  51bc10031847e9965c4f2c16a0a66552309ce28ea82b1afa8cef736643ebaa27
 
 # TODO: automake >= 1.15
-#AUTOMAKE.FETCH.url = http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
-#AUTOMAKE.FETCH.md5 = 716946a105ca228ab545fc37a70df3a3
+#AUTOMAKE.FETCH.url    = http://ftp.gnu.org/gnu/automake/automake-1.15.tar.gz
+#AUTOMAKE.FETCH.sha256 = 7946e945a96e28152ba5a6beb0625ca715c6e32ac55f2e353ef54def0c8ed924

--- a/contrib/bzip2/module.defs
+++ b/contrib/bzip2/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,BZIP2,bzip2))
 $(eval $(call import.CONTRIB.defs,BZIP2))
 
-BZIP2.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/bzip2-1.0.6-official.tar.gz
+BZIP2.FETCH.url =  https://download.handbrake.fr/handbrake/contrib/bzip2-1.0.6-official.tar.gz
 BZIP2.FETCH.url += http://www.bzip.org/1.0.6/bzip2-1.0.6.tar.gz
-BZIP2.FETCH.md5 =  00b516f4704d4a7cb50a1d97e6e8e15b
+BZIP2.FETCH.sha256    = a2848f34fcd5d6cf47def00461fcb528a0484d8edef8208d6d2e2909dc61d9cd
 BZIP2.FETCH.basename  = bzip2-1.0.6-official.tar.gz
 BZIP2.EXTRACT.tarbase = bzip2-1.0.6
 

--- a/contrib/cmake/module.defs
+++ b/contrib/cmake/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,CMAKE,cmake))
 $(eval $(call import.CONTRIB.defs,CMAKE))
 
-CMAKE.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/cmake-3.3.2.tar.gz
-CMAKE.FETCH.url += https://cmake.org/files/v3.3/cmake-3.3.2.tar.gz
-CMAKE.FETCH.md5 =  5febbd11bcaac854a27eebaf4a124be2
+CMAKE.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/cmake-3.3.2.tar.gz
+CMAKE.FETCH.url    += https://cmake.org/files/v3.3/cmake-3.3.2.tar.gz
+CMAKE.FETCH.sha256 =  e75a178d6ebf182b048ebfe6e0657c49f0dc109779170bad7ffcb17463f2fc22
 
 CMAKE.CONFIGURE.deps =
 CMAKE.CONFIGURE.shared =

--- a/contrib/fdk-aac/module.defs
+++ b/contrib/fdk-aac/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,FDKAAC,fdkaac))
 $(eval $(call import.CONTRIB.defs,FDKAAC))
 
-FDKAAC.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/fdk-aac-0.1.4.tar.gz
-FDKAAC.FETCH.url += http://sourceforge.net/projects/opencore-amr/files/fdk-aac/fdk-aac-0.1.4.tar.gz
-FDKAAC.FETCH.md5 =  e274a7d7f6cd92c71ec5c78e4dc9f8b7
+FDKAAC.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/fdk-aac-0.1.4.tar.gz
+FDKAAC.FETCH.url    += http://sourceforge.net/projects/opencore-amr/files/fdk-aac/fdk-aac-0.1.4.tar.gz
+FDKAAC.FETCH.sha256 =  5910fe788677ca13532e3f47b7afaa01d72334d46a2d5e1d1f080f1173ff15ab
 
 # fdk-aac configure script fails to add compiler optimizations if the
 # CFLAGS env variable is set during configure.  Since we set it, we

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -9,13 +9,13 @@ endif
 $(eval $(call import.MODULE.defs,FFMPEG,ffmpeg,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FFMPEG))
 
-FFMPEG.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libav-11.3.tar.gz
-FFMPEG.FETCH.url += https://libav.org/releases/libav-11.3.tar.gz
-FFMPEG.FETCH.md5 =  1a2eb461b98e0f1d1d6c4d892d51ac9b
+FFMPEG.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libav-11.3.tar.gz
+FFMPEG.FETCH.url    += https://libav.org/releases/libav-11.3.tar.gz
+FFMPEG.FETCH.sha256 =  5a6f6d5529d2074a5a9665bd3e048cbaefbfd88d57f0b59604baa0ce3602967e
 
 # TODO: libav >= 11.4
-#FFMPEG.FETCH.url = https://libav.org/releases/libav-11.4.tar.gz
-#FFMPEG.FETCH.md5 = 133fab51636f47d01c25b80f33f6ae3f
+#FFMPEG.FETCH.url    = https://libav.org/releases/libav-11.4.tar.gz
+#FFMPEG.FETCH.sha256 = 5a6f6d5529d2074a5a9665bd3e048cbaefbfd88d57f0b59604baa0ce3602967e
 
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =

--- a/contrib/fontconfig/module.defs
+++ b/contrib/fontconfig/module.defs
@@ -2,9 +2,9 @@ __deps__ := FREETYPE LIBXML2 LIBICONV
 $(eval $(call import.MODULE.defs,FONTCONFIG,fontconfig,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FONTCONFIG))
 
-FONTCONFIG.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/fontconfig-2.12.1.tar.bz2
-FONTCONFIG.FETCH.url += https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.1.tar.bz2
-FONTCONFIG.FETCH.md5 =  b5af5a423ee3b5cfc34846838963c058
+FONTCONFIG.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/fontconfig-2.12.1.tar.bz2
+FONTCONFIG.FETCH.url    += https://www.freedesktop.org/software/fontconfig/release/fontconfig-2.12.1.tar.bz2
+FONTCONFIG.FETCH.sha256 =  b449a3e10c47e1d1c7a6ec6e2016cca73d3bd68fbbd4f0ae5cc6b573f7d6c7f3
 
 #
 # Under MinGW:

--- a/contrib/freetype/module.defs
+++ b/contrib/freetype/module.defs
@@ -2,8 +2,8 @@ __deps__ := BZIP ZLIB
 $(eval $(call import.MODULE.defs,FREETYPE,freetype,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FREETYPE))
 
-FREETYPE.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/freetype-2.6.5.tar.bz2
-FREETYPE.FETCH.url += https://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
-FREETYPE.FETCH.md5 =  6a386964e18ba28cb93370e57a19031b
+FREETYPE.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/freetype-2.6.5.tar.bz2
+FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.6.5.tar.bz2
+FREETYPE.FETCH.sha256 =  e20a6e1400798fd5e3d831dd821b61c35b1f9a6465d6b18a53a9df4cf441acf0
 
 FREETYPE.CONFIGURE.extra = --with-harfbuzz=no --with-png=no

--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -5,9 +5,9 @@ endif
 $(eval $(call import.MODULE.defs,FRIBIDI,fribidi))
 $(eval $(call import.CONTRIB.defs,FRIBIDI))
 
-FRIBIDI.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/fribidi-0.19.7.tar.bz2
-FRIBIDI.FETCH.url += http://fribidi.org/download/fribidi-0.19.7.tar.bz2
-FRIBIDI.FETCH.md5 =  6c7e7cfdd39c908f7ac619351c1c5c23
+FRIBIDI.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/fribidi-0.19.7.tar.bz2
+FRIBIDI.FETCH.url    += http://fribidi.org/download/fribidi-0.19.7.tar.bz2
+FRIBIDI.FETCH.sha256 =  08222a6212bbc2276a2d55c3bf370109ae4a35b689acbc66571ad2a670595a8e
 
 ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
     FRIBIDI.CONFIGURE.extra = --with-glib=no

--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -2,9 +2,9 @@ __deps__ := FONTCONFIG FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url = http://download.handbrake.fr/handbrake/contrib/harfbuzz-1.3.0.tar.bz2
-HARFBUZZ.FETCH.url += https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.0.tar.bz2
-HARFBUZZ.FETCH.md5 = a82d49ff67197bc3c96ea34b98880c52
+HARFBUZZ.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/harfbuzz-1.3.0.tar.bz2
+HARFBUZZ.FETCH.url    += https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-1.3.0.tar.bz2
+HARFBUZZ.FETCH.sha256 =  b04be31633efee2cae1d62d46434587302554fa837224845a62565ec68a0334d
 
 # Tell configure where to find our versions of freetype and fontconfig
 HARFBUZZ.CONFIGURE.extra = \

--- a/contrib/jansson/module.defs
+++ b/contrib/jansson/module.defs
@@ -1,12 +1,12 @@
 $(eval $(call import.MODULE.defs,JANSSON,jansson))
 $(eval $(call import.CONTRIB.defs,JANSSON))
 
-JANSSON.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/jansson-2.6.tar.bz2
-JANSSON.FETCH.url += http://www.digip.org/jansson/releases/jansson-2.6.tar.bz2
-JANSSON.FETCH.md5 =  c70a52488db623a26f7213c7c6b7c878
+JANSSON.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/jansson-2.6.tar.bz2
+JANSSON.FETCH.url    += http://www.digip.org/jansson/releases/jansson-2.6.tar.bz2
+JANSSON.FETCH.sha256 =  d2cc63ee7f6dcda6c9a8f0b558f94b8f25f048706b7cbd6a79d3e877b738cd4d
 
 # TODO: jansson >= 2.7
-#JANSSON.FETCH.url + http://www.digip.org/jansson/releases/jansson-2.7.tar.bz2
-#JANSSON.FETCH.md5 = ffac352f9c5f80a6ae8145d451af2c0e
+#JANSSON.FETCH.url    + http://www.digip.org/jansson/releases/jansson-2.7.tar.bz2
+#JANSSON.FETCH.sha256 = 459f2b7cf22fb676286723f26169a17cf111fbfb6f54e3dc2ec6b6f9f4a97bdc
 
 JANSSON.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; mkdir m4; autoreconf -fiv;

--- a/contrib/lame/module.defs
+++ b/contrib/lame/module.defs
@@ -1,8 +1,8 @@
 $(eval $(call import.MODULE.defs,LAME,lame))
 $(eval $(call import.CONTRIB.defs,LAME))
 
-LAME.FETCH.url = http://download.handbrake.fr/handbrake/contrib/lame-3.98.tar.gz
-LAME.FETCH.md5 = 7036b52e792538fd665595d56b9e49a0
+LAME.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/lame-3.98.tar.gz
+LAME.FETCH.sha256 = 40235e84dfe4760ad3f352590a64b7bda1502a386c97d06229df356426e37686
 LAME.EXTRACT.tarbase = lame
 
 ifneq (none,$(FFMPEG.GCC.g))
@@ -10,11 +10,11 @@ ifneq (none,$(FFMPEG.GCC.g))
 endif
 
 # TODO: Upstream archive differs
-#LAME.FETCH.url = http://sourceforge.net/projects/lame/files/lame/3.98/lame-398.tar.gz
-#LAME.FETCH.md5 = f44b9f8e1b5d8835d0a77f9cc9cedd1c
+#LAME.FETCH.url    = http://sourceforge.net/projects/lame/files/lame/3.98/lame-398.tar.gz
+#LAME.FETCH.sha256 = 8396bcb425ddcbfb8027d5712fa8878a2257006ccbe3ac7a772e1652e43d19b1
 #LAME.FETCH.distfile  = lame-3.98.tar.gz
 #LAME.EXTRACT.tarbase = lame
 #
 # TODO: lame >= 3.99.5, tarbase unnecessary
-#LAME.FETCH.md5 = 84835b313d4a8b68f5349816d33e07ce
-#LAME.FETCH.url = http://sourceforge.net/projects/lame/files/lame/3.99/lame-3.99.5.tar.gz
+#LAME.FETCH.sha256 = 24346b4158e4af3bd9f2e194bb23eb473c75fb7377011523353196b19b9a23ff
+#LAME.FETCH.url    = http://sourceforge.net/projects/lame/files/lame/3.99/lame-3.99.5.tar.gz

--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -2,9 +2,9 @@ __deps__ := YASM FONTCONFIG FREETYPE FRIBIDI HARFBUZZ
 $(eval $(call import.MODULE.defs,LIBASS,libass,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBASS))
 
-LIBASS.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libass-0.13.2.tar.gz
-LIBASS.FETCH.url += https://github.com/libass/libass/releases/download/0.13.2/libass-0.13.2.tar.gz
-LIBASS.FETCH.md5 = b4d82616bb18e8e954b18746a105a3b8
+LIBASS.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libass-0.13.2.tar.gz
+LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.13.2/libass-0.13.2.tar.gz
+LIBASS.FETCH.sha256 =  8baccf663553b62977b1c017d18b3879835da0ef79dc4d3b708f2566762f1d5e
 
 # Tell configure where to find our versions of freetype and fontconfig
 LIBASS.CONFIGURE.extra = \

--- a/contrib/libbluray/module.defs
+++ b/contrib/libbluray/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBBLURAY,libbluray,PKGCONFIG LIBXML2 FREETYPE))
 $(eval $(call import.CONTRIB.defs,LIBBLURAY))
 
-LIBBLURAY.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libbluray-0.9.3.tar.bz2
-LIBBLURAY.FETCH.url += http://download.videolan.org/pub/videolan/libbluray/0.9.3/libbluray-0.9.3.tar.bz2
-LIBBLURAY.FETCH.md5 =  c51fd34f933431559371be30b59cff51
+LIBBLURAY.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libbluray-0.9.3.tar.bz2
+LIBBLURAY.FETCH.url    += http://download.videolan.org/pub/videolan/libbluray/0.9.3/libbluray-0.9.3.tar.bz2
+LIBBLURAY.FETCH.sha256 =  a6366614ec45484b51fe94fcd1975b3b8716f90f038a33b24d59978de3863ce0
 
 ifneq (max,$(LIBBLURAY.GCC.g))
 	LIBBLURAY.CONFIGURE.extra += --disable-debug

--- a/contrib/libdvdnav/module.defs
+++ b/contrib/libdvdnav/module.defs
@@ -1,13 +1,13 @@
 $(eval $(call import.MODULE.defs,LIBDVDNAV,libdvdnav,PKGCONFIG LIBDVDREAD))
 $(eval $(call import.CONTRIB.defs,LIBDVDNAV))
 
-LIBDVDNAV.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libdvdnav-5.0.1.tar.bz2
-LIBDVDNAV.FETCH.url += http://download.videolan.org/pub/videolan/libdvdnav/5.0.1/libdvdnav-5.0.1.tar.bz2
-LIBDVDNAV.FETCH.md5 =  81e30fb57eaf9f61aa6513a7bd85bd74
+LIBDVDNAV.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libdvdnav-5.0.1.tar.bz2
+LIBDVDNAV.FETCH.url    += http://download.videolan.org/pub/videolan/libdvdnav/5.0.1/libdvdnav-5.0.1.tar.bz2
+LIBDVDNAV.FETCH.sha256 =  72b1cb8266f163d4a1481b92c7b6c53e6dc9274d2a6befb08ffc351fe7a4a2a9
 
 # TODO: libdvdnav >= 5.0.3
-#LIBDVDNAV.FETCH.url = http://download.videolan.org/pub/videolan/libdvdnav/5.0.3/libdvdnav-5.0.3.tar.bz2
-#LIBDVDNAV.FETCH.md5 = e9ea4de3bd8f204e61301d407d09f033
+#LIBDVDNAV.FETCH.url    = http://download.videolan.org/pub/videolan/libdvdnav/5.0.3/libdvdnav-5.0.3.tar.bz2
+#LIBDVDNAV.FETCH.sha256 = 5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d
 
 LIBDVDNAV.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
 

--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,12 +1,12 @@
 $(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread,PKGCONFIG))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
-LIBDVDREAD.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libdvdread-5.0.0-6-gcb1ae87.tar.gz
-LIBDVDREAD.FETCH.md5 = 607a5dd41b0dd2f35433d6deac79b99e
+LIBDVDREAD.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libdvdread-5.0.0-6-gcb1ae87.tar.gz
+LIBDVDREAD.FETCH.sha256 = d2e4200c3c5d5f812892f9c14851c94e2f707d54e7328946c6397ac999f15f17
 
 # TODO: libdvdread >= 5.0.3
-#LIBDVDREAD.FETCH.url = https://download.videolan.org/pub/videolan/libdvdread/5.0.3/libdvdread-5.0.3.tar.bz2
-#LIBDVDREAD.FETCH.md5 = b7b7d2a782087ed2a913263087083715
+#LIBDVDREAD.FETCH.url    = https://download.videolan.org/pub/videolan/libdvdread/5.0.3/libdvdread-5.0.3.tar.bz2
+#LIBDVDREAD.FETCH.sha256 = 321cdf2dbdc83c96572bc583cd27d8c660ddb540ff16672ecb28607d018ed82b
 
 LIBDVDREAD.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
 

--- a/contrib/libgnurx/module.defs
+++ b/contrib/libgnurx/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBGNURX,libgnurx))
 $(eval $(call import.CONTRIB.defs,LIBGNURX))
 
-LIBGNURX.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/mingw-libgnurx-2.5.1-src.tar.gz
-LIBGNURX.FETCH.url += http://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/mingw-regex-2.5.1/mingw-libgnurx-2.5.1-src.tar.gz
-LIBGNURX.FETCH.md5 =  35c8fed3101ca1f253e9b6b1966661f6
+LIBGNURX.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/mingw-libgnurx-2.5.1-src.tar.gz
+LIBGNURX.FETCH.url    += http://sourceforge.net/projects/mingw/files/Other/UserContributed/regex/mingw-regex-2.5.1/mingw-libgnurx-2.5.1-src.tar.gz
+LIBGNURX.FETCH.sha256 =  7147b7f806ec3d007843b38e19f42a5b7c65894a57ffc297a76b0dcd5f675d76
 LIBGNURX.EXTRACT.tarbase = mingw-libgnurx-2.5.1
 
 LIBGNURX.CONFIGURE.env += AR="$(AR.exe)"

--- a/contrib/libiconv/module.defs
+++ b/contrib/libiconv/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBICONV,libiconv))
 $(eval $(call import.CONTRIB.defs,LIBICONV))
 
-LIBICONV.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libiconv-1.14.tar.gz
-LIBICONV.FETCH.url += https://ftp.gnu.org/gnu/libiconv/libiconv-1.14.tar.gz
-LIBICONV.FETCH.md5 = e34509b1623cec449dfeb73d7ce9c6c6
+LIBICONV.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libiconv-1.14.tar.gz
+LIBICONV.FETCH.url    += https://ftp.gnu.org/gnu/libiconv/libiconv-1.14.tar.gz
+LIBICONV.FETCH.sha256 =  72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613
 
 # this contrib will not build under MinGW with -std=gnu99
 ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))

--- a/contrib/libmfx/module.defs
+++ b/contrib/libmfx/module.defs
@@ -1,8 +1,8 @@
 $(eval $(call import.MODULE.defs,LIBMFX,libmfx))
 $(eval $(call import.CONTRIB.defs,LIBMFX))
 
-LIBMFX.FETCH.url = http://download.handbrake.fr/contrib/mfx_dispatch-9f4a84d7.tar.gz
-LIBMFX.FETCH.md5 = 694058b83b43b39b7e5b5fc38dbe2b88
+LIBMFX.FETCH.url    = https://download.handbrake.fr/contrib/mfx_dispatch-9f4a84d7.tar.gz
+LIBMFX.FETCH.sha256 = e07d1024e86998ac3992620f5db0f999af51cc700f7de90da2ebbe1e8a3b6efe
 
 LIBMFX.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; autoreconf -fiv;
 

--- a/contrib/libogg/module.defs
+++ b/contrib/libogg/module.defs
@@ -1,14 +1,14 @@
 $(eval $(call import.MODULE.defs,LIBOGG,libogg))
 $(eval $(call import.CONTRIB.defs,LIBOGG))
 
-LIBOGG.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libogg-1.3.0.tar.gz
-LIBOGG.FETCH.url += http://downloads.xiph.org/releases/ogg/libogg-1.3.0.tar.gz
-LIBOGG.FETCH.md5 =  0a7eb40b86ac050db3a789ab65fe21c2
+LIBOGG.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libogg-1.3.0.tar.gz
+LIBOGG.FETCH.url    += http://downloads.xiph.org/releases/ogg/libogg-1.3.0.tar.gz
+LIBOGG.FETCH.sha256 =  a8de807631014615549d2356fd36641833b8288221cea214f8a72750efe93780
 LIBOGG.EXTRACT.tarbase = libogg-1.3.0
 
 # TODO: libogg >= 1.3.2, tarbase unnecessary
 #LIBOGG.FETCH.url = http://downloads.xiph.org/releases/ogg/libogg-1.3.2.tar.gz
-#LIBOGG.FETCH.md5 = b72e1a1dbadff3248e4ed62a4177e937
+#LIBOGG.FETCH.sha256 = e19ee34711d7af328cb26287f4137e70630e7261b17cbe3cd41011d73a654692
 
 LIBOGG.CONFIGURE.extra = --disable-sdl
 

--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBOPUS,libopus))
 $(eval $(call import.CONTRIB.defs,LIBOPUS))
 
-LIBOPUS.FETCH.url = http://download.handbrake.fr/contrib/opus-1.1.3.tar.gz
-LIBOPUS.FETCH.url += http://downloads.xiph.org/releases/opus/opus-1.1.3.tar.gz
-LIBOPUS.FETCH.md5 = 32bbb6b557fe1b6066adc0ae1f08b629
+LIBOPUS.FETCH.url    =  https://download.handbrake.fr/contrib/opus-1.1.3.tar.gz
+LIBOPUS.FETCH.url    += http://downloads.xiph.org/releases/opus/opus-1.1.3.tar.gz
+LIBOPUS.FETCH.sha256 =  58b6fe802e7e30182e95d0cde890c0ace40b6f125cffc50635f0ad2eef69b633
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs

--- a/contrib/libsamplerate/module.defs
+++ b/contrib/libsamplerate/module.defs
@@ -1,13 +1,13 @@
 $(eval $(call import.MODULE.defs,LIBSAMPLERATE,libsamplerate))
 $(eval $(call import.CONTRIB.defs,LIBSAMPLERATE))
 
-LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.4.tar.gz
-LIBSAMPLERATE.FETCH.md5 = 69ec6c05f487458f688dda8f3e722e5d
+LIBSAMPLERATE.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.4.tar.gz
+LIBSAMPLERATE.FETCH.sha256 = 4b4af3ecaee05c8875a9b113c6a2f816f06f283fb882914e57b21c0b08b67b75
 LIBSAMPLERATE.EXTRACT.tarbase = libsamplerate
 
 # TODO: libsamplerate >= 0.1.8, tarbase unnecessary
-#LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.8.tar.gz
-#LIBSAMPLERATE.FETCH.md5 = 1c7fb25191b4e6e3628d198a66a84f47
 
 # Disable to avoid Carbon.h dependency on OSX
+#LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.8.tar.gz
+#LIBSAMPLERATE.FETCH.md5 = 1c7fb25191b4e6e3628d198a66a84f47
 LIBSAMPLERATE.CONFIGURE.extra = --disable-sndfile

--- a/contrib/libsamplerate/module.defs
+++ b/contrib/libsamplerate/module.defs
@@ -5,11 +5,6 @@ LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamp
 LIBSAMPLERATE.FETCH.md5 = 69ec6c05f487458f688dda8f3e722e5d
 LIBSAMPLERATE.EXTRACT.tarbase = libsamplerate
 
-# TODO: Upstream archive differs
-#LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.4.tar.gz
-#LIBSAMPLERATE.FETCH.md5 = f6fafd5d4971a2442352c72bc3598cbd
-#LIBSAMPLERATE.EXTRACT.tarbase = libsamplerate
-#
 # TODO: libsamplerate >= 0.1.8, tarbase unnecessary
 #LIBSAMPLERATE.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libsamplerate-0.1.8.tar.gz
 #LIBSAMPLERATE.FETCH.md5 = 1c7fb25191b4e6e3628d198a66a84f47

--- a/contrib/libtheora/module.defs
+++ b/contrib/libtheora/module.defs
@@ -1,13 +1,13 @@
 $(eval $(call import.MODULE.defs,LIBTHEORA,libtheora,LIBOGG LIBVORBIS))
 $(eval $(call import.CONTRIB.defs,LIBTHEORA))
 
-LIBTHEORA.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libtheora-1.1.0.tar.bz2
-LIBTHEORA.FETCH.url += http://downloads.xiph.org/releases/theora/libtheora-1.1.0.tar.bz2
-LIBTHEORA.FETCH.md5 =  d0f83cf7f13e2b3bd068a858ca1398ad
+LIBTHEORA.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libtheora-1.1.0.tar.bz2
+LIBTHEORA.FETCH.url    += http://downloads.xiph.org/releases/theora/libtheora-1.1.0.tar.bz2
+LIBTHEORA.FETCH.sha256 =  74be9fe9f85d18c45bdcbb018cebf12c74e2234aeecb4d4c4cb92d80bdd287e2
 
 # TODO: libtheora >= 1.1.1
-#LIBTHEORA.FETCH.url = http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2
-#LIBTHEORA.FETCH.md5 = 292ab65cedd5021d6b7ddd117e07cd8e
+#LIBTHEORA.FETCH.url    = http://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2
+#LIBTHEORA.FETCH.sha256 = b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc
 
 LIBTHEORA.CONFIGURE.extra = \
     --disable-examples \

--- a/contrib/libtool/module.defs
+++ b/contrib/libtool/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,LIBTOOL,libtool,AUTOCONF AUTOMAKE PKGCONFIG))
 $(eval $(call import.CONTRIB.defs,LIBTOOL))
 
-LIBTOOL.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libtool-2.4.2.tar.gz
-LIBTOOL.FETCH.url += http://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
-LIBTOOL.FETCH.md5 =  d2f3b7d4627e69e13514a40e72a24d50
+LIBTOOL.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libtool-2.4.2.tar.gz
+LIBTOOL.FETCH.url    += http://ftp.gnu.org/gnu/libtool/libtool-2.4.2.tar.gz
+LIBTOOL.FETCH.sha256 =  b38de44862a987293cd3d8dfae1c409d514b6c4e794ebc93648febf9afc38918
 
 # TODO: libtool >= 2.4.6
-#LIBTOOL.FETCH.url = http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
-#LIBTOOL.FETCH.md5 = addf44b646ddb4e3919805aa88fa7c5e
+#LIBTOOL.FETCH.url    = http://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz
+#LIBTOOL.FETCH.sha256 = e3bd4d5d3d025a36c21dd6af7ea818a2afcd4dfc1ea5a17b39d7854bcd0c06e3

--- a/contrib/libvorbis/module.defs
+++ b/contrib/libvorbis/module.defs
@@ -1,13 +1,13 @@
 $(eval $(call import.MODULE.defs,LIBVORBIS,libvorbis,LIBOGG))
 $(eval $(call import.CONTRIB.defs,LIBVORBIS))
 
-LIBVORBIS.FETCH.url = http://download.handbrake.fr/handbrake/contrib/libvorbis-aotuv_b6.03.tar.bz2
-LIBVORBIS.FETCH.md5 = 586d2ac0fa13f32cba78be5db4a16330
+LIBVORBIS.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libvorbis-aotuv_b6.03.tar.bz2
+LIBVORBIS.FETCH.sha256 = 95455420f07e4b3abdf32bda9f5921e9ed3f1afdc3739098dc090150a42fd7fd
 LIBVORBIS.EXTRACT.tarbase = aotuv-b6.03_20110424
 
 # TODO: libvorbis >= 1.3.5 (upstream variant aotuv no longer exists), tarbase unnecessary
-#LIBVORBIS.FETCH.url = http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz
-#LIBVORBIS.FETCH.md5 = 7220e089f3be3412a2317d6fde9e3944
+#LIBVORBIS.FETCH.url    = http://downloads.xiph.org/releases/vorbis/libvorbis-1.3.5.tar.gz
+#LIBVORBIS.FETCH.sha256 = 6efbcecdd3e5dfbf090341b485da9d176eb250d893e3eb378c428a2db38301ce
 
 LIBVORBIS.CONFIGURE.extra = --with-ogg=$(call fn.ABSOLUTE,$(CONTRIB.build/)) HAVE_PKG_CONFIG="no"
 

--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -7,9 +7,9 @@ endif
 $(eval $(call import.MODULE.defs,LIBVPX,libvpx,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBVPX))
 
-LIBVPX.FETCH.url =  http://download.handbrake.fr/contrib/libvpx-1.5.0.tar.bz2
-LIBVPX.FETCH.url += http://downloads.webmproject.org/releases/webm/libvpx-1.5.0.tar.bz2
-LIBVPX.FETCH.md5 =  49e59dd184caa255886683facea56fca
+LIBVPX.FETCH.url    =  https://download.handbrake.fr/contrib/libvpx-1.5.0.tar.bz2
+LIBVPX.FETCH.url    += http://downloads.webmproject.org/releases/webm/libvpx-1.5.0.tar.bz2
+LIBVPX.FETCH.sha256 =  306d67908625675f8e188d37a81fbfafdf5068b09d9aa52702b6fbe601c76797
 
 LIBVPX.CONFIGURE.args.host =
 LIBVPX.CONFIGURE.deps  =

--- a/contrib/libxml2/module.defs
+++ b/contrib/libxml2/module.defs
@@ -2,14 +2,14 @@ __deps__ := LIBICONV
 $(eval $(call import.MODULE.defs,LIBXML2,libxml2,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBXML2))
 
-LIBXML2.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/libxml2-2.7.7.tar.gz
-LIBXML2.FETCH.url += ftp://xmlsoft.org/libxml2/libxml2-2.7.7.tar.gz
-LIBXML2.FETCH.md5 =  9abc9959823ca9ff904f1fbcf21df066
+LIBXML2.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/libxml2-2.7.7.tar.gz
+LIBXML2.FETCH.url    += ftp://xmlsoft.org/libxml2/libxml2-2.7.7.tar.gz
+LIBXML2.FETCH.sha256 =  af5b781418ba4fff556fa43c50086658ea8a2f31909c2b625c2ce913a1d9eb68
 LIBXML2.EXTRACT.tarbase = libxml2-2.7.7
 
 # TODO: libxml2 >= 2.9.2, tarbase unnecessary
-#LIBXML2.FETCH.url = ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz
-#LIBXML2.FETCH.md5 = 9e6a9aca9d155737868b3dc5fd82f788
+#LIBXML2.FETCH.url    = ftp://xmlsoft.org/libxml2/libxml2-2.9.2.tar.gz
+#LIBXML2.FETCH.sha256 = 5178c30b151d044aefb1b08bf54c3003a0ac55c59c866763997529d60770d5bc
 
 # The Python components do not build on MinGW due to the lack of a select() call
 # in the MinGW environment.

--- a/contrib/m4/module.defs
+++ b/contrib/m4/module.defs
@@ -1,6 +1,6 @@
 $(eval $(call import.MODULE.defs,M4,m4))
 $(eval $(call import.CONTRIB.defs,M4))
 
-M4.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/m4-1.4.17.tar.bz2
-M4.FETCH.url += https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.bz2
-M4.FETCH.md5 =  8a1787edcba75ae5cd1dc40d7d8ed03a
+M4.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/m4-1.4.17.tar.bz2
+M4.FETCH.url    += https://ftp.gnu.org/gnu/m4/m4-1.4.17.tar.bz2
+M4.FETCH.sha256 =  8e4e1f963932136ed45dcd5afb0c6e237e96a6fcdcd2a2fa6755040859500d70

--- a/contrib/pkgconfig/module.defs
+++ b/contrib/pkgconfig/module.defs
@@ -1,12 +1,12 @@
 $(eval $(call import.MODULE.defs,PKGCONFIG,pkgconfig))
 $(eval $(call import.CONTRIB.defs,PKGCONFIG))
 
-PKGCONFIG.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/pkg-config-0.28.tar.gz
-PKGCONFIG.FETCH.url += http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz
-PKGCONFIG.FETCH.md5 =  aa3c86e67551adc3ac865160e34a2a0d
+PKGCONFIG.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/pkg-config-0.28.tar.gz
+PKGCONFIG.FETCH.url    += http://pkgconfig.freedesktop.org/releases/pkg-config-0.28.tar.gz
+PKGCONFIG.FETCH.sha256 =  6b6eb31c6ec4421174578652c7e141fdaae2dabad1021f420d8713206ac1f845
 
 # TODO: pkg-config >= 0.29 (test this extensively)
-#PKGCONFIG.FETCH.url = http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz
-#PKGCONFIG.FETCH.md5 = 77f27dce7ef88d0634d0d6f90e03a77f
+#PKGCONFIG.FETCH.url    = http://pkgconfig.freedesktop.org/releases/pkg-config-0.29.tar.gz
+#PKGCONFIG.FETCH.sha256 = c8507705d2a10c67f385d66ca2aae31e81770cc0734b4191eb8c489e864a006b
 
 PKGCONFIG.CONFIGURE.extra = --with-internal-glib --disable-host-tool

--- a/contrib/pthreadw32/module.defs
+++ b/contrib/pthreadw32/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,PTHREADW32,pthreadw32))
 $(eval $(call import.CONTRIB.defs,PTHREADW32))
 
-PTHREADW32.FETCH.url = http://download.handbrake.fr/handbrake/contrib/pthreads-w32-2-9-1-release.tar.gz
-PTHREADW32.FETCH.url += ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.tar.gz
-PTHREADW32.FETCH.md5 = 36ba827d6aa0fa9f9ae740a35626e2e3
+PTHREADW32.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/pthreads-w32-2-9-1-release.tar.gz
+PTHREADW32.FETCH.url    += ftp://sourceware.org/pub/pthreads-win32/pthreads-w32-2-9-1-release.tar.gz
+PTHREADW32.FETCH.sha256 =  e6aca7aea8de33d9c8580bcb3a0ea3ec0a7ace4ba3f4e263ac7c7b66bc95fb4d
 
 PTHREADW32.CONFIGURE = $(TOUCH.exe) $@
 

--- a/contrib/x264/module.defs
+++ b/contrib/x264/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,X264,x264,YASM PTHREADW32))
 $(eval $(call import.CONTRIB.defs,X264))
 
-X264.FETCH.url  = http://download.handbrake.fr/handbrake/contrib/x264-snapshot-20160809-2245-stable.tar.bz2
-X264.FETCH.url += https://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20160809-2245-stable.tar.bz2
-X264.FETCH.md5  = 7ca36de9a2c57c1711ecb517e60d815d
+X264.FETCH.url     =  https://download.handbrake.fr/handbrake/contrib/x264-snapshot-20160809-2245-stable.tar.bz2
+X264.FETCH.url     += https://ftp.videolan.org/pub/videolan/x264/snapshots/x264-snapshot-20160809-2245-stable.tar.bz2
+X264.FETCH.sha256  =  dca0938011ff07f02a24244bfb610958c612763c6dfa9d5731276c3cfcb3a832
 
 X264.GCC.args.c_std =
 

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,10 +2,10 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url =  http://download.handbrake.fr/contrib/x265_2.1-1.tar.gz
-X265.FETCH.url += https://bitbucket.org/multicoreware/x265/downloads/x265_2.1.tar.gz
-X265.FETCH.url += https://download.videolan.org/pub/videolan/x265/x265_2.1.tar.gz
-X265.FETCH.md5 =  2d9cb183d2675dfb325abdedd2424bfa
+X265.FETCH.url    =  https://download.handbrake.fr/contrib/x265_2.1-1.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.1.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.1.tar.gz
+X265.FETCH.sha256 =  88fcb9af4ba52c0757ac9c0d8cd5ec79951a22905ae886897e06954353d6a643
 X265.FETCH.basename  = x265_2.1-1.tar.gz
 X265.EXTRACT.tarbase = x265_2.1
 

--- a/contrib/yasm/module.defs
+++ b/contrib/yasm/module.defs
@@ -1,6 +1,6 @@
 $(eval $(call import.MODULE.defs,YASM,yasm))
 $(eval $(call import.CONTRIB.defs,YASM))
 
-YASM.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/yasm-1.3.0.tar.gz
-YASM.FETCH.url += https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
-YASM.FETCH.md5 =  fc9e586751ff789b34b1f21d572d96af
+YASM.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/yasm-1.3.0.tar.gz
+YASM.FETCH.url    += https://www.tortall.net/projects/yasm/releases/yasm-1.3.0.tar.gz
+YASM.FETCH.sha256 =  3dce6601b495f5b3d45b59f7d2492a340ee7e84b5beca17e48f862502bd5603f

--- a/contrib/zlib/module.defs
+++ b/contrib/zlib/module.defs
@@ -5,11 +5,6 @@ ZLIB.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/zlib-1.2.3.tar.
 ZLIB.FETCH.md5 =  af3358a811ad3469a2e54db49f77d52a
 ZLIB.EXTRACT.tarbase = zlib
 
-# TODO: Upstream archive differs
-#ZLIB.FETCH.url += http://sourceforge.net/projects/libpng/files/zlib/1.2.3/zlib-1.2.3.tar.gz
-#ZLIB.FETCH.md5 =  debc62758716a169df9f62e6ab2bc634
-#ZLIB.EXTRACT.tarbase = zlib
-#
 # TODO: zlib >= 1.2.8
 #ZLIB.FETCH.url += http://sourceforge.net/projects/libpng/files/zlib/1.2.8/zlib-1.2.8.tar.gz
 #ZLIB.FETCH.md5 =  44d667c142d7cda120332623eab69f40

--- a/contrib/zlib/module.defs
+++ b/contrib/zlib/module.defs
@@ -1,13 +1,13 @@
 $(eval $(call import.MODULE.defs,ZLIB,zlib))
 $(eval $(call import.CONTRIB.defs,ZLIB))
 
-ZLIB.FETCH.url =  http://download.handbrake.fr/handbrake/contrib/zlib-1.2.3.tar.gz
-ZLIB.FETCH.md5 =  af3358a811ad3469a2e54db49f77d52a
+ZLIB.FETCH.url    =  https://download.handbrake.fr/handbrake/contrib/zlib-1.2.3.tar.gz
+ZLIB.FETCH.sha256 =  18d648555e4fc6f64aad462e4ebb5a00a205617a2292c99a30fe157c1cec1e65
 ZLIB.EXTRACT.tarbase = zlib
 
 # TODO: zlib >= 1.2.8
-#ZLIB.FETCH.url += http://sourceforge.net/projects/libpng/files/zlib/1.2.8/zlib-1.2.8.tar.gz
-#ZLIB.FETCH.md5 =  44d667c142d7cda120332623eab69f40
+#ZLIB.FETCH.url    += http://sourceforge.net/projects/libpng/files/zlib/1.2.8/zlib-1.2.8.tar.gz
+#ZLIB.FETCH.sha256 =  36658cb768a54c1d4dec43c3116c27ed893e88b02ecfcb44f2166f9c0b7f2a0d
 #ZLIB.EXTRACT.tarbase = zlib
 
 ZLIB.CONFIGURE.args = !sete @dir !env !exe @prefix !extra

--- a/make/df-fetch.py
+++ b/make/df-fetch.py
@@ -75,7 +75,7 @@ class Tool(hb_distfile.Tool):
         self.parser.description = 'Fetch and verify distfile data integrity.'
         self.parser.add_option('--disable', default=False, action='store_true', help='do nothing and exit with error')
         self.parser.add_option('--jobs', default=1, action='store', metavar='N', type='int', help='allow N download jobs at once')
-        self.parser.add_option('--md5', default=None, action='store', metavar='HASH', help='verify MD5 HASH against data')
+        self.parser.add_option('--sha256', default=None, action='store', metavar='HASH', help='verify sha256 HASH against data')
         self.parser.add_option('--accept-url', default=[], action='append', metavar='SPEC', help='accept URL regex pattern')
         self.parser.add_option('--deny-url', default=[], action='append', metavar='SPEC', help='deny URL regex pattern')
         self.parser.add_option('--exhaust-url', default=None, action='store_true', help='try all active distfiles')
@@ -172,7 +172,7 @@ class URL(object):
 
     def _download(self, error, ensure):
         filename = tool.options.output
-        hasher = hashlib.md5()
+        hasher = hashlib.sha256()
         if filename:
             tool.infof('downloading %s to %s\n' % (self.url,filename))
             ftmp = tool.mktmpname(filename)
@@ -209,19 +209,19 @@ class URL(object):
             raise error('expected %d bytes, got %d bytes' % (content_length,data_total))
         s = 'download total: %9d bytes\n' % data_total
         if filename:
-            s += 'MD5 (%s) = %s' % (filename,hasher.hexdigest())
+            s += 'sha256 (%s) = %s' % (filename,hasher.hexdigest())
         else:
-            s += 'MD5 = %s' % (hasher.hexdigest())
-        if tool.options.md5:
-            md5_pass = tool.options.md5 == hasher.hexdigest()
-            s += ' (%s)' % ('pass' if md5_pass else 'fail; expecting %s' % tool.options.md5)
+            s += 'sha256 = %s' % (hasher.hexdigest())
+        if tool.options.sha256:
+            sha256_pass = tool.options.sha256 == hasher.hexdigest()
+            s += ' (%s)' % ('pass' if sha256_pass else 'fail; expecting %s' % tool.options.sha256)
         tool.infof('%s\n' % s)
-        if filename and tool.options.md5:
-            if md5_pass:
+        if filename and tool.options.sha256:
+            if sha256_pass:
                 if os.access(filename, os.F_OK) and not os.access(filename, os.W_OK):
                     raise error("permission denied: '%s'" % filename)
             else:
-                raise error("expected MD5 hash '%s', got '%s'" % (tool.options.md5, hasher.hexdigest()))
+                raise error("expected sha256 hash '%s', got '%s'" % (tool.options.sha256, hasher.hexdigest()))
             os.rename(ftmp,filename)
             del ensure.unlink_ftmp
 

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -31,10 +31,10 @@ define import.CONTRIB.defs
     $(1).FETCH.distfile = $$(CONTRIB.download/)$$($(1).FETCH.basename)
     $(1).FETCH.target   = $$($(1).FETCH.distfile)
     define $(1).FETCH
-        $$(DF.FETCH.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.md5),--md5 $$($(1).FETCH.md5)) --output $$@ $$($(1).FETCH.url)
+        $$(DF.FETCH.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.sha256),--sha256 $$($(1).FETCH.sha256)) --output $$@ $$($(1).FETCH.url)
     endef
     define $(1).FETCH.test
-        $$(DF.FETCH.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.md5),--md5 $$($(1).FETCH.md5)) --exhaust-url $$($(1).FETCH.url)
+        $$(DF.FETCH.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.sha256),--sha256 $$($(1).FETCH.sha256)) --exhaust-url $$($(1).FETCH.url)
     endef
 
     ##
@@ -42,7 +42,7 @@ define import.CONTRIB.defs
     ##
     $(1).VERIFY.target = $$($(1).build/).stamp.verify
     define $(1).VERIFY
-        $$(DF.VERIFY.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.md5),--md5 $$($(1).FETCH.md5)) $$($(1).FETCH.distfile)
+        $$(DF.VERIFY.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.sha256),--sha256 $$($(1).FETCH.sha256)) $$($(1).FETCH.distfile)
         $$(TOUCH.exe) $$@
     endef
 


### PR DESCRIPTION
As discussed on IRC with @sr55 there, this is a  pull request that implements the changes to switch from MD5 validated contrib downloads to SHA256 validated downloads.

I didn't touch the ffmpeg patch file (as the mentions of md5 didn't seem to be related).

I was able to build this successfully on Mac OS X 10.11.6, but haven't tested other platforms. I am espescially unsure whether it still works for linux as there are a lot of rules for generating packages containing dh_md5sum. I am a little unsure what that does, so if you give me a headsup, I can change all of them to dh_sha256sum as well.
