### PR TITLE
Fix to build libvpx on FreeBSD.

### DIFF
--- a/contrib/libvpx/P02-freebsd-configure.patch
+++ b/contrib/libvpx/P02-freebsd-configure.patch
@@ -1,0 +1,11 @@
+--- libvpx-1.7.0/configure.orig	2018-01-25 07:25:44.000000000 +0900
++++ libvpx-1.7.0/configure	2018-05-21 22:21:02.266701000 +0900
+@@ -170,7 +170,7 @@
+     [ -f "${source_path}/${t}.mk" ] && enable_feature ${t}
+ done
+ 
+-if ! diff --version >/dev/null; then
++if ! hash diff 2>/dev/null; then
+   die "diff missing: Try installing diffutils via your package manager."
+ fi
+ 


### PR DESCRIPTION
On FreeBSD, libvpx build fails as followings.

```
set -e; /bin/mkdir -p ./contrib/libvpx/libvpx-1.7.0/; cd ./contrib/libvpx/libvpx
-1.7.0/; CC=/usr/local/bin/gcc CFLAGS="-I/home/yuichiro/HandBrake/build/contrib/
include -std=gnu99 -mfpmath=sse -msse2 -DLIBICONV_PLUG" CXX=/usr/local/bin/g++ C
XXFLAGS="-I/home/yuichiro/HandBrake/build/contrib/include -mfpmath=sse -msse2 -D
LIBICONV_PLUG" CPPFLAGS="-I/home/yuichiro/HandBrake/build/contrib/include -mfpma
th=sse -msse2 -DLIBICONV_PLUG" LDFLAGS="-L/home/yuichiro/HandBrake/build/contrib
/lib -DLIBICONV_PLUG" PKG_CONFIG_PATH="/home/yuichiro/HandBrake/build/contrib/li
b/pkgconfig" ./configure --prefix=/home/yuichiro/HandBrake/build/contrib/ --disa
ble-shared --enable-static --as=yasm --enable-vp8-encoder --disable-vp8-decoder 
--enable-vp9-encoder --disable-vp9-decoder --disable-examples --disable-docs --d
isable-unit-tests
diff: unrecognized option `--version'
usage: diff [-abdilpTtw] [-c | -e | -f | -n | -q | -u] [--ignore-case]
            [--no-ignore-case] [--normal] [--strip-trailing-cr] [--tabsize]
            [-I pattern] [-L label] file1 file2
       diff [-abdilpTtw] [-I pattern] [-L label] [--ignore-case]
            [--no-ignore-case] [--normal] [--strip-trailing-cr] [--tabsize]
            -C number file1 file2
       diff [-abdiltw] [-I pattern] [--ignore-case] [--no-ignore-case]
            [--normal] [--strip-trailing-cr] [--tabsize] -D string file1 file2
       diff [-abdilpTtw] [-I pattern] [-L label] [--ignore-case]
            [--no-ignore-case] [--normal] [--tabsize] [--strip-trailing-cr]
            -U number file1 file2
       diff [-abdilNPprsTtw] [-c | -e | -f | -n | -q | -u] [--ignore-case]
            [--no-ignore-case] [--normal] [--tabsize] [-I pattern] [-L label]
            [-S name] [-X file] [-x pattern] dir1 dir2
diff missing: Try installing diffutils via your package manager.
```

libvpx's configure checks `diff --version`,
but FreeBSD's diff doesn't support --version option.
Fix to use `hash` command to check if diff is available or not.