### PR TITLE
Specify flatpak branch when building the bundle

### DIFF
--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -74,14 +74,14 @@ $(PKG.gui.flatpak): GNUmakefile $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
 	$(SRC/)scripts/create_flatpak_manifest.py -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.ghb.json
 	flatpak-builder --default-branch=$(PKG.flatpak.branch) --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.ghb.json
-	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) fr.handbrake.ghb
+	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) fr.handbrake.ghb $(PKG.flatpak.branch)
 
 $(PKG.cli.flatpak): GNUmakefile $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
 	$(SRC/)scripts/create_flatpak_manifest.py -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
 	flatpak-builder --default-branch=$(PKG.flatpak.branch) --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
-	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) fr.handbrake.HandBrakeCLI
+	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) fr.handbrake.HandBrakeCLI $(PKG.flatpak.branch)
 
 #
 # Debian binary package rules


### PR DESCRIPTION
**Description of Change:**

This change supplies the flatpak "branch" to the `flatpak build-bundle` command, following through on 70a0ad3b0088f86fa26e3f8fe9006834155c7d4d.

70a0ad3b0088f86fa26e3f8fe9006834155c7d4d marked all flatpak builds as either `development` or `stable` branch by passing that parameter to the `flatpak-builder` command. But the next command in the flatpak build script turns those artifacts into a single-file bundle. This command depends on knowing the branch too -- see http://docs.flatpak.org/en/latest/flatpak-command-reference.html#flatpak-build-bundle . If `development` or `stable` isn't passed to `flatpak build-bundle` too, then it will assume the branch is `master`. (https://github.com/flatpak/flatpak/blob/8f73dbd32d9d542ddf6046d64e6a9bd81fc93796/app/flatpak-builtins-build-bundle.c#L565-L568)

Without this commit, the flatpak build will fail when it gets to that line (note the refspec not found line):

```
flatpak build-bundle ./pkg/flatpak/HandBrake-Flatpak.repo ./pkg/flatpak/HandBrake-20180704201056-5887814-master-build-x86_64.flatpak fr.handbrake.ghb
error: Refspec 'app/fr.handbrake.ghb/x86_64/master' not found
make: *** [../pkg/linux/module.rules:77: pkg/flatpak/HandBrake-20180704201056-5887814-master-build-x86_64.flatpak] Error 1
ERROR: Job failed: exit code 1
```

With this change, the builds complete.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [X] Fedora Linux 28