### PR TITLE
Update WinGUI build script: allow SignTool.exe location to be specified and assume x64

### DIFF
--- a/win/CS/build.xml
+++ b/win/CS/build.xml
@@ -4,7 +4,7 @@
   Homepage: <http://handbrake.fr>.
   It may be used under the terms of the GNU General Public License
   
-  HandBrake Build Scipt for usage with Jenkins.
+  HandBrake Build Script for usage with Jenkins.
   Usage: 
     msbuild build.xml /t:Nightly
     msbuild build.xml /t:Release
@@ -38,7 +38,7 @@
   <Target Name="Nightly" DependsOnTargets="$(NightlyDependsOn)"/>
   <Target Name="Release" DependsOnTargets="$(InstallDependsOn)"/>
 
-  <!-- Build All Components (WPF, ApplicationServices, Interop -->
+  <!-- Build All Components (WPF, ApplicationServices, Interop) -->
   <Target Name="BuildRelease">
     <MSBuild Projects ="@(ProjectsToBuild)"
              ContinueOnError ="false"

--- a/win/CS/build.xml
+++ b/win/CS/build.xml
@@ -11,7 +11,7 @@
   Example with code signing:
     msbuild build.xml /p:Platform=x64 /t:Release /p:SignThumbprint=XYZ /p:SignTimestampServer=http://time.certum.pl/
     
-  Reuqires: libhb.dll to be in the release folder.
+  Requires: libhb.dll to be in the release folder.
   
 -->
 <Project DefaultTargets="Nightly" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
@@ -49,7 +49,7 @@
 
   <!-- Code Signing Configuration -->
   <PropertyGroup Condition="'$(SignToolLocation)'==''">
-    <SighToolLocation>C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\SignTool.exe</SighToolLocation>
+    <SignToolLocation>C:\Program Files (x86)\Windows Kits\10\bin\10.0.15063.0\x64\SignTool.exe</SignToolLocation>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(SignThumbprint)'!=''">
@@ -62,7 +62,7 @@
     <Exec Command="copy $(MSBuildProjectDirectory)\HandBrakeWPF\handbrakepineapple.ico $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="xcopy $(MSBuildProjectDirectory)\doc $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\doc /I /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="makensis $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\MakeNightly64.nsi" Condition="$(Platform) == 'x64'" />
-    <Exec Command="&quot;$(SighToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
   </Target>
 
   <Target Name="ReleasePostBuild">
@@ -70,7 +70,7 @@
     <Exec Command="copy $(MSBuildProjectDirectory)\HandBrakeWPF\handbrakepineapple.ico $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="xcopy $(MSBuildProjectDirectory)\doc $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\doc /I /Y" Condition="$(Platform) == 'x64'" />
     <Exec Command="makensis $(MSBuildProjectDirectory)\HandBrakeWPF\bin\x64\Release\Installer64.nsi" Condition="$(Platform) == 'x64'" />
-    <Exec Command="&quot;$(SighToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign /sha1 $(SignThumbprint) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\$(Platform)\Release\*Win_GUI.exe&quot;"  Condition="'$(SignThumbprint)' != ''" />
   </Target>
 
 </Project>

--- a/win/CS/build.xml
+++ b/win/CS/build.xml
@@ -6,10 +6,10 @@
   
   HandBrake Build Scipt for usage with Jenkins.
   Usage: 
-    msbuild build.xml /p:Platform=x64 /t:Nightly
-    msbuild build.xml /p:Platform=x64 /t:Release
+    msbuild build.xml /t:Nightly
+    msbuild build.xml /t:Release
   Example with code signing:
-    msbuild build.xml /p:Platform=x64 /t:Release /p:SignThumbprint=XYZ /p:SignTimestampServer=http://time.certum.pl/
+    msbuild build.xml /t:Release /p:SignThumbprint=XYZ /p:SignTimestampServer=http://time.certum.pl/
     
   Requires: libhb.dll to be in the release folder.
   


### PR DESCRIPTION
This PR addresses one bug in the msbuild script for WinGUI, and makes a few minor tweaks to the comment illustrating how to use the script.

1. A bug used the property name Sig**h**ToolLocation but checked the condition whether Sig**n**ToolLocation was blank. This made it more difficult to override the location of `SignTool.exe`, because specifying `/p:SignToolLocation` would not achieve the desired effect. That has been fixed.
2. The example at the top of the script contained an explicit setting of the `Platform` parameter, a remnant of the old days when HandBrake supported x86 Windows. But as of ecbd10efbdf286b9a5248fd0a870036cd4437360 , only x64 builds are being made, and the default in the script is to build for x64, so there's no need to specify `/p:Platform=x64`.
3. Inconsequential typos in comments with no effect on functionality are fixed.

I don't know if the official project's Jenkins builds are affected by the SignToolLocation flag. Overall, these changes shouldn't affect many people, since I assume most people building the Windows GUI are doing it from within Visual Studio instead of using msbuild.