### PR TITLE
contrib: update libdvdnav and libdvdread to version 6.0.0

### DIFF
--- a/contrib/libdvdnav/module.defs
+++ b/contrib/libdvdnav/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDVDNAV,libdvdnav,LIBDVDREAD))
 $(eval $(call import.CONTRIB.defs,LIBDVDNAV))
 
-LIBDVDNAV.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/libdvdnav-5.0.3.tar.bz2
-LIBDVDNAV.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdnav/5.0.3/libdvdnav-5.0.3.tar.bz2
-LIBDVDNAV.FETCH.sha256  = 5097023e3d2b36944c763f1df707ee06b19dc639b2b68fb30113a5f2cbf60b6d
+LIBDVDNAV.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/libdvdnav-6.0.0.tar.bz2
+LIBDVDNAV.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdnav/6.0.0/libdvdnav-6.0.0.tar.bz2
+LIBDVDNAV.FETCH.sha256  = f0a2711b08a021759792f8eb14bb82ff8a3c929bf88c33b64ffcddaa27935618
 
 ifneq (max,$(LIBDVDNAV.GCC.g))
     LIBDVDNAV.GCC.D += NDEBUG

--- a/contrib/libdvdread/P00-mingw-dlfcn.patch
+++ b/contrib/libdvdread/P00-mingw-dlfcn.patch
@@ -1,11 +1,12 @@
---- libdvdread-5.0.3/src/dvd_input.c.orig	2015-01-28 11:17:27.000000000 -0500
-+++ libdvdread-5.0.3/src/dvd_input.c	2017-07-10 19:12:12.000000000 -0400
-@@ -55,7 +55,7 @@
+diff --git a/src/dvd_input.c b/src/dvd_input.c
+index d28efe7..26f0e54 100644
+--- a/src/dvd_input.c
++++ b/src/dvd_input.c
+@@ -53,7 +53,7 @@ int         (*dvdinput_read)  (dvd_input_t, void *, int, int);
  # else
- # if defined(WIN32)
+ #   if defined(WIN32)
  /* Only needed on MINGW at the moment */
--#  include "../msvc/contrib/dlfcn.c"
-+#  include "msvc/msvc/contrib/dlfcn.c"
+-#    include "../msvc/contrib/dlfcn.c"
++#    include "msvc/msvc/contrib/dlfcn.c"
+ #   endif
  # endif
- #endif
- 

--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
-LIBDVDREAD.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/libdvdread-5.0.3.tar.bz2
-LIBDVDREAD.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdread/5.0.3/libdvdread-5.0.3.tar.bz2
-LIBDVDREAD.FETCH.sha256  = 321cdf2dbdc83c96572bc583cd27d8c660ddb540ff16672ecb28607d018ed82b
+LIBDVDREAD.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/libdvdread-6.0.0.tar.bz2
+LIBDVDREAD.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdread/6.0.0/libdvdread-6.0.0.tar.bz2
+LIBDVDREAD.FETCH.sha256  = b33b1953b4860545b75f6efc06e01d9849e2ea4f797652263b0b4af6dd10f935
 
 ifeq (1-mingw,$(BUILD.cross)-$(BUILD.system))
     LIBDVDREAD.CONFIGURE.extra = --enable-dlfcn


### PR DESCRIPTION
libdvdread 6.0.0 contains a fix for issue #1544 (fix write after free in ifoFree functions and probably additional checks on DVDReadBytes arguments).

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux