### PR TITLE
Fontconfig configuration path not actually set during the build

### DIFF
--- a/contrib/fontconfig/module.defs
+++ b/contrib/fontconfig/module.defs
@@ -91,13 +91,13 @@ ifeq (darwin,$(BUILD.system))
 FONTCONFIG.CONFIGURE.extra += \
     LIBXML2_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lxml2" \
     LIBXML2_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/libxml2" \
-    --with-fcpath=/usr/X11/lib/X11/fontconfig \
+    --with-baseconfigdir=/usr/X11/lib/X11/fontconfig \
     --with-cache-dir=~/Library/Caches/fontconfig \
     --with-default-fonts=/Library/Fonts \
     --with-add-fonts=/System/Library/Fonts,/Library/Fonts,~/Library/Fonts
 else ifeq (linux,$(BUILD.system))
 FONTCONFIG.CONFIGURE.extra += \
-    --with-fcpath=/etc/fonts \
+    --with-baseconfigdir=/etc/fonts \
     --with-cache-dir=/var/cache/fontconfig
 endif
 


### PR DESCRIPTION
Starting from commit 19f6610d3d3bc0a4144a7612294a47bfcf307371 (first released in 0.9.6 from what I can tell), while building Fontconfig, HandBrake tells it the location of the platform’s default Fontconfig configuration file using the `--with-fcpath=` option of its `configure` script. However, this option does not exist in stock Fontconfig. The commit that introduced this included a patch that added this option to Fontconfig’s `configure`, but later, commit e54567afa69515253a484e76aed75eb37da71269 (first released in 1.0.0) silently removed this patch. Since then, passing the option to `configure` does absolutely nothing, and Fontconfig’s configuration path is not set.

This produces the following error message in the log:

```
Fontconfig error: Cannot load default config file
```

and causes HandBrake to ignore many system fonts while burning subtitles on macOS. We had one user on #libass today who actually reported SRT subtitles not showing at all, although I’m not completely sure that this is the entire cause.

Current Fontconfig allows the configuration path to be set using the option `--with-baseconfigdir=`, with the exact same values that HandBrake currently uses for `--with-fcpath=`.

(The version of Fontconfig that HandBrake used at the time of the original commit with `--with-fcpath=` _also_ had an option for this, albeit with a different name: `--with-confdir=`. I really have no idea why the `--with-fcpath=` hack was introduced.)

Alternatively on Linux, both current and past versions of Fontconfig allow the path `/etc/fonts` to be set using the option `--sysconfdir=/etc`. After #610, Fontconfig will only be used on Linux, so this may be preferable as a possibly more future-proof solution (in case Fontconfig changes the name of `--with-baseconfigdir=` once again). Then again, isn’t Fontconfig not built on Linux at all since 13e4fc1725bc45b9f59adcba9228f0554dc90e35 (released in 0.9.9)?

Er, actually, what about platforms other than Windows, macOS and Linux? It seems that they don’t have the Fontconfig configuration path set at all, and I don’t know if they get Fontconfig files bundled like Windows releases do.