### PR TITLE
qsv: fixing mfx compilation options for Linux support

### DIFF
--- a/contrib/libmfx/A00-linux-path-fix.patch
+++ b/contrib/libmfx/A00-linux-path-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/src/mfx_library_iterator_linux.cpp b/src/mfx_library_iterator_linux.cpp
+index 46ad511..e2269f3 100644
+--- a/src/mfx_library_iterator_linux.cpp
++++ b/src/mfx_library_iterator_linux.cpp
+@@ -332,8 +332,7 @@ mfxStatus MFXLibraryIterator::Init(eMfxImplType implType, mfxIMPL impl, const mf
+     // set the required library's implementation type
+     m_implType = implType;
+ 
+-    snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),
+-             "%s/%s/%04x/%04x", mfx_storage_opt, mfx_folder, m_vendorID, m_deviceID);
++    snprintf(m_path, sizeof(m_path)/sizeof(m_path[0]),"%s/%s", mfx_storage_opt, mfx_folder);
+ 
+     m_libs_num = mfx_list_libraries(m_path, (MFX_LIB_HARDWARE == implType), &m_libs);
+ 

--- a/contrib/libmfx/module.defs
+++ b/contrib/libmfx/module.defs
@@ -6,7 +6,7 @@ LIBMFX.FETCH.sha256 = e07d1024e86998ac3992620f5db0f999af51cc700f7de90da2ebbe1e8a
 
 LIBMFX.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; autoreconf -fiv;
 
-ifneq (1,$(FEATURE.qsv))
+ifeq (1,$(BUILD.cross))
 LIBMFX.CONFIGURE.extra = --without-libva_drm --without-libva_x11
 endif
 

--- a/contrib/libmfx/module.defs
+++ b/contrib/libmfx/module.defs
@@ -6,7 +6,9 @@ LIBMFX.FETCH.sha256 = e07d1024e86998ac3992620f5db0f999af51cc700f7de90da2ebbe1e8a
 
 LIBMFX.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; autoreconf -fiv;
 
+ifneq (1,$(FEATURE.qsv))
 LIBMFX.CONFIGURE.extra = --without-libva_drm --without-libva_x11
+endif
 
 ## optional static libs need to be marked
 LIBMFX.OSL.libs  = mfx


### PR DESCRIPTION
Adds preliminary support for QSV on Linux, 
requires [MSS](https://software.intel.com/en-us/intel-media-server-studio) to be installed for run.

To build on PC without MSS installed and without iGPU/QSV :  `libdrm and libva` dev. packages should be still taken from MSS, compiled and placed that pkg-config can find it. 