### PR TITLE
.editorconfig and bit of refactoring

### DIFF
--- a/win/CS/.editorconfig
+++ b/win/CS/.editorconfig
@@ -1,0 +1,3 @@
+[*.{cs,xaml}]
+indent_style = space
+indent_size = 4

--- a/win/CS/HandBrake.ApplicationServices/Interop/EventArgs/EncodeProgressEventArgs.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/EventArgs/EncodeProgressEventArgs.cs
@@ -40,13 +40,10 @@ namespace HandBrake.ApplicationServices.Interop.EventArgs
         /// <param name="passCount">
         /// The pass count.
         /// </param>
-        /// <param name="isMuxing">
-        /// A flag to indicate we are muxing.
+        /// <param name="stateCode">
+        /// The code for the state the encode process is in.
         /// </param>
-        /// <param name="isSearching">
-        /// Gets a value indicating that we are in the searching process.
-        /// </param>
-        public EncodeProgressEventArgs(double fractionComplete, double currentFrameRate, double averageFrameRate, TimeSpan estimatedTimeLeft, int passId, int pass, int passCount, bool isMuxing, bool isSearching)
+        public EncodeProgressEventArgs(double fractionComplete, double currentFrameRate, double averageFrameRate, TimeSpan estimatedTimeLeft, int passId, int pass, int passCount, string stateCode)
         {
             this.FractionComplete = fractionComplete;
             this.CurrentFrameRate = currentFrameRate;
@@ -55,8 +52,7 @@ namespace HandBrake.ApplicationServices.Interop.EventArgs
             this.PassId = passId;
             this.Pass = pass;
             this.PassCount = passCount;
-            this.IsMuxing = isMuxing;
-            this.IsSearching = isSearching;
+            this.StateCode = stateCode;
         }
 
         /// <summary>
@@ -101,14 +97,9 @@ namespace HandBrake.ApplicationServices.Interop.EventArgs
         public int PassCount { get; private set; }
 
         /// <summary>
-        /// Gets a value indicating that we are in the muxing process.
+        /// Gets the state code of the encode process.
         /// </summary>
-        public bool IsMuxing { get; private set; }
-
-        /// <summary>
-        /// Gets a value indicating that we are in the searching process.
-        /// </summary>
-        public bool IsSearching { get; }
+        public string StateCode { get; }
 
         /// <summary>
         /// Gets a value indicating that we are doing a subtitle scan pass.

--- a/win/CS/HandBrake.ApplicationServices/Interop/Interfaces/IHandBrakeInstance.cs
+++ b/win/CS/HandBrake.ApplicationServices/Interop/Interfaces/IHandBrakeInstance.cs
@@ -98,12 +98,12 @@ namespace HandBrake.ApplicationServices.Interop.Interfaces
         /// The index of the preview to get (0-based).
         /// </param>
         /// <param name="deinterlace">
-        /// Enable basic deinterlace of preview images. 1 = on. 0 = off.
+        /// True to enable basic deinterlace of preview images.
         /// </param>
         /// <returns>
         /// An image with the requested preview.
         /// </returns>
-        Bitmap GetPreview(PreviewSettings job, int previewNumber, int deinterlace);
+        Bitmap GetPreview(PreviewSettings job, int previewNumber, bool deinterlace);
 
         /// <summary>
         /// Pauses the current encode.

--- a/win/CS/HandBrakeWPF/Services/Encode/LibEncode.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/LibEncode.cs
@@ -16,6 +16,7 @@ namespace HandBrakeWPF.Services.Encode
     using HandBrake.ApplicationServices.Interop;
     using HandBrake.ApplicationServices.Interop.EventArgs;
     using HandBrake.ApplicationServices.Interop.Interfaces;
+    using HandBrake.ApplicationServices.Interop.Json.State;
     using HandBrake.ApplicationServices.Model;
     using HandBrake.ApplicationServices.Services.Logging;
     using HandBrake.ApplicationServices.Services.Logging.Interfaces;
@@ -183,8 +184,8 @@ namespace HandBrakeWPF.Services.Encode
                 TaskCount = e.PassCount,
                 ElapsedTime = DateTime.Now - this.startTime, 
                 PassId = e.PassId,
-                IsMuxing = e.IsMuxing,
-                IsSearching = e.IsSearching
+                IsMuxing = e.StateCode == TaskState.Muxing.Code,
+                IsSearching = e.StateCode == TaskState.Searching.Code
             };
 
             this.InvokeEncodeStatusChanged(args);

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -207,13 +207,7 @@ namespace HandBrakeWPF.Services.Scan
                                                    PixelAspectY = job.PixelAspectY
                                                };
 
-                int deinterlaceOn = 0;
-                if (job.DeinterlaceFilter != DeinterlaceFilter.Off)
-                {
-                    deinterlaceOn = 1;
-                }
-                
-                bitmapImage = BitmapUtilities.ConvertToBitmapImage(this.instance.GetPreview(settings, preview, deinterlaceOn));
+                bitmapImage = BitmapUtilities.ConvertToBitmapImage(this.instance.GetPreview(settings, preview, job.DeinterlaceFilter != DeinterlaceFilter.Off));
             }
             catch (AccessViolationException e)
             {


### PR DESCRIPTION
Did a bit of refactoring and added an .editorconfig file to enforce the "spaces for tabs" setting.

Instead of passing through 2 booleans, I pass the state code, which has information for both and includes other detail.