### PR TITLE
text subs: use generic font family names

### DIFF
--- a/libhb/deccc608sub.c
+++ b/libhb/deccc608sub.c
@@ -1799,7 +1799,7 @@ static int decccInit( hb_work_object_t * w, hb_job_t * job )
         int height = job->title->geometry.height - job->crop[0] - job->crop[1];
         int width = job->title->geometry.width - job->crop[2] - job->crop[3];
         int safe_height = 0.8 * job->title->geometry.height;
-        hb_subtitle_add_ssa_header(w->subtitle, "monospace",
+        hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_MONO,
                                    .08 * safe_height, width, height);
     }
     // When rendering subs, we need to push rollup subtitles out

--- a/libhb/deccc608sub.c
+++ b/libhb/deccc608sub.c
@@ -1799,7 +1799,7 @@ static int decccInit( hb_work_object_t * w, hb_job_t * job )
         int height = job->title->geometry.height - job->crop[0] - job->crop[1];
         int width = job->title->geometry.width - job->crop[2] - job->crop[3];
         int safe_height = 0.8 * job->title->geometry.height;
-        hb_subtitle_add_ssa_header(w->subtitle, "Courier New",
+        hb_subtitle_add_ssa_header(w->subtitle, "monospace",
                                    .08 * safe_height, width, height);
     }
     // When rendering subs, we need to push rollup subtitles out

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -675,7 +675,7 @@ static int decsrtInit( hb_work_object_t * w, hb_job_t * job )
         // Generate generic SSA Script Info.
         int height = job->title->geometry.height - job->crop[0] - job->crop[1];
         int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-        hb_subtitle_add_ssa_header(w->subtitle, "Arial",
+        hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
                                    .066 * job->title->geometry.height,
                                    width, height);
     }

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -675,7 +675,7 @@ static int decsrtInit( hb_work_object_t * w, hb_job_t * job )
         // Generate generic SSA Script Info.
         int height = job->title->geometry.height - job->crop[0] - job->crop[1];
         int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-        hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
+        hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_SANS,
                                    .066 * job->title->geometry.height,
                                    width, height);
     }

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -251,7 +251,7 @@ static int dectx3gInit( hb_work_object_t * w, hb_job_t * job )
     // For now we just create a generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
+    hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_SANS,
                                .066 * job->title->geometry.height,
                                width, height);
 

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -251,7 +251,7 @@ static int dectx3gInit( hb_work_object_t * w, hb_job_t * job )
     // For now we just create a generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, "Arial",
+    hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
                                .066 * job->title->geometry.height,
                                width, height);
 

--- a/libhb/decutf8sub.c
+++ b/libhb/decutf8sub.c
@@ -37,7 +37,7 @@ static int decutf8Init(hb_work_object_t *w, hb_job_t *job)
     // Generate generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
+    hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_SANS,
                                .066 * job->title->geometry.height,
                                width, height);
 

--- a/libhb/decutf8sub.c
+++ b/libhb/decutf8sub.c
@@ -37,7 +37,7 @@ static int decutf8Init(hb_work_object_t *w, hb_job_t *job)
     // Generate generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, "Arial",
+    hb_subtitle_add_ssa_header(w->subtitle, "sans-serif",
                                .066 * job->title->geometry.height,
                                width, height);
 

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -525,3 +525,12 @@ void                 hb_chapter_queue_close(hb_chapter_queue_t **_q);
 void                 hb_chapter_enqueue(hb_chapter_queue_t *q, hb_buffer_t *b);
 void                 hb_chapter_dequeue(hb_chapter_queue_t *q, hb_buffer_t *b);
 
+/* Font names used for rendering subtitles */
+#if defined(SYS_MINGW)
+#define HB_FONT_MONO "Lucida Console"
+#define HB_FONT_SANS "sans-serif"
+#else
+#define HB_FONT_MONO "monospace"
+#define HB_FONT_SANS "sans-serif"
+#endif
+

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -675,7 +675,7 @@ static int cc608sub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
     int safe_height = 0.8 * job->title->geometry.height;
     // Use fixed widht font for CC
-    hb_subtitle_add_ssa_header(filter->subtitle, "Courier New",
+    hb_subtitle_add_ssa_header(filter->subtitle, "monospace",
                                .08 * safe_height, width, height);
     return ssa_post_init(filter, job);
 }
@@ -686,7 +686,7 @@ static int textsub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     // to have the header rewritten with the correct dimensions.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(filter->subtitle, "Arial",
+    hb_subtitle_add_ssa_header(filter->subtitle, "sans-serif",
                                .066 * job->title->geometry.height,
                                width, height);
     return ssa_post_init(filter, job);

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -675,7 +675,7 @@ static int cc608sub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
     int safe_height = 0.8 * job->title->geometry.height;
     // Use fixed widht font for CC
-    hb_subtitle_add_ssa_header(filter->subtitle, "monospace",
+    hb_subtitle_add_ssa_header(filter->subtitle, HB_FONT_MONO,
                                .08 * safe_height, width, height);
     return ssa_post_init(filter, job);
 }
@@ -686,7 +686,7 @@ static int textsub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     // to have the header rewritten with the correct dimensions.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(filter->subtitle, "sans-serif",
+    hb_subtitle_add_ssa_header(filter->subtitle, HB_FONT_SANS,
                                .066 * job->title->geometry.height,
                                width, height);
     return ssa_post_init(filter, job);


### PR DESCRIPTION
Allows the platform more flexibility in choosing the "best" font for the
platform.