### PR TITLE
subtitles: simplify and shorten subtitle descriptions

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -2352,8 +2352,7 @@ subtitle_track_opts_set(signal_user_data_t *ud, const gchar *name,
         char idx[4];
 
         subtitle = hb_list_item(title->list_subtitle, ii);
-        opt = g_strdup_printf("%d - %s (%s)", ii+1, subtitle->lang,
-                              hb_subsource_name(subtitle->source));
+        opt = g_strdup_printf("%d - %s", ii+1, subtitle->lang);
         snprintf(idx, 4, "%d", ii);
 
         gtk_list_store_append(store, &iter);

--- a/gtk/src/subtitlehandler.c
+++ b/gtk/src/subtitlehandler.c
@@ -386,9 +386,7 @@ subtitle_get_track_description(GhbValue *settings, GhbValue *subsettings)
             subtitle = ghb_get_subtitle_info(title, track);
             if (subtitle != NULL)
             {
-                desc = g_strdup_printf("%d - %s (%s)", track + 1,
-                                       subtitle->lang,
-                                       hb_subsource_name(subtitle->source));
+                desc = g_strdup_printf("%d - %s", track + 1, subtitle->lang);
             }
         }
     }

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -95,11 +95,6 @@ static void add_subtitle(int track, hb_list_t *list_subtitle, BLURAY_STREAM_INFO
 
     subtitle->track = track;
     subtitle->id = bdsub->pid;
-    lang = lang_for_code2( (char*)bdsub->lang );
-    snprintf( subtitle->lang, sizeof( subtitle->lang ), "%s",
-              strlen(lang->native_name) ? lang->native_name : lang->eng_name);
-    snprintf( subtitle->iso639_2, sizeof( subtitle->iso639_2 ), "%s",
-              lang->iso639_2);
 
     switch ( bdsub->coding_type )
     {
@@ -113,6 +108,13 @@ static void add_subtitle(int track, hb_list_t *list_subtitle, BLURAY_STREAM_INFO
             free( subtitle );
             return;
     }
+    lang = lang_for_code2( (char*)bdsub->lang );
+    snprintf(subtitle->lang, sizeof( subtitle->lang ), "%s [%s]",
+             strlen(lang->native_name) ? lang->native_name : lang->eng_name,
+             hb_subsource_name(subtitle->source));
+    snprintf(subtitle->iso639_2, sizeof( subtitle->iso639_2 ), "%s",
+             lang->iso639_2);
+
     subtitle->reg_desc = STR4_TO_UINT32("HDMV");
     subtitle->stream_type = bdsub->coding_type;
     subtitle->codec = codec;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4682,10 +4682,10 @@ int hb_subtitle_add(const hb_job_t * job, const hb_subtitle_config_t * subtitlec
 
 int hb_srt_add( const hb_job_t * job,
                 const hb_subtitle_config_t * subtitlecfg,
-                const char *lang )
+                const char *lang_code )
 {
     hb_subtitle_t *subtitle;
-    iso639_lang_t *language = NULL;
+    iso639_lang_t *lang = NULL;
 
     subtitle = calloc( 1, sizeof( *subtitle ) );
     if (subtitle == NULL)
@@ -4699,14 +4699,16 @@ int hb_srt_add( const hb_job_t * job,
     subtitle->source = SRTSUB;
     subtitle->codec = WORK_DECSRTSUB;
 
-    language = lang_for_code2(lang);
-    if (language == NULL)
+    lang = lang_for_code2(lang_code);
+    if (lang == NULL)
     {
-        hb_log("hb_srt_add: unknown language code (%s)", lang);
-        language = lang_for_code2("und");
+        hb_log("hb_srt_add: unknown language code (%s)", lang_code);
+        lang = lang_for_code2("und");
     }
-    strcpy(subtitle->lang, language->eng_name);
-    strcpy(subtitle->iso639_2, language->iso639_2);
+    snprintf(subtitle->lang, sizeof(subtitle->lang), "%s [%s]",
+             strlen(lang->native_name) ? lang->native_name : lang->eng_name,
+             hb_subsource_name(subtitle->source));
+    strcpy(subtitle->iso639_2, lang->iso639_2);
 
     subtitle->config = *subtitlecfg;
     hb_list_add(job->list_subtitle, subtitle);

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -242,22 +242,22 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
             break;
     }
 
-    strcat(subtitle->lang, " [");
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat(subtitle->lang, "4:3, ");
+            strcat(subtitle->lang, ", 4:3");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat(subtitle->lang, "Wide Screen, ");
+            strcat(subtitle->lang, ", Wide Screen");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat(subtitle->lang, "Letterbox, ");
+            strcat(subtitle->lang, ", Letterbox");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat(subtitle->lang, "Pan & Scan, ");
+            strcat(subtitle->lang, ", Pan & Scan");
             break;
     }
+    strcat(subtitle->lang, " [");
     strcat(subtitle->lang, hb_subsource_name(subtitle->source));
     strcat(subtitle->lang, "]");
 

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -213,53 +213,56 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (lang_extension)
     {
         case 2:
-            strcat( subtitle->lang, " (Caption with bigger size character)" );
+            strcat(subtitle->lang, ", Large Type");
             break;
         case 3:
-            strcat( subtitle->lang, " (Caption for Children)" );
+            strcat(subtitle->lang, ", Children");
             break;
         case 5:
-            strcat( subtitle->lang, " (Closed Caption)" );
+            strcat(subtitle->lang, ", Closed Caption");
             break;
         case 6:
-            strcat( subtitle->lang, " (Closed Caption with bigger size character)" );
+            strcat(subtitle->lang, ", Closed Caption, Large Type");
             break;
         case 7:
-            strcat( subtitle->lang, " (Closed Caption for Children)" );
+            strcat(subtitle->lang, ", Closed Caption, Children");
             break;
         case 9:
-            strcat( subtitle->lang, " (Forced Caption)" );
+            strcat(subtitle->lang, ", Forced");
             break;
         case 13:
-            strcat( subtitle->lang, " (Director's Commentary)" );
+            strcat(subtitle->lang, ", Director's Commentary");
             break;
         case 14:
-            strcat( subtitle->lang, " (Director's Commentary with bigger size character)" );
+            strcat(subtitle->lang, ", Director's Commentary, Large Type");
             break;
         case 15:
-            strcat( subtitle->lang, " (Director's Commentary for Children)" );
+            strcat(subtitle->lang, " (Director's Commentary, Children");
         default:
             break;
     }
 
+    strcat(subtitle->lang, " [");
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat( subtitle->lang, " (4:3)" );
+            strcat(subtitle->lang, "4:3, ");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat( subtitle->lang, " (Wide Screen)" );
+            strcat(subtitle->lang, "Wide Screen, ");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat( subtitle->lang, " (Letterbox)" );
+            strcat(subtitle->lang, "Letterbox, ");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat( subtitle->lang, " (Pan & Scan)" );
+            strcat(subtitle->lang, "Pan & Scan, ");
             break;
     }
+    strcat(subtitle->lang, hb_subsource_name(subtitle->source));
+    strcat(subtitle->lang, "]");
 
-    hb_log( "scan: id=0x%x, lang=%s, 3cc=%s ext=%i", subtitle->id,
-            subtitle->lang, subtitle->iso639_2, lang_extension );
+    hb_log("scan: id=0x%x, lang=%s, 3cc=%s ext=%i", subtitle->id,
+           subtitle->lang, subtitle->iso639_2, lang_extension);
 
     hb_list_add(list_subtitle, subtitle);
 }

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -213,31 +213,31 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (lang_extension)
     {
         case 2:
-            strcat(subtitle->lang, ", Large Type");
+            strcat(subtitle->lang, " Large Type");
             break;
         case 3:
-            strcat(subtitle->lang, ", Children");
+            strcat(subtitle->lang, " Children");
             break;
         case 5:
-            strcat(subtitle->lang, ", Closed Caption");
+            strcat(subtitle->lang, " Closed Caption");
             break;
         case 6:
-            strcat(subtitle->lang, ", Closed Caption, Large Type");
+            strcat(subtitle->lang, " Closed Caption, Large Type");
             break;
         case 7:
-            strcat(subtitle->lang, ", Closed Caption, Children");
+            strcat(subtitle->lang, " Closed Caption, Children");
             break;
         case 9:
-            strcat(subtitle->lang, ", Forced");
+            strcat(subtitle->lang, " Forced");
             break;
         case 13:
-            strcat(subtitle->lang, ", Director's Commentary");
+            strcat(subtitle->lang, " Director's Commentary");
             break;
         case 14:
-            strcat(subtitle->lang, ", Director's Commentary, Large Type");
+            strcat(subtitle->lang, " Director's Commentary, Large Type");
             break;
         case 15:
-            strcat(subtitle->lang, ", Director's Commentary, Children");
+            strcat(subtitle->lang, " Director's Commentary, Children");
         default:
             break;
     }
@@ -245,16 +245,16 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat(subtitle->lang, ", 4:3");
+            strcat(subtitle->lang, " (4:3)");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat(subtitle->lang, ", Wide Screen");
+            strcat(subtitle->lang, " (Wide Screen)");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat(subtitle->lang, ", Letterbox");
+            strcat(subtitle->lang, " (Letterbox)");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat(subtitle->lang, ", Pan & Scan");
+            strcat(subtitle->lang, " (Pan & Scan)");
             break;
     }
     strcat(subtitle->lang, " [");

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -237,7 +237,7 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
             strcat(subtitle->lang, ", Director's Commentary, Large Type");
             break;
         case 15:
-            strcat(subtitle->lang, " (Director's Commentary, Children");
+            strcat(subtitle->lang, ", Director's Commentary, Children");
         default:
             break;
     }

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -381,7 +381,7 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
             strcat(subtitle->lang, ", Director's Commentary, Large Type");
             break;
         case 15:
-            strcat(subtitle->lang, " (Director's Commentary, Children");
+            strcat(subtitle->lang, ", Director's Commentary, Children");
         default:
             break;
     }

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -386,22 +386,22 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
             break;
     }
 
-    strcat(subtitle->lang, " [");
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat(subtitle->lang, "4:3, ");
+            strcat(subtitle->lang, ", 4:3");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat(subtitle->lang, "Wide Screen, ");
+            strcat(subtitle->lang, ", Wide Screen");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat(subtitle->lang, "Letterbox, ");
+            strcat(subtitle->lang, ", Letterbox");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat(subtitle->lang, "Pan & Scan, ");
+            strcat(subtitle->lang, ", Pan & Scan");
             break;
     }
+    strcat(subtitle->lang, " [");
     strcat(subtitle->lang, hb_subsource_name(subtitle->source));
     strcat(subtitle->lang, "]");
 

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -357,53 +357,56 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (lang_extension)
     {
         case 2:
-            strcat( subtitle->lang, " (Caption with bigger size character)" );
+            strcat(subtitle->lang, ", Large Type");
             break;
         case 3:
-            strcat( subtitle->lang, " (Caption for Children)" );
+            strcat(subtitle->lang, ", Children");
             break;
         case 5:
-            strcat( subtitle->lang, " (Closed Caption)" );
+            strcat(subtitle->lang, ", Closed Caption");
             break;
         case 6:
-            strcat( subtitle->lang, " (Closed Caption with bigger size character)" );
+            strcat(subtitle->lang, ", Closed Caption, Large Type");
             break;
         case 7:
-            strcat( subtitle->lang, " (Closed Caption for Children)" );
+            strcat(subtitle->lang, ", Closed Caption, Children");
             break;
         case 9:
-            strcat( subtitle->lang, " (Forced Caption)" );
+            strcat(subtitle->lang, ", Forced");
             break;
         case 13:
-            strcat( subtitle->lang, " (Director's Commentary)" );
+            strcat(subtitle->lang, ", Director's Commentary");
             break;
         case 14:
-            strcat( subtitle->lang, " (Director's Commentary with bigger size character)" );
+            strcat(subtitle->lang, ", Director's Commentary, Large Type");
             break;
         case 15:
-            strcat( subtitle->lang, " (Director's Commentary for Children)" );
+            strcat(subtitle->lang, " (Director's Commentary, Children");
         default:
             break;
     }
 
+    strcat(subtitle->lang, " [");
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat( subtitle->lang, " (4:3)" );
+            strcat(subtitle->lang, "4:3, ");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat( subtitle->lang, " (Wide Screen)" );
+            strcat(subtitle->lang, "Wide Screen, ");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat( subtitle->lang, " (Letterbox)" );
+            strcat(subtitle->lang, "Letterbox, ");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat( subtitle->lang, " (Pan & Scan)" );
+            strcat(subtitle->lang, "Pan & Scan, ");
             break;
     }
+    strcat(subtitle->lang, hb_subsource_name(subtitle->source));
+    strcat(subtitle->lang, "]");
 
-    hb_log( "scan: id=0x%x, lang=%s, 3cc=%s ext=%i", subtitle->id,
-            subtitle->lang, subtitle->iso639_2, lang_extension );
+    hb_log("scan: id=0x%x, lang=%s, 3cc=%s ext=%i", subtitle->id,
+           subtitle->lang, subtitle->iso639_2, lang_extension);
 
     hb_list_add(list_subtitle, subtitle);
 }

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -357,31 +357,31 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (lang_extension)
     {
         case 2:
-            strcat(subtitle->lang, ", Large Type");
+            strcat(subtitle->lang, " Large Type");
             break;
         case 3:
-            strcat(subtitle->lang, ", Children");
+            strcat(subtitle->lang, " Children");
             break;
         case 5:
-            strcat(subtitle->lang, ", Closed Caption");
+            strcat(subtitle->lang, " Closed Caption");
             break;
         case 6:
-            strcat(subtitle->lang, ", Closed Caption, Large Type");
+            strcat(subtitle->lang, " Closed Caption, Large Type");
             break;
         case 7:
-            strcat(subtitle->lang, ", Closed Caption, Children");
+            strcat(subtitle->lang, " Closed Caption, Children");
             break;
         case 9:
-            strcat(subtitle->lang, ", Forced");
+            strcat(subtitle->lang, " Forced");
             break;
         case 13:
-            strcat(subtitle->lang, ", Director's Commentary");
+            strcat(subtitle->lang, " Director's Commentary");
             break;
         case 14:
-            strcat(subtitle->lang, ", Director's Commentary, Large Type");
+            strcat(subtitle->lang, " Director's Commentary, Large Type");
             break;
         case 15:
-            strcat(subtitle->lang, ", Director's Commentary, Children");
+            strcat(subtitle->lang, " Director's Commentary, Children");
         default:
             break;
     }
@@ -389,16 +389,16 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     switch (style)
     {
         case HB_VOBSUB_STYLE_4_3:
-            strcat(subtitle->lang, ", 4:3");
+            strcat(subtitle->lang, " (4:3)");
             break;
         case HB_VOBSUB_STYLE_WIDE:
-            strcat(subtitle->lang, ", Wide Screen");
+            strcat(subtitle->lang, " (Wide Screen)");
             break;
         case HB_VOBSUB_STYLE_LETTERBOX:
-            strcat(subtitle->lang, ", Letterbox");
+            strcat(subtitle->lang, " (Letterbox)");
             break;
         case HB_VOBSUB_STYLE_PANSCAN:
-            strcat(subtitle->lang, ", Pan & Scan");
+            strcat(subtitle->lang, " (Pan & Scan)");
             break;
     }
     strcat(subtitle->lang, " [");

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -537,29 +537,33 @@ void hb_display_job_info(hb_job_t *job)
         {
             if( job->indepth_scan )
             {
-                hb_log( "   + subtitle, %s (track %d, id 0x%x) %s [%s]",
+                hb_log( "   + subtitle, %s (track %d, id 0x%x, %s)",
                         subtitle->lang, subtitle->track, subtitle->id,
-                        subtitle->format == PICTURESUB ? "Picture" : "Text",
-                        hb_subsource_name( subtitle->source ) );
+                        subtitle->format == PICTURESUB ? "Picture" : "Text");
             }
             else if( subtitle->source == SRTSUB )
             {
                 /* For SRT, print offset and charset too */
-                hb_log( " * subtitle track %d, %s (track %d, id 0x%x) Text [SRT] -> %s%s, offset: %"PRId64", charset: %s",
-                        subtitle->out_track, subtitle->lang, subtitle->track, subtitle->id,
-                        subtitle->config.dest == RENDERSUB ? "Render/Burn-in" : "Passthrough",
-                        subtitle->config.default_track ? ", Default" : "",
-                        subtitle->config.offset, subtitle->config.src_codeset );
+                hb_log(" * subtitle track %d, %s (track %d, id 0x%x, Text) -> "
+                       "%s%s, offset: %"PRId64", charset: %s",
+                       subtitle->out_track, subtitle->lang, subtitle->track,
+                       subtitle->id,
+                       subtitle->config.dest == RENDERSUB ? "Render/Burn-in"
+                                                          : "Passthrough",
+                       subtitle->config.default_track ? ", Default" : "",
+                       subtitle->config.offset, subtitle->config.src_codeset);
             }
             else
             {
-                hb_log( " * subtitle track %d, %s (track %d, id 0x%x) %s [%s] -> %s%s%s",
-                        subtitle->out_track, subtitle->lang, subtitle->track, subtitle->id,
-                        subtitle->format == PICTURESUB ? "Picture" : "Text",
-                        hb_subsource_name( subtitle->source ),
-                        subtitle->config.dest == RENDERSUB ? "Render/Burn-in" : "Passthrough",
-                        subtitle->config.force ? ", Forced Only" : "",
-                        subtitle->config.default_track ? ", Default" : "" );
+                hb_log(" * subtitle track %d, %s (track %d, id 0x%x, %s) -> "
+                       "%s%s%s",
+                       subtitle->out_track, subtitle->lang, subtitle->track,
+                       subtitle->id,
+                       subtitle->format == PICTURESUB ? "Picture" : "Text",
+                       subtitle->config.dest == RENDERSUB ? "Render/Burn-in"
+                                                          : "Passthrough",
+                       subtitle->config.force ? ", Forced Only" : "",
+                       subtitle->config.default_track ? ", Default" : "" );
             }
         }
     }

--- a/macosx/HBSubtitles.m
+++ b/macosx/HBSubtitles.m
@@ -60,31 +60,10 @@ extern NSString *keySubTrackSrtFileURLBookmark;
 
         NSMutableArray *sourceTracks = [job.title.subtitlesTracks mutableCopy];
 
-        NSMutableSet<NSString *> *forcedSourceNamesArray = [NSMutableSet set];
         int foreignAudioType = VOBSUB;
-        for (NSDictionary *dict in _sourceTracks)
-        {
-            enum subsource source = [dict[keySubTrackType] intValue];
-            NSString *name = @(hb_subsource_name(source));
-            // if the subtitle track can be forced, add its source name to the array
-            if (hb_subtitle_can_force(source) && name.length)
-            {
-                [forcedSourceNamesArray addObject:name];
-            }
-        }
 
         // now set the name of the Foreign Audio Search track
-        NSMutableString *foreignAudioSearchTrackName = [@"Foreign Audio Search (Bitmap)" mutableCopy];
-        if (forcedSourceNamesArray.count)
-        {
-            [foreignAudioSearchTrackName appendFormat:@" ("];
-            for (NSString *name in forcedSourceNamesArray)
-            {
-                [foreignAudioSearchTrackName appendFormat:@"%@, ", name];
-            }
-            [foreignAudioSearchTrackName deleteCharactersInRange:NSMakeRange(foreignAudioSearchTrackName.length - 2, 2)];
-            [foreignAudioSearchTrackName appendFormat:@")"];
-        }
+        NSMutableString *foreignAudioSearchTrackName = [@"Foreign Audio Search" mutableCopy];
 
         // Add the none and foreign track to the source array
         NSDictionary *none = @{  keySubTrackName: NSLocalizedString(@"None", nil)};

--- a/macosx/HBTitle.m
+++ b/macosx/HBTitle.m
@@ -218,12 +218,10 @@ extern NSString *keySubTrackType;
             NSString *bitmapOrText  = subtitle->format == PICTURESUB ? @"Bitmap" : @"Text";
             NSString *subSourceName = @(hb_subsource_name(subtitle->source));
 
-            // Use the native language name if available
-            iso639_lang_t *language = lang_for_code2(subtitle->iso639_2);
-            NSString *nativeLanguage = strlen(language->native_name) ? @(language->native_name) : @(language->eng_name);
+            NSString *lang = @(subtitle->lang);
 
             /* create a dictionary of source subtitle information to store in our array */
-            [tracks addObject:@{keySubTrackName: [NSString stringWithFormat:@"%d: %@ (%@) (%@)", i, nativeLanguage, bitmapOrText, subSourceName],
+            [tracks addObject:@{keySubTrackName: [NSString stringWithFormat:@"%d: %@", i, lang],
                                               keySubTrackType: @(subtitle->source),
                                               keySubTrackLanguageIsoCode: @(subtitle->iso639_2)}];
         }

--- a/test/test.c
+++ b/test/test.c
@@ -655,11 +655,7 @@ static void PrintTitleInfo( hb_title_t * title, int feature )
     {
         hb_subtitle_t *subtitle;
         subtitle = hb_list_item( title->list_subtitle, i );
-        fprintf( stderr, "    + %d, %s (iso639-2: %s) (%s)(%s)\n",
-                 i + 1, subtitle->lang,
-                 subtitle->iso639_2,
-                 (subtitle->format == TEXTSUB) ? "Text" : "Bitmap",
-                 hb_subsource_name(subtitle->source));
+        fprintf(stderr, "    + %d, %s\n", i + 1, subtitle->lang);
     }
 
     if(title->detected_interlacing)

--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Subtitle.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Subtitle.cs
@@ -134,7 +134,7 @@ namespace HandBrakeWPF.Services.Scan.Model
         /// <returns>A string formatted as: {track #} {language}</returns>
         public override string ToString()
         {
-            return this.SubtitleType == SubtitleType.ForeignAudioSearch ? "Foreign Audio Scan" : string.Format("{0} {1} ({2})", this.TrackNumber, this.Language, this.TypeString);
+            return this.SubtitleType == SubtitleType.ForeignAudioSearch ? "Foreign Audio Scan" : string.Format("{0} {1}", this.TrackNumber, this.Language);
         }
 
         /// <summary>

--- a/win/CS/HandBrakeWPF/ViewModels/SubtitlesViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/SubtitlesViewModel.cs
@@ -63,7 +63,7 @@ namespace HandBrakeWPF.ViewModels
             this.Langauges = LanguageUtilities.MapLanguages().Keys;
             this.CharacterCodes = CharCodesUtilities.GetCharacterCodes();
 
-            this.ForeignAudioSearchTrack = new Subtitle { SubtitleType = SubtitleType.ForeignAudioSearch, Language = "Foreign Audio Search (Bitmap)" };
+            this.ForeignAudioSearchTrack = new Subtitle { SubtitleType = SubtitleType.ForeignAudioSearch, Language = "Foreign Audio Search" };
             this.SourceTracks = new List<Subtitle> { this.ForeignAudioSearchTrack };
         }
 


### PR DESCRIPTION
Generally, it eliminates parens to make things more readable.

I.e. it turns this:
English (Closed Caption)(Wide Screen)(Bitmap)(VOBSUB)

Into this:
English, Closed Caption [Wide Screen, VOBSUB]