### PR TITLE
[Interop] Mixdown additions and direct JSON jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Visual Studio
 win/CS/*/bin
 win/CS/*/obj
+win/CS/.vs
 win/CS/**/*.suo
 win/CS/*.VC.opendb
 win/CS/*.VC.db

--- a/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/HandBrakeEncoderHelpers.cs
@@ -244,6 +244,16 @@ namespace HandBrake.ApplicationServices.Interop
             return Mixdowns.SingleOrDefault(m => m.ShortName == shortName);
         }
 
+		/// <summary>
+		/// Gets the mixdown with the specified ID.
+		/// </summary>
+		/// <param name="id">The mixdown ID.</param>
+		/// <returns>The requested mixdown.</returns>
+	    public static HBMixdown GetMixdown(int id)
+	    {
+		    return Mixdowns.SingleOrDefault(m => m.Id == id);
+	    }
+
         /// <summary>
         /// Gets the container with the specified short name.
         /// </summary>
@@ -488,6 +498,17 @@ namespace HandBrake.ApplicationServices.Interop
             int defaultMixdown = HBFunctions.hb_mixdown_get_default((uint)encoder.Id, layout);
             return Mixdowns.Single(m => m.Id == defaultMixdown);
         }
+
+		/// <summary>
+		/// Sanitizes the given sample rate for the given encoder.
+		/// </summary>
+		/// <param name="encoder">The encoder.</param>
+		/// <param name="sampleRate">The sample rate to sanitize.</param>
+		/// <returns>The sanitized sample rate.</returns>
+	    public static int SanitizeSampleRate(HBAudioEncoder encoder, int sampleRate)
+	    {
+		    return HBFunctions.hb_audio_samplerate_find_closest(sampleRate, (uint)encoder.Id);
+	    }
 
         /// <summary>
         /// Gets the bitrate limits for the given audio codec, sample rate and mixdown.

--- a/win/CS/HandBrake.ApplicationServices/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/HbLib/HbFunctions.cs
@@ -201,6 +201,8 @@ namespace HandBrake.ApplicationServices.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_audio_samplerate_get_next", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr hb_audio_samplerate_get_next(IntPtr last);
 
+        [DllImport("hb", EntryPoint = "hb_audio_samplerate_find_closest", CallingConvention = CallingConvention.Cdecl)]
+	    public static extern int hb_audio_samplerate_find_closest(int samplerate, uint codec);
 
         [DllImport("hb", EntryPoint = "hb_audio_bitrate_get_best", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_audio_bitrate_get_best(uint codec, int bitrate, int samplerate, int mixdown);


### PR DESCRIPTION
Added a couple mixdown utility methods.
Also added ability to start an encode via JSON string rather than the model. This is handy for a debug feature where you can copy a JSON job from the log and tweak it quickly to see what happens.
Added the .vs folder to .gitignore.