### PR TITLE
Allow audio fallback to be "None"

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1689,6 +1689,31 @@ ghb_audio_encoder_opts_set_with_mask(
     }
 }
 
+void
+ghb_audio_encoder_opts_add_none(GtkComboBox *combo)
+{
+    GtkTreeIter iter;
+    GtkListStore *store;
+
+    store = GTK_LIST_STORE(gtk_combo_box_get_model (combo));
+    gtk_list_store_append(store, &iter);
+    gtk_list_store_set(store, &iter,
+                       0, "<small>None</small>",
+                       1, TRUE,
+                       2, "none",
+                       3, (gdouble)HB_ACODEC_INVALID,
+                       -1);
+}
+
+static void
+audio_encoder_opts_add_none(
+    GtkBuilder *builder,
+    const gchar *name)
+{
+    GtkComboBox *combo = GTK_COMBO_BOX(GHB_WIDGET(builder, name));
+    ghb_audio_encoder_opts_add_none(combo);
+}
+
 const hb_encoder_t*
 ghb_lookup_audio_encoder(const char *name)
 {
@@ -1787,6 +1812,7 @@ acodec_fallback_opts_set(signal_user_data_t *ud, const gchar *name,
     (void)data; // Silence "unused variable" warning
 
     audio_encoder_opts_set_with_mask(ud->builder, name, ~0, HB_ACODEC_PASS_FLAG);
+    audio_encoder_opts_add_none(ud->builder, name);
 }
 
 void

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2188,7 +2188,7 @@ int hb_audio_encoder_get_fallback_for_passthru(int passthru)
             break;
 
         default:
-            gid = HB_GID_NONE; // will never match an enabled encoder
+            return HB_ACODEC_INVALID;
             break;
     }
     while ((audio_encoder = hb_audio_encoder_get_next(audio_encoder)) != NULL)

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2293,7 +2293,7 @@ fail:
 
 const char* hb_audio_encoder_get_short_name(int encoder)
 {
-    if (!(encoder & HB_ACODEC_ANY) && encoder != HB_ACODEC_NONE)
+    if (!(encoder & HB_ACODEC_ANY))
         goto fail;
 
     const hb_encoder_t *audio_encoder = NULL;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -309,6 +309,7 @@ hb_encoder_internal_t hb_audio_encoders[]  =
     { { "AAC",                "aac",        NULL,                          0,                     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_AAC,        },
     { { "HE-AAC",             "haac",       NULL,                          0,                     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, HB_GID_ACODEC_AAC_HE,     },
     // actual encoders
+    { { "None",               "none",       "None",                        HB_ACODEC_NONE,        0,                               }, NULL, 1, HB_GID_NONE,              },
     { { "AAC (CoreAudio)",    "ca_aac",     "AAC (Apple AudioToolbox)",    HB_ACODEC_CA_AAC,      HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, HB_GID_ACODEC_AAC,        },
     { { "HE-AAC (CoreAudio)", "ca_haac",    "HE-AAC (Apple AudioToolbox)", HB_ACODEC_CA_HAAC,     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, HB_GID_ACODEC_AAC_HE,     },
     { { "AAC (FDK)",          "fdk_aac",    "AAC (libfdk_aac)",            HB_ACODEC_FDK_AAC,     HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 1, HB_GID_ACODEC_AAC,        },
@@ -372,6 +373,7 @@ static int hb_audio_encoder_is_enabled(int encoder)
         // the following encoders are always enabled
         case HB_ACODEC_LAME:
         case HB_ACODEC_VORBIS:
+        case HB_ACODEC_NONE:
             return 1;
 
         default:
@@ -2291,7 +2293,7 @@ fail:
 
 const char* hb_audio_encoder_get_short_name(int encoder)
 {
-    if (!(encoder & HB_ACODEC_ANY))
+    if (!(encoder & HB_ACODEC_ANY) && encoder != HB_ACODEC_NONE)
         goto fail;
 
     const hb_encoder_t *audio_encoder = NULL;
@@ -2522,7 +2524,7 @@ int hb_autopassthru_get_encoder(int in_codec, int copy_mask, int fallback,
         else if (audio_encoder->codec == fallback)
         {
             i++;
-            if (!(audio_encoder->muxers & muxer))
+            if (!(audio_encoder->muxers & muxer) && fallback != HB_ACODEC_NONE)
                 fallback = hb_audio_encoder_get_default(muxer);
         }
         if (i > 1)

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2357,8 +2357,8 @@ void hb_autopassthru_apply_settings(hb_job_t *job)
                                                                   job->acodec_copy_mask,
                                                                   job->acodec_fallback,
                                                                   job->mux);
-            if (!(audio->config.out.codec & HB_ACODEC_PASS_FLAG) &&
-                !(audio->config.out.codec & HB_ACODEC_MASK))
+            if (audio->config.out.codec == HB_ACODEC_NONE ||
+                audio->config.out.codec == HB_ACODEC_INVALID)
             {
                 hb_log("Auto Passthru: passthru not possible and no valid fallback specified, dropping track %d",
                        audio->config.out.track );
@@ -2368,16 +2368,8 @@ void hb_autopassthru_apply_settings(hb_job_t *job)
             }
             if (!(audio->config.out.codec & HB_ACODEC_PASS_FLAG))
             {
-                if (audio->config.out.codec == job->acodec_fallback)
-                {
-                    hb_log("Auto Passthru: passthru not possible for track %d, using fallback",
-                           audio->config.out.track);
-                }
-                else
-                {
-                    hb_log("Auto Passthru: passthru and fallback not possible for track %d, using default encoder",
-                           audio->config.out.track);
-                }
+                hb_log("Auto Passthru: passthru not possible for track %d, using fallback",
+                       audio->config.out.track);
                 if (audio->config.out.mixdown <= 0)
                 {
                     audio->config.out.mixdown =
@@ -2508,31 +2500,36 @@ void hb_autopassthru_print_settings(hb_job_t *job)
 int hb_autopassthru_get_encoder(int in_codec, int copy_mask, int fallback,
                                 int muxer)
 {
-    int i = 0;
+    int out_codec_result_set = 0;
+    int fallback_result_set  = 0;
+    int out_codec_result = HB_ACODEC_INVALID;
+    int fallback_result  = HB_ACODEC_INVALID;
     const hb_encoder_t *audio_encoder = NULL;
     int out_codec = (copy_mask & in_codec) | HB_ACODEC_PASS_FLAG;
+
     // sanitize fallback encoder and selected passthru
     // note: invalid fallbacks are caught in hb_autopassthru_apply_settings
     while ((audio_encoder = hb_audio_encoder_get_next(audio_encoder)) != NULL)
     {
-        if (audio_encoder->codec == out_codec)
+        if (!out_codec_result_set && audio_encoder->codec == out_codec)
         {
-            i++;
-            if (!(audio_encoder->muxers & muxer))
-                out_codec = 0;
+            out_codec_result_set = 1;
+            if (audio_encoder->muxers & muxer)
+                out_codec_result = out_codec;
         }
-        else if (audio_encoder->codec == fallback)
+        else if (!fallback_result_set && audio_encoder->codec == fallback)
         {
-            i++;
-            if (!(audio_encoder->muxers & muxer) && fallback != HB_ACODEC_NONE)
-                fallback = hb_audio_encoder_get_default(muxer);
+            fallback_result_set  = 1;
+            if ((audio_encoder->muxers & muxer) || fallback == HB_ACODEC_NONE)
+                fallback_result = fallback;
         }
-        if (i > 1)
+        if (out_codec_result_set && fallback_result_set)
         {
             break;
         }
     }
-    return (out_codec & HB_ACODEC_PASS_MASK) ? out_codec : fallback;
+    return (out_codec_result != HB_ACODEC_INVALID) ? out_codec_result :
+                                                     fallback_result;
 }
 
 hb_container_t* hb_container_get_from_format(int format)

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -681,6 +681,7 @@ struct hb_job_s
 /* Audio starts here */
 /* Audio Codecs: Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/NativeConstants.cs when changing these consts */
 #define HB_ACODEC_INVALID   0x00000000
+#define HB_ACODEC_NONE      0x00000001
 #define HB_ACODEC_MASK      0x07FFFF00
 #define HB_ACODEC_LAME      0x00000200
 #define HB_ACODEC_VORBIS    0x00000400

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -682,7 +682,7 @@ struct hb_job_s
 /* Audio Codecs: Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/NativeConstants.cs when changing these consts */
 #define HB_ACODEC_INVALID   0x00000000
 #define HB_ACODEC_NONE      0x00000001
-#define HB_ACODEC_MASK      0x07FFFF00
+#define HB_ACODEC_MASK      0x07FFFF01
 #define HB_ACODEC_LAME      0x00000200
 #define HB_ACODEC_VORBIS    0x00000400
 #define HB_ACODEC_AC3       0x00000800

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -492,7 +492,7 @@ static int sanitize_audio_codec(int in_codec, int out_codec,
              !(in_codec & out_codec & HB_ACODEC_PASS_MASK))
     {
         codec = hb_audio_encoder_get_fallback_for_passthru(out_codec);
-        if (codec == 0)
+        if (codec == HB_ACODEC_INVALID)
             codec = fallback;
     }
 
@@ -507,7 +507,7 @@ static int sanitize_audio_codec(int in_codec, int out_codec,
             break;
         }
     }
-    if (codec == 0)
+    if (codec == HB_ACODEC_INVALID)
         codec = hb_audio_encoder_get_default(mux);
     return codec;
 }


### PR DESCRIPTION
When audio fallback is "None", a failure to do passthru will result in
no output audio track being added.

If your GUI uses hb_preset_job_init() and/or hb_preset_job_add_audio() to populate your job with audio, then simply setting preset key "AudioEncoderFallback" to "none" is all that is required from the GUI.  If you are populating the job yourself, then adding a "none" option is pretty much all on you.