### PR TITLE
contrib: Update to libvpx 1.6.1.

### DIFF
--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -7,9 +7,9 @@ endif
 $(eval $(call import.MODULE.defs,LIBVPX,libvpx,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBVPX))
 
-LIBVPX.FETCH.url     = https://download.handbrake.fr/contrib/libvpx-1.5.0.tar.bz2
-LIBVPX.FETCH.url    += http://downloads.webmproject.org/releases/webm/libvpx-1.5.0.tar.bz2
-LIBVPX.FETCH.sha256  = 306d67908625675f8e188d37a81fbfafdf5068b09d9aa52702b6fbe601c76797
+LIBVPX.FETCH.url     = https://download.handbrake.fr/contrib/libvpx-1.6.1.tar.bz2
+LIBVPX.FETCH.url    += https://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.6.1.tar.bz2
+LIBVPX.FETCH.sha256  = 1c2c0c2a97fba9474943be34ee39337dee756780fc12870ba1dc68372586a819
 
 LIBVPX.CONFIGURE.args.host =
 LIBVPX.CONFIGURE.deps  =
@@ -19,7 +19,6 @@ LIBVPX.CONFIGURE.extra =  \
     --disable-vp8-decoder \
     --enable-vp9-encoder  \
     --disable-vp9-decoder \
-    --disable-vp10        \
     --disable-examples    \
     --disable-docs        \
     --disable-unit-tests


### PR DESCRIPTION
Please upload the necessary archive to the VM: https://storage.googleapis.com/downloads.webmproject.org/releases/webm/libvpx-1.6.1.tar.bz2
SHA256: 1c2c0c2a97fba9474943be34ee39337dee756780fc12870ba1dc68372586a819

Performance improvements appear to be overstated. Using the VP9 MKV 1080p30 preset on a short sample, encoding was slow as a dog and average FPS was exactly the same as with libvpx 1.5.0. That said, I did notice what appeared to be slightly better quality around transitions, despite video track being ~3.5% smaller. Perhaps performance is improved slightly in constant quality mode, and quality is improved slightly when targeting bit rate. I will politely decline to continue testing at single digit frames per second. 😅 