### PR TITLE
mac: Revise main window typography and alignment.

### DIFF
--- a/macosx/English.lproj/AddPreset.xib
+++ b/macosx/English.lproj/AddPreset.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13770" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="8000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13770"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -25,7 +25,7 @@
         <window title="New Preset" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="dbZ-Wo-9nG" userLabel="AddPresetPanel">
             <windowStyleMask key="styleMask" titled="YES" resizable="YES"/>
             <rect key="contentRect" x="421" y="536" width="480" height="239"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
             <view key="contentView" misplaced="YES" id="AcO-9f-fnb">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="239"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -111,9 +111,9 @@ Gw
                             <accessibilityConnection property="title" destination="zDq-QP-LAu" id="meT-EW-QiO"/>
                         </connections>
                     </textField>
-                    <button toolTip="Audio Defaults control which audio track(s) and settings are used when the preset is selected." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aez-2b-JXx">
-                        <rect key="frame" x="94" y="68" width="156" height="28"/>
-                        <buttonCell key="cell" type="push" title="Edit Selection Behavior…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="a0j-nw-n23">
+                    <button toolTip="Selection Behavior determines the track(s) and settings used when the preset is selected." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aez-2b-JXx">
+                        <rect key="frame" x="94" y="68" width="132" height="28"/>
+                        <buttonCell key="cell" type="push" title="Selection Behavior…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="a0j-nw-n23">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
@@ -184,9 +184,9 @@ Gw
                             </constraints>
                         </view>
                     </box>
-                    <button toolTip="Subtitles Defaults control which subtitles track(s) and settings are used when the preset is selected." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nWJ-0b-fUA">
-                        <rect key="frame" x="94" y="40" width="156" height="28"/>
-                        <buttonCell key="cell" type="push" title="Edit Selection Behavior…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="LPX-Rc-KLa">
+                    <button toolTip="Selection Behavior determines the track(s) and settings used when the preset is selected." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nWJ-0b-fUA">
+                        <rect key="frame" x="94" y="40" width="132" height="28"/>
+                        <buttonCell key="cell" type="push" title="Selection Behavior…" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="LPX-Rc-KLa">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                         </buttonCell>
@@ -240,12 +240,12 @@ None uses the currently set dimensions.
 Custom allows you to set a maximum width and/or height.
 
 Source maximum uses the full dimensions of each source.</string>
-                        <popUpButtonCell key="cell" type="push" title="New Category…" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="Sf8-HP-mhE" id="mZR-uO-YA8">
+                        <popUpButtonCell key="cell" type="push" title="New Category…" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="Sf8-HP-mhE" id="mZR-uO-YA8">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="smallSystem"/>
                             <menu key="menu" title="OtherViews" id="tQ1-PN-kvh">
                                 <items>
-                                    <menuItem title="New Category…" id="Sf8-HP-mhE">
+                                    <menuItem title="New Category…" state="on" id="Sf8-HP-mhE">
                                         <modifierMask key="keyEquivalentModifierMask"/>
                                         <connections>
                                             <action selector="showNewCategoryWindow:" target="-2" id="a4V-O5-hXQ"/>

--- a/macosx/English.lproj/MainWindow.xib
+++ b/macosx/English.lproj/MainWindow.xib
@@ -637,7 +637,7 @@ Blu-ray and DVD sources often have multiple titles, the longest of which is typi
                     <constraint firstItem="1554" firstAttribute="leading" secondItem="1553" secondAttribute="trailing" constant="4" id="F7e-S1-ofK"/>
                     <constraint firstItem="1548" firstAttribute="trailing" secondItem="5493" secondAttribute="trailing" id="FOi-gl-8CU"/>
                     <constraint firstItem="1561" firstAttribute="baseline" secondItem="gfs-4j-YSE" secondAttribute="baseline" id="HGj-mW-j31"/>
-                    <constraint firstItem="5505" firstAttribute="baseline" secondItem="1553" secondAttribute="baseline" id="IAD-5h-866"/>
+                    <constraint firstItem="1553" firstAttribute="firstBaseline" secondItem="5505" secondAttribute="baseline" id="IAD-5h-866"/>
                     <constraint firstItem="d0E-xw-bxh" firstAttribute="top" secondItem="1561" secondAttribute="bottom" constant="16" id="IJL-MH-5Jk"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1554" secondAttribute="trailing" constant="20" id="IkE-3r-B30"/>
                     <constraint firstItem="1541" firstAttribute="top" secondItem="1539" secondAttribute="bottom" constant="13" id="JKu-P6-MMV"/>
@@ -680,7 +680,6 @@ Blu-ray and DVD sources often have multiple titles, the longest of which is typi
                     <constraint firstItem="1474" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="qm5-es-UMl"/>
                     <constraint firstItem="5513" firstAttribute="baseline" secondItem="1540" secondAttribute="firstBaseline" id="rTF-gL-AHw"/>
                     <constraint firstItem="5493" firstAttribute="baseline" secondItem="5521" secondAttribute="baseline" id="rau-a9-VIU"/>
-                    <constraint firstItem="5513" firstAttribute="centerY" secondItem="1553" secondAttribute="centerY" id="uIj-6L-KkR"/>
                     <constraint firstItem="5513" firstAttribute="firstBaseline" secondItem="5491" secondAttribute="baseline" id="uzB-gd-5xg"/>
                     <constraint firstItem="1541" firstAttribute="leading" secondItem="1540" secondAttribute="trailing" constant="6" id="vAS-wg-SY2"/>
                     <constraint firstItem="1541" firstAttribute="baseline" secondItem="5180" secondAttribute="baseline" id="wJe-gN-ir1"/>

--- a/macosx/English.lproj/MainWindow.xib
+++ b/macosx/English.lproj/MainWindow.xib
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13770" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="8000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13770"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
+        <capability name="Alignment constraints to the first baseline" minToolsVersion="6.0"/>
         <capability name="box content view" minToolsVersion="7.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -46,7 +47,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="41" y="572" width="920" height="610"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
             <view key="contentView" id="2" customClass="HBFocusRingView">
                 <rect key="frame" x="0.0" y="0.0" width="920" height="610"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -65,43 +66,43 @@
                             </tabViewItem>
                             <tabViewItem label="Dimensions" identifier="2" id="eij-Sn-QmJ" userLabel="PictureTab">
                                 <view key="view" id="nvx-9b-6fF">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Filters" identifier="" id="0UB-bG-kwS">
                                 <view key="view" id="JAj-E3-Cq2">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Video" identifier="1" id="1477">
                                 <view key="view" id="1478">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Audio" identifier="3" id="1475">
                                 <view key="view" id="1476">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Subtitles" identifier="4" id="5194">
                                 <view key="view" id="5195">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Chapters" identifier="5" id="1989">
                                 <view key="view" id="1990">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Advanced" identifier="6" id="2015">
                                 <view key="view" id="2016">
-                                    <rect key="frame" x="10" y="25" width="874" height="349"/>
+                                    <rect key="frame" x="10" y="29" width="874" height="348"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </tabViewItem>
@@ -119,9 +120,9 @@
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1540">
-                        <rect key="frame" x="24" y="552" width="31" height="14"/>
+                        <rect key="frame" x="18" y="552" width="33" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Title:" id="4907">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="smallSystemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -130,9 +131,9 @@
                         </connections>
                     </textField>
                     <popUpButton toolTip="Source range selection. By default, all chapters are selected and the entire source is encoded." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5513">
-                        <rect key="frame" x="528" y="548" width="84" height="22"/>
+                        <rect key="frame" x="524" y="548" width="84" height="22"/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="78" id="9zG-wg-7fT"/>
+                            <constraint firstAttribute="width" constant="78" id="AE2-gg-fra"/>
                         </constraints>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" id="5514">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -141,6 +142,7 @@
                         </popUpButtonCell>
                         <accessibility description="Range Selection"/>
                         <connections>
+                            <accessibilityConnection property="title" destination="4NG-AB-JWs" id="D9J-Ih-cYu"/>
                             <binding destination="-2" name="enabled" keyPath="self.job" id="OMf-GZ-Uvf">
                                 <dictionary key="options">
                                     <string key="NSValueTransformerName">NSIsNotNil</string>
@@ -150,25 +152,9 @@
                             <binding destination="-2" name="content" keyPath="self.job.range.types" id="jpv-yJ-Fca"/>
                         </connections>
                     </popUpButton>
-                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="5180">
-                        <rect key="frame" x="434" y="552" width="38" height="14"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Angle:" id="5185">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                        <connections>
-                            <binding destination="-2" name="textColor" keyPath="self.labelColor" id="pe4-ce-1x7"/>
-                            <binding destination="5676" name="hidden" keyPath="values.UseDvdNav" id="GhV-lP-BWw">
-                                <dictionary key="options">
-                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
-                                </dictionary>
-                            </binding>
-                        </connections>
-                    </textField>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1552">
-                        <rect key="frame" x="18" y="94" width="51" height="14"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Save as:" id="4913">
+                        <rect key="frame" x="18" y="94" width="52" height="14"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Save As:" id="4913">
                             <font key="font" metaFont="smallSystemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -178,9 +164,9 @@
                         </connections>
                     </textField>
                     <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="1553">
-                        <rect key="frame" x="798" y="552" width="53" height="14"/>
+                        <rect key="frame" x="753" y="553" width="57" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Duration:" id="4914">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="smallSystemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -193,7 +179,7 @@
                         </connections>
                     </textField>
                     <textField toolTip="Duration of the selected source range in Hours:Minutes:Seconds." horizontalHuggingPriority="750" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="1554">
-                        <rect key="frame" x="849" y="552" width="53" height="14"/>
+                        <rect key="frame" x="810" y="553" width="53" height="14"/>
                         <textFieldCell key="cell" selectable="YES" sendsActionOnEndEditing="YES" alignment="right" title="00:00:00" id="4915">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -224,7 +210,7 @@
                         </connections>
                     </textField>
                     <textField toolTip="File name. This is what your new video will be named." verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1561">
-                        <rect key="frame" x="75" y="91" width="385" height="19"/>
+                        <rect key="frame" x="76" y="91" width="382" height="19"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" continuous="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="4919">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
@@ -245,7 +231,7 @@
                         </connections>
                     </textField>
                     <textField hidden="YES" toolTip="First second to encode." verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5491">
-                        <rect key="frame" x="617" y="549" width="54" height="19"/>
+                        <rect key="frame" x="613" y="549" width="54" height="19"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="54" id="siy-Fa-XFI"/>
                         </constraints>
@@ -273,7 +259,7 @@
                         </connections>
                     </textField>
                     <textField hidden="YES" toolTip="First frame to encode." verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5521">
-                        <rect key="frame" x="617" y="549" width="54" height="19"/>
+                        <rect key="frame" x="613" y="549" width="54" height="19"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="54" id="uYc-eu-FMx"/>
                         </constraints>
@@ -301,10 +287,7 @@
                         </connections>
                     </textField>
                     <textField hidden="YES" toolTip="Last second to encode." verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5493">
-                        <rect key="frame" x="725" y="549" width="54" height="19"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="54" id="eR9-sP-12e"/>
-                        </constraints>
+                        <rect key="frame" x="686" y="549" width="54" height="19"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="5494">
                             <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" minimumIntegerDigits="0" maximumIntegerDigits="42" id="tD5-HN-B7h">
                                 <real key="minimum" value="0.0"/>
@@ -329,10 +312,7 @@
                         </connections>
                     </textField>
                     <textField hidden="YES" toolTip="Last frame to encode." verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5523">
-                        <rect key="frame" x="725" y="549" width="54" height="19"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="54" id="hnh-Qr-XGf"/>
-                        </constraints>
+                        <rect key="frame" x="686" y="549" width="54" height="19"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="5524">
                             <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" minimumIntegerDigits="0" maximumIntegerDigits="42" id="WrK-kN-ZN0">
                                 <real key="minimum" value="0.0"/>
@@ -370,13 +350,15 @@
                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="3205">
                         <rect key="frame" x="123" y="587" width="777" height="5"/>
                     </box>
-                    <progressIndicator hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" fixedFrame="YES" maxValue="1" bezeled="NO" controlSize="small" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="3203">
-                        <rect key="frame" x="391" y="584" width="510" height="12"/>
-                        <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMinY="YES"/>
+                    <progressIndicator hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" ambiguous="YES" maxValue="1" bezeled="NO" controlSize="small" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="3203">
+                        <rect key="frame" x="392" y="584" width="510" height="12"/>
                     </progressIndicator>
                     <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="5505">
-                        <rect key="frame" x="673" y="552" width="50" height="14"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="through" id="5506">
+                        <rect key="frame" x="667" y="553" width="20" height="14"/>
+                        <constraints>
+                            <constraint firstAttribute="width" constant="16" id="cXg-jy-xg2"/>
+                        </constraints>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="–" id="5506">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -390,7 +372,7 @@
                         </connections>
                     </textField>
                     <popUpButton toolTip="First chapter to encode." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1545">
-                        <rect key="frame" x="614" y="548" width="60" height="22"/>
+                        <rect key="frame" x="610" y="548" width="60" height="22"/>
                         <constraints>
                             <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="54" id="vZd-Mh-LS2"/>
                         </constraints>
@@ -415,9 +397,9 @@
                         </connections>
                     </popUpButton>
                     <popUpButton toolTip="Last chapter to encode." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1548">
-                        <rect key="frame" x="722" y="548" width="60" height="22"/>
+                        <rect key="frame" x="683" y="548" width="60" height="22"/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="54" id="gHt-KC-cvj"/>
+                            <constraint firstAttribute="width" constant="54" id="WE2-RM-vv1"/>
                         </constraints>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="1550" id="4911">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -440,9 +422,9 @@
                         </connections>
                     </popUpButton>
                     <popUpButton toolTip="Video angle to encode. Only applicable to multi-angle DVD and Blu-ray." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5181">
-                        <rect key="frame" x="475" y="548" width="44" height="22"/>
+                        <rect key="frame" x="424" y="548" width="44" height="22"/>
                         <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="38" id="MSf-YG-61y"/>
+                            <constraint firstAttribute="width" constant="38" id="N2X-6I-cPa"/>
                         </constraints>
                         <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="clipping" state="on" borderStyle="borderAndBezel" inset="2" arrowPosition="arrowAtCenter" preferredEdge="maxY" selectedItem="5184" id="5182">
                             <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
@@ -477,7 +459,7 @@ IA
                         </connections>
                     </popUpButton>
                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1541">
-                        <rect key="frame" x="56" y="548" width="318" height="22"/>
+                        <rect key="frame" x="52" y="548" width="318" height="22"/>
                         <string key="toolTip">Title, or video clip, to encode. The longest title is selected by default.
 
 Blu-ray and DVD sources often have multiple titles, the longest of which is typically the main feature.</string>
@@ -532,9 +514,9 @@ Blu-ray and DVD sources often have multiple titles, the longest of which is typi
                         </connections>
                     </button>
                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfs-4j-YSE">
-                        <rect key="frame" x="478" y="94" width="20" height="14"/>
+                        <rect key="frame" x="476" y="94" width="22" height="14"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="To:" id="rfK-nQ-Aq2">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="smallSystemBold"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -603,69 +585,109 @@ Blu-ray and DVD sources often have multiple titles, the longest of which is typi
                             </binding>
                         </connections>
                     </popUpButton>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="5180">
+                        <rect key="frame" x="380" y="552" width="41" height="14"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Angle:" id="5185">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="-2" name="textColor" keyPath="self.labelColor" id="pe4-ce-1x7"/>
+                            <binding destination="5676" name="hidden" keyPath="values.UseDvdNav" id="GhV-lP-BWw">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
+                    </textField>
+                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="100" translatesAutoresizingMaskIntoConstraints="NO" id="4NG-AB-JWs">
+                        <rect key="frame" x="478" y="552" width="43" height="14"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="right" title="Range:" id="IxV-PW-oYh">
+                            <font key="font" metaFont="smallSystemBold"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <binding destination="-2" name="textColor" keyPath="self.labelColor" id="NpP-Z0-hPs"/>
+                            <binding destination="5676" name="hidden" keyPath="values.UseDvdNav" id="Ag8-0e-Pok">
+                                <dictionary key="options">
+                                    <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                </dictionary>
+                            </binding>
+                        </connections>
+                    </textField>
                 </subviews>
                 <constraints>
+                    <constraint firstItem="5181" firstAttribute="baseline" secondItem="5180" secondAttribute="baseline" id="0WT-DF-xwh"/>
+                    <constraint firstItem="1548" firstAttribute="baseline" secondItem="5523" secondAttribute="baseline" id="1o2-Bi-1WX"/>
+                    <constraint firstItem="5513" firstAttribute="centerY" secondItem="1554" secondAttribute="centerY" id="1vC-eV-nkM"/>
                     <constraint firstItem="PJi-21-hie" firstAttribute="leading" secondItem="gfs-4j-YSE" secondAttribute="trailing" constant="10" id="2dV-0m-kAI"/>
-                    <constraint firstItem="1548" firstAttribute="leading" secondItem="5505" secondAttribute="trailing" constant="4" id="3Im-Oh-Qb2"/>
                     <constraint firstItem="1539" firstAttribute="baseline" secondItem="1538" secondAttribute="baseline" id="3gB-bu-uWq"/>
-                    <constraint firstItem="5180" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1541" secondAttribute="trailing" constant="34" id="3jj-9R-W0d"/>
-                    <constraint firstItem="1548" firstAttribute="baseline" secondItem="1553" secondAttribute="baseline" id="7VK-6I-NVd"/>
-                    <constraint firstItem="5513" firstAttribute="leading" secondItem="5181" secondAttribute="trailing" constant="15" id="7WT-Ln-g26"/>
+                    <constraint firstItem="5180" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="1541" secondAttribute="trailing" constant="15" id="3jj-9R-W0d"/>
+                    <constraint firstItem="1548" firstAttribute="leading" secondItem="5493" secondAttribute="leading" id="4IG-eQ-55R"/>
                     <constraint firstItem="5491" firstAttribute="leading" secondItem="1545" secondAttribute="leading" id="8FJ-NN-iqQ"/>
                     <constraint firstItem="bWH-Lp-mKY" firstAttribute="baseline" secondItem="1627" secondAttribute="baseline" id="A8O-c5-J59"/>
                     <constraint firstItem="d0E-xw-bxh" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="-4" id="ANc-YO-rUk"/>
-                    <constraint firstItem="5505" firstAttribute="leading" secondItem="1545" secondAttribute="trailing" constant="4" id="Ck9-KU-sKu"/>
                     <constraint firstItem="1562" firstAttribute="baseline" secondItem="gfs-4j-YSE" secondAttribute="baseline" id="D6B-x1-Rm7"/>
+                    <constraint firstItem="5513" firstAttribute="baseline" secondItem="4NG-AB-JWs" secondAttribute="baseline" id="DBY-X8-nQP"/>
                     <constraint firstItem="3205" firstAttribute="leading" secondItem="1539" secondAttribute="trailing" constant="13" id="EOg-9m-BWr"/>
                     <constraint firstItem="gfs-4j-YSE" firstAttribute="leading" secondItem="1561" secondAttribute="trailing" constant="20" id="Eeg-iK-8sW"/>
                     <constraint firstAttribute="trailing" secondItem="1562" secondAttribute="trailing" constant="20" id="Evo-6G-PeG"/>
-                    <constraint firstItem="1554" firstAttribute="leading" secondItem="1553" secondAttribute="trailing" constant="2" id="F7e-S1-ofK"/>
-                    <constraint firstItem="5493" firstAttribute="baseline" secondItem="1548" secondAttribute="baseline" id="H06-Tc-tOR"/>
+                    <constraint firstItem="1554" firstAttribute="leading" secondItem="1553" secondAttribute="trailing" constant="4" id="F7e-S1-ofK"/>
+                    <constraint firstItem="1548" firstAttribute="trailing" secondItem="5493" secondAttribute="trailing" id="FOi-gl-8CU"/>
                     <constraint firstItem="1561" firstAttribute="baseline" secondItem="gfs-4j-YSE" secondAttribute="baseline" id="HGj-mW-j31"/>
+                    <constraint firstItem="5505" firstAttribute="baseline" secondItem="1553" secondAttribute="baseline" id="IAD-5h-866"/>
                     <constraint firstItem="d0E-xw-bxh" firstAttribute="top" secondItem="1561" secondAttribute="bottom" constant="16" id="IJL-MH-5Jk"/>
-                    <constraint firstAttribute="trailing" secondItem="1554" secondAttribute="trailing" constant="20" id="IkE-3r-B30"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1554" secondAttribute="trailing" constant="20" id="IkE-3r-B30"/>
                     <constraint firstItem="1541" firstAttribute="top" secondItem="1539" secondAttribute="bottom" constant="13" id="JKu-P6-MMV"/>
                     <constraint firstAttribute="trailing" secondItem="d0E-xw-bxh" secondAttribute="trailing" constant="-4" id="KQg-Rf-J0d"/>
                     <constraint firstItem="1538" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="KkG-gY-C8Q"/>
+                    <constraint firstItem="1548" firstAttribute="baseline" secondItem="5493" secondAttribute="baseline" id="O5E-wM-4OR"/>
                     <constraint firstItem="1539" firstAttribute="centerY" secondItem="3205" secondAttribute="centerY" id="O7P-Hr-rDa"/>
-                    <constraint firstItem="5523" firstAttribute="baseline" secondItem="1548" secondAttribute="baseline" id="OLX-ZM-ub6"/>
+                    <constraint firstItem="5505" firstAttribute="leading" secondItem="5491" secondAttribute="trailing" constant="2" id="Pqo-aS-4ll"/>
                     <constraint firstAttribute="trailing" secondItem="3205" secondAttribute="trailing" constant="20" id="QkZ-Q7-VGX"/>
+                    <constraint firstItem="5493" firstAttribute="leading" secondItem="5505" secondAttribute="trailing" constant="1" id="T3d-Cb-1TT"/>
                     <constraint firstItem="1561" firstAttribute="leading" secondItem="1552" secondAttribute="trailing" constant="8" id="TLF-qk-2Eq"/>
-                    <constraint firstItem="5181" firstAttribute="baseline" secondItem="5513" secondAttribute="baseline" id="TXU-d9-fn4"/>
                     <constraint firstItem="bWH-Lp-mKY" firstAttribute="top" secondItem="1541" secondAttribute="bottom" constant="14" id="Tex-Li-ACD"/>
                     <constraint firstItem="1539" firstAttribute="leading" secondItem="1538" secondAttribute="trailing" constant="6" id="Ue2-hw-ZPH"/>
                     <constraint firstItem="1562" firstAttribute="leading" secondItem="PJi-21-hie" secondAttribute="trailing" constant="2" id="UgJ-hP-CRv"/>
                     <constraint firstAttribute="bottom" secondItem="d0E-xw-bxh" secondAttribute="bottom" id="Unb-Sk-dKC"/>
                     <constraint firstItem="5491" firstAttribute="baseline" secondItem="1545" secondAttribute="baseline" id="V1s-WC-STL"/>
                     <constraint firstItem="1627" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="VV8-Hu-yZk"/>
-                    <constraint firstItem="5180" firstAttribute="baseline" secondItem="5181" secondAttribute="baseline" id="Waw-Re-s7M"/>
-                    <constraint firstItem="1540" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="26" id="YBA-8V-7wA"/>
+                    <constraint firstItem="1545" firstAttribute="leading" secondItem="5513" secondAttribute="trailing" constant="8" symbolic="YES" id="VYv-xB-5lU"/>
+                    <constraint firstItem="1540" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="YBA-8V-7wA"/>
                     <constraint firstAttribute="trailing" secondItem="1474" secondAttribute="trailing" constant="20" id="ZCa-qk-7Xv"/>
                     <constraint firstItem="1553" firstAttribute="baseline" secondItem="1554" secondAttribute="baseline" id="bRf-Gk-M03"/>
-                    <constraint firstItem="1553" firstAttribute="leading" secondItem="1548" secondAttribute="trailing" constant="21" id="dKm-u9-rqb"/>
                     <constraint firstItem="1561" firstAttribute="top" secondItem="1474" secondAttribute="bottom" constant="16" id="dN9-Oy-x6I"/>
-                    <constraint firstItem="5505" firstAttribute="baseline" secondItem="1548" secondAttribute="baseline" id="dlS-oW-ki1"/>
+                    <constraint firstItem="5181" firstAttribute="leading" secondItem="5180" secondAttribute="trailing" constant="8" symbolic="YES" id="eLj-9B-zqH"/>
+                    <constraint firstItem="4NG-AB-JWs" firstAttribute="leading" secondItem="5181" secondAttribute="trailing" constant="15" id="elN-eT-exW"/>
+                    <constraint firstItem="5493" firstAttribute="trailing" secondItem="5523" secondAttribute="trailing" id="fEO-qG-sc6"/>
                     <constraint firstItem="1474" firstAttribute="top" secondItem="bWH-Lp-mKY" secondAttribute="bottom" constant="16" id="fWK-a5-vqI"/>
                     <constraint firstItem="1538" firstAttribute="top" secondItem="2" secondAttribute="top" constant="14" id="fuA-H3-g7K"/>
                     <constraint firstItem="1540" firstAttribute="baseline" secondItem="1541" secondAttribute="baseline" id="gBD-ib-Qcp"/>
                     <constraint firstItem="gfs-4j-YSE" firstAttribute="centerY" secondItem="PJi-21-hie" secondAttribute="centerY" id="gR5-Tl-M5T"/>
+                    <constraint firstItem="5523" firstAttribute="leading" secondItem="5493" secondAttribute="leading" id="gm6-wR-wHe"/>
                     <constraint firstItem="1628" firstAttribute="leading" secondItem="bWH-Lp-mKY" secondAttribute="trailing" constant="8" id="hxV-pb-HlV"/>
                     <constraint firstAttribute="trailing" secondItem="1628" secondAttribute="trailing" constant="20" id="k3w-7F-PJy"/>
-                    <constraint firstItem="5523" firstAttribute="leading" secondItem="1548" secondAttribute="leading" id="kaO-gX-UDh"/>
                     <constraint firstItem="5521" firstAttribute="leading" secondItem="1545" secondAttribute="leading" id="lHl-eR-GrT"/>
+                    <constraint firstItem="5181" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="427" id="lQH-Ps-Y4Y"/>
+                    <constraint firstItem="5513" firstAttribute="top" secondItem="3203" secondAttribute="bottom" constant="15" id="lh4-o3-opS"/>
+                    <constraint firstItem="1553" firstAttribute="leading" secondItem="5493" secondAttribute="trailing" constant="15" id="loK-nJ-aD6"/>
                     <constraint firstItem="1552" firstAttribute="baseline" secondItem="1561" secondAttribute="baseline" id="n18-gY-q1Z"/>
                     <constraint firstItem="5521" firstAttribute="baseline" secondItem="1545" secondAttribute="baseline" id="oUt-oK-ID4"/>
+                    <constraint firstItem="5513" firstAttribute="baseline" secondItem="5521" secondAttribute="baseline" id="qNC-a2-F0F"/>
                     <constraint firstItem="1474" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="qm5-es-UMl"/>
-                    <constraint firstItem="5513" firstAttribute="baseline" secondItem="1545" secondAttribute="baseline" id="r0Y-xU-wAS"/>
-                    <constraint firstItem="1545" firstAttribute="baseline" secondItem="5505" secondAttribute="baseline" id="rlc-p0-WUw"/>
-                    <constraint firstItem="5181" firstAttribute="leading" secondItem="5180" secondAttribute="trailing" constant="8" id="ru3-ii-5wc"/>
-                    <constraint firstItem="1545" firstAttribute="leading" secondItem="5513" secondAttribute="trailing" constant="8" id="txa-Sh-9Cl"/>
+                    <constraint firstItem="5513" firstAttribute="baseline" secondItem="1540" secondAttribute="firstBaseline" id="rTF-gL-AHw"/>
+                    <constraint firstItem="5493" firstAttribute="baseline" secondItem="5521" secondAttribute="baseline" id="rau-a9-VIU"/>
+                    <constraint firstItem="5513" firstAttribute="centerY" secondItem="1553" secondAttribute="centerY" id="uIj-6L-KkR"/>
+                    <constraint firstItem="5513" firstAttribute="firstBaseline" secondItem="5491" secondAttribute="baseline" id="uzB-gd-5xg"/>
                     <constraint firstItem="1541" firstAttribute="leading" secondItem="1540" secondAttribute="trailing" constant="6" id="vAS-wg-SY2"/>
                     <constraint firstItem="1541" firstAttribute="baseline" secondItem="5180" secondAttribute="baseline" id="wJe-gN-ir1"/>
                     <constraint firstItem="bWH-Lp-mKY" firstAttribute="centerY" secondItem="1628" secondAttribute="centerY" id="wqQ-KS-MuK"/>
                     <constraint firstItem="1552" firstAttribute="leading" secondItem="2" secondAttribute="leading" constant="20" id="x7n-hu-WyG"/>
+                    <constraint firstItem="5513" firstAttribute="leading" secondItem="4NG-AB-JWs" secondAttribute="trailing" constant="8" id="xIa-Em-cbA"/>
                     <constraint firstItem="bWH-Lp-mKY" firstAttribute="leading" secondItem="1627" secondAttribute="trailing" constant="8" id="xar-Kr-fKk"/>
-                    <constraint firstItem="5493" firstAttribute="leading" secondItem="1548" secondAttribute="leading" id="zSf-ta-BBL"/>
                 </constraints>
             </view>
             <toolbar key="toolbar" implicitIdentifier="E92CA47A-01F7-432A-A61C-28FE4D58C2CD" explicitIdentifier="HBMainWindowToolbar" displayMode="iconAndLabel" sizeMode="regular" id="7g3-gy-bUl">

--- a/macosx/English.lproj/Preferences.xib
+++ b/macosx/English.lproj/Preferences.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13156.6" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="8000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13156.6"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,7 +24,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="136" y="318" width="500" height="200"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1058"/>
             <value key="minSize" type="size" width="212" height="107"/>
             <view key="contentView" id="6">
                 <rect key="frame" x="0.0" y="0.0" width="500" height="200"/>
@@ -221,7 +221,7 @@
                             </connections>
                         </popUpButton>
                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="491">
-                            <rect key="frame" x="93" y="268" width="156" height="22"/>
+                            <rect key="frame" x="93" y="268" width="155" height="22"/>
                             <popUpButtonCell key="cell" type="push" title="Notification" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="2" imageScaling="proportionallyDown" inset="2" selectedItem="499" id="492">
                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="smallSystem"/>
@@ -366,9 +366,8 @@
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="46" id="JL9-J5-9Pf"/>
                             </constraints>
-                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="fIj-Tz-ghb">
+                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Note: these settings only apply to official presets. Custom presets may be configured using the Selection Behavior controls." id="fIj-Tz-ghb">
                                 <font key="font" metaFont="smallSystem"/>
-                                <string key="title">Note: these settings only to official presets. Language selection for custom presets may be configured in the Audio Defaults settings.</string>
                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
@@ -496,7 +495,7 @@
                             </connections>
                         </popUpButton>
                         <button toolTip="Use libdvdnav to read DVDs. Only disable this for problematic DVDs where libdvdread works better (rare)." verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="398">
-                            <rect key="frame" x="102" y="126" width="218" height="18"/>
+                            <rect key="frame" x="102" y="126" width="219" height="18"/>
                             <buttonCell key="cell" type="check" title="Use libdvdnav (instead of libdvdread)" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="399">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="smallSystem"/>
@@ -658,7 +657,7 @@
                             </connections>
                         </button>
                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ybi-46-yhY">
-                            <rect key="frame" x="102" y="235" width="253" height="18"/>
+                            <rect key="frame" x="102" y="235" width="254" height="18"/>
                             <string key="toolTip">Show the Advanced Options Panel for x264 settings.
 
 This setting is no longer supported and may be removed in a future version. Use at your own risk!</string>

--- a/macosx/HBAudioDefaults.h
+++ b/macosx/HBAudioDefaults.h
@@ -19,7 +19,7 @@ typedef NS_ENUM(NSUInteger, HBAudioTrackSelectionBehavior) {
 
 /**
  *  HBAudioSettings
- *  Stores the audio defaults settings.
+ *  Stores the audio defaults (selection behavior) settings.
  */
 @interface HBAudioDefaults : NSObject <NSSecureCoding, NSCopying, HBPresetCoding>
 

--- a/macosx/HBAudioTrackPreset.h
+++ b/macosx/HBAudioTrackPreset.h
@@ -10,8 +10,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  HBAudioTrackPreset
- *  a KVO enabled class used in the Audio Defaults panels,
- *  automatically validates the values.
+ *  a KVO enabled class used in the Audio Defaults
+ *  (Selection Behavior) panels, automatically
+ *  validates the values.
  */
 @interface HBAudioTrackPreset : NSObject <NSSecureCoding, NSCopying>
 

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -631,7 +631,7 @@
         else
         {
             // User chose to cancel the scan
-            [HBUtilities writeToActivityLog:"Cannot open physical dvd, scan cancelled"];
+            [HBUtilities writeToActivityLog:"Cannot open physical dvd, scan canceled"];
             canScan = NO;
         }
     }

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -38,7 +38,7 @@ typedef NS_ENUM(NSUInteger, HBState) {
 // These constants specify the result of a scan or encode.
 typedef NS_ENUM(NSUInteger, HBCoreResult) {
     HBCoreResultDone,
-    HBCoreResultCancelled,
+    HBCoreResultCanceled,
     HBCoreResultFailed,
 };
 

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -311,7 +311,7 @@ typedef void (^HBCoreCleanupHandler)(void);
 - (void)cancelScan
 {
     hb_scan_stop(_hb_handle);
-    [HBUtilities writeToActivityLog:"%s scan cancelled", self.name.UTF8String];
+    [HBUtilities writeToActivityLog:"%s scan canceled", self.name.UTF8String];
 }
 
 #pragma mark - Preview images
@@ -463,7 +463,7 @@ typedef void (^HBCoreCleanupHandler)(void);
             [HBUtilities writeToActivityLog:"%s work done", self.name.UTF8String];
             break;
         case HB_ERROR_CANCELED:
-            result = HBCoreResultCancelled;
+            result = HBCoreResultCanceled;
             [HBUtilities writeToActivityLog:"%s work canceled", self.name.UTF8String];
             break;
         default:

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -316,7 +316,7 @@
         }
     }
 
-    // Audio Defaults
+    // Audio Defaults (Selection Behavior)
     job->acodec_copy_mask = 0;
 
     HBAudioDefaults *audioDefaults = self.audio.defaults;

--- a/macosx/HBPicture+UIAdditions.m
+++ b/macosx/HBPicture+UIAdditions.m
@@ -91,35 +91,7 @@
 
 - (NSString *)shortInfo
 {
-    return [NSString stringWithFormat:NSLocalizedString(@"%dx%d Storage, %dx%d Display\n %d : %d PAR, %@ DAR", nil),
-            self.width, self.height, self.displayWidth, self.height,
-            self.parWidth, self.parHeight, [self displayAspectInfo]];
-}
-
-- (NSString *)displayAspectInfo
-{
-    int dar_width, dar_height;
-    NSString *str;
-
-    hb_reduce(&dar_width, &dar_height, self.displayWidth, self.height);
-    int iaspect = dar_width * 9 / dar_height;
-    if (dar_width > 2 * dar_height)
-    {
-        str = [NSString stringWithFormat:@"%.2g : 1", (double)dar_width / dar_height];
-    }
-    else if (iaspect <= 16 && iaspect >= 15)
-    {
-        str = [NSString stringWithFormat:@"%.2g : 9", (double)dar_width * 9 / dar_height];
-    }
-    else if (iaspect <= 12 && iaspect >= 11)
-    {
-        str = [NSString stringWithFormat:@"%.2g : 3", (double)dar_width * 3 / dar_height];
-    }
-    else
-    {
-        str = [NSString stringWithFormat:@"%d : %d", dar_width, dar_height];
-    }
-    return str;
+    return [NSString stringWithFormat:NSLocalizedString(@"%dx%d Storage, %dx%d Display", nil), self.width, self.height, self.displayWidth, self.height];
 }
 
 - (NSString *)sourceInfo

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -239,7 +239,7 @@
 
 /**
  * This method will clear the queue of any encodes that are not still pending
- * this includes both successfully completed encodes as well as cancelled encodes
+ * this includes both successfully completed encodes as well as canceled encodes
  */
 - (void)removeCompletedJobs
 {
@@ -662,9 +662,9 @@
 
     self.currentLog = nil;
 
-    // Check to see if the encode state has not been cancelled
+    // Check to see if the encode state has not been canceled
     // to determine if we should send it to external app.
-    if (result != HBCoreResultCancelled)
+    if (result != HBCoreResultCanceled)
     {
         // Send to tagger
         [self sendToExternalApp:job];
@@ -675,7 +675,7 @@
         case HBCoreResultDone:
             job.state = HBJobStateCompleted;
             break;
-        case HBCoreResultCancelled:
+        case HBCoreResultCanceled:
             job.state = HBJobStateCanceled;
             break;
         default:
@@ -697,8 +697,8 @@
             info = NSLocalizedString(@"Encode Finished.", @"");
             [self jobCompletedAlerts:job result:result];
             break;
-        case HBCoreResultCancelled:
-            info = NSLocalizedString(@"Encode Cancelled.", @"");
+        case HBCoreResultCanceled:
+            info = NSLocalizedString(@"Encode Canceled.", @"");
             break;
         default:
             info = NSLocalizedString(@"Encode Failed.", @"");
@@ -1185,7 +1185,7 @@
 
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:NSLocalizedString(@"You are currently encoding. What would you like to do?", nil)];
-    [alert setInformativeText:NSLocalizedString(@"Your encode will be cancelled if you don't continue encoding.", nil)];
+    [alert setInformativeText:NSLocalizedString(@"Your encode will be canceled if you don't continue encoding.", nil)];
     [alert addButtonWithTitle:NSLocalizedString(@"Continue Encoding", nil)];
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel Current and Stop", nil)];
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel Current and Continue", nil)];


### PR DESCRIPTION
I probably screwed up something important since I'm not too familiar with Xcode IB. That said, the type changes look mostly aligned with the comment here: https://github.com/HandBrake/HandBrake/issues/833#issuecomment-322450242

From the comment:

![UI](https://user-images.githubusercontent.com/70239/29315418-3a8bd7ac-8191-11e7-9204-19489be4ce4e.png)

Changes:

![screen shot 2017-12-04 at 9 24 00 am](https://user-images.githubusercontent.com/70239/33557411-2bf9ebb6-d8d5-11e7-931d-e4c2ebfd5ed4.png)

- Bold `Title:`, `Angle:`, `Duration:`
- Add `Range:`
- `through` -> `–`
- Duration label and readout spaced +2px
- Revise horizontal spacing for all of the above
- Capitalize Save As
- Bold `To:`

Also:

- Cancelled -> canceled (not visible in screenshot)
- Audio Defaults -> Selection Behavior in comments/tooltips
- Remove Summary > Size > PAR/DAR

TODO:

- Adjust vertical spacing for the progress area; it's too short when encoding is canceled/complete
- Bold `Encoding Job N of O (M remaining):  filename.ext` line

Comments welcome.