### PR TITLE
libopus: run autoreconf

### DIFF
--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -7,3 +7,5 @@ LIBOPUS.FETCH.sha256  = cfafd339ccd9c5ef8d6ab15d7e1a412c054bf4cb4ecbbbcc78c12ef2
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs
+
+LIBOPUS.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;


### PR DESCRIPTION
configure.ac is modified by the patch from #1380

Fixes https://github.com/HandBrake/HandBrake/issues/1398.