### PR TITLE
Allows to use clang/clang++ compiler on FreeBSD.

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -22,6 +22,11 @@ FFMPEG.CONFIGURE.build =
 FFMPEG.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
 FFMPEG.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
 
+ifeq (freebsd,$(BUILD.system))
+	FFMPEG.CONFIGURE.env += CFLAGS=-I$(LOCALBASE)/include
+	FFMPEG.CONFIGURE.env += LDFLAGS=-L$(LOCALBASE)/lib
+endif
+
 FFMPEG.CONFIGURE.extra = \
     --enable-gpl \
     --disable-doc \

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -49,7 +49,7 @@ LIBHB.GCC.D += __LIBHB__ USE_PTHREAD
 LIBHB.GCC.I += $(LIBHB.build/) $(CONTRIB.build/)include
 
 ifeq ($(BUILD.system),freebsd)
-    LIBHB.GCC.I += /usr/local/include/libxml2
+    LIBHB.GCC.I += $(LOCALBASE)/include/libxml2
 else ifneq (,$(filter $(BUILD.system),darwin cygwin mingw))
     LIBHB.GCC.I += $(CONTRIB.build/)include/libxml2
 else

--- a/make/configure.py
+++ b/make/configure.py
@@ -1512,7 +1512,7 @@ try:
     class Tools:
         ar    = ToolProbe( 'AR.exe',    'ar', abort=True )
         cp    = ToolProbe( 'CP.exe',    'cp', abort=True )
-        gcc   = ToolProbe( 'GCC.gcc',   'gcc', IfHost( 'gcc-4', '*-*-cygwin*' ))
+        gcc   = ToolProbe( 'GCC.gcc',   'gcc', IfHost( 'clang', '*-*-freebsd*' ), IfHost( 'gcc-4', '*-*-cygwin*' ))
 
         if host.match( '*-*-darwin*' ):
             gmake = ToolProbe( 'GMAKE.exe', 'make', 'gmake', abort=True )

--- a/make/variant/freebsd.defs
+++ b/make/variant/freebsd.defs
@@ -1,5 +1,10 @@
+# LOCALBASE is where FreeBSD ports are installed. default is '/usr/local'.
+LOCALBASE  ?= /usr/local
+
 TARGET.dylib.ext = .so
 
+GCC.I       = $(LOCALBASE)/include
+GCC.L       = $(LOCALBASE)/lib
 GCC.D       = LIBICONV_PLUG
 
 GCC.args.dylib = -shared

--- a/test/module.defs
+++ b/test/module.defs
@@ -81,6 +81,7 @@ else ifeq ($(BUILD.system),linux)
 else ifeq ($(BUILD.system),kfreebsd)
     TEST.GCC.l += pthread dl m
 else ifeq ($(BUILD.system),freebsd)
+    TEST.GCC.L += $(LOCALBASE)/lib
     TEST.GCC.l += pthread m
 else ifeq ($(BUILD.system),solaris)
     TEST.GCC.l += pthread nsl socket


### PR DESCRIPTION
**Description of Change:**

You know FreeBSD default C/C++ compiler is clang/clang++.
This pull request allows to use clang/clang++ on FreeBSD.
If gcc is installed, HandBrake configure uses gcc as same as before.

The difference (that I need to take care) between gcc and clang is search path of headers and libraries.

FreeBSD gcc is built with --prefix=/usr/local.
By this option, gcc searches include files in /usr/local/include and
library files in /usr/local/lib automatically.

FreeBSD clang doesn't.
So I provide /usr/local/include and /usr/local/lib for build options.

/usr/local is default install path of FreeBSD ports.
FreeBSD ports uses `LOCALBASE` variable to indicate where FreeBSD ports are installed.

c.f.
https://github.com/freebsd/freebsd-ports/blob/master/Mk/bsd.port.mk#L450-L451

I followed this manner in `make/variant/freebsd.defs` and refers `LOCALBASE` variable if needed.

I confirmed this branch works on all supported versions of FreeBSD (11.2, 11.1, 10.4) and head (known as CURRENT before).

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] FreeBSD
