### PR TITLE
Add support for Bt.2020 color tags and SMPTE ST 2084

### DIFF
--- a/libhb/common.h
+++ b/libhb/common.h
@@ -545,21 +545,27 @@ struct hb_job_s
     int             color_prim;
     int             color_transfer;
     int             color_matrix;
-// see https://developer.apple.com/quicktime/icefloe/dispatch019.html#colr
-#define HB_COLR_PRI_BT709     1
-#define HB_COLR_PRI_UNDEF     2
-#define HB_COLR_PRI_EBUTECH   5 // use for bt470bg
-#define HB_COLR_PRI_SMPTEC    6 // smpte170m; also use for bt470m and smpte240m
-// 0, 3-4, 7-65535: reserved
-#define HB_COLR_TRA_BT709     1 // also use for bt470m, bt470bg and smpte170m
-#define HB_COLR_TRA_UNDEF     2
-#define HB_COLR_TRA_SMPTE240M 7
-// 0, 3-6, 8-65535: reserved
-#define HB_COLR_MAT_BT709     1
-#define HB_COLR_MAT_UNDEF     2
-#define HB_COLR_MAT_SMPTE170M 6 // also use for fcc and bt470bg
-#define HB_COLR_MAT_SMPTE240M 7
-// 0, 3-5, 8-65535: reserved
+// see https://developer.apple.com/library/content/technotes/tn2162/_index.html
+//     https://developer.apple.com/library/content/documentation/QuickTime/QTFF/QTFFChap3/qtff3.html#//apple_ref/doc/uid/TP40000939-CH205-125526
+//     libav pixfmt.h
+#define HB_COLR_PRI_BT709        1
+#define HB_COLR_PRI_UNDEF        2
+#define HB_COLR_PRI_EBUTECH      5 // use for bt470bg
+#define HB_COLR_PRI_SMPTEC       6 // smpte170m; also use for bt470m and smpte240m
+#define HB_COLR_PRI_BT2020       9
+// 0, 3-4, 7-8, 10-65535: reserved/not implemented
+#define HB_COLR_TRA_BT709        1 // also use for bt470m, bt470bg, smpte170m, bt2020_10 and bt2020_12
+#define HB_COLR_TRA_UNDEF        2
+#define HB_COLR_TRA_SMPTE240M    7
+#define HB_COLR_TRA_SMPTEST2084  16
+// 0, 3-6, 8-15, 17-65535: reserved/not implemented
+#define HB_COLR_MAT_BT709        1
+#define HB_COLR_MAT_UNDEF        2
+#define HB_COLR_MAT_SMPTE170M    6 // also use for fcc and bt470bg
+#define HB_COLR_MAT_SMPTE240M    7
+#define HB_COLR_MAT_BT2020_NCL   9
+#define HB_COLR_MAT_BT2020_CL    10
+// 0, 3-5, 8, 11-65535: reserved/not implemented
 
     hb_list_t     * list_chapter;
 

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1697,6 +1697,8 @@ static int get_color_prim(int color_primaries, hb_geometry_t geometry, hb_ration
         case AVCOL_PRI_SMPTE170M:
         case AVCOL_PRI_SMPTE240M:
             return HB_COLR_PRI_SMPTEC;
+        case AVCOL_PRI_BT2020:
+            return HB_COLR_PRI_BT2020;
         default:
         {
             if ((geometry.width >= 1280 || geometry.height >= 720)||
@@ -1719,6 +1721,10 @@ static int get_color_transfer(int color_trc)
     {
         case AVCOL_TRC_SMPTE240M:
             return HB_COLR_TRA_SMPTE240M;
+        /* enable this when implemented in Libav
+        case AVCOL_TRC_SMPTEST2084:
+            return HB_COLR_TRA_SMPTEST2084;
+        */
         default:
             // ITU BT.601, BT.709, anything else
             return HB_COLR_TRA_BT709;
@@ -1738,6 +1744,10 @@ static int get_color_matrix(int colorspace, hb_geometry_t geometry)
             return HB_COLR_MAT_SMPTE170M;
         case AVCOL_SPC_SMPTE240M:
             return HB_COLR_MAT_SMPTE240M;
+        case AVCOL_SPC_BT2020_NCL:
+            return HB_COLR_MAT_BT2020_NCL;
+        case AVCOL_SPC_BT2020_CL:
+            return HB_COLR_MAT_BT2020_CL;
         default:
         {
             if ((geometry.width >= 1280 || geometry.height >= 720)||

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -692,11 +692,17 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     // set and enable colorimetry (video signal information)
     switch (job->color_matrix_code)
     {
-        case 4:
+        case 5:
             // custom
             pv->param.videoSignalInfo.ColourPrimaries         = job->color_prim;
             pv->param.videoSignalInfo.TransferCharacteristics = job->color_transfer;
             pv->param.videoSignalInfo.MatrixCoefficients      = job->color_matrix;
+            break;
+        case 4:
+            // ITU BT.2020 UHD content
+            pv->param.videoSignalInfo.ColourPrimaries         = HB_COLR_PRI_BT2020;
+            pv->param.videoSignalInfo.TransferCharacteristics = HB_COLR_TRA_BT709;
+            pv->param.videoSignalInfo.MatrixCoefficients      = HB_COLR_MAT_BT2020_NCL;
             break;
         case 3:
             // ITU BT.709 HD content

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -369,12 +369,19 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
 
     /* set up the VUI color model & gamma to match what the COLR atom
      * set in muxmp4.c says. See libhb/muxmp4.c for notes. */
-    if( job->color_matrix_code == 4 )
+    if( job->color_matrix_code == 5 )
     {
         // Custom
         param.vui.i_colorprim = job->color_prim;
         param.vui.i_transfer  = job->color_transfer;
         param.vui.i_colmatrix = job->color_matrix;
+    }
+    else if( job->color_matrix_code == 4 )
+    {
+        // ITU BT.2020 UHD content
+        param.vui.i_colorprim = HB_COLR_PRI_BT2020;
+        param.vui.i_transfer  = HB_COLR_TRA_BT709;
+        param.vui.i_colmatrix = HB_COLR_MAT_BT2020_NCL;
     }
     else if( job->color_matrix_code == 3 )
     {

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -174,7 +174,12 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
             strcpy(transfer,    "bt709");
             strcpy(colormatrix, "bt709");
             break;
-        case 4: // custom
+        case 4: // ITU BT.2020 UHD content
+            strcpy(colorprim,   "bt2020");
+            strcpy(transfer,    "bt709");
+            strcpy(colormatrix, "bt2020nc");
+            break;
+        case 5: // custom
             snprintf(colorprim,   sizeof(colorprim),   "%d", job->color_prim);
             snprintf(transfer,    sizeof(transfer),    "%d", job->color_transfer);
             snprintf(colormatrix, sizeof(colormatrix), "%d", job->color_matrix);

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -219,6 +219,11 @@ int hb_ff_get_colorspace(int color_matrix)
         case HB_COLR_MAT_BT709:
             color_space = SWS_CS_ITU709;
             break;
+        /* enable this when implemented in Libav
+        case HB_COLR_MAT_BT2020:
+            color_space = SWS_CS_BT2020;
+            break;
+         */
         default:
             break;
     }

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -501,15 +501,16 @@ void hb_display_job_info(hb_job_t *job)
             }
         }
 
-        if (job->color_matrix_code && (job->vcodec == HB_VCODEC_X264_MASK))
+        if (job->color_matrix_code &&
+        	(job->vcodec == HB_VCODEC_X264_MASK) || (job->vcodec == HB_VCODEC_X265_MASK))
         {
             // color matrix is set:
-            // 1) at the stream    level (x264  only),
-            // 2) at the container level (mp4v2 only)
+            // 1) at the stream    level (x264, x265, qsv  only),
             hb_log("     + custom color matrix: %s",
                    job->color_matrix_code == 1 ? "ITU Bt.601 (NTSC)" :
                    job->color_matrix_code == 2 ? "ITU Bt.601 (PAL)"  :
-                   job->color_matrix_code == 3 ? "ITU Bt.709 (HD)"   : "Custom");
+                   job->color_matrix_code == 3 ? "ITU Bt.709 (HD)"   :
+                   job->color_matrix_code == 4 ? "ITU Bt.2020 (UHD)"   : "Custom");
         }
     }
 

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -350,6 +350,14 @@ static void hb_error_handler(const char *errmsg)
                                       0.1916769, 0.0865638, 0.9583847};
             return CGColorSpaceCreateCalibratedRGB(whitePoint, blackPoint, gamma, matrix);
         }
+        case HB_COLR_PRI_BT2020:
+        {
+            // Rec. 2020
+            const CGFloat matrix[] = {0.6369580, 0.2627002, 0.0000000,
+                                      0.1446169, 0.6779981, 0.0280727,
+                                      0.1688810, 0.0593017, 1.0609851};
+            return CGColorSpaceCreateCalibratedRGB(whitePoint, blackPoint, gamma, matrix);
+        }
         case HB_COLR_PRI_BT709:
         default:
         {

--- a/test/test.c
+++ b/test/test.c
@@ -1530,6 +1530,7 @@ static void ShowHelp()
 "                           (default: set by preset, typically 2)\n"
 "   -M, --color-matrix <string>\n"
 "                           Set the color space signaled by the output:\n"
+"                               2020\n"
 "                               709\n"
 "                               601\n"
 "                               ntsc (same as 601)\n"
@@ -2721,6 +2722,8 @@ static int ParseOptions( int argc, char ** argv )
                         color_matrix_code = 2;
                     else if( !strcmp( optarg, "709" ) )
                         color_matrix_code = 3;
+                    else if( !strcmp( optarg, "2020" ) )
+                        color_matrix_code = 4;
                 } break;
             case MIN_DURATION:
                 min_title_duration = strtol( optarg, NULL, 0 );


### PR DESCRIPTION
We need to pass through the new color tags commonly used for HDR/UHD (add the newest marketing buzzword here).

Caveats:
SWS_CS_BT2020 still not implemented in Libav (yuv<->rgb conversion)
AVCOL_TRC_SMPTEST2084 enum value requires Libav 12
reading Bt.2020 values nclc atom from mov container requires a Libav after version 12 ( https://github.com/libav/libav/commit/4b07ebf1eb13561492f7e3c30a67f34415016b3e )  