### PR TITLE
remove GCC.I and GCC.L for FreeBSD

### DIFF
--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -49,6 +49,7 @@ LIBHB.GCC.D += __LIBHB__ USE_PTHREAD
 LIBHB.GCC.I += $(LIBHB.build/) $(CONTRIB.build/)include
 
 ifeq ($(BUILD.system),freebsd)
+    LIBHB.GCC.I += $(LOCALBASE)/include
     LIBHB.GCC.I += $(LOCALBASE)/include/libxml2
 else ifneq (,$(filter $(BUILD.system),darwin cygwin mingw))
     LIBHB.GCC.I += $(CONTRIB.build/)include/libxml2

--- a/make/variant/freebsd.defs
+++ b/make/variant/freebsd.defs
@@ -3,8 +3,6 @@ LOCALBASE  ?= /usr/local
 
 TARGET.dylib.ext = .so
 
-GCC.I       = $(LOCALBASE)/include
-GCC.L       = $(LOCALBASE)/lib
 GCC.D       = LIBICONV_PLUG
 
 GCC.args.dylib = -shared


### PR DESCRIPTION
**Description of Change:**
This Pull Request fixes that I reported in https://github.com/HandBrake/HandBrake/pull/1691#issuecomment-441413373 .

I found that GCC.I and GCC.L are too strong configuration that forces to search for the specific path first.
If a contrib library (ex. x265) is installed from Ports, and Ports library version is different from contrib, "GCC.I=/usr/local/include" looks up Ports library headers first and it can be different definitions from contrib headers.
We should look up contrib headers before Ports library headers.

**Test on:**

- [x] FreeBSD
