### PR TITLE
contrib: add lzma support

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := YASM FDKAAC LIBVPX LAME LIBOPUS LIBSPEEX
+__deps__ := YASM FDKAAC LIBVPX LAME LIBOPUS LIBSPEEX XZ
 ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBMFX
 endif
@@ -63,6 +63,7 @@ FFMPEG.CONFIGURE.extra = \
     --disable-decoder=wmv3_crystalhd \
     --disable-bzlib \
     --disable-zlib \
+    --enable-lzma \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"
 

--- a/contrib/xz/module.defs
+++ b/contrib/xz/module.defs
@@ -1,0 +1,15 @@
+$(eval $(call import.MODULE.defs,XZ,xz))
+$(eval $(call import.CONTRIB.defs,XZ))
+
+XZ.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/xz-5.2.4.tar.bz2
+XZ.FETCH.url    += https://tukaani.org/xz/xz-5.2.4.tar.bz2
+XZ.FETCH.sha256  = 3313fd2a95f43d88e44264e6b015e7d03053e681860b0d5d3f9baca79c57b7bf
+
+XZ.CONFIGURE.extra = \
+    --disable-xz \
+    --disable-xzdec \
+    --disable-lzmadec \
+    --disable-lzmainfo \
+    --disable-scripts \
+    --disable-doc
+

--- a/contrib/xz/module.rules
+++ b/contrib/xz/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,XZ))
+$(eval $(call import.CONTRIB.rules,XZ))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -177,7 +177,7 @@ PKG_CHECK_MODULES(GHB, [$GHB_PACKAGES])
 
 GHB_CFLAGS="$HBINC $GHB_CFLAGS"
 
-HB_LIBS="-lhandbrake -lavresample -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex"
+HB_LIBS="-lhandbrake -lavresample -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
 
 case $host in
   *-*-mingw*)

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -185,6 +185,12 @@ else
     LIBHB.GCC.l += z
 endif
 
+ifneq ($(HAS.xz),1)
+LIBHB.dll.libs += $(CONTRIB.build/)lib/liblzma.a
+else
+    LIBHB.GCC.l += lzma
+endif
+
 LIBHB.GCC.args.extra.dylib++ += -Wl,--out-implib,$(LIBHB.lib)
 LIBHB.GCC.l += bcrypt ws2_32 uuid ole32
 ifeq ($(HAS.dlfcn),1)

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1C15C82B1CD7722500368223 /* libharfbuzz.a */; };
 		1C7776A2202300DD001C31EB /* HBRenamePresetController.m in Sources */ = {isa = PBXBuildFile; fileRef = 1C7776A0202300DC001C31EB /* HBRenamePresetController.m */; };
 		1C7776A5202301D5001C31EB /* HBRenamePresetController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1C7776A3202301D5001C31EB /* HBRenamePresetController.xib */; };
+		1CBC683420BE014800A26CC2 /* liblzma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC683320BE014800A26CC2 /* liblzma.a */; };
+		1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC683320BE014800A26CC2 /* liblzma.a */; };
 		226268E11572CC7300477B4E /* libavresample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 226268DF1572CC7300477B4E /* libavresample.a */; };
 		22DD2C4B177B95DA00EF50D3 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
@@ -330,6 +332,7 @@
 		1C7776A0202300DC001C31EB /* HBRenamePresetController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HBRenamePresetController.m; sourceTree = "<group>"; };
 		1C7776A1202300DC001C31EB /* HBRenamePresetController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBRenamePresetController.h; sourceTree = "<group>"; };
 		1C7776A4202301D5001C31EB /* English */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = English; path = English.lproj/HBRenamePresetController.xib; sourceTree = "<group>"; };
+		1CBC683320BE014800A26CC2 /* liblzma.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblzma.a; path = "external/contrib/lib/liblzma.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		226268DF1572CC7300477B4E /* libavresample.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libavresample.a; path = external/contrib/lib/libavresample.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22CC9E74191EBEA500C69D81 /* libx265.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libx265.a; path = external/contrib/lib/libx265.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DD2C49177B94DB00EF50D3 /* libvpx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvpx.a; path = external/contrib/lib/libvpx.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -648,6 +651,7 @@
 				27D6C75814B102DA00B785E4 /* libfreetype.a in Frameworks */,
 				27D6C75A14B102DA00B785E4 /* libfribidi.a in Frameworks */,
 				27D6C75F14B102DA00B785E4 /* libmp3lame.a in Frameworks */,
+				1CBC683420BE014800A26CC2 /* liblzma.a in Frameworks */,
 				1C0695AC20BD193D001543DA /* libpostproc.a in Frameworks */,
 				27D6C76514B102DA00B785E4 /* libogg.a in Frameworks */,
 				27D6C76714B102DA00B785E4 /* libsamplerate.a in Frameworks */,
@@ -685,6 +689,7 @@
 				A9ABD1AA1E2A0F8F00EC8B65 /* CoreGraphics.framework in Frameworks */,
 				A9ABD1A61E2A0F0700EC8B65 /* CoreText.framework in Frameworks */,
 				A91119A31C7DD591001C463C /* IOKit.framework in Frameworks */,
+				1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */,
 				A91119A21C7DD58B001C463C /* Cocoa.framework in Frameworks */,
 				1C53DE8D20BD598D006BBCA8 /* libspeex.a in Frameworks */,
 				A9736F1F1C7DA667008F1D18 /* Foundation.framework in Frameworks */,
@@ -739,6 +744,7 @@
 			isa = PBXGroup;
 			children = (
 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
+				1CBC683320BE014800A26CC2 /* liblzma.a */,
 				1C0695AA20BD193D001543DA /* libpostproc.a */,
 				1C0695AB20BD193D001543DA /* libswresample.a */,
 				27D6C72414B1019100B785E4 /* libhandbrake.a */,

--- a/make/configure.py
+++ b/make/configure.py
@@ -1686,6 +1686,18 @@ int main ()
         libz = LDProbe( 'static zlib', '%s -static' % Tools.gcc.pathname, '-lz', libz_test )
         libz.run()
 
+        xz_test = """
+#include <stdio.h>
+#include <lzma.h>
+int main ()
+{
+  lzma_stream_decoder(NULL, 0, 0);
+  return 0;
+}
+"""
+        xz = LDProbe( 'static xz', '%s -static' % Tools.gcc.pathname, '-llzma', xz_test )
+        xz.run()
+
         iconv_test = """
 #include <stdio.h>
 #include <iconv.h>
@@ -1893,6 +1905,8 @@ int main()
             doc.add( 'HAS.bz2', 1 )
         if not libz.fail:
             doc.add( 'HAS.libz', 1 )
+        if not xz.fail:
+            doc.add( 'HAS.xz', 1 )
         if not iconv.fail:
             doc.add( 'HAS.iconv', 1 )
         if not regex.fail:

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -118,7 +118,7 @@ define import.CONTRIB.defs
         $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra *D)"
         $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra *D)"
     endif
-    $(1).CONFIGURE.env.CPPFLAGS = CPPFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?extra *D)"
+    $(1).CONFIGURE.env.CPPFLAGS = CPPFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver *D)"
     $(1).CONFIGURE.env.LDFLAGS  = LDFLAGS="-L$$(call fn.ABSOLUTE,$(CONTRIB.build/))lib $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?extra.exe *D)"
     $(1).CONFIGURE.env.PKG_CONFIG_PATH  = PKG_CONFIG_PATH="$$(call fn.ABSOLUTE,$$(CONTRIB.build/))lib/pkgconfig"
 

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -102,6 +102,9 @@ ifneq (,$(filter $(BUILD.system),cygwin mingw))
 ifneq ($(HAS.iconv),1)
     MODULES += contrib/libiconv
 endif
+ifneq ($(HAS.xz),1)
+    MODULES += contrib/xz
+endif
 ifneq ($(HAS.libz),1)
     MODULES += contrib/zlib
 endif

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -98,6 +98,10 @@ ifeq (1,$(FEATURE.qsv))
     MODULES += contrib/libmfx
 endif
 
+ifneq (,$(filter $(BUILD.system),darwin))
+    MODULES += contrib/xz
+endif
+
 ifneq (,$(filter $(BUILD.system),cygwin mingw))
 ifneq ($(HAS.iconv),1)
     MODULES += contrib/libiconv

--- a/pkg/linux/debian/control.artful
+++ b/pkg/linux/debian/control.artful
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.bionic
+++ b/pkg/linux/debian/control.bionic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.trusty
+++ b/pkg/linux/debian/control.trusty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.xenial
+++ b/pkg/linux/debian/control.xenial
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avresample avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
         dvdread fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
-        bluray freetype xml2 bz2 z jansson harfbuzz opus speex
+        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma
 
 ifeq (,$(filter $(BUILD.system),darwin cygwin mingw))
     TEST.GCC.l += fontconfig


### PR DESCRIPTION
lzma may be used by the ffmpeg tiff decoder which can be used in
matroska files.