### PR TITLE
opencl: Workaround broken drivers that crash when you call clGetPlatf…

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -143,7 +143,7 @@ int hb_avcodec_open(AVCodecContext *avctx, AVCodec *codec,
     return ret;
 }
 
-int hb_get_opencl_enabled (hb_handle_t * h)
+int hb_get_opencl_enabled(hb_handle_t * h)
 {
     return h->enable_opencl;
 }

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -416,19 +416,20 @@ void hb_log_level_set(hb_handle_t *h, int level)
     global_verbosity_level = level;
 }
 
-
-hb_handle_t * hb_init( int verbose )
+/*
+ * Enable or disable support for OpenCL detection.
+ */
+void hb_opencl_status_set(hb_handle_t *h, int enable_opencl)
 {
-    return (hb_handle_t *) hb_init_cl(verbose, 0); // Default OpenCL to OFF.
+    h->enable_opencl = enable_opencl;
 }
 
 /**
  * libhb initialization routine.
  * @param verbose HB_DEBUG_NONE or HB_DEBUG_ALL.
- * @param Enable OpenCL detection and support.
  * @return Handle to hb_handle_t for use on all subsequent calls to libhb.
  */
-hb_handle_t * hb_init_cl( int verbose, int enable_opencl )
+hb_handle_t * hb_init_cl( int verbose )
 {
     hb_handle_t * h = calloc( sizeof( hb_handle_t ), 1 );
 
@@ -449,8 +450,6 @@ hb_handle_t * hb_init_cl( int verbose, int enable_opencl )
     h->pause_lock = hb_lock_init();
 
     h->interjob = calloc( sizeof( hb_interjob_t ), 1 );
-    
-    h->enable_opencl = enable_opencl;
 
     /* Start library thread */
     hb_log( "hb_init: starting libhb thread" );

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -644,7 +644,10 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     hb_log(" - logical processor count: %d", hb_get_cpu_count());
 
     /* Print OpenCL info here so that it's in all scan and encode logs */
-    hb_opencl_info_print();
+    if (h->enable_opencl)
+    {
+        hb_opencl_info_print();
+    }
 
 #ifdef USE_QSV
     /* Print QSV info here so that it's in all scan and encode logs */

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -143,7 +143,7 @@ int hb_avcodec_open(AVCodecContext *avctx, AVCodec *codec,
     return ret;
 }
 
-int hb_get_opencl_enabled(hb_handle_t * h)
+int hb_get_opencl_enabled(hb_handle_t *h)
 {
     return h->enable_opencl;
 }

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -429,7 +429,7 @@ void hb_opencl_status_set(hb_handle_t *h, int enable_opencl)
  * @param verbose HB_DEBUG_NONE or HB_DEBUG_ALL.
  * @return Handle to hb_handle_t for use on all subsequent calls to libhb.
  */
-hb_handle_t * hb_init_cl( int verbose )
+hb_handle_t * hb_init( int verbose )
 {
     hb_handle_t * h = calloc( sizeof( hb_handle_t ), 1 );
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -419,7 +419,7 @@ void hb_log_level_set(hb_handle_t *h, int level)
 /*
  * Enable or disable support for OpenCL detection.
  */
-void hb_opencl_status_set(hb_handle_t *h, int enable_opencl)
+void hb_opencl_set_enable(hb_handle_t *h, int enable_opencl)
 {
     h->enable_opencl = enable_opencl;
 }
@@ -441,7 +441,7 @@ hb_handle_t * hb_init( int verbose )
     /* Initialize opaque for PowerManagement purposes */
     h->system_sleep_opaque = hb_system_sleep_opaque_init();
 
-    h->title_set.list_title = hb_list_init();
+	h->title_set.list_title = hb_list_init();
     h->jobs       = hb_list_init();
 
     h->state_lock  = hb_lock_init();
@@ -643,7 +643,7 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     hb_log(" - logical processor count: %d", hb_get_cpu_count());
 
     /* Print OpenCL info here so that it's in all scan and encode logs */
-    if (h->enable_opencl)
+    if (hb_get_opencl_enabled(h))
     {
         hb_opencl_info_print();
     }

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -49,7 +49,7 @@ int           hb_check_update( hb_handle_t * h, char ** version );
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
 
-int           hb_opencl_set_enable(hb_handle_t *h);
+int           hb_opencl_set_enable(hb_handle_t *h, int enable_opencl);
 
 /* hb_scan()
    Scan the specified path. Can be a DVD device, a VIDEO_TS folder or

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -32,7 +32,7 @@ void          hb_register( hb_work_object_t * );
 void          hb_register_logger( void (*log_cb)(const char* message) );
 hb_handle_t * hb_init( int verbose );
 void          hb_log_level_set(hb_handle_t *h, int level);
-void          hb_opencl_status_set(hb_handle_t *h, int enable_opencl);
+void          hb_opencl_set_enable(hb_handle_t *h, int enable_opencl);
 
 /* hb_get_version() */
 const char  * hb_get_full_description();
@@ -49,7 +49,7 @@ int           hb_check_update( hb_handle_t * h, char ** version );
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
 
-int           hb_opencl_set_enable(hb_handle_t *h, int enable_opencl);
+int           hb_get_opencl_enabled(hb_handle_t *h);
 
 /* hb_scan()
    Scan the specified path. Can be a DVD device, a VIDEO_TS folder or

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -31,8 +31,8 @@ extern "C" {
 void          hb_register( hb_work_object_t * );
 void          hb_register_logger( void (*log_cb)(const char* message) );
 hb_handle_t * hb_init( int verbose );
-hb_handle_t * hb_init_cl( int verbose, int enable_opencl );
 void          hb_log_level_set(hb_handle_t *h, int level);
+void          hb_opencl_status_set(hb_handle_t *h, int enable_opencl);
 
 /* hb_get_version() */
 const char  * hb_get_full_description();

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -31,6 +31,7 @@ extern "C" {
 void          hb_register( hb_work_object_t * );
 void          hb_register_logger( void (*log_cb)(const char* message) );
 hb_handle_t * hb_init( int verbose );
+hb_handle_t * hb_init_cl( int verbose, int enable_opencl );
 void          hb_log_level_set(hb_handle_t *h, int level);
 
 /* hb_get_version() */
@@ -47,6 +48,8 @@ int           hb_check_update( hb_handle_t * h, char ** version );
 
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
+
+int           hb_get_opencl_enabled (hb_handle_t * h);
 
 /* hb_scan()
    Scan the specified path. Can be a DVD device, a VIDEO_TS folder or

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -49,7 +49,7 @@ int           hb_check_update( hb_handle_t * h, char ** version );
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
 
-int           hb_get_opencl_enabled (hb_handle_t * h);
+int           hb_opencl_set_enable(hb_handle_t *h);
 
 /* hb_scan()
    Scan the specified path. Can be a DVD device, a VIDEO_TS folder or

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1022,7 +1022,7 @@ skip_preview:
 
         // TODO: check video dimensions
         hb_handle_t * hb_handle = (hb_handle_t *)data->h;
-        if (hb_opencl_set_enable(hb_handle)
+        if (hb_get_opencl_enabled(hb_handle)
         {
              title->opencl_support = !!hb_opencl_available();
         }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1021,8 +1021,13 @@ skip_preview:
         title->video_decode_support = vid_info.video_decode_support;
 
         // TODO: check video dimensions
-        title->opencl_support = !!hb_opencl_available();
-
+        hb_handle_t * hb_handle = (hb_handle_t *)data->h;
+        int enable_opencl = hb_get_opencl_enabled(hb_handle);
+        if (enable_opencl)
+        {
+             title->opencl_support = !!hb_opencl_available();
+        }
+        
         // compute the aspect ratio based on the storage dimensions and PAR.
         hb_reduce(&title->dar.num, &title->dar.den,
                   title->geometry.par.num * title->geometry.width,

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1022,8 +1022,7 @@ skip_preview:
 
         // TODO: check video dimensions
         hb_handle_t * hb_handle = (hb_handle_t *)data->h;
-        int enable_opencl = hb_get_opencl_enabled(hb_handle);
-        if (enable_opencl)
+        if (hb_opencl_set_enable(hb_handle)
         {
              title->opencl_support = !!hb_opencl_available();
         }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1022,7 +1022,7 @@ skip_preview:
 
         // TODO: check video dimensions
         hb_handle_t * hb_handle = (hb_handle_t *)data->h;
-        if (hb_get_opencl_enabled(hb_handle)
+        if (hb_get_opencl_enabled(hb_handle))
         {
              title->opencl_support = !!hb_opencl_available();
         }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1021,7 +1021,7 @@ skip_preview:
         title->video_decode_support = vid_info.video_decode_support;
 
         // TODO: check video dimensions
-        hb_handle_t * hb_handle = (hb_handle_t *)data->h;
+        hb_handle_t *hb_handle = (hb_handle_t *)data->h;
         if (hb_get_opencl_enabled(hb_handle))
         {
              title->opencl_support = !!hb_opencl_available();


### PR DESCRIPTION
…ormIDs with valid inputs.We have a crash in  clGetPlatformIDS

https://github.com/HandBrake/HandBrake/blob/3f1f6175ce804dd46ce4d3913611477731389a9f/libhb/opencl.c#L259

`  cl_device_id *device_ids = NULL;
    hb_opencl_device_t *device = NULL;
    cl_platform_id *platform_ids = NULL;
    cl_uint i, j, num_platforms, num_devices;
    if (opencl->clGetPlatformIDs(0, NULL, &num_platforms) != CL_SUCCESS || !num_platforms)
    `

What appears to be happening, is the NULL pointer is getting accesseed which is causing the stack to die with a seg fault. 

It appears to be a bug in the Intel OpenCL Driver but I'm wondering if we can figure out a workaround to stop the crash and goto fail.

`Scanning title 1 of 1, preview 10, 100.00 %
Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 1748.0x2830]
0x00007ffbf541a74a in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
(gdb) bt
#0  0x00007ffbf541a74a in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
#1  0x00007ffbf541836b in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
#2  0x00007ffbf54a6e97 in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
#3  0x00007ffbf54a2bae in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
#4  0x00007ffbf54a2d77 in igdrcl64!clGetCLObjectInfoINTEL () from C:\WINDOWS\SYSTEM32\igdrcl64.dll
#5  0x00007ffc36cfa35f in ntdll!RtlDeactivateActivationContextUnsafeFast () from C:\WINDOWS\SYSTEM32\ntdll.dll
#6  0x00007ffc36ce3d2d in ntdll!LdrUnloadAlternateResourceModuleEx () from C:\WINDOWS\SYSTEM32\ntdll.dll
#7  0x00007ffc36ce1621 in ntdll!RtlCreateHeap () from C:\WINDOWS\SYSTEM32\ntdll.dll
#8  0x00007ffc36d1eefc in ntdll!LdrUnloadDll () from C:\WINDOWS\SYSTEM32\ntdll.dll
#9  0x00007ffc36d1ee24 in ntdll!LdrUnloadDll () from C:\WINDOWS\SYSTEM32\ntdll.dll
#10 0x00007ffc3406248d in KERNELBASE!FreeLibrary () from C:\WINDOWS\System32\KernelBase.dll
#11 0x00007ffc01ab10bf in clGetDeviceIDsFromDX9MediaAdapterKHR () from C:\WINDOWS\SYSTEM32\IntelOpenCL64.dll
#12 0x00007ffc01a9110b in clGetPlatformIDs () from C:\WINDOWS\SYSTEM32\IntelOpenCL64.dll
#13 0x00007ffc280510ba in ?? () from C:\WINDOWS\SYSTEM32\OpenCL.dll
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
(gdb)`