### PR TITLE
Unbreak non-mingw cross.

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -503,7 +503,7 @@ class BuildAction( Action, list ):
             if self.match( '*mingw*' ):
                 self.systemf = 'MinGW'
             elif self.systemf:
-                self.systemf[0] = self.systemf[0].upper()
+                self.systemf = self.systemf.capitalize()
             self.title = '%s %s' % (build.systemf,self.machine)
         else:
             self.title = '%s %s' % (build.systemf,arch.mode.mode)


### PR DESCRIPTION
Strings in python are immutable and it results in:

Traceback (most recent call last):
  File "make/configure.py", line 1592, in <module>
    action.run()
  File "make/configure.py", line 287, in run
    self._action()
  File "make/configure.py", line 506, in _action
    self.systemf[0] = self.systemf[0].upper()
TypeError: 'str' object does not support item assignment