### PR TITLE
fix race in getting sequence_id of completed job

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3553,7 +3553,7 @@ update_status(hb_state_t *state, ghb_instance_status_t *status)
         status->state &= ~GHB_STATE_SEARCHING;
     }
 #undef p
-#define p state->param.workdone
+#define p state->param.working
     if (state->state & HB_STATE_WORKDONE)
     {
         status->state |= GHB_STATE_WORKDONE;
@@ -3561,6 +3561,7 @@ update_status(hb_state_t *state, ghb_instance_status_t *status)
         status->state &= ~GHB_STATE_PAUSED;
         status->state &= ~GHB_STATE_WORKING;
         status->state &= ~GHB_STATE_SEARCHING;
+        status->unique_id = p.sequence_id;
         switch (p.error)
         {
         case HB_ERROR_NONE:

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -1097,7 +1097,7 @@ struct hb_state_s
 
         struct
         {
-            /* HB_STATE_WORKING */
+            /* HB_STATE_WORKING || HB_STATE_SEARCHING || HB_STATE_WORKDONE */
 #define HB_PASS_SUBTITLE    -1
 #define HB_PASS_ENCODE      0
 #define HB_PASS_ENCODE_1ST  1   // Some code depends on these values being
@@ -1112,13 +1112,8 @@ struct hb_state_s
             int   minutes;
             int   seconds;
             int   sequence_id;
-        } working;
-
-        struct
-        {
-            /* HB_STATE_WORKDONE */
             hb_error_code error;
-        } workdone;
+        } working;
 
         struct
         {

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1805,11 +1805,10 @@ static void thread_func( void * _h )
         {
             hb_thread_close( &h->work_thread );
 
-            hb_log( "libhb: work result = %d",
-                    h->work_error );
+            hb_log( "libhb: work result = %d", h->work_error );
             hb_lock( h->state_lock );
-            h->state.state                = HB_STATE_WORKDONE;
-            h->state.param.workdone.error = h->work_error;
+            h->state.state               = HB_STATE_WORKDONE;
+            h->state.param.working.error = h->work_error;
 
             hb_unlock( h->state_lock );
         }

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -92,10 +92,11 @@ hb_dict_t* hb_state_to_dict( hb_state_t * state)
         break;
     case HB_STATE_WORKDONE:
         dict = json_pack_ex(&error, 0,
-            "{s:o, s{s:o}}",
+            "{s:o, s{s:o, s:o}}",
             "State", hb_value_string(state_s),
             "WorkDone",
-                "Error",    hb_value_int(state->param.workdone.error));
+                "SequenceID",   hb_value_int(state->param.working.sequence_id),
+                "Error",        hb_value_int(state->param.working.error));
         break;
     case HB_STATE_MUXING:
         dict = json_pack_ex(&error, 0,

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -456,7 +456,7 @@ typedef void (^HBCoreCleanupHandler)(void);
     }
 
     HBCoreResult result = HBCoreResultDone;
-    switch (_hb_state->param.workdone.error)
+    switch (_hb_state->param.working.error)
     {
         case HB_ERROR_NONE:
             result = HBCoreResultDone;

--- a/test/test.c
+++ b/test/test.c
@@ -1022,7 +1022,7 @@ static int HandleEvents(hb_handle_t * h, hb_dict_t *preset_dict)
         }
 #undef p
 
-#define p s.param.workdone
+#define p s.param.working
         case HB_STATE_WORKDONE:
             /* Print error if any, then exit */
             if (json)


### PR DESCRIPTION
The sequence_id was only available for the WORKING state and not the
WORKDONE state.  But frontends poll for status periodically and can miss
all status updates for the WORKING state if the file is very short or an
error occurs early during transcoding.  When WORKING status is missed,
there was no way to know the sequence_id associated with the WORKDONE
status.

sequence_id is now valid for WORKDONE state and SequenceID has been added to the json for Workdone status.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
