### PR TITLE
contrib: Update to libopus 1.2.1.

### DIFF
--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,11 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBOPUS,libopus))
 $(eval $(call import.CONTRIB.defs,LIBOPUS))
 
-LIBOPUS.FETCH.url     = https://download.handbrake.fr/contrib/opus-1.1.3.tar.gz
-LIBOPUS.FETCH.url    += http://downloads.xiph.org/releases/opus/opus-1.1.3.tar.gz
-LIBOPUS.FETCH.sha256  = 58b6fe802e7e30182e95d0cde890c0ace40b6f125cffc50635f0ad2eef69b633
+LIBOPUS.FETCH.url     = https://download.handbrake.fr/contrib/opus-1.2.1.tar.gz
+LIBOPUS.FETCH.url    += https://archive.mozilla.org/pub/opus/opus-1.2.1.tar.gz
+LIBOPUS.FETCH.sha256  = cfafd339ccd9c5ef8d6ab15d7e1a412c054bf4cb4ecbbbcc78c12ef2def70732
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs
-
-LIBOPUS.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;


### PR DESCRIPTION
Closes #799.

Please upload the tarball and verify hash, thanks.

Tested building on Mac and mingw-w64. Tested encoding on Mac.