### PR TITLE
x265: bump to version 2.3

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,12 +2,12 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.2.tar.gz
-X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.2.tar.gz
-X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.2.tar.gz
-X265.FETCH.sha256  = b872552535e41fbffa03ba7cbcd3479c42c4053868309292e78e147b7773ac4b
-X265.FETCH.basename  = x265_2.2.tar.gz
-X265.EXTRACT.tarbase = x265_2.2
+X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.3.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.3.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.3.tar.gz
+X265.FETCH.sha256  = 47520ac3424790168ea5c2db4a3cf12ca4d55a1790720007916652f07af3e41f
+X265.FETCH.basename  = x265_2.3.tar.gz
+X265.EXTRACT.tarbase = x265_2.3
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -6,8 +6,6 @@ X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.3.tar.gz
 X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.3.tar.gz
 X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.3.tar.gz
 X265.FETCH.sha256  = 47520ac3424790168ea5c2db4a3cf12ca4d55a1790720007916652f07af3e41f
-X265.FETCH.basename  = x265_2.3.tar.gz
-X265.EXTRACT.tarbase = x265_2.3
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,12 +2,12 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.1-1.tar.gz
-X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.1.tar.gz
-X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.1.tar.gz
-X265.FETCH.sha256  = 88fcb9af4ba52c0757ac9c0d8cd5ec79951a22905ae886897e06954353d6a643
-X265.FETCH.basename  = x265_2.1-1.tar.gz
-X265.EXTRACT.tarbase = x265_2.1
+X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.2.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.2.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.2.tar.gz
+X265.FETCH.sha256  = b872552535e41fbffa03ba7cbcd3479c42c4053868309292e78e147b7773ac4b
+X265.FETCH.basename  = x265_2.2.tar.gz
+X265.EXTRACT.tarbase = x265_2.2
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
x265 2.3
-----------
Encoder enhancements
----------------------------------
1. New SSIM-based RD-cost computation for improved visual quality,
   and efficiency; use --ssim-rd to exercise.
2. Multi-pass encoding can now share analysis information from prior
   passes (in addition to rate-control information) to improve performance
   and quality of subsequent passes; to your multi-pass command-lines that
   use the --pass option, add --multi-pass-opt-distortion to share
   distortion information, and --multi-pass-opt-analysis to share other
   analysis information.
3. A dedicated thread pool for lookahead can now be specified with
   --lookahead-threads.
4. --dynamic-rd dynamically increase analysis in areas where the bitrate
   is being capped by VBV; works for both CRF and ABR encodes with VBV
   settings.
5. The number of bits used to signal the delta-QP can be optimized with
   the --opt-cu-delta-qp option; found to be useful in some scenarios for
   lower bitrate targets.
6. Experimental feature option:–aq-motion adds new QP offsets based on
   relative motion of a block with respect to the movement of the frame.

API changes
-------------------
1. Reconfigure API now supports signalling new scaling lists.
2. x265 application’s csv functionality now reports time (in milliseconds)
   taken to encode each frame.
3. --strict-cbr enables stricter bitrate adherence by adding filler bits
   when achieved bitrate is lower than the target; earlier, it was only
   reacting when the achieved rate was higher.
4. --hdr can be used to ensure that max-cll and max-fall values are
   always signaled (even if 0,0).

Bug fixes
--------------
1. Fixed incorrect HW thread counting on MacOS platform.
2. Fixed scaling lists support for 4:4:4 videos.
3. Inconsistent output fix for --opt-qp-pss by removing last slice’s
   QP from cost calculation.
4. VTune profiling (enabled using ENABLE_VTUNE CMake option) now also
   works with 2017 VTune builds.

x265 2.2
-----------
Encoder enhancements
----------------------------------
1. Enhancements to TU selection algorithm with early-outs for improved
speed; use --limit-tu to exercise.
2. New motion search method SEA (Successive Elimination Algorithm)
supported now as –me 4
3. Bit-stream optimizations to improve fields in PPS and SPS for
bit-rate savings through --[no-]opt-qp-pps,
--[no-]opt-ref-list-length-pps, and --[no-]multi-pass-opt-rps.
4. Enabled using VBV constraints when encoding without WPP.
5. All param options dumped in SEI packet in bitstream when info
selected.
6. x265 now supports POWERPC-based systems. Several key functions also
have optimized ALTIVEC kernels.

API changes
-------------------
1. Options to disable SEI and optional-VUI messages from bitstream made
more descriptive.
2. New option --scenecut-bias to enable controlling bias to mark
scene-cuts via cli.
3. Support mono and mono16 color spaces for y4m input.
4. --min-cu-size of 64 no-longer supported for reasons of visual quality
(was crashing earlier anyways.)
5. API for CSV now expects version string for better integration of x265
into other applications.

Bug fixes
--------------
1. Several fixes to slice-based encoding.
2. --log2-max-poc-lsb‘s range limited according to HEVC spec.
3. Restrict MVs to within legal boundaries when encoding.