### PR TITLE
libhb: read video rotation from libav.

### DIFF
--- a/libhb/common.h
+++ b/libhb/common.h
@@ -992,6 +992,7 @@ struct hb_title_s
 
     int           preview_count;
     int           has_resolution_change;
+    enum { HB_ROTATION_0, HB_ROTATION_90, HB_ROTATION_180, HB_ROTATION_270 } rotation;
     hb_geometry_t geometry;
     hb_rational_t dar;             // aspect ratio for the title's video
     hb_rational_t container_dar;   // aspect ratio from container (0 if none)

--- a/libhb/hbffmpeg.h
+++ b/libhb/hbffmpeg.h
@@ -15,6 +15,7 @@
 #include "libavutil/opt.h"
 #include "libavutil/avutil.h"
 #include "libavutil/downmix_info.h"
+#include "libavutil/display.h"
 #include "libswscale/swscale.h"
 #include "libavresample/avresample.h"
 #include "common.h"

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5534,6 +5534,37 @@ static hb_title_t *ffmpeg_title_scan( hb_stream_t *stream, hb_title_t *title )
                 title->geometry.par.den = ic->streams[i]->sample_aspect_ratio.den;
             }
 
+            int j;
+            for (j = 0; j < ic->streams[i]->nb_side_data; j++)
+            {
+                AVPacketSideData sd = ic->streams[i]->side_data[j];
+                switch (sd.type)
+                {
+                    case AV_PKT_DATA_DISPLAYMATRIX:
+                    {
+                        int rotation = av_display_rotation_get((int32_t *)sd.data);
+                        switch (rotation) {
+                            case 90:
+                                title->rotation = HB_ROTATION_90;
+                                break;
+                            case 180:
+                            case -180:
+                                title->rotation = HB_ROTATION_180;
+                                break;
+                            case -90:
+                            case 270:
+                                title->rotation = HB_ROTATION_270;
+                                break;
+                            default:
+                                break;
+                        }
+                        break;
+                    }
+                    default:
+                        break;
+                }
+            }
+
             title->video_codec = WORK_DECAVCODECV;
             title->video_codec_param = codecpar->codec_id;
             if (ic->iformat->raw_codec_id != AV_CODEC_ID_NONE)


### PR DESCRIPTION
Read the rotation value from libav and store it in the title struct.
Next step would be to use this value in hb_preset_apply_title() to automatically add the rotate filter or sum the value to the rotate filter if the preset already had one.