### PR TITLE
QSV: Adding D11 support for encode

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -668,8 +668,8 @@ int qsv_enc_init(hb_work_private_t *pv)
     if ((MFXQueryIMPL   (qsv->mfx_session, &impl)    == MFX_ERR_NONE) &&
         (MFXQueryVersion(qsv->mfx_session, &version) == MFX_ERR_NONE))
     {
-        hb_log("qsv_enc_init: using '%s' implementation, API: %"PRIu16".%"PRIu16"",
-               hb_qsv_impl_get_name(impl), version.Major, version.Minor);
+        hb_log("qsv_enc_init: using '%s %s' implementation, API: %"PRIu16".%"PRIu16"",
+               hb_qsv_impl_get_name(impl), hb_qsv_impl_get_via_name(impl), version.Major, version.Minor);
     }
     else
     {

--- a/libhb/qsv_common.h
+++ b/libhb/qsv_common.h
@@ -35,7 +35,7 @@ typedef struct hb_qsv_info_s
 {
     // each info struct only corresponds to one CodecId and implementation combo
     const mfxU32  codec_id;
-    const mfxIMPL implementation;
+    mfxIMPL implementation;
 
     // whether the encoder is available for this implementation
     int available;
@@ -188,6 +188,7 @@ uint8_t     hb_qsv_frametype_xlat(uint16_t qsv_frametype, uint16_t *out_flags);
 
 int         hb_qsv_impl_set_preferred(const char *name);
 const char* hb_qsv_impl_get_name(int impl);
+const char* hb_qsv_impl_get_via_name(int impl);
 
 void hb_qsv_force_workarounds(); // for developers only
 


### PR DESCRIPTION
Adding support of DirectX 11 to try first and before DirectX 9 for encode,
helps to use QSV as second GPU and headless mode.

Decode part will be shared as separate patch.