### PR TITLE
Refactor the color tag code, and pass it to the FFmpeg encoders.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3738,6 +3738,10 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->pass_id    = HB_PASS_ENCODE;
     job->vrate      = title->vrate;
 
+    job->color_prim     = title->color_prim;
+    job->color_transfer = title->color_transfer;
+    job->color_matrix   = title->color_matrix;
+
     job->mux = HB_MUX_MP4;
 
     job->list_audio = hb_list_init();

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -554,7 +554,6 @@ struct hb_job_s
     char           *encoder_level;
     int             areBframes;
 
-    int             color_matrix_code;
     int             color_prim;
     int             color_transfer;
     int             color_matrix;

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -713,45 +713,9 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     pv->param.videoParam->AsyncDepth = job->qsv.async_depth;
 
     // set and enable colorimetry (video signal information)
-    switch (job->color_matrix_code)
-    {
-        case 5:
-            // custom
-            pv->param.videoSignalInfo.ColourPrimaries         = job->color_prim;
-            pv->param.videoSignalInfo.TransferCharacteristics = job->color_transfer;
-            pv->param.videoSignalInfo.MatrixCoefficients      = job->color_matrix;
-            break;
-        case 4:
-            // ITU BT.2020 UHD content
-            pv->param.videoSignalInfo.ColourPrimaries         = HB_COLR_PRI_BT2020;
-            pv->param.videoSignalInfo.TransferCharacteristics = HB_COLR_TRA_BT709;
-            pv->param.videoSignalInfo.MatrixCoefficients      = HB_COLR_MAT_BT2020_NCL;
-            break;
-        case 3:
-            // ITU BT.709 HD content
-            pv->param.videoSignalInfo.ColourPrimaries         = HB_COLR_PRI_BT709;
-            pv->param.videoSignalInfo.TransferCharacteristics = HB_COLR_TRA_BT709;
-            pv->param.videoSignalInfo.MatrixCoefficients      = HB_COLR_MAT_BT709;
-            break;
-        case 2:
-            // ITU BT.601 DVD or SD TV content (PAL)
-            pv->param.videoSignalInfo.ColourPrimaries         = HB_COLR_PRI_EBUTECH;
-            pv->param.videoSignalInfo.TransferCharacteristics = HB_COLR_TRA_BT709;
-            pv->param.videoSignalInfo.MatrixCoefficients      = HB_COLR_MAT_SMPTE170M;
-            break;
-        case 1:
-            // ITU BT.601 DVD or SD TV content (NTSC)
-            pv->param.videoSignalInfo.ColourPrimaries         = HB_COLR_PRI_SMPTEC;
-            pv->param.videoSignalInfo.TransferCharacteristics = HB_COLR_TRA_BT709;
-            pv->param.videoSignalInfo.MatrixCoefficients      = HB_COLR_MAT_SMPTE170M;
-            break;
-        default:
-            // detected during scan
-            pv->param.videoSignalInfo.ColourPrimaries         = job->title->color_prim;
-            pv->param.videoSignalInfo.TransferCharacteristics = job->title->color_transfer;
-            pv->param.videoSignalInfo.MatrixCoefficients      = job->title->color_matrix;
-            break;
-    }
+    pv->param.videoSignalInfo.ColourPrimaries          = job->color_prim;
+    pv->param.videoSignalInfo.TransferCharacteristics  = job->color_transfer;
+    pv->param.videoSignalInfo.MatrixCoefficients       = job->color_matrix;
     pv->param.videoSignalInfo.ColourDescriptionPresent = 1;
 
     // parse user-specified encoder options, if present
@@ -799,17 +763,9 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     // reload colorimetry in case values were set in encoder_options
     if (pv->param.videoSignalInfo.ColourDescriptionPresent)
     {
-        job->color_matrix_code = 4;
         job->color_prim        = pv->param.videoSignalInfo.ColourPrimaries;
         job->color_transfer    = pv->param.videoSignalInfo.TransferCharacteristics;
         job->color_matrix      = pv->param.videoSignalInfo.MatrixCoefficients;
-    }
-    else
-    {
-        job->color_matrix_code = 0;
-        job->color_prim        = HB_COLR_PRI_UNDEF;
-        job->color_transfer    = HB_COLR_TRA_UNDEF;
-        job->color_matrix      = HB_COLR_MAT_UNDEF;
     }
 
     // sanitize values that may exceed the Media SDK variable size

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -390,6 +390,11 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     hb_log( "encavcodec: encoding with stored aspect %d/%d",
             job->par.num, job->par.den );
 
+    // set colorimetry
+    context->color_primaries = job->color_prim;
+    context->color_trc       = job->color_transfer;
+    context->colorspace      = job->color_matrix;
+
     if( job->mux & HB_MUX_MASK_MP4 )
     {
         context->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -389,48 +389,9 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
 
     /* set up the VUI color model & gamma to match what the COLR atom
      * set in muxmp4.c says. See libhb/muxmp4.c for notes. */
-    if( job->color_matrix_code == 5 )
-    {
-        // Custom
-        param.vui.i_colorprim = job->color_prim;
-        param.vui.i_transfer  = job->color_transfer;
-        param.vui.i_colmatrix = job->color_matrix;
-    }
-    else if( job->color_matrix_code == 4 )
-    {
-        // ITU BT.2020 UHD content
-        param.vui.i_colorprim = HB_COLR_PRI_BT2020;
-        param.vui.i_transfer  = HB_COLR_TRA_BT709;
-        param.vui.i_colmatrix = HB_COLR_MAT_BT2020_NCL;
-    }
-    else if( job->color_matrix_code == 3 )
-    {
-        // ITU BT.709 HD content
-        param.vui.i_colorprim = HB_COLR_PRI_BT709;
-        param.vui.i_transfer  = HB_COLR_TRA_BT709;
-        param.vui.i_colmatrix = HB_COLR_MAT_BT709;
-    }
-    else if( job->color_matrix_code == 2 )
-    {
-        // ITU BT.601 DVD or SD TV content (PAL)
-        param.vui.i_colorprim = HB_COLR_PRI_EBUTECH;
-        param.vui.i_transfer  = HB_COLR_TRA_BT709;
-        param.vui.i_colmatrix = HB_COLR_MAT_SMPTE170M;
-    }
-    else if( job->color_matrix_code == 1 )
-    {
-        // ITU BT.601 DVD or SD TV content (NTSC)
-        param.vui.i_colorprim = HB_COLR_PRI_SMPTEC;
-        param.vui.i_transfer  = HB_COLR_TRA_BT709;
-        param.vui.i_colmatrix = HB_COLR_MAT_SMPTE170M;
-    }
-    else
-    {
-        // detected during scan
-        param.vui.i_colorprim = job->title->color_prim;
-        param.vui.i_transfer  = job->title->color_transfer;
-        param.vui.i_colmatrix = job->title->color_matrix;
-    }
+    param.vui.i_colorprim = job->color_prim;
+    param.vui.i_transfer  = job->color_transfer;
+    param.vui.i_colmatrix = job->color_matrix;
 
     /* place job->encoder_options in an hb_dict_t for convenience */
     hb_dict_t * x264_opts = NULL;
@@ -464,7 +425,6 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
 
     /* Reload colorimetry settings in case custom values were set
      * in the encoder_options string */
-    job->color_matrix_code = 4;
     job->color_prim = param.vui.i_colorprim;
     job->color_transfer = param.vui.i_transfer;
     job->color_matrix = param.vui.i_colmatrix;

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -155,39 +155,10 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
      * flags, if any, should be set in the x265_param struct).
      */
     char colorprim[11], transfer[11], colormatrix[11];
-    switch (job->color_matrix_code)
-    {
-        case 1: // ITU BT.601 DVD or SD TV content (NTSC)
-            strcpy(colorprim,   "smpte170m");
-            strcpy(transfer,        "bt709");
-            strcpy(colormatrix, "smpte170m");
-            break;
-        case 2: // ITU BT.601 DVD or SD TV content (PAL)
-            strcpy(colorprim,     "bt470bg");
-            strcpy(transfer,        "bt709");
-            strcpy(colormatrix, "smpte170m");
-            break;
-        case 3: // ITU BT.709 HD content
-            strcpy(colorprim,   "bt709");
-            strcpy(transfer,    "bt709");
-            strcpy(colormatrix, "bt709");
-            break;
-        case 4: // ITU BT.2020 UHD content
-            strcpy(colorprim,   "bt2020");
-            strcpy(transfer,    "bt709");
-            strcpy(colormatrix, "bt2020nc");
-            break;
-        case 5: // custom
-            snprintf(colorprim,   sizeof(colorprim),   "%d", job->color_prim);
-            snprintf(transfer,    sizeof(transfer),    "%d", job->color_transfer);
-            snprintf(colormatrix, sizeof(colormatrix), "%d", job->color_matrix);
-            break;
-        default: // detected during scan
-            snprintf(colorprim,   sizeof(colorprim),   "%d", job->title->color_prim);
-            snprintf(transfer,    sizeof(transfer),    "%d", job->title->color_transfer);
-            snprintf(colormatrix, sizeof(colormatrix), "%d", job->title->color_matrix);
-            break;
-    }
+    snprintf(colorprim,   sizeof(colorprim),   "%d", job->color_prim);
+    snprintf(transfer,    sizeof(transfer),    "%d", job->color_transfer);
+    snprintf(colormatrix, sizeof(colormatrix), "%d", job->color_matrix);
+
     if (param_parse(pv, param, "colorprim",   colorprim)   ||
         param_parse(pv, param, "transfer",    transfer)    ||
         param_parse(pv, param, "colormatrix", colormatrix))
@@ -219,7 +190,6 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
      * Reload colorimetry settings in case custom
      * values were set in the encoder_options string.
      */
-    job->color_matrix_code = 4;
     job->color_prim        = param->vui.colorPrimaries;
     job->color_transfer    = param->vui.transferCharacteristics;
     job->color_matrix      = param->vui.matrixCoeffs;

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -645,11 +645,13 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     hb_dict_set(source_dict, "Range", range_dict);
 
     hb_dict_t *video_dict = hb_dict_get(dict, "Video");
-    if (job->color_matrix_code > 0)
-    {
-        hb_dict_set(video_dict, "ColorMatrixCode",
-                            hb_value_int(job->color_matrix_code));
-    }
+    hb_dict_set(video_dict, "ColorPrimaries",
+                hb_value_int(job->color_prim));
+    hb_dict_set(video_dict, "ColorTransfer",
+                hb_value_int(job->color_transfer));
+    hb_dict_set(video_dict, "ColorMatrix",
+                hb_value_int(job->color_matrix));
+
     if (job->vquality > HB_INVALID_VIDEO_QUALITY)
     {
         hb_dict_set(video_dict, "Quality", hb_value_double(job->vquality));
@@ -994,10 +996,10 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     // PAR {Num, Den}
     "s?{s:i, s:i},"
     // Video {Codec, Quality, Bitrate, Preset, Tune, Profile, Level, Options
-    //        TwoPass, Turbo, ColorMatrixCode,
+    //        TwoPass, Turbo, ColorPrimaries, ColorTransfer, ColorMatrix,
     //        QSV {Decode, AsyncDepth}}
     "s:{s:o, s?f, s?i, s?s, s?s, s?s, s?s, s?s,"
-    "   s?b, s?b, s?i,"
+    "   s?b, s?b, s?i, s?i, s?i,"
     "   s?{s?b, s?i}},"
     // Audio {CopyMask, FallbackEncoder, AudioList}
     "s?{s?o, s?o, s?o},"
@@ -1041,7 +1043,9 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             "Options",              unpack_s(&video_options),
             "TwoPass",              unpack_b(&job->twopass),
             "Turbo",                unpack_b(&job->fastfirstpass),
-            "ColorMatrixCode",      unpack_i(&job->color_matrix_code),
+            "ColorPrimaries",       unpack_i(&job->color_prim),
+            "ColorTransfer",        unpack_i(&job->color_transfer),
+            "ColorMatrix",          unpack_i(&job->color_matrix),
             "QSV",
                 "Decode",           unpack_b(&job->qsv.decode),
                 "AsyncDepth",       unpack_i(&job->qsv.async_depth),

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -566,18 +566,8 @@ void hb_display_job_info(hb_job_t *job)
             }
         }
 
-        if (job->color_matrix_code &&
-            ((job->vcodec & HB_VCODEC_X264_MASK) ||
-             (job->vcodec & HB_VCODEC_X265_MASK)))
-        {
-            // color matrix is set:
-            // 1) at the stream    level (x264, x265, qsv  only),
-            hb_log("     + custom color matrix: %s",
-                   job->color_matrix_code == 1 ? "ITU Bt.601 (NTSC)" :
-                   job->color_matrix_code == 2 ? "ITU Bt.601 (PAL)"  :
-                   job->color_matrix_code == 3 ? "ITU Bt.709 (HD)"   :
-                   job->color_matrix_code == 4 ? "ITU Bt.2020 (UHD)"   : "Custom");
-        }
+        hb_log("     + color profile: %d-%d-%d",
+               job->color_prim, job->color_transfer, job->color_matrix);
     }
 
     if (job->indepth_scan)


### PR DESCRIPTION
Simplified a bit the color matrix code -> color primaries/transfer/matrix conversion. Set the job color values in hb_job_init, and pass the color tag to FFmpeg encoders.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux