### PR TITLE
Fix libavresample link order and nvenc target to build on FreeBSD.

### DIFF
--- a/contrib/ffmpeg/P00-freebsd-configure.patch
+++ b/contrib/ffmpeg/P00-freebsd-configure.patch
@@ -1,0 +1,11 @@
+--- a/configure.bak	2018-06-16 10:12:16.000000000 +0900
++++ b/configure	2018-06-30 17:38:01.378774000 +0900
+@@ -6325,7 +6325,7 @@
+ 
+ if enabled x86; then
+     case $target_os in
+-        mingw32*|mingw64*|win32|win64|linux|cygwin*)
++        mingw32*|mingw64*|win32|win64|linux|freebsd|cygwin*)
+             ;;
+         *)
+             disable ffnvcodec cuvid nvdec nvenc

--- a/test/module.defs
+++ b/test/module.defs
@@ -14,7 +14,7 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 TEST.libs = $(LIBHB.a)
 
 TEST.GCC.l = \
-        ass avresample avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
+        ass avformat avfilter avcodec avutil avresample swresample postproc mp3lame dvdnav \
         dvdread fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
         bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma


### PR DESCRIPTION
**Description of Change:**
There are two problems for building on FreeBSD.

1. ffmpeg configure doesn't have target of freebsd for nvenc.
2. avfilter referes to avresample. It seems link order is reversed.

This pull request is a fix for these problems.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
- [x] FreeBSD

I've never tried nvenc, because I don't have any nvidia card.
CPU encoding works fine for me.