### PR TITLE
contrib: Update to Jansson 2.10.

### DIFF
--- a/contrib/jansson/module.defs
+++ b/contrib/jansson/module.defs
@@ -1,12 +1,8 @@
 $(eval $(call import.MODULE.defs,JANSSON,jansson))
 $(eval $(call import.CONTRIB.defs,JANSSON))
 
-JANSSON.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/jansson-2.6.tar.bz2
-JANSSON.FETCH.url    += http://www.digip.org/jansson/releases/jansson-2.6.tar.bz2
-JANSSON.FETCH.sha256  = d2cc63ee7f6dcda6c9a8f0b558f94b8f25f048706b7cbd6a79d3e877b738cd4d
-
-# TODO: jansson >= 2.7
-#JANSSON.FETCH.url    + http://www.digip.org/jansson/releases/jansson-2.7.tar.bz2
-#JANSSON.FETCH.sha256 = 459f2b7cf22fb676286723f26169a17cf111fbfb6f54e3dc2ec6b6f9f4a97bdc
+JANSSON.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/jansson-2.10.tar.bz2
+JANSSON.FETCH.url    += http://www.digip.org/jansson/releases/jansson-2.10.tar.bz2
+JANSSON.FETCH.sha256  = 241125a55f739cd713808c4e0089986b8c3da746da8b384952912ad659fa2f5a
 
 JANSSON.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; mkdir m4; autoreconf -fiv;


### PR DESCRIPTION
See https://github.com/akheron/jansson/blob/master/CHANGES

I was hoping updating this would help with cross compiling on Mac, targeting Windows. It didn't, but here we are.