### PR TITLE
MacGUI: Revise stop encoding dialog.

### DIFF
--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -1276,25 +1276,25 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
 
     NSAlert *alert = [[NSAlert alloc] init];
     [alert setMessageText:NSLocalizedString(@"You are currently encoding. What would you like to do?", @"Queue Alert -> cancel rip message")];
-    [alert setInformativeText:NSLocalizedString(@"Your encode will be canceled if you don't continue encoding.", @"Queue Alert -> cancel rip informative text")];
+    [alert setInformativeText:NSLocalizedString(@"Select Continue Encoding to dismiss this dialog without making changes.", @"Queue Alert -> cancel rip informative text")];
     [alert addButtonWithTitle:NSLocalizedString(@"Continue Encoding", @"Queue Alert -> cancel rip first button")];
-    [alert addButtonWithTitle:NSLocalizedString(@"Cancel Current and Stop", @"Queue Alert -> cancel rip second button")];
-    [alert addButtonWithTitle:NSLocalizedString(@"Cancel Current and Continue", @"Queue Alert -> cancel rip third button")];
-    [alert addButtonWithTitle:NSLocalizedString(@"Finish Current and Stop", @"Queue Alert -> cancel rip fourth button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Skip Current Job", @"Queue Alert -> cancel rip second button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Stop After Current Job", @"Queue Alert -> cancel rip third button")];
+    [alert addButtonWithTitle:NSLocalizedString(@"Stop All", @"Queue Alert -> cancel rip fourth button")];
     [alert setAlertStyle:NSAlertStyleCritical];
 
     [alert beginSheetModalForWindow:window completionHandler:^(NSModalResponse returnCode) {
         if (returnCode == NSAlertSecondButtonReturn)
         {
-            [self cancelCurrentJobAndStop];
+            [self cancelCurrentJobAndContinue];
         }
         else if (returnCode == NSAlertThirdButtonReturn)
         {
-            [self cancelCurrentJobAndContinue];
+            [self finishCurrentAndStop];
         }
         else if (returnCode == NSAlertThirdButtonReturn + 1)
         {
-            [self finishCurrentAndStop];
+            [self cancelCurrentJobAndStop];
         }
     }];
 }


### PR DESCRIPTION
Final:

<img width="997" alt="screen shot 2018-11-02 at 6 46 40 am" src="https://user-images.githubusercontent.com/70239/47911170-1e899480-de6b-11e8-807c-dde21c2cf0b3.png">

---

Closes #1179.

German translation will need a minor update.

- Description changed to "Select Continue Encoding to dismiss this dialog without making changes."
- `Cancel Current and Stop` -> `Stop All Jobs` and moved to far left
- `Finish Current and Stop` -> `Finish Current Job, Then Stop` and moved to second from left
- `Cancel Current and Continue` -> `Skip Current Job` and moved to third from left
- `Continue Encoding` unchanged

<img width="997" alt="screen shot 2018-09-04 at 2 48 11 am" src="https://user-images.githubusercontent.com/70239/45015200-ee4e8280-afee-11e8-81a4-b6c840fc3b73.png">

As you can see, the order is from potentially most effective to least effective. Additionally, the primary verbiage is Stop/Finish/Skip/Continue.

Constructive criticism is welcome as always.