### PR TITLE
Minor UI improvements to Windows GUI

### DIFF
--- a/win/CS/HandBrakeWPF/Views/ChaptersView.xaml
+++ b/win/CS/HandBrakeWPF/Views/ChaptersView.xaml
@@ -31,7 +31,8 @@
         <DataGrid Grid.Row="2" Margin="10" ItemsSource="{Binding Chapters}" 
                   VerticalAlignment="Stretch"  AutoGenerateColumns="False"
                   CanUserSortColumns="False" CanUserReorderColumns="False" CanUserResizeColumns="False" CanUserResizeRows="False"
-                  CanUserAddRows="False" CanUserDeleteRows="False" HeadersVisibility="Column">
+                  CanUserAddRows="False" CanUserDeleteRows="False" HeadersVisibility="Column"
+                  HorizontalGridLinesBrush="#FFABADB3" VerticalGridLinesBrush="#FFABADB3">
             <DataGrid.CellStyle>
                 <Style TargetType="DataGridCell">
                     <Setter Property="MinHeight" Value="22" />

--- a/win/CS/HandBrakeWPF/Views/MainView.xaml
+++ b/win/CS/HandBrakeWPF/Views/MainView.xaml
@@ -64,6 +64,11 @@
             <Menu Height="23"
                   HorizontalAlignment="Stretch"
                   VerticalAlignment="Top">
+                <Menu.Resources>
+                    <Style TargetType="MenuItem">
+                        <Setter Property="Height" Value="23" />
+                    </Style>
+                </Menu.Resources>
                 <MenuItem Header="_File">
                     <MenuItem Header="{x:Static Properties:ResourcesUI.MainView_SourceOpen}" cal:Message.Attach="[Event Click] = [Action SelectSourceWindow]" InputGestureText="Alt + O" />
                     <Separator />


### PR DESCRIPTION
**Description of Change:**
There are 2 changes:
1. Make the MenuItems in the main menu the same height as the menu they're in, so that the text centred vertically in the menu.
1. Change the colour of the grid lines in the chapters table to a grey colour rather than solid black. I used the same grey as outlines TextBoxes by default.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [-] macOS 10.13+ (N/A windows only)
- [-] Ubuntu Linux (N/A windows only)

**Screenshots (If relevant):**
Before and after for the menu:  
![off-centre-menu](https://user-images.githubusercontent.com/13986933/41379376-b9e7ee3a-6f59-11e8-89fc-df2768b09446.PNG)  
![centred-menu](https://user-images.githubusercontent.com/13986933/41379440-dfd487ca-6f59-11e8-9eba-52fa9583840f.PNG)

Before and after for the table:
![hard-gridlines](https://user-images.githubusercontent.com/13986933/41379461-ebd3ca36-6f59-11e8-8077-02e063f459f7.PNG)  
![soft-gridlines](https://user-images.githubusercontent.com/13986933/41379464-eeb362c0-6f59-11e8-8eed-eb4b69864b9a.PNG)

