### PR TITLE
Fix mingw64-crt build when environment variables CC/CXX are exported

### DIFF
--- a/scripts/mingw-w64-build
+++ b/scripts/mingw-w64-build
@@ -413,6 +413,8 @@ default install-dir: ${HOME}/toolchains/mingw-w64-${MINGW_W64_VER}-gcc-${GCC_VER
     make install-gcc >> "${BUILD_DIR}/gcc.log" 2>&1 || return 1
 
     # mingw-w64 runtime
+    export CC=""
+    export CXX=""
     echo "  mingw-w64 ${MINGW_W64_VER} runtime"
     local MINGW_W64_CONFIG_EXTRA
     MINGW_W64_CONFIG_EXTRA=()


### PR DESCRIPTION
The mingw64 CRT build system will continue to use the values indicated
in the environment variables CC/CXX if present, causing the script to
attempt (and fail) to build with the Linux C complier rather than the
newly built mingw64 cross compiler.