### PR TITLE
contrib: Add universal archiver command for combining x265 libs.

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -42,19 +42,15 @@ X265.SOURCE.libs = \
 	$(X265.BUILD.dir)/10bit/libx265_main10.a \
 	$(X265.BUILD.dir)/12bit/libx265_main12.a
 
-ifeq (darwin, $(BUILD.system))
-    define X265.LINK
-        libtool -static -o $@ $(X265.SOURCE.libs)
-    endef
+ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
+    X265.O.ext = .obj
 else
-    X265.arscript = $(X265.BUILD.dir)/script.ar
-    define X265.LINK
-        echo "CREATE $@" > $(X265.arscript)
-        for a in $(X265.SOURCE.libs); do \
-            (echo "ADDLIB $$a" >> $(X265.arscript)); \
-        done
-        echo "SAVE" >> $(X265.arscript)
-        echo "END" >> $(X265.arscript)
-        $(AR.exe) -M < $(X265.arscript)
-    endef
+    X265.O.ext = .o
 endif
+
+define X265.LINK
+    for a in $(X265.SOURCE.libs); do \
+        ($(RM.exe) -rf "$$a"_o && $(MKDIR.exe) -p "$$a"_o && $(AR.exe) x "$$a" && $(MV.exe) *$(X265.O.ext) "$$a"_o && $(AR.exe) cq $@ "$$a"_o/*$(X265.O.ext)); \
+    done
+    $(AR.exe) s $@
+endef


### PR DESCRIPTION
Resolves an issue with GNU vs system libtool on Mac, which also does not support ar -M.