### PR TITLE
contrib: nlmeans prefilter passthru mode fixes

### DIFF
--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -1138,7 +1138,7 @@ static hb_buffer_t * nlmeans_filter_flush(hb_filter_private_t *pv)
             }
             if (pv->prefilter[c] & NLMEANS_PREFILTER_MODE_PASSTHRU)
             {
-                nlmeans_prefilter(&pv->frame[f].plane[c], pv->prefilter[c]);
+                nlmeans_prefilter(&frame->plane[c], pv->prefilter[c]);
                 nlmeans_deborder(&frame->plane[c], buf->plane[c].data,
                                  buf->plane[c].width, buf->plane[c].stride,
                                  buf->plane[c].height);

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -581,8 +581,17 @@ static void nlmeans_prefilter(BorderedPlane *src,
         }
 
         // Assign result
-        src->mem_pre   = mem_pre;
-        src->image_pre = image_pre;
+        if (filter_type & NLMEANS_PREFILTER_MODE_PASSTHRU)
+        {
+            // No swap needed as nlmeans_alloc() set src->mem_pre == src->mem
+            src->mem   = mem_pre;
+            src->image = image_pre;
+        }
+        else
+        {
+            src->mem_pre   = mem_pre;
+            src->image_pre = image_pre;
+        }
 
         // Recreate borders
         nlmeans_border(mem_pre, w, h, border);


### PR DESCRIPTION
Hi -- Here are two potential fixes for the nlmeans filter, specifically for the prefilter pass-thru mode.

First, I noticed commit 29a49a8 updated one nlmeans_prefilter() call, but there's another in the flush function which may need to be updated too.

Second, from the code and comments it seemed that the intent of the pass-thru mode was to cause the prefilter's result to be the filter's output, skipping the actual nlmeans filter: when the pass-thru flag is true, nlmeans_prefilter() is called but not nlmeans_plane(), and the intro comments say that prefilter enum 2049 means: "Mean 3x3 passthru (NLMeans off, prefilter is the output)".

However, I found that the using 2049 or any prefilter+2048 enum setting simply produced output identical to the input.  I believe this is because nlmeans_prefilter() is writing into the src->mem_pre buffer but that is then ignored if nlmeans_plane() is skipped.  Simply writing the prefilter output to src->mem instead was sufficient, in my tests, to cause the prefilter results to be output from the filter.

I hope these are helpful possible fixes; if not, my apologies!  (Thanks for the great implementation of nlmeans, BTW ... so much faster with the parallelization than ffmpeg's!)  Thanks, Chris.