### PR TITLE
Remove the unused "rows" header from the chapters DataGrid (WinGui)

### DIFF
--- a/win/CS/HandBrakeWPF/Views/ChaptersView.xaml
+++ b/win/CS/HandBrakeWPF/Views/ChaptersView.xaml
@@ -31,7 +31,7 @@
         <DataGrid Grid.Row="2" Margin="10" ItemsSource="{Binding Chapters}" 
                   VerticalAlignment="Stretch"  AutoGenerateColumns="False"
                   CanUserSortColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserResizeRows="False"
-                  CanUserAddRows="False" CanUserDeleteRows="False">
+                  CanUserAddRows="False" CanUserDeleteRows="False" HeadersVisibility="Column">
             <DataGrid.CellStyle>
                 <Style TargetType="DataGridCell">
                     <Setter Property="MinHeight" Value="22" />


### PR DESCRIPTION
**Description of Change:**
The DataGrid used to show chaptes has a weird padding on the left that comes from an unused "rows" column. This change sets the HeadersVisibility to not show that column

**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
Before:  
![before](https://user-images.githubusercontent.com/13986933/41199891-f797036c-6c91-11e8-9739-807e80f7ffa0.PNG)

After:  
![after](https://user-images.githubusercontent.com/13986933/41199892-fd4338d0-6c91-11e8-863a-d4bedd910a97.PNG)


