### PR TITLE
use language code for prefered track selection

### DIFF
--- a/win/CS/HandBrakeWPF/ViewModels/AudioViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/AudioViewModel.cs
@@ -495,9 +495,10 @@ namespace HandBrakeWPF.ViewModels
             if (this.AudioBehaviours.SelectedLangauges.Count > 0)
             {
                 string langName = this.AudioBehaviours.SelectedLangauges.FirstOrDefault(w => !w.Equals(Constants.Any));
-                if (!string.IsNullOrEmpty(langName))
+                string langCode = LanguageUtilities.GetLanguageCode(langName);
+                if (!string.IsNullOrEmpty(langCode))
                 {
-                    preferredAudioTracks = this.SourceTracks.Where(item => item.Language.Contains(langName));
+                    preferredAudioTracks = this.SourceTracks.Where(item => item.LanguageCode.Contains(langCode));
                 }
             }
 

--- a/win/CS/HandBrakeWPF/ViewModels/SubtitlesViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/SubtitlesViewModel.cs
@@ -602,7 +602,9 @@ namespace HandBrakeWPF.ViewModels
         /// </returns>
         private string GetPreferredSubtitleTrackLanguage()
         {
-            return this.SubtitleBehaviours.SelectedLangauges.FirstOrDefault(w => w != Constants.Any);
+            string langName = this.SubtitleBehaviours.SelectedLangauges.FirstOrDefault(w => w != Constants.Any);
+            string langCode = LanguageUtilities.GetLanguageCode(langName);
+            return langCode;
         }
 
         /// <summary>


### PR DESCRIPTION
Instead of the string "Japanese", some rips of japanese material contain the string "日本語" in the language name of subs and audio tracks.
This fix tries to use the language code instead (i.e "jpn"), to avoid the mismatch between "Japanese" and "日本語". This allows a proper selection of Japanse subs and audio tracks.