### PR TITLE
Fix arithmetic exception in hb_set_anamorphic_size2() when displaying…

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -789,7 +789,7 @@ void hb_set_anamorphic_size2(hb_geometry_t *src_geo,
     int cropped_width = src_geo->width - geo->crop[2] - geo->crop[3];
     int cropped_height = src_geo->height - geo->crop[0] - geo->crop[1];
     double storage_aspect = (double)cropped_width / cropped_height;
-    int mod = geo->modulus ? EVEN(geo->modulus) : 2;
+    int mod = (geo->modulus > 0) ? EVEN(geo->modulus) : 2;
 
     // Sanitize PAR
     if (geo->geometry.par.num == 0 || geo->geometry.par.den == 0)


### PR DESCRIPTION
**Description of Change:**

HandBrake crashes when displaying the preview, right when all thumbnail are created and the 'preview progressbar' is done. The Arch Linux build has been systematically segfaulting for a week and its been pissing me off so I took a closer look at this. Repository version is 1.1.1 and building from git didn't changed anything.

I don't know if this is the right fix, but on my machine, the problem is in hb_set_anamorphic_size2() with:
`int mod = geo->modulus ? EVEN(geo->modulus) : 2;`
and because geo->modulus equals -1 for the last of the preview jobs (0 for the other), it crashes when doing:
`width = MULTIPLE_MOD_UP(geo->geometry.width, mod);`
later in the fonction.

With:
`int mod = (geo->modulus > 0) ? EVEN(geo->modulus) : 2;`
It stops crashing and all previews are back looking normal.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Arch Linux

**Log file output (If relevant):**

```
Thread 1 "ghb" received signal SIGFPE, Arithmetic exception.
0x000055555566cf36 in hb_set_anamorphic_size2 ()
(gdb) bt
#0  0x000055555566cf36 in hb_set_anamorphic_size2 ()
#1  0x0000555555666831 in ghb_get_preview_image ()
#2  0x000055555565cb86 in init_preview_image ()
#3  0x000055555565ccce in ghb_set_preview_image ()
#4  0x00007ffff39c2c96 in  () at /usr/lib/libgobject-2.0.so.0
#5  0x00007ffff39de9e9 in g_signal_emit_valist () at /usr/lib/libgobject-2.0.so.0
#6  0x00007ffff39df130 in g_signal_emit () at /usr/lib/libgobject-2.0.so.0
#7  0x00007ffff39c2a4d in g_closure_invoke () at /usr/lib/libgobject-2.0.so.0
#8  0x00007ffff39d5e40 in  () at /usr/lib/libgobject-2.0.so.0
#9  0x00007ffff39de6f6 in g_signal_emit_valist () at /usr/lib/libgobject-2.0.so.0
#10 0x00007ffff39df130 in g_signal_emit () at /usr/lib/libgobject-2.0.so.0
#11 0x00007ffff5953678 in  () at /usr/lib/libgtk-3.so.0
#12 0x0000555555654fc1 in ghb_update_widget ()
#13 0x000055555565532a in ghb_ui_settings_update ()
#14 0x0000555555655be6 in ghb_settings_to_ui ()
#15 0x00005555556367f4 in ghb_load_post_settings.part ()
#16 0x0000555555638715 in title_changed_cb ()
#17 0x00007ffff39c2a4d in g_closure_invoke () at /usr/lib/libgobject-2.0.so.0
#18 0x00007ffff39d5e40 in  () at /usr/lib/libgobject-2.0.so.0
#19 0x00007ffff39de6f6 in g_signal_emit_valist () at /usr/lib/libgobject-2.0.so.0
#20 0x00007ffff39df130 in g_signal_emit () at /usr/lib/libgobject-2.0.so.0
#21 0x00007ffff59a9c7b in  () at /usr/lib/libgtk-3.so.0
#22 0x00007ffff59aca0c in gtk_combo_box_set_active_iter () at /usr/lib/libgtk-3.so.0
#23 0x0000555555654e50 in ghb_update_widget ()
---Type <return> to continue, or q <return> to quit---
```
