### PR TITLE
libhb: force title rescan after completing a job encode

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -659,6 +659,11 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
                                    store_previews, min_duration );
 }
 
+void hb_force_rescan( hb_handle_t * h )
+{
+    h->title_set.path[0] = 0;
+}
+
 /**
  * Returns the list of titles found.
  * @param h Handle to hb_handle_t

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -58,6 +58,7 @@ void          hb_scan( hb_handle_t *, const char * path,
                        int title_index, int preview_count,
                        int store_previews, uint64_t min_duration );
 void          hb_scan_stop( hb_handle_t * );
+void          hb_force_rescan( hb_handle_t * );
 uint64_t      hb_first_duration( hb_handle_t * );
 
 /* hb_get_titles()

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -92,6 +92,8 @@ static void work_func( void * _work )
 
     while( !*work->die && ( job = hb_list_item( work->jobs, 0 ) ) )
     {
+        hb_handle_t * h = job->h;
+
         hb_list_rem( work->jobs, job );
         hb_list_t * passes = hb_list_init();
 
@@ -143,6 +145,10 @@ static void work_func( void * _work )
             hb_job_close(&job);
         }
         hb_list_close(&passes);
+
+        // Force rescan of next source processed by this hb_handle_t
+        // TODO: Fix this ugly hack!
+        hb_force_rescan(h);
     }
 
     free( work );


### PR DESCRIPTION
Fixes https://forum.handbrake.fr/viewtopic.php?f=12&t=35583