### PR TITLE
Enabled "Per monitor DPI awareness"

### DIFF
--- a/win/CS/HandBrakeWPF/app.config
+++ b/win/CS/HandBrakeWPF/app.config
@@ -3,4 +3,8 @@
   <startup>
     <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
   </startup>
+  <runtime>
+    <!-- Required for "Per monitor DPI scaling" on .NET < 4.6.2 -->
+    <AppContextSwitchOverrides value="Switch.System.Windows.DoNotScaleForDpiChanges=false"/>
+  </runtime>
 </configuration>

--- a/win/CS/HandBrakeWPF/app.manifest
+++ b/win/CS/HandBrakeWPF/app.manifest
@@ -60,4 +60,14 @@
     </dependentAssembly>
   </dependency>
 
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- The combination of below two tags have the following effect : 
+      1) Per-Monitor for >= Windows 10 Anniversary Update
+      2) System < Windows 10 Anniversary Update -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings"> PerMonitor</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+    </windowsSettings>
+  </application>
+
 </assembly>


### PR DESCRIPTION
This commit adds entries to app.config and app.manifest to enable per monitor DPI awareness in Windows 10. The application will behave as before on platforms that do not support this.

Handbrake currently supports system-wide DPI scaling because WPF supports this by default. However, it does not support per-monitor DPI awareness. This is a new feature in Windows 10 that allows the DPI scaling factor to be different across monitors. This commit adds support for this feature.

The implementation was done using official Microsoft documentation:
https://github.com/Microsoft/WPF-Samples/tree/master/PerMonitorDPI