### PR TITLE
contrib: Update to x265 2.5.

### DIFF
--- a/contrib/x265/P00-mingw-lib.patch
+++ b/contrib/x265/P00-mingw-lib.patch
@@ -1,0 +1,11 @@
+--- x265_2.5/source/x265-extras.h.orig	2017-07-13 07:20:07.000000000 -0400
++++ x265_2.5/source/x265-extras.h	2017-07-31 13:20:23.000000000 -0400
+@@ -33,7 +33,7 @@
+ extern "C" {
+ #endif
+ 
+-#if _WIN32
++#ifdef X265_API_IMPORTS
+ #define LIBAPI __declspec(dllexport)
+ #else
+ #define LIBAPI

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,10 +2,10 @@ __deps__ := YASM CMAKE
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.4.tar.gz
-X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.4.tar.gz
-X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.4.tar.gz
-X265.FETCH.sha256  = 9c2aa718d78f6fecdd783f08ab83b98d3169e5f670404da4c16439306907d729
+X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.5.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
+X265.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
 
 X265.CONFIGURE.exe         = cmake
 X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"


### PR DESCRIPTION
Works fine on Mac.

Breaks hb.dll similarly to #825.