### PR TITLE
Draw text (on Dock) using monospaced digits

### DIFF
--- a/macosx/DockTextField.m
+++ b/macosx/DockTextField.m
@@ -37,7 +37,16 @@
 {
     if (self.isHidden)
         return;
-    
+
+    NSFont *font;
+    if ([[NSFont class] respondsToSelector:@selector(monospacedDigitSystemFontOfSize:weight:)]) {
+        // On macOS 10.11+ the monospaced digit system is available.
+        font = [NSFont monospacedDigitSystemFontOfSize:DOCK_TEXTFIELD_FONTSIZE weight:NSFontWeightBold];
+    } else {
+        // macOS 10.10- use the default system font.
+        font = [NSFont boldSystemFontOfSize:DOCK_TEXTFIELD_FONTSIZE];
+    }
+
     NSRect blackOutlineFrame = NSMakeRect(0.0, 0.0, [self bounds].size.width, [self bounds].size.height-1.0);
     double radius = self.bounds.size.height / 2;
 
@@ -46,7 +55,7 @@
     
     NSMutableDictionary *drawStringAttributes = [[NSMutableDictionary alloc] init];
 	[drawStringAttributes setValue:[NSColor whiteColor] forKey:NSForegroundColorAttributeName];
-    [drawStringAttributes setValue:[NSFont boldSystemFontOfSize:DOCK_TEXTFIELD_FONTSIZE] forKey:NSFontAttributeName];
+    [drawStringAttributes setValue:font forKey:NSFontAttributeName];
 	NSShadow *stringShadow = [[NSShadow alloc] init];
 	[stringShadow setShadowColor:[NSColor blackColor]];
 	NSSize shadowSize;


### PR DESCRIPTION
According to [Apple](https://developer.apple.com/videos/play/wwdc2015/804/), instead of monospaced digits, macOS 10.11+ displays proportional numbers by default. The code in this pull request fixes that, at least for progress drawn over the Dock icon.

(Note I'm **not** using a monospaced font, only the digits are monospaced)