### PR TITLE
opencl: fixing leaks for clBuffers

### DIFF
--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -142,6 +142,10 @@ static void hb_crop_scale_close( hb_filter_object_t * filter )
         {
             HB_OCL_BUF_FREE(hb_ocl, pv->os->bicubic_x_weights);
             HB_OCL_BUF_FREE(hb_ocl, pv->os->bicubic_y_weights);
+            if (pv->os->initialized == 1)
+            {
+                hb_ocl->clReleaseKernel(pv->os->m_kernel);
+            }
         }
         free(pv->os);
     }

--- a/libhb/openclwrapper.c
+++ b/libhb/openclwrapper.c
@@ -1126,6 +1126,11 @@ int hb_cl_free_mapped_buffer(cl_mem mem, unsigned char *addr)
         hb_ocl->clWaitForEvents(1, &event);
     else
         hb_log("hb_free_mapped_buffer: error %d", status);
+
+    status = hb_ocl->clReleaseMemObject(mem);
+    if (status != CL_SUCCESS)
+        hb_log("hb_free_mapped_buffer: release error %d",status);
+
     return (status == CL_SUCCESS) ? 1 : 0;
 }
 

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1831,6 +1831,12 @@ cleanup:
     }
 
     hb_buffer_pool_free();
+
+    if (job->use_opencl)
+    {
+        hb_release_opencl_run_env();
+    }
+
     hb_job_close(&job);
 }
 


### PR DESCRIPTION
should help to fix: https://github.com/HandBrake/HandBrake/issues/503

before:
     39 unique,   154 total, **543164236** byte(s) of potential possible leak(s)
after:
     35 unique,   121 total, **19527570** byte(s) of potential possible leak(s)

additional tests would be good 