### PR TITLE
GUI Build Support for FreeBSD

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -184,6 +184,9 @@ case $host in
 	fi
     HB_LIBS="$HB_LIBS -lregex -luuid"
     ;;
+  *-*-freebsd*)
+    HB_LIBS="$HB_LIBS -lpthread"
+    ;;
   *)
     HB_LIBS="$HB_LIBS -ldl -lpthread"
     ;;

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -46,6 +46,9 @@
 #include <dbus/dbus-glib.h>
 #include <dbus/dbus-glib-lowlevel.h>
 
+#if defined( __FreeBSD__ )
+#include <sys/socket.h>
+#endif
 #include <netinet/in.h>
 #include <netdb.h>
 
@@ -5865,4 +5868,3 @@ void ghb_container_empty(GtkContainer *c)
 {
     gtk_container_foreach(c, container_empty_cb, NULL);
 }
-

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -64,6 +64,8 @@ else ifeq ($(BUILD.system),darwin)
     LIBHB.m += $(wildcard $(LIBHB.src/)platform/macosx/*.m)
 else ifeq ($(BUILD.system),linux)
     LIBHB.GCC.D += SYS_LINUX _LARGEFILE_SOURCE _FILE_OFFSET_BITS=64
+else ifeq ($(BUILD.system),freebsd)
+    LIBHB.GCC.D += SYS_FREEBSD _LARGEFILE_SOURCE _FILE_OFFSET_BITS=64
 else ifeq ($(BUILD.system),mingw)
     LIBHB.GCC.D += SYS_MINGW
 ifneq ($(HAS.pthread),1)
@@ -76,13 +78,13 @@ else
     LIBHB.platform.D = SYS_UNKNOWN
 endif
 
-ifeq (1,$(FEATURE.qsv))    
+ifeq (1,$(FEATURE.qsv))
     LIBHB.GCC.D += USE_QSV HAVE_THREADS=1
-endif  
+endif
 
 ifeq (1,$(FEATURE.x265))
     LIBHB.GCC.D += USE_X265
-endif  
+endif
 
 ifeq (1,$(COMPAT.strtok_r))
     LIBHB.GCC.D += HB_NEED_STRTOK_R

--- a/make/configure.py
+++ b/make/configure.py
@@ -1891,6 +1891,10 @@ int main()
             doc.add( 'HAS.regex', 1 )
         if strtok_r.fail:
             doc.add( 'COMPAT.strtok_r', 1 )
+
+    elif build.system == 'freebsd':
+        doc.add( 'HAS.pthread', 1 )
+
     else:
         doc.addBlank()
         if not strerror_r.fail:
@@ -1921,9 +1925,6 @@ int main()
     else:
         doc.add( 'GCC.sysroot', '' )
         doc.add( 'GCC.minver', '' )
-
-    if build.match( '*-*-freebsd*' ):
-        doc.add( 'HAS.pthread', 1 )
 
     if build.match( 'i?86-*' ):
         doc.add( 'LIBHB.GCC.D', 'ARCH_X86_32', append=True )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1892,11 +1892,10 @@ int main()
         if strtok_r.fail:
             doc.add( 'COMPAT.strtok_r', 1 )
 
-    elif build.system == 'freebsd':
-        doc.add( 'HAS.pthread', 1 )
-
     else:
         doc.addBlank()
+        if build.system == 'freebsd':
+            doc.add( 'HAS.pthread', 1 )
         if not strerror_r.fail:
             doc.add( 'HAS.strerror_r', 1 )
 

--- a/make/configure.py
+++ b/make/configure.py
@@ -581,6 +581,9 @@ class ArchAction( Action ):
             pass
         elif host.match( '*-*-solaris*' ):
             pass
+        elif host.match( '*-*-freebsd.*' ):
+            self.mode['i386']   = 'i386-portsbuild-freebsd%s' % (host.release)
+            self.mode['amd64'] = 'amd64-portsbuild-freebsd%s' % (host.release)
         else:
             self.msg_pass = 'WARNING'
 
@@ -1284,16 +1287,18 @@ def createCLI():
     h = IfHost( 'enable assembly code in non-contrib modules', 'NOMATCH*-*-darwin*', 'NOMATCH*-*-linux*', none=optparse.SUPPRESS_HELP ).value
     grp.add_option( '--enable-asm', default=False, action='store_true', help=h )
 
-    h = IfHost( 'disable GTK GUI', '*-*-linux*', none=optparse.SUPPRESS_HELP ).value
+    h = IfHost( 'disable GTK GUI', '*-*-linux*', '*-*-freebsd*', none=optparse.SUPPRESS_HELP ).value
     grp.add_option( '--disable-gtk', default=False, action='store_true', help=h )
 
-    h = IfHost( 'disable GTK GUI update checks', '*-*-linux*', none=optparse.SUPPRESS_HELP ).value
+    h = IfHost( 'disable GTK GUI update checks', '*-*-linux*', '*-*-freebsd*', none=optparse.SUPPRESS_HELP ).value
+
     grp.add_option( '--disable-gtk-update-checks', default=False, action='store_true', help=h )
 
     h = IfHost( 'enable GTK GUI (mingw)', '*-*-mingw*', none=optparse.SUPPRESS_HELP ).value
     grp.add_option( '--enable-gtk-mingw', default=False, action='store_true', help=h )
 
-    h = IfHost( 'disable GStreamer (live preview)', '*-*-linux*', none=optparse.SUPPRESS_HELP ).value
+    h = IfHost( 'disable GStreamer (live preview)', '*-*-linux*', '*-*-freebsd*', none=optparse.SUPPRESS_HELP ).value
+
     grp.add_option( '--disable-gst', default=False, action='store_true', help=h )
 
     h = IfHost( 'enable Intel Quick Sync Video (QSV) hardware acceleration', '*-*-*', none=optparse.SUPPRESS_HELP ).value
@@ -1345,7 +1350,7 @@ def createCLI():
     h = IfHost( 'Build and use local pkg-config', '*-*-darwin*', none=optparse.SUPPRESS_HELP ).value
     grp.add_option( '--enable-local-pkgconfig', default=False, action='store_true', help=h )
 
-    h = IfHost( 'Build extra contribs for flatpak packaging', '*-*-linux*', none=optparse.SUPPRESS_HELP ).value
+    h = IfHost( 'Build extra contribs for flatpak packaging', '*-*-linux*', '*-*-freebsd*', none=optparse.SUPPRESS_HELP ).value
     grp.add_option( '--flatpak', default=False, action='store_true', help=h )
     cli.add_option_group( grp )
 
@@ -1917,9 +1922,14 @@ int main()
         doc.add( 'GCC.sysroot', '' )
         doc.add( 'GCC.minver', '' )
 
+    if build.match( '*-*-freebsd*' ):
+        doc.add( 'HAS.pthread', 1 )
+
     if build.match( 'i?86-*' ):
         doc.add( 'LIBHB.GCC.D', 'ARCH_X86_32', append=True )
     elif build.match( 'x86_64-*' ):
+        doc.add( 'LIBHB.GCC.D', 'ARCH_X86_64', append=True )
+    elif build.match( 'amd64-*' ):
         doc.add( 'LIBHB.GCC.D', 'ARCH_X86_64', append=True )
 
     if options.enable_asm and ( not Tools.yasm.fail or options.enable_local_yasm ):
@@ -1933,7 +1943,7 @@ int main()
             else:
                 doc.add( 'LIBHB.YASM.f', 'elf32' )
             doc.add( 'LIBHB.YASM.m', 'x86' )
-        elif build.match( 'x86_64-*' ):
+        elif build.match( 'x86_64-*' ) or build.match( 'amd64-*' ):
             asm = 'x86'
             doc.add( 'LIBHB.GCC.D', 'HAVE_MMX ARCH_X86_64', append=True )
             if build.match( '*-*-darwin*' ):

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -136,6 +136,11 @@ ifeq (1-linux,$(FEATURE.gtk)-$(BUILD.system))
     MODULES += gtk
 endif
 
+ifeq (1-freebsd,$(FEATURE.gtk)-$(BUILD.system))
+    ## build gtk when gtk+freebsd
+    MODULES += gtk
+endif
+
 ifeq (1-kfreebsd,$(FEATURE.gtk)-$(BUILD.system))
     ## build gtk when gtk+kfreebsd
     MODULES += gtk

--- a/make/variant/freebsd.defs
+++ b/make/variant/freebsd.defs
@@ -1,5 +1,7 @@
 TARGET.dylib.ext = .so
 
+GCC.D       = LIBICONV_PLUG
+
 GCC.args.dylib = -shared
 GCC.args.pic   = 1
 

--- a/test/module.defs
+++ b/test/module.defs
@@ -13,7 +13,7 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 
 TEST.libs = $(LIBHB.a)
 
-TEST.GCC.l = \
+TEST.GCC.l = pthread \
         ass avresample avformat avcodec avfilter avutil mp3lame dvdnav \
         dvdread fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
@@ -62,7 +62,7 @@ else ifeq ($(BUILD.system),linux)
 else ifeq ($(BUILD.system),kfreebsd)
     TEST.GCC.l += pthread dl m
 else ifeq ($(BUILD.system),freebsd)
-    TEST.GCC.l += iconv pthread m
+    TEST.GCC.l += pthread m
 else ifeq ($(BUILD.system),solaris)
     TEST.GCC.l += pthread nsl socket
 ifneq (,$(filter $(BUILD.release),2.10))

--- a/test/module.defs
+++ b/test/module.defs
@@ -13,7 +13,7 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 
 TEST.libs = $(LIBHB.a)
 
-TEST.GCC.l = pthread \
+TEST.GCC.l = \
         ass avresample avformat avcodec avfilter avutil mp3lame dvdnav \
         dvdread fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \


### PR DESCRIPTION
Here is a fix to support FreeBSD GUI build.

This fix makes enable to build `ghb` in the same procedure
of the document.

https://handbrake.fr/docs/en/latest/developer/build-bsd.html

I think this fix doesn't break Linux build process.
But I don't test it.

Please check this on Linux and merge this Pull Request.
Thank you.
