### PR TITLE
LinGUI checkbox control adjustments (see #833).

### DIFF
--- a/gtk/po/af.po
+++ b/gtk/po/af.po
@@ -791,7 +791,7 @@ msgstr "iPod 5G-ondersteuning"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr ""
 
 msgid ""

--- a/gtk/po/cs.po
+++ b/gtk/po/cs.po
@@ -845,7 +845,7 @@ msgstr "Podpora pro iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Přidat iPod Atom, jenž je potřeba některými staršími zařízeními iPod."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Vyladěno pro internet"
 
 msgid ""

--- a/gtk/po/da.po
+++ b/gtk/po/da.po
@@ -640,7 +640,7 @@ msgstr "iPod 5G-understøttelse"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Tilføj iPod-Atom der kræves af nogle ældre iPods."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Web-optimeret"
 
 msgid ""

--- a/gtk/po/de.po
+++ b/gtk/po/de.po
@@ -641,7 +641,7 @@ msgstr "iPod 5G-Unterstützung"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Das von einigen älteren iPods benötigte iPod Atom hinzufügen."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "weboptimiert"
 
 msgid ""

--- a/gtk/po/es.po
+++ b/gtk/po/es.po
@@ -641,7 +641,7 @@ msgstr "Soporte iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Agregar \"átomo\" iPod requerido por algunos iPods antiguos."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Optimizado para web"
 
 msgid ""

--- a/gtk/po/fr.po
+++ b/gtk/po/fr.po
@@ -645,7 +645,7 @@ msgstr "iPod 5G Support"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Ajoute l'iPod Atom requis par certains iPods anciens."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Optimisé pour le Web"
 
 msgid ""

--- a/gtk/po/it_IT.po
+++ b/gtk/po/it_IT.po
@@ -641,7 +641,7 @@ msgstr "Supporto iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Ottimizzato per il web"
 
 msgid ""

--- a/gtk/po/ja_JP.po
+++ b/gtk/po/ja_JP.po
@@ -817,7 +817,7 @@ msgstr "iPod 5G サポート"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "一部の古い iPod のための iPod Atom を追加します。"
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "ウェブに最適化"
 
 msgid ""

--- a/gtk/po/ko.po
+++ b/gtk/po/ko.po
@@ -640,7 +640,7 @@ msgstr "iPod 5G 지원"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "일부 구형 iPods에 필요한 iPod Atom 추가"
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "웹에 최적화"
 
 msgid ""

--- a/gtk/po/no.po
+++ b/gtk/po/no.po
@@ -640,7 +640,7 @@ msgstr "IPod 4G Støtte"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Legg til iPod Atom som brukes av noen eldre versjoner av iPod."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Internett optimalisert"
 
 msgid ""

--- a/gtk/po/pt_BR.po
+++ b/gtk/po/pt_BR.po
@@ -640,7 +640,7 @@ msgstr ""
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr ""
 
 msgid ""

--- a/gtk/po/ro_RO.po
+++ b/gtk/po/ro_RO.po
@@ -640,7 +640,7 @@ msgstr "Suport iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Adaugă iPod Atom necesare unor iPod-uri vechi."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Optimizat Web"
 
 msgid ""

--- a/gtk/po/ru.po
+++ b/gtk/po/ru.po
@@ -832,7 +832,7 @@ msgstr "Поддержка iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Добавить iPod Atom, необходимый некоторым старым плеерам."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Оптимизация для интернет-трансляции"
 
 msgid ""

--- a/gtk/po/sk.po
+++ b/gtk/po/sk.po
@@ -747,7 +747,7 @@ msgstr "Podpora pre iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Optimalizácia pre web"
 
 msgid ""

--- a/gtk/po/sv.po
+++ b/gtk/po/sv.po
@@ -845,7 +845,7 @@ msgstr "iPod 5G-stöd"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Lägg till iPod Atom, nödvändiga för vissa äldre iPod:ar."
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "Webboptimerad"
 
 msgid ""

--- a/gtk/po/th.po
+++ b/gtk/po/th.po
@@ -641,7 +641,7 @@ msgstr "รองรับ iPod 5G"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "เพิ่ม iPod Atom ที่ต้องการโดย iPods เก่าบางรุ่น"
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "ให้เหมาะกับเว็บ"
 
 msgid ""

--- a/gtk/po/zh_CN.po
+++ b/gtk/po/zh_CN.po
@@ -748,7 +748,7 @@ msgstr "iPod 5G 支持"
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-msgid "Web optimized"
+msgid "Web Optimized"
 msgstr "为网络观看做优化"
 
 msgid ""

--- a/gtk/src/ghb.m4
+++ b/gtk/src/ghb.m4
@@ -1504,7 +1504,7 @@ This is often the feature title of a DVD.</property>
                             </child>
                             <child>
                               <object class="GtkCheckButton" id="Mp4HttpOptimize">
-                                <property name="label" translatable="yes">Web optimized</property>
+                                <property name="label" translatable="yes">Web Optimized</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>

--- a/gtk/src/ghb.m4
+++ b/gtk/src/ghb.m4
@@ -1503,15 +1503,14 @@ This is often the feature title of a DVD.</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="AlignAVStart">
-                                <property name="label" translatable="yes">Align A/V Start</property>
+                              <object class="GtkCheckButton" id="Mp4HttpOptimize">
+                                <property name="label" translatable="yes">Web optimized</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Aligns the initial timestamps of all audio and video streams by
-inserting blank frames or dropping frames. May improve audio/video
-sync for broken players that do not honor MP4 edit lists.</property>
+                                <property name="tooltip_text" translatable="yes">Optimize the layout of the MP4 file for progressive download.
+This allows a player to initiate playback before downloading the entire file.</property>
                                 <property name="halign">start</property>
                                 <property name="draw_indicator">True</property>
                                 <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
@@ -1524,14 +1523,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkCheckButton" id="Mp4HttpOptimize">
-                                <property name="label" translatable="yes">Web optimized</property>
+                              <object class="GtkCheckButton" id="AlignAVStart">
+                                <property name="label" translatable="yes">Align A/V Start</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Optimize the layout of the MP4 file for progressive download.
-This allows a player to initiate playback before downloading the entire file.</property>
+                                <property name="tooltip_text" translatable="yes">Aligns the initial timestamps of all audio and video streams by
+inserting blank frames or dropping frames. May improve audio/video
+sync for broken players that do not honor MP4 edit lists.</property>
                                 <property name="halign">start</property>
                                 <property name="draw_indicator">True</property>
                                 <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>


### PR DESCRIPTION
From #833, "Ordering and capitalization of Web Optimized, Align A/V Start, iPod 5G Support controls".

Would like @jstebbins' eyes on this before merging. Also, I'm not sure whether `top_attach` and `left_attach` values need editing after reordering the controls.