### PR TITLE
contrib: Update to Libav 12.3.

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -6,12 +6,16 @@ ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBMFX
 endif
 
+# workaround for potential race condition
+# where x264 may fail to find nasm later
+__deps__ += X264
+
 $(eval $(call import.MODULE.defs,FFMPEG,ffmpeg,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FFMPEG))
 
-FFMPEG.FETCH.url =  https://download.handbrake.fr/handbrake/contrib/libav-12.2.tar.gz
-FFMPEG.FETCH.url += https://libav.org/releases/libav-12.2.tar.gz
-FFMPEG.FETCH.sha256 = 49c3ccda32458192c00ab25b30f4d1a6a4772b83458cbbf3a25b210d0688f55c
+FFMPEG.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libav-12.3.tar.gz
+FFMPEG.FETCH.url   += https://libav.org/releases/libav-12.3.tar.gz
+FFMPEG.FETCH.sha256 = 115b659022dd387f662e26fbc5bc0cc14ec18daa100003ffd34f4da0479b272e
 
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =


### PR DESCRIPTION
Changelog: https://git.libav.org/?p=libav.git;a=blob;f=Changelog;hb=refs/tags/v12.3

Adds a workaround to ensure x264 is built first. Otherwise, it may fail to find nasm later.

Closes #1181.

Please upload the tarball and verify hash. Thanks!