### PR TITLE
QSV: Main10 should be default profile

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -864,7 +864,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     pv->param.videoParam->mfx.FrameInfo.Height        = job->qsv.enc_info.align_height;
 
     // parse user-specified codec profile and level
-    if (hb_qsv_profile_parse(&pv->param, pv->qsv_info, job->encoder_profile))
+    if (hb_qsv_profile_parse(&pv->param, pv->qsv_info, job->encoder_profile, job->vcodec))
     {
         hb_error("encqsvInit: bad profile %s", job->encoder_profile);
         return -1;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1557,7 +1557,7 @@ int hb_qsv_param_parse(hb_qsv_param_t *param, hb_qsv_info_t *info,
     return error ? HB_QSV_PARAM_BAD_VALUE : HB_QSV_PARAM_OK;
 }
 
-int hb_qsv_profile_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, const char *profile_key)
+int hb_qsv_profile_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, const char *profile_key, const int codec)
 {
     hb_triplet_t *profile = NULL;
     if (profile_key != NULL && *profile_key && strcasecmp(profile_key, "auto"))
@@ -1589,6 +1589,15 @@ int hb_qsv_profile_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, const char 
             return -1;
         }
         param->videoParam->mfx.CodecProfile = profile->value;
+    }
+    /* HEVC 10 bits defautls to Main 10 */
+    else if (((profile_key != NULL && !strcasecmp(profile_key, "auto")) || profile_key == NULL) && 
+              codec == HB_VCODEC_QSV_H265_10BIT &&
+              param->videoParam->mfx.CodecId == MFX_CODEC_HEVC &&
+              qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G6)
+    {
+         profile = &hb_qsv_h265_profiles[1];
+         param->videoParam->mfx.CodecProfile = profile->value;
     }
     return 0;
 }

--- a/libhb/qsv_common.h
+++ b/libhb/qsv_common.h
@@ -165,7 +165,7 @@ float hb_qsv_atof    (const char *str, int *err);
 int hb_qsv_param_default_preset(hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info, const char *preset);
 int hb_qsv_param_default       (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info);
 int hb_qsv_param_parse         (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *key, const char *value);
-int hb_qsv_profile_parse       (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key);
+int hb_qsv_profile_parse       (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key, const int codec);
 int hb_qsv_level_parse         (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *level_key);
 
 typedef struct


### PR DESCRIPTION
Just to avoid some confusion(s) when HEVC10b is used