### PR TITLE
contrib: Update to x265 2.4.

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,10 +2,10 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.3.tar.gz
-X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.3.tar.gz
-X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.3.tar.gz
-X265.FETCH.sha256  = 47520ac3424790168ea5c2db4a3cf12ca4d55a1790720007916652f07af3e41f
+X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.4.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.4.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.4.tar.gz
+X265.FETCH.sha256  = 9c2aa718d78f6fecdd783f08ab83b98d3169e5f670404da4c16439306907d729
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
Closes #761.

## x265 Version 2.4

Release date - 22nd April, 2017.

### Encoder enhancements

- HDR10+ supported. Dynamic metadata may be either supplied as a bitstream via the userSEI field of x265_picture, or as a json jile that can be parsed by x265 and inserted into the bitstream; use --dhdr10-info to specify json file name, and --dhdr10-opt to enable optimization of inserting tone-map information only at IDR frames, or when the tone map information changes.
- Lambda tables for 8, 10, and 12-bit encoding revised, resulting in significant enhancement to subjective visual quality.
- Enhanced HDR10 encoding with HDR-specific QP optimzations for chroma, and luma planes of WCG content enabled; use --hdr-opt to activate.
- Ability to accept analysis information from other previous encodes (that may or may not be x265), and selectively reuse and refine analysis for encoding subsequent passes enabled with the --refine-level option.
- Slow and veryslow presets receive a 20% speed boost at iso-quality by enabling the --limit-tu option.
- The bitrate target for x265 can now be dynamically reconfigured via the reconfigure API.
- Performance optimized SAO algorithm introduced via the --limit-sao option; seeing 10% speed benefits at faster presets.

### API changes

- x265_reconfigure API now also accepts rate-control parameters for dynamic reconfiguration.
- Several additions to data fields in x265_analysis to support --refine-level: see x265.h for more details.

### Bug fixes

- Avoid negative offsets in x265 lambda2 table with SAO enabled.
- Fix mingw32 build error.
- Seek now enabled for pipe input, in addition to file-based input
- Fix issue of statically linking core-utils not working in linux.
- Fix visual artifacts with --multi-pass-opt-distortion with VBV.
- Fix bufferFill stats reported in csv.
