### PR TITLE
respect CC environment variable

### DIFF
--- a/gtk/module.rules
+++ b/gtk/module.rules
@@ -17,6 +17,8 @@ $(GTK.CONFIGURE.stamp): $(GTK.src/)configure.ac $(GTK.src/)src/Makefile.am
 	set -e; cd $(GTK.build/); $(call fn.ABSOLUTE,$(GTK.src/))configure \
 		$(GTK.CONFIGURE.extra) \
 		PKG_CONFIG_PATH=$(BUILD/)contrib/lib/pkgconfig:$(PKG_CONFIG_PATH) \
+		CC="$(GCC.gcc)" \
+		CXX="$(GCC.gxx)" \
 		CFLAGS="$(call fn.ARGS,GTK.GCC,.g .O *D ?extra)" \
 		LDFLAGS="$(call fn.ARGS,GTK.GCC,?strip .g .O ?extra.exe)" \
 		PYTHON="$(PYTHON.exe)" \

--- a/make/configure.py
+++ b/make/configure.py
@@ -1512,7 +1512,12 @@ try:
     class Tools:
         ar    = ToolProbe( 'AR.exe',    'ar', abort=True )
         cp    = ToolProbe( 'CP.exe',    'cp', abort=True )
-        gcc   = ToolProbe( 'GCC.gcc',   'gcc', IfHost( 'clang', '*-*-freebsd*' ), IfHost( 'gcc-4', '*-*-cygwin*' ))
+        gcc_tools = ['GCC.gcc',
+                     IfHost( os.environ.get('CC', None), '*-*-freebsd*' ),
+                     'gcc',
+                     IfHost( 'clang', '*-*-freebsd*' ),
+                     IfHost( 'gcc-4', '*-*-cygwin*' )]
+        gcc   = ToolProbe(*filter(None, gcc_tools))
 
         if host.match( '*-*-darwin*' ):
             gmake = ToolProbe( 'GMAKE.exe', 'make', 'gmake', abort=True )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1513,7 +1513,7 @@ try:
         ar    = ToolProbe( 'AR.exe',    'ar', abort=True )
         cp    = ToolProbe( 'CP.exe',    'cp', abort=True )
         gcc_tools = ['GCC.gcc',
-                     IfHost( os.environ.get('CC', None), '*-*-freebsd*' ),
+                     os.environ.get('CC', None),
                      'gcc',
                      IfHost( 'clang', '*-*-freebsd*' ),
                      IfHost( 'gcc-4', '*-*-cygwin*' )]

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -1,5 +1,5 @@
 GCC.gcc = gcc
-GCC.gxx = $(dir $(GCC.gcc))$(subst clang,clang++,$(subst gcc,g++,$(notdir $(GCC.gcc))))
+GCC.gxx = $(dir $(GCC.gcc))$(subst cc,c++,$(subst clang,clang++,$(subst gcc,g++,$(notdir $(GCC.gcc)))))
 
 GCC.strip   = $$(if $$(filter none,$$(GCC.g)),1)
 GCC.dylib   = 1
@@ -91,7 +91,7 @@ GCC.args.extra.exe++   = $(LDFLAGS)
 
 define import.GCC
     $(1).GCC.gcc = $$(GCC.gcc)
-    $(1).GCC.gxx = $$(dir $$($(1).GCC.gcc))$$(subst clang,clang++,$$(subst gcc,g++,$$(notdir $$($(1).GCC.gcc))))
+    $(1).GCC.gxx = $$(dir $$($(1).GCC.gcc))$$(subst cc,c++,$$(subst clang,clang++,$$(subst gcc,g++,$$(notdir $$($(1).GCC.gcc)))))
 
     $(1).GCC.pipe    = $$(GCC.pipe)
     $(1).GCC.c_std   = $$(GCC.c_std)

--- a/make/variant/freebsd.defs
+++ b/make/variant/freebsd.defs
@@ -14,3 +14,7 @@ GCC.args.g.none = -g0
 GCC.args.g.min  = -g1
 GCC.args.g.std  = -g2
 GCC.args.g.max  = -g3
+
+GCC.MAJOR_VERSION = $(shell $(GCC.gcc) -dumpversion | cut -f 1 -d .)
+GCC.LDFLAGS = -lc++ -Wl,-rpath=$(LOCALBASE)/lib/gcc$(GCC.MAJOR_VERSION)
+LDFLAGS += $(if $(findstring gcc, $(GCC.gcc)), $(GCC.LDFLAGS), )


### PR DESCRIPTION
**Description of Change:**
This pull request fixes #1674 issue.
We use the compiler that CC environment variable indicates.
If CC is ommited, use gcc or clang which is installed.
If gcc is chosen, we need to add `-Wl,-rpath` option to make runtime linker
linking gcc's runtime libraries from installed path. 
For example, gcc7's runtime libraries are installed in `/usr/local/lib/gcc7` by default.
And we also need to link libc++ first to make libc++ initializer is called on runtime.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
- [x] FreeBSD

All following test cases have passed on FreeBSD 13-CURRENT r340391.

1. default (gcc is not installed, CC is omitted)
1. gcc7 (gcc7 is installed, CC is omitted)
1. gcc8 (gcc8 is installed, CC is omitted)
1. CC=cc (use FreeBSD default compiler, clang)
1. CC=clang (same as above)
1. CC=gcc (use FreeBSD default gcc from Ports. gcc7 for now)
1. CC=gcc7 (use gcc7 from Ports)
1. CC=gcc8 (use gcc8 from Ports)
1. CC=clang60 (use clang 6.0 from Ports)
1. CC=clang70 (use clang 7.0 from Ports)

