### PR TITLE
Mac: D&D opening file could cause crash

### DIFF
--- a/macosx/HBSummaryViewController.m
+++ b/macosx/HBSummaryViewController.m
@@ -45,16 +45,17 @@
 
 - (void)setJob:(HBJob *)job
 {
-    _job = job;
     if (job)
     {
+        _job = job;
         [self addJobObservers];
         [self updateLabels];
     }
     else
     {
-        [self resetLabels];
         [self removeJobObservers];
+        [self resetLabels];
+        _job = job;
     }
 }
 


### PR DESCRIPTION
- remove observers ASAP