### PR TITLE
x265: add support for 8/10/12 bit encoding in single static lib

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -7,6 +7,9 @@ X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5
 X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
 X265.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
 
+# Silence "warning: overriding recipe for target" messages
+X265.FETCH.target =
+
 X265.INSTALL.args.dir = -j 1 -C $(X265.BUILD.dir)/8bit install;
 X265.INSTALL.extra = $(CP.exe) $(X265.BUILD.dir)/libx265.a $(CONTRIB.build/)lib
 X265.INSTALL.args = !make @dir !extra
@@ -26,7 +29,8 @@ X265.OSL.libs  = x265
 X265.OSL.files = $(foreach i,$(X265.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build/)lib/lib$(i).a))
 
 # Override operations that are not needed
-X265.FETCH = $(TOUCH.exe) $@
+X265.FETCH =
+X265.VERIFY = $(TOUCH.exe) $@
 X265.EXTRACT = $(TOUCH.exe) $@
 X265.PATCH = $(TOUCH.exe) $@
 X265.CONFIGURE = $(TOUCH.exe) $@

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -1,4 +1,4 @@
-__deps__ := YASM CMAKE
+__deps__ := YASM CMAKE X265_8 X265_10 X265_12
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
@@ -7,30 +7,14 @@ X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5
 X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
 X265.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
 
-X265.CONFIGURE.exe         = cmake
-X265.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265.CONFIGURE.prefix)"
-X265.CONFIGURE.deps        =
-X265.CONFIGURE.static      =
-X265.CONFIGURE.shared      = -DENABLE_SHARED=OFF
-X265.CONFIGURE.extra       = -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=OFF -DENABLE_LIBNUMA=OFF
+X265.INSTALL.args.dir = -j 1 -C $(X265.BUILD.dir)/8bit install;
+X265.INSTALL.extra = $(CP.exe) $(X265.BUILD.dir)/libx265.a $(CONTRIB.build/)lib
+X265.INSTALL.args = !make @dir !extra
 
-ifneq (none,$(X265.GCC.g))
-    X265.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
-endif
-
-ifeq (1,$(BUILD.cross))
-    ifeq (mingw,$(BUILD.system))
-        X265.CONFIGURE.extra += -DWIN32=ON
-    endif
-    X265.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265.CONFIGURE.host)"
-    X265.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265.CONFIGURE.build)"
-else
-    X265.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265.CONFIGURE.host)"
-    ifeq (1,$(FEATURE.local_yasm))
-        X265.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
-        X265.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
-    endif
-endif
+X265.CLEAN.make = $(RM.exe)
+X265.CLEAN.args.dir = cd $(1);
+X265.CLEAN.extra = libx265.a
+X265.CLEAN.args = @dir !make !extra
 
 ## find CMakeLists.txt
 X265.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265.EXTRACT.dir/)source/)"
@@ -38,3 +22,7 @@ X265.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265.EXTRACT.dir/)source/)"
 ## optional static libs need to be marked
 X265.OSL.libs  = x265
 X265.OSL.files = $(foreach i,$(X265.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build/)lib/lib$(i).a))
+
+# Override operations that are not needed
+X265.CONFIGURE = $(TOUCH.exe) $@
+X265.BUILD = $(TOUCH.exe) $@

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -34,7 +34,7 @@ X265.SOURCE.libs = \
 
 ifeq (darwin, $(BUILD.system))
     define X265.LINK
-        libtool -static -o libx265.a $(X265.SOURCE.libs)
+        libtool -static -o $@ $(X265.SOURCE.libs)
     endef
 else
     X265.arscript = $(X265.BUILD.dir)/script.ar

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -11,6 +11,8 @@ X265.INSTALL.args.dir = -j 1 -C $(X265.BUILD.dir)/8bit install;
 X265.INSTALL.extra = $(CP.exe) $(X265.BUILD.dir)/libx265.a $(CONTRIB.build/)lib
 X265.INSTALL.args = !make @dir !extra
 
+X265.UNINSTALL.dir = $(X265.BUILD.dir)/8bit
+
 X265.CLEAN.make = $(RM.exe)
 X265.CLEAN.args.dir = cd $(1);
 X265.CLEAN.extra = libx265.a
@@ -24,6 +26,9 @@ X265.OSL.libs  = x265
 X265.OSL.files = $(foreach i,$(X265.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build/)lib/lib$(i).a))
 
 # Override operations that are not needed
+X265.FETCH = $(TOUCH.exe) $@
+X265.EXTRACT = $(TOUCH.exe) $@
+X265.PATCH = $(TOUCH.exe) $@
 X265.CONFIGURE = $(TOUCH.exe) $@
 X265.BUILD = $(TOUCH.exe) $@
 

--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -26,3 +26,25 @@ X265.OSL.files = $(foreach i,$(X265.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build
 # Override operations that are not needed
 X265.CONFIGURE = $(TOUCH.exe) $@
 X265.BUILD = $(TOUCH.exe) $@
+
+X265.SOURCE.libs = \
+	$(X265.BUILD.dir)/8bit/libx265_main.a \
+	$(X265.BUILD.dir)/10bit/libx265_main10.a \
+	$(X265.BUILD.dir)/12bit/libx265_main12.a
+
+ifeq (darwin, $(BUILD.system))
+    define X265.LINK
+        libtool -static -o libx265.a $(X265.SOURCE.libs)
+    endef
+else
+    X265.arscript = $(X265.BUILD.dir)/script.ar
+    define X265.LINK
+        echo "CREATE $@" > $(X265.arscript)
+        for a in $(X265.SOURCE.libs); do \
+            (echo "ADDLIB $$a" >> $(X265.arscript)); \
+        done
+        echo "SAVE" >> $(X265.arscript)
+        echo "END" >> $(X265.arscript)
+        $(AR.exe) -M < $(X265.arscript)
+    endef
+endif

--- a/contrib/x265/module.rules
+++ b/contrib/x265/module.rules
@@ -2,12 +2,6 @@ $(eval $(call import.MODULE.rules,X265))
 $(eval $(call import.CONTRIB.rules,X265))
 
 $(X265.BUILD.dir)/libx265.a: $(X265.deps)
-	echo "CREATE $@" > script.ar
-	echo "ADDLIB $(X265.BUILD.dir)/8bit/libx265_main.a" >> script.ar
-	echo "ADDLIB $(X265.BUILD.dir)/10bit/libx265_main10.a" >> script.ar
-	echo "ADDLIB $(X265.BUILD.dir)/12bit/libx265_main12.a" >> script.ar
-	echo "SAVE" >> script.ar
-	echo "END" >> script.ar
-	$(AR.exe) -M < script.ar
+	$(X265.LINK)
 
 $(X265.INSTALL.target): $(X265.BUILD.dir)/libx265.a

--- a/contrib/x265/module.rules
+++ b/contrib/x265/module.rules
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.rules,X265))
 $(eval $(call import.CONTRIB.rules,X265))
 
-$(X265.BUILD.dir)/libx265.a: $(X265.deps)
+$(X265.BUILD.dir)/libx265.a: $(X265.deps) $(X265.BUILD.target)
 	$(X265.LINK)
 
 $(X265.INSTALL.target): $(X265.BUILD.dir)/libx265.a

--- a/contrib/x265/module.rules
+++ b/contrib/x265/module.rules
@@ -1,2 +1,13 @@
 $(eval $(call import.MODULE.rules,X265))
 $(eval $(call import.CONTRIB.rules,X265))
+
+$(X265.BUILD.dir)/libx265.a: $(X265.deps)
+	echo "CREATE $@" > script.ar
+	echo "ADDLIB $(X265.BUILD.dir)/8bit/libx265_main.a" >> script.ar
+	echo "ADDLIB $(X265.BUILD.dir)/10bit/libx265_main10.a" >> script.ar
+	echo "ADDLIB $(X265.BUILD.dir)/12bit/libx265_main12.a" >> script.ar
+	echo "SAVE" >> script.ar
+	echo "END" >> script.ar
+	$(AR.exe) -M < script.ar
+
+$(X265.INSTALL.target): $(X265.BUILD.dir)/libx265.a

--- a/contrib/x265_10bit/P00-mingw-lib.patch
+++ b/contrib/x265_10bit/P00-mingw-lib.patch
@@ -1,0 +1,11 @@
+--- x265_2.5/source/x265-extras.h.orig	2017-07-13 07:20:07.000000000 -0400
++++ x265_2.5/source/x265-extras.h	2017-07-31 13:20:23.000000000 -0400
+@@ -33,7 +33,7 @@
+ extern "C" {
+ #endif
+ 
+-#if _WIN32
++#ifdef X265_API_IMPORTS
+ #define LIBAPI __declspec(dllexport)
+ #else
+ #define LIBAPI

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -1,0 +1,49 @@
+__deps__ := YASM CMAKE
+$(eval $(call import.MODULE.defs,X265_10,x265_10,$(__deps__),x265))
+$(eval $(call import.CONTRIB.defs,X265_10))
+
+X265_10.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.5.tar.gz
+X265_10.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5.tar.gz
+X265_10.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
+X265_10.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
+
+# Silence "warning: overriding recipe for target" messages
+X265_10.FETCH.target =
+
+X265_10.build_dir             = 10bit
+X265_10.CONFIGURE.exe         = cmake
+X265_10.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265_10.CONFIGURE.prefix)"
+X265_10.CONFIGURE.deps        =
+X265_10.CONFIGURE.static      =
+X265_10.CONFIGURE.shared      = -DENABLE_SHARED=OFF
+X265_10.CONFIGURE.extra       = -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=ON -DENABLE_LIBNUMA=OFF -DEXPORT_C_API=OFF
+
+ifneq (none,$(X265_10.GCC.g))
+    X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+endif
+
+ifeq (1,$(BUILD.cross))
+    ifeq (mingw,$(BUILD.system))
+        X265_10.CONFIGURE.extra += -DWIN32=ON
+    endif
+    X265_10.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_10.CONFIGURE.host)"
+    X265_10.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.build)"
+else
+    X265_10.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.host)"
+    ifeq (1,$(FEATURE.local_yasm))
+        X265_10.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+        X265_10.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+    endif
+endif
+
+## find CMakeLists.txt
+X265_10.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265_10.EXTRACT.dir/)source/)"
+
+X265_10.INSTALL.make = $(MV.exe)
+X265_10.INSTALL.args.dir = cd $(1);
+X265_10.INSTALL.extra = libx265.a libx265_main10.a
+X265_10.INSTALL.args = @dir !make !extra
+
+# Override operations that are not needed
+X265_10.EXTRACT = $(TOUCH.exe) $@
+X265_10.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -1,4 +1,4 @@
-__deps__ := YASM CMAKE
+__deps__ := YASM CMAKE X265_8
 $(eval $(call import.MODULE.defs,X265_10,x265_10,$(__deps__),x265))
 $(eval $(call import.CONTRIB.defs,X265_10))
 
@@ -45,5 +45,6 @@ X265_10.INSTALL.extra = libx265.a libx265_main10.a
 X265_10.INSTALL.args = @dir !make !extra
 
 # Override operations that are not needed
+X265_10.FETCH = $(TOUCH.exe) $@
 X265_10.EXTRACT = $(TOUCH.exe) $@
 X265_10.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -45,6 +45,6 @@ X265_10.INSTALL.extra = libx265.a libx265_main10.a
 X265_10.INSTALL.args = @dir !make !extra
 
 # Override operations that are not needed
-X265_10.FETCH = $(TOUCH.exe) $@
+X265_10.FETCH =
 X265_10.EXTRACT = $(TOUCH.exe) $@
 X265_10.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -48,3 +48,4 @@ X265_10.INSTALL.args = @dir !make !extra
 X265_10.FETCH =
 X265_10.EXTRACT = $(TOUCH.exe) $@
 X265_10.PATCH = $(TOUCH.exe) $@
+X265.XCLEAN =

--- a/contrib/x265_10bit/module.rules
+++ b/contrib/x265_10bit/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,X265_10))
+$(eval $(call import.CONTRIB.rules,X265_10))

--- a/contrib/x265_12bit/P00-mingw-lib.patch
+++ b/contrib/x265_12bit/P00-mingw-lib.patch
@@ -1,0 +1,11 @@
+--- x265_2.5/source/x265-extras.h.orig	2017-07-13 07:20:07.000000000 -0400
++++ x265_2.5/source/x265-extras.h	2017-07-31 13:20:23.000000000 -0400
+@@ -33,7 +33,7 @@
+ extern "C" {
+ #endif
+ 
+-#if _WIN32
++#ifdef X265_API_IMPORTS
+ #define LIBAPI __declspec(dllexport)
+ #else
+ #define LIBAPI

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -1,0 +1,49 @@
+__deps__ := YASM CMAKE
+$(eval $(call import.MODULE.defs,X265_12,x265_12,$(__deps__),x265))
+$(eval $(call import.CONTRIB.defs,X265_12))
+
+X265_12.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.5.tar.gz
+X265_12.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5.tar.gz
+X265_12.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
+X265_12.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
+
+# Silence "warning: overriding recipe for target" messages
+X265_12.FETCH.target =
+
+X265_12.build_dir             = 12bit
+X265_12.CONFIGURE.exe         = cmake
+X265_12.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265_12.CONFIGURE.prefix)"
+X265_12.CONFIGURE.deps        =
+X265_12.CONFIGURE.static      =
+X265_12.CONFIGURE.shared      = -DENABLE_SHARED=OFF
+X265_12.CONFIGURE.extra       = -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=ON -DENABLE_LIBNUMA=OFF -DEXPORT_C_API=OFF -DMAIN12=ON
+
+ifneq (none,$(X265_12.GCC.g))
+    X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+endif
+
+ifeq (1,$(BUILD.cross))
+    ifeq (mingw,$(BUILD.system))
+        X265_12.CONFIGURE.extra += -DWIN32=ON
+    endif
+    X265_12.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_12.CONFIGURE.host)"
+    X265_12.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.build)"
+else
+    X265_12.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.host)"
+    ifeq (1,$(FEATURE.local_yasm))
+        X265_12.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+        X265_12.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+    endif
+endif
+
+## find CMakeLists.txt
+X265_12.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265_12.EXTRACT.dir/)source/)"
+
+X265_12.INSTALL.make = $(MV.exe)
+X265_12.INSTALL.args.dir = cd $(1);
+X265_12.INSTALL.extra = libx265.a libx265_main12.a
+X265_12.INSTALL.args = @dir !make !extra
+
+# Override operations that are not needed
+X265_12.EXTRACT = $(TOUCH.exe) $@
+X265_12.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -1,4 +1,4 @@
-__deps__ := YASM CMAKE
+__deps__ := YASM CMAKE X265_8
 $(eval $(call import.MODULE.defs,X265_12,x265_12,$(__deps__),x265))
 $(eval $(call import.CONTRIB.defs,X265_12))
 
@@ -45,5 +45,6 @@ X265_12.INSTALL.extra = libx265.a libx265_main12.a
 X265_12.INSTALL.args = @dir !make !extra
 
 # Override operations that are not needed
+X265_12.FETCH = $(TOUCH.exe) $@
 X265_12.EXTRACT = $(TOUCH.exe) $@
 X265_12.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -48,3 +48,4 @@ X265_12.INSTALL.args = @dir !make !extra
 X265_12.FETCH =
 X265_12.EXTRACT = $(TOUCH.exe) $@
 X265_12.PATCH = $(TOUCH.exe) $@
+X265.XCLEAN =

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -45,6 +45,6 @@ X265_12.INSTALL.extra = libx265.a libx265_main12.a
 X265_12.INSTALL.args = @dir !make !extra
 
 # Override operations that are not needed
-X265_12.FETCH = $(TOUCH.exe) $@
+X265_12.FETCH =
 X265_12.EXTRACT = $(TOUCH.exe) $@
 X265_12.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_12bit/module.rules
+++ b/contrib/x265_12bit/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,X265_12))
+$(eval $(call import.CONTRIB.rules,X265_12))

--- a/contrib/x265_8bit/P00-mingw-lib.patch
+++ b/contrib/x265_8bit/P00-mingw-lib.patch
@@ -1,0 +1,11 @@
+--- x265_2.5/source/x265-extras.h.orig	2017-07-13 07:20:07.000000000 -0400
++++ x265_2.5/source/x265-extras.h	2017-07-31 13:20:23.000000000 -0400
+@@ -33,7 +33,7 @@
+ extern "C" {
+ #endif
+ 
+-#if _WIN32
++#ifdef X265_API_IMPORTS
+ #define LIBAPI __declspec(dllexport)
+ #else
+ #define LIBAPI

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -1,0 +1,49 @@
+__deps__ := YASM CMAKE
+$(eval $(call import.MODULE.defs,X265_8,x265_8,$(__deps__),x265))
+$(eval $(call import.CONTRIB.defs,X265_8))
+
+X265_8.FETCH.url     = https://download.handbrake.fr/contrib/x265_2.5.tar.gz
+X265_8.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2.5.tar.gz
+X265_8.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
+X265_8.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
+
+# Silence "warning: overriding recipe for target" messages
+X265_8.FETCH.target =
+
+X265_8.build_dir             = 8bit
+X265_8.CONFIGURE.exe         = cmake
+X265_8.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265_8.CONFIGURE.prefix)"
+X265_8.CONFIGURE.deps        =
+X265_8.CONFIGURE.static      =
+X265_8.CONFIGURE.shared      = -DENABLE_SHARED=OFF
+X265_8.CONFIGURE.extra       = -DENABLE_CLI=OFF -DHIGH_BIT_DEPTH=OFF -DENABLE_LIBNUMA=OFF -DEXTRA_LIB="x265_main10.a;x265_main12.a" -DEXTRA_LINK_FLAGS=-L. -DLINKED_10BIT=ON -DLINKED_12BIT=ON
+
+ifneq (none,$(X265_8.GCC.g))
+    X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+endif
+
+ifeq (1,$(BUILD.cross))
+    ifeq (mingw,$(BUILD.system))
+        X265_8.CONFIGURE.extra += -DWIN32=ON
+    endif
+    X265_8.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_8.CONFIGURE.host)"
+    X265_8.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.build)"
+else
+    X265_8.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.host)"
+    ifeq (1,$(FEATURE.local_yasm))
+        X265_8.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+        X265_8.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
+    endif
+endif
+
+## find CMakeLists.txt
+X265_8.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(X265_8.EXTRACT.dir/)source/)"
+
+X265_8.INSTALL.make = $(MV.exe)
+X265_8.INSTALL.args.dir = cd $(1);
+X265_8.INSTALL.extra = libx265.a libx265_main.a
+X265_8.INSTALL.args = @dir !make !extra
+
+# Override operations that are not needed
+X265_8.EXTRACT = $(TOUCH.exe) $@
+X265_8.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -44,6 +44,3 @@ X265_8.INSTALL.args.dir = cd $(1);
 X265_8.INSTALL.extra = libx265.a libx265_main.a
 X265_8.INSTALL.args = @dir !make !extra
 
-# Override operations that are not needed
-X265_8.EXTRACT = $(TOUCH.exe) $@
-X265_8.PATCH = $(TOUCH.exe) $@

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -7,9 +7,6 @@ X265_8.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_2
 X265_8.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_2.5.tar.gz
 X265_8.FETCH.sha256  = 2e53259b504a7edb9b21b9800163b1ff4c90e60c74e23e7001d423c69c5d3d17
 
-# Silence "warning: overriding recipe for target" messages
-X265_8.FETCH.target =
-
 X265_8.build_dir             = 8bit
 X265_8.CONFIGURE.exe         = cmake
 X265_8.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(X265_8.CONFIGURE.prefix)"

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -41,3 +41,5 @@ X265_8.INSTALL.args.dir = cd $(1);
 X265_8.INSTALL.extra = libx265.a libx265_main.a
 X265_8.INSTALL.args = @dir !make !extra
 
+# Override operations that are not needed
+X265.XCLEAN =

--- a/contrib/x265_8bit/module.rules
+++ b/contrib/x265_8bit/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,X265_8))
+$(eval $(call import.CONTRIB.rules,X265_8))

--- a/make/include/base.defs
+++ b/make/include/base.defs
@@ -12,6 +12,13 @@ define import.MODULE.defs
     ## module name (lowercase)
     $(1).name = $(2)
 
+    ## module build directory
+    ifeq (,$(4))
+        $(1).dir = $(2)
+    else
+        $(1).dir = $(4)
+    endif
+
     ## list of prerequisite modules (uppercase)
     $(1).prerequisites = $(3)
 

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -18,10 +18,11 @@ define import.CONTRIB.defs
     ##
     ## common values useful across targets
     ##
-    $(1).src/   = $$(SRC/)contrib/$($(1).name)/
-    $(1).build/ = $$(CONTRIB.build/)$($(1).name)/
+    $(1).src/   = $$(SRC/)contrib/$($(1).dir)/
+    $(1).build/ = $$(CONTRIB.build/)$($(1).dir)/
     ## add prerequisites and autotool modules for all contribs
     $(1).deps   = $$(foreach n,$($(1).prerequisites) $(if $(filter $1,$(AUTOTOOL_MODULES)),,$(AUTOTOOL_MODULES)),$$($$n.INSTALL.target))
+    $(1).build_dir =
 
     ##
     ## target: fetch
@@ -40,7 +41,7 @@ define import.CONTRIB.defs
     ##
     ## target: verify
     ##
-    $(1).VERIFY.target = $$($(1).build/).stamp.verify
+    $(1).VERIFY.target = $$($(1).build/).stamp.$$($(1).name).verify
     define $(1).VERIFY
         $$(DF.VERIFY.exe) --config $(BUILD/)distfile.cfg $$(if $$($(1).FETCH.sha256),--sha256 $$($(1).FETCH.sha256)) $$($(1).FETCH.distfile)
         $$(TOUCH.exe) $$@
@@ -51,7 +52,7 @@ define import.CONTRIB.defs
     ##
     $(1).EXTRACT.tarbase = $$(strip $$(foreach x,tar.bz2 tar.gz,$$(patsubst %.$$(x),%,$$(filter %.$$(x),$$($(1).FETCH.basename)))))
     $(1).EXTRACT.dir/    = $$($(1).build/)$$($(1).EXTRACT.tarbase)/
-    $(1).EXTRACT.target  = $$($(1).build/).stamp.extract
+    $(1).EXTRACT.target  = $$($(1).build/).stamp.$$($(1).name).extract
     define $(1).EXTRACT
         $$(RM.exe) -fr $$($(1).EXTRACT.dir/)
         $$(TAR.exe) xfC $$($(1).FETCH.distfile) $$($(1).build/)
@@ -71,7 +72,7 @@ define import.CONTRIB.defs
 
     endef
 
-    $(1).PATCH.target = $$($(1).build/).stamp.patch
+    $(1).PATCH.target = $$($(1).build/).stamp.$$($(1).name).patch
     define $(1).PATCH
         $$(foreach p,$$($(1).PATCH.srcs),$$(call $(1).PATCH.item,$$($(1).EXTRACT.dir/),$$(p)))
         $$(TOUCH.exe) $$@
@@ -81,7 +82,7 @@ define import.CONTRIB.defs
     ## target: configure
     ##
     $(1).CONFIGURE.sete       = set -e;
-    $(1).CONFIGURE.dir        = $$($(1).EXTRACT.dir/)
+    $(1).CONFIGURE.dir        = $$($(1).EXTRACT.dir/)$$($(1).build_dir)
     $(1).CONFIGURE.bootstrap  =
     $(1).CONFIGURE.exe        = ./configure
     $(1).CONFIGURE.host       = $$(CONTRIB.host)
@@ -92,7 +93,7 @@ define import.CONTRIB.defs
     $(1).CONFIGURE.static     = --enable-static
     $(1).CONFIGURE.extra      =
 
-    $(1).CONFIGURE.args.dir    = cd $$(1);
+    $(1).CONFIGURE.args.dir    = $$(MKDIR.exe) -p $$(1); cd $$(1);
     $(1).CONFIGURE.args.host   = --host=$$(1)
     $(1).CONFIGURE.args.build  = --build=$$(1)
     $(1).CONFIGURE.args.prefix = --prefix=$$(1)
@@ -124,7 +125,7 @@ define import.CONTRIB.defs
     $(1).CONFIGURE.env.args = !CC !CFLAGS !CXX !CXXFLAGS !CPPFLAGS !LD !LDFLAGS !PKG_CONFIG_PATH !LOCAL_PATH !CROSS
     $(1).CONFIGURE.env = $$(call fn.ARGS,$(1).CONFIGURE.env,$$($(1).CONFIGURE.env.args))
 
-    $(1).CONFIGURE.target = $$($(1).build/).stamp.configure
+    $(1).CONFIGURE.target = $$($(1).build/).stamp.$$($(1).name).configure
     define $(1).CONFIGURE
         $$(call fn.ARGS,$(1).CONFIGURE,$$($(1).CONFIGURE.args))
         $$(TOUCH.exe) $$@
@@ -135,14 +136,14 @@ define import.CONTRIB.defs
     ##
     $(1).BUILD.env      =
     $(1).BUILD.make     = $$(MAKE)
-    $(1).BUILD.dir      = $$($(1).EXTRACT.dir/)
+    $(1).BUILD.dir      = $$($(1).EXTRACT.dir/)$$($(1).build_dir)
     $(1).BUILD.extra    =
     $(1).BUILD.ntargets =
 
     $(1).BUILD.args = !env !make @dir !extra !ntargets
     $(1).BUILD.args.dir = -C $$(1)
 
-    $(1).BUILD.target = $$($(1).build/).stamp.build
+    $(1).BUILD.target = $$($(1).build/).stamp.$$($(1).name).build
     define $(1).BUILD
         $$(call fn.ARGS,$(1).BUILD,$$($(1).BUILD.args))
         $$(TOUCH.exe) $$@
@@ -152,7 +153,7 @@ define import.CONTRIB.defs
     ## target: install
     ##
     $(1).INSTALL.make     = $$(MAKE)
-    $(1).INSTALL.dir      = $$($(1).EXTRACT.dir/)
+    $(1).INSTALL.dir      = $$($(1).EXTRACT.dir/)$$($(1).build_dir)
     $(1).INSTALL.extra    =
     $(1).INSTALL.ntargets =
 
@@ -160,7 +161,7 @@ define import.CONTRIB.defs
     $(1).INSTALL.args.dir = -j 1 -C $$(1) install
 
     $(1).INSTALL.mkdirs = $$(CONTRIB.build/)lib/ $$(CONTRIB.build/)include/
-    $(1).INSTALL.target = $$($(1).build/).stamp.install
+    $(1).INSTALL.target = $$($(1).build/).stamp.$$($(1).name).install
     define $(1).INSTALL
         $$(call fn.ARGS,$(1).INSTALL,$$($(1).INSTALL.args))
         $$(TOUCH.exe) $$@
@@ -170,7 +171,7 @@ define import.CONTRIB.defs
     ## target: uninstall
     ##
     $(1).UNINSTALL.make     = $$(MAKE)
-    $(1).UNINSTALL.dir      = $$($(1).EXTRACT.dir/)
+    $(1).UNINSTALL.dir      = $$($(1).EXTRACT.dir/)$$($(1).build_dir)
     $(1).UNINSTALL.extra    =
     $(1).UNINSTALL.ntargets = uninstall
 
@@ -186,7 +187,7 @@ define import.CONTRIB.defs
     ## target: clean
     ##
     $(1).CLEAN.make     = $$(MAKE)
-    $(1).CLEAN.dir      = $$($(1).EXTRACT.dir/)
+    $(1).CLEAN.dir      = $$($(1).EXTRACT.dir/)$$($(1).build_dir)
     $(1).CLEAN.extra    =
     $(1).CLEAN.ntargets = clean
 

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -199,6 +199,10 @@ define import.CONTRIB.defs
         $$(RM.exe) -f $$($(1).BUILD.target)
     endef
 
+    define $(1).XCLEAN
+	    $$(RM.exe) -fr $$($(1).build/)
+    endef
+
     ##
     ## other values used to aid prerequisite dirs and cleanup
     ##
@@ -341,7 +345,7 @@ $($(1).name).clean:
 ## target: xclean
 ##
 $($(1).name).xclean: $($(1).name).uninstall
-	$$(RM.exe) -fr $$($(1).build/)
+	-$$($(1).XCLEAN)
 
 ##
 ## alias: module name is same as build

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -74,6 +74,9 @@ endif
 
 ifeq (1,$(FEATURE.x265))
     MODULES += contrib/x265
+    MODULES += contrib/x265_8bit
+    MODULES += contrib/x265_10bit
+    MODULES += contrib/x265_12bit
 endif
 
 MODULES += contrib/ffmpeg


### PR DESCRIPTION
This builds libx265 statically 3 times with the appropriate settings for creating 8, 10, and 12 bit encoders.  Then merges the 3 static libraries that were built into one static library with support for all 3 encoders.

I've only tested that this works on linux so far.  I would expect mingw to work the same since it uses the same gnu library archiver 'ar'.  OSX may need different treatment. x265 example x265/build/linux/multilib.sh uses BSD libtool to merge libraries.