### PR TITLE
MacGUI: Address presets menu and controls issues.

### DIFF
--- a/macosx/English.lproj/HBRenamePresetController.xib
+++ b/macosx/English.lproj/HBRenamePresetController.xib
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+    <dependencies>
+        <deployment identifier="macosx"/>
+        <development version="8000" identifier="xcode"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <objects>
+        <customObject id="-2" userLabel="File's Owner" customClass="HBRenamePresetController">
+            <connections>
+                <outlet property="name" destination="UXm-yG-bgW" id="htS-T7-qP0"/>
+                <outlet property="renameButton" destination="WEv-SR-3sw" id="lRz-JT-RDG"/>
+                <outlet property="window" destination="C4G-OG-ksc" id="oNS-V8-CBz"/>
+            </connections>
+        </customObject>
+        <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
+        <customObject id="-3" userLabel="Application" customClass="NSObject"/>
+        <window title="Rename Preset" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" oneShot="NO" releasedWhenClosed="NO" showsToolbarButton="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="C4G-OG-ksc">
+            <windowStyleMask key="styleMask" titled="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="283" y="305" width="290" height="132"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1418"/>
+            <view key="contentView" id="3oN-GT-JmW">
+                <rect key="frame" x="0.0" y="0.0" width="290" height="132"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A8w-ij-o7q">
+                        <rect key="frame" x="18" y="95" width="114" height="17"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="New preset name:" id="Pe0-gr-Yv4">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UXm-yG-bgW">
+                        <rect key="frame" x="20" y="65" width="250" height="22"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="Untitled" drawsBackground="YES" id="NQn-fS-Rbd">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                        <connections>
+                            <outlet property="delegate" destination="-2" id="Iwm-TQ-ug8"/>
+                        </connections>
+                    </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HkI-lC-Q2A">
+                        <rect key="frame" x="106" y="13" width="82" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="N2f-jz-YyX">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="dismiss:" target="-2" id="LVI-0f-38c"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WEv-SR-3sw" userLabel="Rename Button">
+                        <rect key="frame" x="187" y="13" width="89" height="32"/>
+                        <buttonCell key="cell" type="push" title="Rename" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Z9M-dc-5Ml">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="rename:" target="-2" id="BAK-gD-GHH"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="UXm-yG-bgW" firstAttribute="trailing" secondItem="WEv-SR-3sw" secondAttribute="trailing" id="FMb-6L-akr"/>
+                    <constraint firstItem="HkI-lC-Q2A" firstAttribute="baseline" secondItem="WEv-SR-3sw" secondAttribute="baseline" id="SxI-wa-yJV"/>
+                    <constraint firstItem="A8w-ij-o7q" firstAttribute="leading" secondItem="UXm-yG-bgW" secondAttribute="leading" id="TKi-pl-2oX"/>
+                    <constraint firstItem="A8w-ij-o7q" firstAttribute="leading" secondItem="3oN-GT-JmW" secondAttribute="leading" constant="20" symbolic="YES" id="Tnf-NN-kbG"/>
+                    <constraint firstAttribute="bottom" secondItem="HkI-lC-Q2A" secondAttribute="bottom" constant="20" symbolic="YES" id="UNd-bY-NCa"/>
+                    <constraint firstItem="A8w-ij-o7q" firstAttribute="top" secondItem="3oN-GT-JmW" secondAttribute="top" constant="20" symbolic="YES" id="ds6-hB-jKz"/>
+                    <constraint firstItem="WEv-SR-3sw" firstAttribute="leading" secondItem="HkI-lC-Q2A" secondAttribute="trailing" constant="11" id="iPl-sl-4rt"/>
+                    <constraint firstAttribute="trailing" secondItem="UXm-yG-bgW" secondAttribute="trailing" constant="20" symbolic="YES" id="nUT-Cq-nKu"/>
+                    <constraint firstItem="UXm-yG-bgW" firstAttribute="top" secondItem="A8w-ij-o7q" secondAttribute="bottom" constant="8" symbolic="YES" id="y1i-GD-vKr"/>
+                </constraints>
+            </view>
+            <connections>
+                <outlet property="delegate" destination="-2" id="7b1-8k-MIb"/>
+            </connections>
+            <point key="canvasLocation" x="66" y="176"/>
+        </window>
+    </objects>
+</document>

--- a/macosx/English.lproj/MainMenu.xib
+++ b/macosx/English.lproj/MainMenu.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13770" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="8000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13770"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -337,12 +337,20 @@
                                     <action selector="insertCategory:" target="-1" id="JL7-bI-H97"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" tag="-1" id="1954">
+                            <menuItem isSeparatorItem="YES" tag="-1" id="ymY-bE-5EP">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
                             </menuItem>
                             <menuItem title="Select Default Preset" tag="-1" id="2421">
                                 <connections>
                                     <action selector="selectDefaultPreset:" target="-1" id="2eH-zk-T3n"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" tag="-1" id="1954">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Delete Preset" tag="-1" id="CN3-Rh-gVf">
+                                <connections>
+                                    <action selector="deletePreset:" target="-1" id="ZGV-Ji-MGc"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" tag="-1" id="CQW-qW-5C5">

--- a/macosx/English.lproj/MainMenu.xib
+++ b/macosx/English.lproj/MainMenu.xib
@@ -345,6 +345,14 @@
                                     <action selector="setDefaultPreset:" target="-1" id="adZ-ic-MKn"/>
                                 </connections>
                             </menuItem>
+                            <menuItem isSeparatorItem="YES" tag="-1" id="2954">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Rename Preset…" tag="-1" id="1GQ-n3-jfY">
+                                <connections>
+                                    <action selector="renamePreset:" target="-1" id="ts9-w0-2WC"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="Delete Preset" tag="-1" id="CN3-Rh-gVf">
                                 <connections>
                                     <action selector="deletePreset:" target="-1" id="ZGV-Ji-MGc"/>

--- a/macosx/English.lproj/MainMenu.xib
+++ b/macosx/English.lproj/MainMenu.xib
@@ -337,16 +337,13 @@
                                     <action selector="insertCategory:" target="-1" id="JL7-bI-H97"/>
                                 </connections>
                             </menuItem>
-                            <menuItem isSeparatorItem="YES" tag="-1" id="ymY-bE-5EP">
-                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
-                            </menuItem>
-                            <menuItem title="Select Default Preset" tag="-1" id="2421">
-                                <connections>
-                                    <action selector="selectDefaultPreset:" target="-1" id="2eH-zk-T3n"/>
-                                </connections>
-                            </menuItem>
                             <menuItem isSeparatorItem="YES" tag="-1" id="1954">
                                 <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Make Default Preset" tag="-1" id="frQ-v5-pRa" userLabel="Make Default Preset">
+                                <connections>
+                                    <action selector="setDefaultPreset:" target="-1" id="adZ-ic-MKn"/>
+                                </connections>
                             </menuItem>
                             <menuItem title="Delete Preset" tag="-1" id="CN3-Rh-gVf">
                                 <connections>
@@ -371,6 +368,14 @@
                             <menuItem title="Reset Official Presets" tag="-1" id="1950">
                                 <connections>
                                     <action selector="addFactoryPresets:" target="6lr-Yy-GMc" id="5Ga-rb-ORy"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" tag="-1" id="ymY-bE-5EP">
+                                <modifierMask key="keyEquivalentModifierMask" command="YES"/>
+                            </menuItem>
+                            <menuItem title="Select Default Preset" tag="-1" id="2421">
+                                <connections>
+                                    <action selector="selectDefaultPreset:" target="-1" id="2eH-zk-T3n"/>
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" tag="-1" id="wgI-bc-Ors">

--- a/macosx/English.lproj/Presets.xib
+++ b/macosx/English.lproj/Presets.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13770" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="13771" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
         <development version="8000" identifier="xcode"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13770"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="13771"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -61,6 +61,9 @@ Overrides all encode settings. Settings may be further adjusted after selecting 
                                                             <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            <connections>
+                                                                <action selector="renamed:" target="-2" id="ZKl-KQ-seA"/>
+                                                            </connections>
                                                         </textFieldCell>
                                                         <connections>
                                                             <binding destination="czB-kB-CXf" name="editable" keyPath="objectValue.isBuiltIn" id="ynB-cm-NHg">

--- a/macosx/HBController.h
+++ b/macosx/HBController.h
@@ -38,8 +38,10 @@
 
 // Manage User presets
 - (IBAction)showAddPresetPanel:(id)sender;
+- (IBAction)showRenamePresetPanel:(id)sender;
 - (IBAction)selectDefaultPreset:(id)sender;
 
+- (IBAction)renamePreset:(id)sender;
 - (IBAction)deletePreset:(id)sender;
 - (IBAction)reloadPreset:(id)sender;
 

--- a/macosx/HBController.h
+++ b/macosx/HBController.h
@@ -40,6 +40,7 @@
 - (IBAction)showAddPresetPanel:(id)sender;
 - (IBAction)selectDefaultPreset:(id)sender;
 
+- (IBAction)deletePreset:(id)sender;
 - (IBAction)reloadPreset:(id)sender;
 
 

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1526,6 +1526,7 @@
 
 - (IBAction)setDefaultPreset:(id)sender
 {
+    fPresetsView.selectedPreset = _currentPreset;
     [fPresetsView setDefault:sender];
 }
 

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1524,6 +1524,11 @@
     fPresetsView.selectedPreset = presetManager.defaultPreset;
 }
 
+- (IBAction)setDefaultPreset:(id)sender
+{
+    [fPresetsView setDefault:sender];
+}
+
 - (IBAction)deletePreset:(id)sender
 {
     HBPreset *preset = [sender representedObject];

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1395,6 +1395,7 @@
         }
         else
         {
+            fPresetsView.selectedPreset = _currentPreset;
             [self.presetsPopover close];
         }
     }

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1527,6 +1527,12 @@
     fPresetsView.selectedPreset = presetManager.defaultPreset;
 }
 
+- (IBAction)deletePreset:(id)sender
+{
+    HBPreset *preset = [sender representedObject];
+    [fPresetsView deletePreset:preset];
+}
+
 - (IBAction)insertCategory:(id)sender
 {
     [fPresetsView insertCategory:sender];

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -253,6 +253,8 @@
         // note that interacting with menus or panels that become key only when needed will not cause a transient popover to close.
         self.presetsPopover.behavior = NSPopoverBehaviorSemitransient;
         self.presetsPopover.delegate = self;
+
+        [fPresetsView loadView];
     }
 
     // Set up the summary view

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1367,10 +1367,7 @@
 
 - (void)selectionDidChange
 {
-    if (fPresetsView.selectedPreset != self.currentPreset || self.edited)
-    {
-        [self applyPreset:fPresetsView.selectedPreset];
-    }
+    [self applyPreset:fPresetsView.selectedPreset];
 }
 
 #pragma mark -  Presets

--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -235,7 +235,7 @@ static NSDictionary            *shortHeightAttr;
     return attrString;
 }
 
-- (NSAttributedString *)pictureAttributedDescription
+- (NSAttributedString *)dimensionsAttributedDescription
 {
     NSMutableAttributedString *attrString = [[NSMutableAttributedString alloc] init];
 
@@ -244,10 +244,10 @@ static NSDictionary            *shortHeightAttr;
     {
         pictureInfo = [pictureInfo stringByAppendingString:@" Keep Aspect Ratio"];
     }
-    [attrString appendString:@"\tPicture: " withAttributes:detailBoldAttr];
-    [attrString appendString:@"\t"          withAttributes:detailAttr];
-    [attrString appendString:pictureInfo    withAttributes:detailAttr];
-    [attrString appendString:@"\n"          withAttributes:detailAttr];
+    [attrString appendString:@"\tDimensions: " withAttributes:detailBoldAttr];
+    [attrString appendString:@"\t"             withAttributes:detailAttr];
+    [attrString appendString:pictureInfo       withAttributes:detailAttr];
+    [attrString appendString:@"\n"             withAttributes:detailAttr];
 
     return attrString;
 }
@@ -600,8 +600,7 @@ static NSDictionary            *shortHeightAttr;
         [attrString appendAttributedString:[self titleAttributedDescription]];
         [attrString appendAttributedString:[self presetAttributedDescription]];
         [attrString appendAttributedString:[self formatAttributedDescription]];
-        [attrString appendAttributedString:[self destinationAttributedDescription]];
-        [attrString appendAttributedString:[self pictureAttributedDescription]];
+        [attrString appendAttributedString:[self dimensionsAttributedDescription]];
         [attrString appendAttributedString:[self filtersAttributedDescription]];
         [attrString appendAttributedString:[self videoAttributedDescription]];
         if (self.audio.countOfTracks > 1)
@@ -612,6 +611,7 @@ static NSDictionary            *shortHeightAttr;
         {
             [attrString appendAttributedString:[self subtitlesAttributedDescription]];
         }
+        [attrString appendAttributedString:[self destinationAttributedDescription]];
     }
 
     [attrString deleteCharactersInRange:NSMakeRange(attrString.length - 1, 1)];

--- a/macosx/HBPresetsViewController.h
+++ b/macosx/HBPresetsViewController.h
@@ -24,6 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite, assign) id<HBPresetsViewControllerDelegate> delegate;
 
+- (IBAction)deletePreset:(id)sender;
+
 - (IBAction)exportPreset:(id)sender;
 - (IBAction)importPreset:(id)sender;
 

--- a/macosx/HBPresetsViewController.h
+++ b/macosx/HBPresetsViewController.h
@@ -24,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readwrite, assign) id<HBPresetsViewControllerDelegate> delegate;
 
+- (IBAction)setDefault:(id)sender;
 - (IBAction)deletePreset:(id)sender;
 
 - (IBAction)exportPreset:(id)sender;

--- a/macosx/HBPresetsViewController.m
+++ b/macosx/HBPresetsViewController.m
@@ -249,6 +249,15 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
     }
 }
 
+- (IBAction)renamed:(id)sender
+{
+    if (self.delegate && [[self.treeController.selectedObjects firstObject] isLeaf])
+    {
+        [self.delegate selectionDidChange];
+        [[NSNotificationCenter defaultCenter] postNotificationName:HBPresetsChangedNotification object:nil];
+    }
+}
+
 - (IBAction)addNewPreset:(id)sender
 {
     if (self.delegate)

--- a/macosx/HBPresetsViewController.m
+++ b/macosx/HBPresetsViewController.m
@@ -261,8 +261,6 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
 {
     if ([self.treeController canRemove])
     {
-        // Save the current selection path and apply it again after the deletion
-        NSIndexPath *currentSelection = [self.treeController selectionIndexPath];
         /* Alert user before deleting preset */
         NSAlert *alert = [NSAlert alertWithMessageText:NSLocalizedString(@"Are you sure you want to permanently delete the selected preset?", nil)
                                          defaultButton:NSLocalizedString(@"Delete Preset", nil)
@@ -276,8 +274,8 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
         if (status == NSAlertDefaultReturn)
         {
             [self.presets deletePresetAtIndexPath:[self.treeController selectionIndexPath]];
+            [self setSelection:self.presets.defaultPreset];
         }
-        [self.treeController setSelectionIndexPath:currentSelection];
     }
 }
 

--- a/macosx/HBPresetsViewController.m
+++ b/macosx/HBPresetsViewController.m
@@ -306,6 +306,7 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
     if (selectedNode.isLeaf)
     {
         self.presets.defaultPreset = selectedNode;
+        [[NSNotificationCenter defaultCenter] postNotificationName:HBPresetsChangedNotification object:nil];
     }
 }
 

--- a/macosx/HBRenamePresetController.h
+++ b/macosx/HBRenamePresetController.h
@@ -1,0 +1,22 @@
+/*  HBRenamePresetController.h
+
+ This file is part of the HandBrake source code.
+ Homepage: <http://handbrake.fr/>.
+ It may be used under the terms of the GNU General Public License. */
+
+#import <Cocoa/Cocoa.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class HBPreset;
+@class HBPresetsManager;
+
+@interface HBRenamePresetController : NSWindowController
+
+- (instancetype)initWithPreset:(HBPreset *)preset presetManager:(HBPresetsManager *)manager;
+
+@property (nonatomic, readonly) HBPreset *preset;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/macosx/HBRenamePresetController.m
+++ b/macosx/HBRenamePresetController.m
@@ -1,0 +1,85 @@
+/*  HBRenamePresetController.m
+
+ This file is part of the HandBrake source code.
+ Homepage: <http://handbrake.fr/>.
+ It may be used under the terms of the GNU General Public License. */
+
+#import "HBRenamePresetController.h"
+
+#import "HBPresetsManager.h"
+#import "HBPreset.h"
+
+@import HandBrakeKit;
+
+@interface HBRenamePresetController () <NSTextFieldDelegate>
+
+@property (nonatomic, strong) IBOutlet NSTextField *name;
+@property (nonatomic, strong) IBOutlet NSButton *renameButton;
+
+@property (nonatomic, strong) HBPreset *preset;
+
+@property (nonatomic, strong) HBPresetsManager *manager;
+
+@end
+
+@implementation HBRenamePresetController
+
+- (instancetype)initWithPreset:(HBPreset *)preset presetManager:(HBPresetsManager *)manager
+{
+    self = [super initWithWindowNibName:@"HBRenamePresetController"];
+    if (self)
+    {
+        NSParameterAssert(preset);
+        NSParameterAssert(manager);
+        _preset = preset;
+        _manager = manager;
+    }
+    return self;
+}
+
+- (void)windowDidLoad
+{
+    [super windowDidLoad];
+
+    self.name.stringValue = self.name.placeholderString = self.preset.name;
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(controlTextDidChange:)
+                                                 name:NSControlTextDidChangeNotification object:nil];
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:NSControlTextDidChangeNotification object:nil];
+}
+
+- (void)controlTextDidChange:(NSNotification *)obj {
+    self.renameButton.enabled = self.name.stringValue.length > 0 ? YES : NO;
+}
+
+- (IBAction)dismiss:(id)sender
+{
+    [self.window orderOut:nil];
+    [NSApp endSheet:self.window returnCode:NSModalResponseCancel];
+}
+
+- (IBAction)rename:(id)sender
+{
+    if (self.name.stringValue.length == 0)
+    {
+        NSAlert *alert = [[NSAlert alloc] init];
+        [alert setMessageText:NSLocalizedString(@"The preset name cannot be empty.", @"")];
+        [alert setInformativeText:NSLocalizedString(@"Please enter a name.", @"")];
+        [alert runModal];
+    }
+    else
+    {
+        [self.preset setName:self.name.stringValue];
+
+        [self.window orderOut:nil];
+        [NSApp endSheet:self.window returnCode:NSModalResponseContinue];
+    }
+}
+
+
+@end

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		1C6D76551CD7733300F5B943 /* libharfbuzz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C15C82B1CD7722500368223 /* libharfbuzz.a */; };
 		1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C15C82B1CD7722500368223 /* libharfbuzz.a */; };
+		1C7776A2202300DD001C31EB /* HBRenamePresetController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7776A0202300DC001C31EB /* HBRenamePresetController.m */; };
+		1C7776A5202301D5001C31EB /* HBRenamePresetController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1C7776A3202301D5001C31EB /* HBRenamePresetController.xib */; };
 		226268E11572CC7300477B4E /* libavresample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 226268DF1572CC7300477B4E /* libavresample.a */; };
 		22DD2C4B177B95DA00EF50D3 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
@@ -316,6 +318,9 @@
 
 /* Begin PBXFileReference section */
 		1C15C82B1CD7722500368223 /* libharfbuzz.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libharfbuzz.a; path = external/contrib/lib/libharfbuzz.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1C7776A0202300DC001C31EB /* HBRenamePresetController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HBRenamePresetController.m; sourceTree = "<group>"; };
+		1C7776A1202300DC001C31EB /* HBRenamePresetController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBRenamePresetController.h; sourceTree = "<group>"; };
+		1C7776A4202301D5001C31EB /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/HBRenamePresetController.xib; sourceTree = "<group>"; };
 		226268DF1572CC7300477B4E /* libavresample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libavresample.a; path = external/contrib/lib/libavresample.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22CC9E74191EBEA500C69D81 /* libx265.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libx265.a; path = external/contrib/lib/libx265.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DD2C49177B94DB00EF50D3 /* libvpx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvpx.a; path = external/contrib/lib/libvpx.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1198,6 +1203,9 @@
 				273F20A014ADBE670021BE6D /* HBPreferencesController.m */,
 				A939DD891FC8826A00135F2A /* HBPresetsMenuBuilder.h */,
 				A939DD8A1FC8826A00135F2A /* HBPresetsMenuBuilder.m */,
+				1C7776A1202300DC001C31EB /* HBRenamePresetController.h */,
+				1C7776A0202300DC001C31EB /* HBRenamePresetController.m */,
+				1C7776A3202301D5001C31EB /* HBRenamePresetController.xib */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -1486,6 +1494,7 @@
 				A9F2EB6F196F12C800066546 /* Audio.xib in Resources */,
 				A9CF25F11990D62C0023F727 /* Presets.xib in Resources */,
 				A9C1839D1A716BCC00C897C2 /* HBTitleSelection.xib in Resources */,
+				1C7776A5202301D5001C31EB /* HBRenamePresetController.xib in Resources */,
 				273F218A14ADDDA10021BE6D /* AdvancedView.xib in Resources */,
 				273F218B14ADDDA10021BE6D /* InfoPlist.strings in Resources */,
 				A932E26C1988334B0047D13E /* AudioDefaults.xib in Resources */,
@@ -1574,6 +1583,7 @@
 				A99F40CF1B624E7E00750170 /* HBPictureViewController.m in Sources */,
 				273F20AF14ADBE670021BE6D /* HBAudioController.m in Sources */,
 				A9DC6C52196F04F6002AE6B4 /* HBSubtitlesController.m in Sources */,
+				1C7776A2202300DD001C31EB /* HBRenamePresetController.m in Sources */,
 				A9F472891976B7F30009EC65 /* HBSubtitlesDefaultsController.m in Sources */,
 				273F20AD14ADBE670021BE6D /* HBAdvancedController.m in Sources */,
 				A9906B2C1A710920001D82D5 /* HBQueueController.m in Sources */,
@@ -1691,6 +1701,14 @@
 /* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
+		1C7776A3202301D5001C31EB /* HBRenamePresetController.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				1C7776A4202301D5001C31EB /* English */,
+			);
+			name = HBRenamePresetController.xib;
+			sourceTree = "<group>";
+		};
 		273F217A14ADDDA10021BE6D /* AdvancedView.xib */ = {
 			isa = PBXVariantGroup;
 			children = (


### PR DESCRIPTION
Fixed some bugs and added `Make Default Preset`, `Delete Preset` to the `Presets` menu.

There may be a better solution than selecting the default preset on delete; I think the idea was to select a nearby existing preset on delete. In my testing, nothing at all was selected after deleting a preset, neither in the presets popover nor the main window control. Making changes to `HBPresetsViewController.m` fixed the issue but I'm not certain these changes will not break some other desired behavior.

Additional issues I found in testing:

- ~~~Renaming a preset via the popover does not update the main window control~~~ Fixed.
- ~~~Changing the default preset via the popover does not update the main window control~~~ Fixed.
- Saving a new preset via the main window control does not select the new preset ~~~(it should)~~~ Hmm, should it?

If I was mistaken about deciding to remove the `Presets` toolbar item, I can add that back, but I don't think it should be at the expense the rest of this. They're not mutually exclusive.

I'm working on adding `Rename Preset…` to the `Presets` menu but it's a bit more involved for me. Only more evidence that IANAMD (I Am Not A Mac Developer). 😸 