### PR TITLE
opus: fix opus.pc pkg-config file for static builds

### DIFF
--- a/contrib/libopus/A00-static-pkg-config.patch
+++ b/contrib/libopus/A00-static-pkg-config.patch
@@ -1,0 +1,38 @@
+diff -ur opus-1.2.1.orig/configure.ac opus-1.2.1/configure.ac
+--- opus-1.2.1.orig/configure.ac	2017-06-26 11:06:46.000000000 -0700
++++ opus-1.2.1/configure.ac	2018-06-01 17:00:15.140159087 -0700
+@@ -812,6 +812,13 @@
+   AC_DEFINE([ENABLE_UPDATE_DRAFT], [1], [Enable bitstream changes from draft-ietf-codec-opus-update])
+ ])
+ 
++AS_IF([test "$enable_shared" = "no"], [
++    LIBM_SHARED=""
++    LIBM_STATIC="$LIBM"
++], [
++    LIBM_SHARED="$LIBM"
++    LIBM_STATIC=""
++])
+ 
+ saved_CFLAGS="$CFLAGS"
+ CFLAGS="$CFLAGS -fvisibility=hidden"
+@@ -843,6 +850,8 @@
+ AC_CHECK_FUNCS([__malloc_hook])
+ 
+ AC_SUBST([PC_BUILD])
++AC_SUBST([LIBM_SHARED])
++AC_SUBST([LIBM_STATIC])
+ 
+ AC_CONFIG_FILES([
+     Makefile
+diff -ur opus-1.2.1.orig/opus.pc.in opus-1.2.1/opus.pc.in
+--- opus-1.2.1.orig/opus.pc.in	2017-06-15 15:24:07.000000000 -0700
++++ opus-1.2.1/opus.pc.in	2018-06-01 17:00:26.500350502 -0700
+@@ -11,6 +11,6 @@
+ Version: @VERSION@
+ Requires:
+ Conflicts:
+-Libs: -L${libdir} -lopus
+-Libs.private: @LIBM@
++Libs: -L${libdir} -lopus @LIBM_STATIC@
++Libs.private: @LIBM_SHARED@
+ Cflags: -I${includedir}/opus


### PR DESCRIPTION
Normally I would use the system libopus on linux.  But for flatpak builds, I need to build our contrib version.

The generated opus.pc file results in undefined symbols during ffmpeg's
configure tests.  libm is not getting added to the link line as
required.  The opus.pc file needs to include -lm in the Libs instead of
Libs.private when generating *only* a static library.

For some reason, these undefined symbols don't cause a problem during a mingw build even though nm on the mingw generated libopus.a shows that the symbols are not defined.  My best guess is that the function used for testing in ffmpeg configure doesn't use those symbols and the mingw linker is smart enough to figure this out while the linux linker just pulls in all functions defined in the same source file.