### PR TITLE
muxavformat: override h.265 'hev1' with 'hvc1'

### DIFF
--- a/contrib/ffmpeg/A20-hvc1-override.patch
+++ b/contrib/ffmpeg/A20-hvc1-override.patch
@@ -1,4 +1,4 @@
-From 63c6b0d98fc7fa11dcfe0415cda896416017d92d Mon Sep 17 00:00:00 2001
+From cc6cb8d44b50082ae3edfed39f484213590c8777 Mon Sep 17 00:00:00 2001
 From: John Stebbins <stebbins@jetheaddev.com>
 Date: Sun, 11 Jun 2017 10:19:14 -0700
 Subject: [PATCH] movenc: Allow use of hvc1 tag for h.265
@@ -6,11 +6,11 @@ Subject: [PATCH] movenc: Allow use of hvc1 tag for h.265
 If AVCodecParameters.codec_tag is 'hvc1' use it instead of 'hev1' for
 h.265 streams.
 ---
- libavformat/movenc.c | 10 +++++++---
- 1 file changed, 7 insertions(+), 3 deletions(-)
+ libavformat/movenc.c | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index e389029..bfcb644 100644
+index e389029..835f588 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
 @@ -726,7 +726,10 @@ static int mov_write_hvcc_tag(AVIOContext *pb, MOVTrack *track)
@@ -25,17 +25,16 @@ index e389029..bfcb644 100644
      return update_size(pb, pos);
  }
  
-@@ -786,7 +789,8 @@ static int mp4_get_codec_tag(AVFormatContext *s, MOVTrack *track)
+@@ -786,6 +789,8 @@ static int mp4_get_codec_tag(AVFormatContext *s, MOVTrack *track)
          return 0;
  
      if      (track->par->codec_id == AV_CODEC_ID_H264)      tag = MKTAG('a','v','c','1');
--    else if (track->par->codec_id == AV_CODEC_ID_HEVC)      tag = MKTAG('h','e','v','1');
 +    else if (track->par->codec_id == AV_CODEC_ID_HEVC &&
-+             tag != MKTAG('h','v','c','1'))                 tag = MKTAG('h','e','v','1');
++             tag == MKTAG('h','v','c','1'))                 ;
+     else if (track->par->codec_id == AV_CODEC_ID_HEVC)      tag = MKTAG('h','e','v','1');
      else if (track->par->codec_id == AV_CODEC_ID_AC3)       tag = MKTAG('a','c','-','3');
      else if (track->par->codec_id == AV_CODEC_ID_DIRAC)     tag = MKTAG('d','r','a','c');
-     else if (track->par->codec_id == AV_CODEC_ID_MOV_TEXT)  tag = MKTAG('t','x','3','g');
-@@ -4496,7 +4500,7 @@ AVOutputFormat ff_mp4_muxer = {
+@@ -4496,7 +4501,7 @@ AVOutputFormat ff_mp4_muxer = {
      .write_packet      = mov_write_packet,
      .write_trailer     = mov_write_trailer,
      .flags             = AVFMT_GLOBALHEADER | AVFMT_ALLOW_FLUSH | AVFMT_TS_NEGATIVE,

--- a/contrib/ffmpeg/A20-hvc1-override.patch
+++ b/contrib/ffmpeg/A20-hvc1-override.patch
@@ -1,4 +1,4 @@
-From cc08f7e0ffb2bd42ba70c5bc56753f8f0436e4d0 Mon Sep 17 00:00:00 2001
+From 63c6b0d98fc7fa11dcfe0415cda896416017d92d Mon Sep 17 00:00:00 2001
 From: John Stebbins <stebbins@jetheaddev.com>
 Date: Sun, 11 Jun 2017 10:19:14 -0700
 Subject: [PATCH] movenc: Allow use of hvc1 tag for h.265
@@ -6,11 +6,11 @@ Subject: [PATCH] movenc: Allow use of hvc1 tag for h.265
 If AVCodecParameters.codec_tag is 'hvc1' use it instead of 'hev1' for
 h.265 streams.
 ---
- libavformat/movenc.c | 8 ++++++--
- 1 file changed, 6 insertions(+), 2 deletions(-)
+ libavformat/movenc.c | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/libavformat/movenc.c b/libavformat/movenc.c
-index e389029..631d37e 100644
+index e389029..bfcb644 100644
 --- a/libavformat/movenc.c
 +++ b/libavformat/movenc.c
 @@ -726,7 +726,10 @@ static int mov_write_hvcc_tag(AVIOContext *pb, MOVTrack *track)
@@ -35,6 +35,15 @@ index e389029..631d37e 100644
      else if (track->par->codec_id == AV_CODEC_ID_AC3)       tag = MKTAG('a','c','-','3');
      else if (track->par->codec_id == AV_CODEC_ID_DIRAC)     tag = MKTAG('d','r','a','c');
      else if (track->par->codec_id == AV_CODEC_ID_MOV_TEXT)  tag = MKTAG('t','x','3','g');
+@@ -4496,7 +4500,7 @@ AVOutputFormat ff_mp4_muxer = {
+     .write_packet      = mov_write_packet,
+     .write_trailer     = mov_write_trailer,
+     .flags             = AVFMT_GLOBALHEADER | AVFMT_ALLOW_FLUSH | AVFMT_TS_NEGATIVE,
+-    .codec_tag         = (const AVCodecTag* const []){ ff_mp4_obj_type, 0 },
++    .codec_tag         = (const AVCodecTag* const []){ ff_codec_movvideo_tags, ff_codec_movaudio_tags, ff_codec_movsubtitle_tags, 0 },
+     .priv_class        = &mp4_muxer_class,
+ };
+ #endif
 -- 
 2.9.3
 

--- a/contrib/ffmpeg/A20-hvc1-override.patch
+++ b/contrib/ffmpeg/A20-hvc1-override.patch
@@ -1,0 +1,40 @@
+From cc08f7e0ffb2bd42ba70c5bc56753f8f0436e4d0 Mon Sep 17 00:00:00 2001
+From: John Stebbins <stebbins@jetheaddev.com>
+Date: Sun, 11 Jun 2017 10:19:14 -0700
+Subject: [PATCH] movenc: Allow use of hvc1 tag for h.265
+
+If AVCodecParameters.codec_tag is 'hvc1' use it instead of 'hev1' for
+h.265 streams.
+---
+ libavformat/movenc.c | 8 ++++++--
+ 1 file changed, 6 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index e389029..631d37e 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -726,7 +726,10 @@ static int mov_write_hvcc_tag(AVIOContext *pb, MOVTrack *track)
+ 
+     avio_wb32(pb, 0);
+     ffio_wfourcc(pb, "hvcC");
+-    ff_isom_write_hvcc(pb, track->vos_data, track->vos_len, 0);
++    if (track->tag == MKTAG('h','v','c','1'))
++        ff_isom_write_hvcc(pb, track->vos_data, track->vos_len, 1);
++    else
++        ff_isom_write_hvcc(pb, track->vos_data, track->vos_len, 0);
+     return update_size(pb, pos);
+ }
+ 
+@@ -786,7 +789,8 @@ static int mp4_get_codec_tag(AVFormatContext *s, MOVTrack *track)
+         return 0;
+ 
+     if      (track->par->codec_id == AV_CODEC_ID_H264)      tag = MKTAG('a','v','c','1');
+-    else if (track->par->codec_id == AV_CODEC_ID_HEVC)      tag = MKTAG('h','e','v','1');
++    else if (track->par->codec_id == AV_CODEC_ID_HEVC &&
++             tag != MKTAG('h','v','c','1'))                 tag = MKTAG('h','e','v','1');
+     else if (track->par->codec_id == AV_CODEC_ID_AC3)       tag = MKTAG('a','c','-','3');
+     else if (track->par->codec_id == AV_CODEC_ID_DIRAC)     tag = MKTAG('d','r','a','c');
+     else if (track->par->codec_id == AV_CODEC_ID_MOV_TEXT)  tag = MKTAG('t','x','3','g');
+-- 
+2.9.3
+

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -331,7 +331,8 @@ static int avformatInit( hb_mux_object_t * m )
         case HB_VCODEC_X265_16BIT:
         case HB_VCODEC_QSV_H265:
         case HB_VCODEC_QSV_H265_10BIT:
-            track->st->codecpar->codec_id = AV_CODEC_ID_HEVC;
+            track->st->codecpar->codec_id  = AV_CODEC_ID_HEVC;
+            track->st->codecpar->codec_tag = MKTAG('h','v','c','1');
 
             if (job->config.h265.headers_length > 0)
             {


### PR DESCRIPTION
This provides compatibility with apple software

This is an alternative to https://github.com/HandBrake/HandBrake/pull/781 that doesn't change libav's default, but allows us to override it