### PR TITLE
MacGui: update German localization (Dec 2018).

### DIFF
--- a/macosx/HandBrakeKit/de.lproj/Localizable.strings
+++ b/macosx/HandBrakeKit/de.lproj/Localizable.strings
@@ -2,11 +2,11 @@
 " - fastdecode" = "- Schnelldekodierung";
 
 /* HBStateFormatter -> work time format */
-" (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)" = "(%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$dh%4$dm%5$ds)";
+" (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)" = " (%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$dh%4$dm%5$ds)";
 
 /* HBStateFormatter -> search time format
    HBStateFormatter -> work time format */
-" (ETA %02dh%02dm%02ds)" = "(ETA %1$dh%2$dm%3$ds)";
+" (ETA %02dh%02dm%02ds)" = " (ETA %1$dh%2$dm%3$ds)";
 
 /* Dimensions description */
 " Keep Aspect Ratio" = "Seitenverhältnis beibehalten";
@@ -153,10 +153,10 @@
 "Framerate: " = "Bildrate:";
 
 /* HBRange -> display name */
-"Frames" = "Bilder";
+"Frames" = "Einzelbilder";
 
 /* Title description */
-"Frames %d through %d" = "Bilder %1$d bis %2$d";
+"Frames %d through %d" = "Einzelbilder %1$d bis %2$d";
 
 /* Audio description */
 "Gain: %.2f" = "Verstärkung: %.2f";

--- a/macosx/de.lproj/AdvancedView.strings
+++ b/macosx/de.lproj/AdvancedView.strings
@@ -119,7 +119,7 @@
 "85.title" = "Item2";
 
 /* Class = "NSTextFieldCell"; title = "Reference Frames:"; ObjectID = "343"; */
-"343.title" = "Bezugsrahmen:";
+"343.title" = "Referenzeinzelbilder:";
 
 /* Class = "NSTextFieldCell"; title = "Maximum B-Frames:"; ObjectID = "344"; */
 "344.title" = "Maximale B-Frames:";
@@ -145,8 +145,8 @@
 /* Class = "NSTextFieldCell"; title = "Adaptive Direct Mode:"; ObjectID = "361"; */
 "361.title" = "Adaptiver Direktmodus:";
 
-/* Class = "NSTextFieldCell"; title = "Current x264 Advanced Option String:"; ObjectID = "363"; */
-"363.title" = "Erweiterte x264-Optionen:";
+/* Class = "NSTextFieldCell"; title = "Current x264 Advanced Option String"; ObjectID = "363"; */
+"363.title" = "Erweiterte x264-Optionen";
 
 /* Class = "NSTextFieldCell"; title = "Deblocking:"; ObjectID = "366"; */
 "366.title" = "Deblocking:";
@@ -208,9 +208,9 @@
 /* Class = "NSTextFieldCell"; title = "Analysis"; ObjectID = "443"; */
 "443.title" = "Analyse";
 
-/* Class = "NSTextFieldCell"; title = "Advanced options not available for the selected codec."; ObjectID = "lPc-aK-FOh"; */
-"lPc-aK-FOh.title" = "Für den ausgewählten Codec sind keine erweiterten Optionen verfügbar.";
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "lV4-j0-O2Y"; */
+"lV4-j0-O2Y.title" = "OK";
 
-/* Class = "NSBox"; title = "Box"; ObjectID = "sPV-JX-8CO"; */
-"sPV-JX-8CO.title" = "Box";
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "w0T-fl-8Fm"; */
+"w0T-fl-8Fm.title" = "Abbrechen";
 

--- a/macosx/de.lproj/HBFiltersViewController.strings
+++ b/macosx/de.lproj/HBFiltersViewController.strings
@@ -7,15 +7,17 @@
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Denoise tune. Further adjusts the Denoise preset to optimize settings for specific scenarios.\n\nNone uses the default preset settings.\n\nFilm refines settings for use with most live action content.\n\nGrain only processes color channels. Useful for preserving the film-like look of luminance grain while reducing or removing color noise.\n\nHigh Motion reduces color smearing in high motion scenes by avoiding temporal processing for color channels. Useful for sports and action videos.\n\nAnimation is useful for cel animation such as anime and cartoons.\n\nTape is useful for low-detail analog tape sources such as VHS, where Film does not produce a desirable result.\n\nSprite is useful for 1-/4-/8-/16-bit 2-dimensional games. Sprite is not designed for high definition video."; ObjectID = "1XQ-md-5cQ"; */
 "1XQ-md-5cQ.ibShadowedToolTip" = "Entrauschabstimmung. Weitere Beeinflussung des Entrauschfilters für spezielle Szenarien.
 
-Ohne: Verwendet die Standardeinstellungen.
+None: Verwendet die Standardeinstellungen.
 
-Film: Einstellung für die meisten Live-Action-Filme.\\n\\nGrain: Bearbeitet nur den Farbkanal. Nützlich um das filmtypische Aussehen mit körniger Luminanz zu erhalten, aber Farbrauschen zu entfernen.
+Film: Einstellung für die meisten Live-Action-Filme.
 
-Schnelle Bewegung: Reduziert farbige Nachzieheffekte bei schnellen Bewegungen indem es zeitweise den Farbkanal nicht bearbeitet. Hilfreich für Sport- und Action-Filme.
+Grain: Bearbeitet nur den Farbkanal. Nützlich um das filmtypische Aussehen mit körniger Luminanz zu erhalten, aber Farbrauschen zu entfernen.
+
+High Motion: Reduziert farbige Nachzieheffekte bei schnellen Bewegungen indem es zeitweise den Farbkanal nicht bearbeitet. Hilfreich für Sport- und Action-Filme.
 
 Animation: Ist nützlich für animierte Filme, wie Anime und Cartoons.
 
-Videoband: Ist gedacht für Filme von analogen Videobändern mit wenig Details, wie VHS, wenn die Film-Einstellung kein vernünftiges Ergebnis produziert.
+Tape: Ist gedacht für Filme von analogen Videobändern mit wenig Details, wie VHS, wenn die Film-Einstellung kein vernünftiges Ergebnis produziert.
 
 Sprite ist nützlich für 1-/4-/8-/16-bit 2D-Spiele. Sprite ist nicht geeignet für qualitativ hochwertige Videos.";
 
@@ -30,9 +32,9 @@ Sprite ist nützlich für 1-/4-/8-/16-bit 2D-Spiele. Sprite ist nicht geeignet f
 
 Ohne: Verwendet die Standardeinstellungen.
 
-Unscharf Maskieren kann abgestimmt werden auf Ultrafein, Fein, Medium, Groß, oder Sehr Grob. Die Auswahl sollte anhand der Auflösung des Ausgangsmaterials und der Feinheit der zu Erhöhenden Details getroffen werden.
+Unscharf Maskieren kann abgestimmt werden auf Ultrafein, Fein, Medium, Grob, oder Sehr Grob. Die Auswahl sollte anhand der Auflösung des Ausgangsmaterials und der Feinheit der zu Erhöhenden Details getroffen werden.
 
-Lapsharp's Abstimmung Film: Ist für die meisten Live-Action-Filme. Film benutzt einen isotropen Laplace-Algorithmus. um alle Kanten identisch zu schärfen und die Luminanz-Informationen werden mehr geschärft als die Farbinformationen.
+Lapsharp's Abstimmung Film: Ist für die meisten Live-Action-Filme. Film benutzt einen isotropen Laplace-Algorithmus um alle Kanten identisch zu schärfen. Luminanz-Informationen (Helligkeit) werden mehr geschärft als die Farbinformationen.
 
 Lapsharp's Abstimmung Grain: Ist ähnlich zu Film, aber verwendet einen benutzt einen isotropen Laplace-Gauss-Algorithmus um die Effekte von Rauschen und Körnung zu reduzieren. Nützlich um Körnungen zu erhalten bzw. als Alternative zur Film-Abstimmung.
 
@@ -134,7 +136,7 @@ Syntax: skip-left=s:skip-right=s:skip-top=s:skip-bottom=s:strict-breaks=s:plane=
 Standard: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Interlace Detection, when enabled, allows the Deinterlace filter to only process interlaced video frames."; ObjectID = "IQG-Nn-HTb"; */
-"IQG-Nn-HTb.ibShadowedToolTip" = "Interlace-Erkennung, wenn aktiviert, erlaubt es dem Deinterlacefilter nur betroffene Videobilder zu bearbeiten.";
+"IQG-Nn-HTb.ibShadowedToolTip" = "Interlace-Erkennung, wenn aktiviert, erlaubt es dem Deinterlacefilter nur betroffene Einzelbilder zu bearbeiten.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Flips (mirrors) the picture on the horizontal axis."; ObjectID = "IWV-25-FSC"; */
 "IWV-25-FSC.ibShadowedToolTip" = "Spiegelt das Bild an der horizontalen Achse.";

--- a/macosx/de.lproj/HBSummaryViewController.strings
+++ b/macosx/de.lproj/HBSummaryViewController.strings
@@ -11,7 +11,7 @@
 "De0-Je-MAm.title" = "A/V synchron";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Aligns the initial timestamps of all audio and video streams by inserting blank frames or dropping frames. May improve audio/video sync for broken players that do not honor MP4 edit lists."; ObjectID = "fPv-Vw-I89"; */
-"fPv-Vw-I89.ibShadowedToolTip" = "Gleicht die Zeitleiste der Video- und Tonspur aneinander an, indem leere Bilder hinzugefügt werden oder Bilder entfernt werden. Kann die Audio/Video-Synchronisation bei manchen defekten Abspielgeräten verbessern, die keine MP4-Änderungslisten mehr berücksichtigen.";
+"fPv-Vw-I89.ibShadowedToolTip" = "Gleicht die Zeitleiste der Video- und Tonspur aneinander an, indem leere Einzelbilder hinzugefügt werden oder Einzelbilder entfernt werden. Kann die Audio/Video-Synchronisation bei manchen defekten Abspielgeräten verbessern, die keine MP4-Bearbeitungslisten berücksichtigen.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Size summary"; ObjectID = "Jaw-pH-rhf"; */
 "Jaw-pH-rhf.ibExternalAccessibilityDescription" = "Größenübersicht";

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -39,16 +39,22 @@
 "Add Jobs To Queue" = "Aufgaben zu Warteschlange hinzufügen";
 
 /* Touch bar */
+"Add Preset" = "Voreinstellung hinzufügen";
+
+/* Touch bar */
+"Add Titles To Queue" = "Alle Titel zur Warteschlange hinzufügen";
+
+/* Touch bar */
 "Add To Queue" = "Zur Warteschlange hinzufügen";
 
 /* Preferences Advanced Toolbar Item */
 "Advanced" = "Erweitert";
 
 /* Delete preset alert -> message */
-"Are you sure you want to permanently delete the selected preset?" = "Sind Sie sicher, dass Sie die ausgewählte Voreinstellung endgültig löschen wollen?";
+"Are you sure you want to permanently delete the selected preset?" = "Soll die ausgewählte Voreinstellung wirklich endgültig gelöscht werden?";
 
 /* Quit Alert -> message */
-"Are you sure you want to quit HandBrake?" = "Sind Sie sicher, dass Sie HandBrake beenden wollen?";
+"Are you sure you want to quit HandBrake?" = "Soll HandBrake wirklich beendet werden?";
 
 /* Copy Protection Alert -> first button */
 "Attempt Scan Anyway" = "Trotzdem überprüfen";
@@ -64,12 +70,6 @@
    Touch bar */
 "Cancel" = "Abbrechen";
 
-/* Queue Alert -> cancel rip third button */
-"Cancel Current and Continue" = "Nur momentane Aufgabe abbrechen";
-
-/* Queue Alert -> cancel rip second button */
-"Cancel Current and Stop" = "Alles abbrechen";
-
 /* Touch bar */
 "Cancel Encoding" = "Encodieren abbrechen";
 
@@ -84,7 +84,7 @@
 "Choose" = "Auswählen";
 
 /* Queue Alert -> cancel rip first button */
-"Continue Encoding" = "Enkodierung fortfahren";
+"Continue Encoding" = "Enkodierung fortsetzen";
 
 /* Copy Protection Alert -> message */
 "Copy-Protected sources are not supported." = "Kopiergeschützte Quellen werden nicht unterstützt.";
@@ -120,20 +120,11 @@
 /* Queue status */
 "Encode Finished." = "Enkodierung beendet.";
 
-/* Video -> Encoder options title */
-"Encoder Options" = "Enkodierungsoptionen";
-
-/* Video -> Advanced panel checkbox */
-"Encoder Options:" = "Enkodierungsoptionen:";
-
 /* Export presets save panel title */
 "Export presets" = "Voreinstellungen exportieren";
 
 /* File already exists alert -> message */
 "File already exists." = "Die Datei existiert bereits.";
-
-/* Queue Alert -> cancel rip fourth button */
-"Finish Current and Stop" = "Nach momentaner Aufgabe abbrechen";
 
 /* Preferences General Toolbar Item */
 "General" = "Allgemein";
@@ -272,6 +263,9 @@
    Touch bar */
 "Scale To Screen" = "An Bildschirm anpassen";
 
+/* Queue Alert -> cancel rip informative text */
+"Select Continue Encoding to dismiss this dialog without making changes." = "Enkodierung fortsetzen wählen um diesen Dialog ohne weitere Änderungen zu schließen.";
+
 /* Preferences -> send to app destination open panel */
 "Select the desired external application" = "Die gewünschte externe Anwendung auswählen";
 
@@ -282,7 +276,16 @@
 "Show" = "Zeigen";
 
 /* Touch bar */
+"Show Activity Window" = "Aktivitätsfenster zeigen";
+
+/* Video -> Advanced editor */
+"Show advanced editor" = "Erweiterte Optionen einblenden";
+
+/* Touch bar */
 "Show Preview Window" = "Vorschau zeigen";
+
+/* Queue Alert -> cancel rip second button */
+"Skip Current Job" = "Momentane Aufgabe überspringen";
 
 /* Touch bar */
 "Slider" = "Schieberegler";
@@ -306,6 +309,12 @@
 
 /* Toolbar Start/Stop Item */
 "Stop" = "Stop";
+
+/* Queue Alert -> cancel rip third button */
+"Stop After Current Job" = "Nach momentaner Aufgabe abbrechen";
+
+/* Queue Alert -> cancel rip fourth button */
+"Stop All" = "Alles abbrechen";
 
 /* Queue -> start/stop menu
    Toolbar Start/Stop Item */
@@ -355,7 +364,7 @@
 "There is already an instance of HandBrake running." = "Es läuft schon eine Instanz von HandBrake.";
 
 /* Invalid destination alert -> informative text */
-"This is not a valid destination directory!" = "Dies ist kein gültiger Pfad für das Ziel.";
+"This is not a valid destination directory!" = "Dies ist kein gültiges Zielverzeichnis.";
 
 /* Video -> Framerate */
 "Variable Framerate" = "Variable Bildfrequenz";
@@ -386,9 +395,6 @@
 
 /* Queue done notification message */
 "Your encode %@ is done!" = "Die Enkodierung %@ ist fertig!";
-
-/* Queue Alert -> cancel rip informative text */
-"Your encode will be canceled if you don't continue encoding." = "Ihre Enkodierung wird abgebrochen, wenn Sie die Enkodierung nicht fortsetzen.";
 
 /* Queue done alert informative text */
 "Your HandBrake queue is done!" = "Alle Aufgaben in Ihrer HandBrake-Warteschlange wurde erfolgreich ausgeführt!";

--- a/macosx/de.lproj/MainWindow.strings
+++ b/macosx/de.lproj/MainWindow.strings
@@ -49,7 +49,7 @@
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Title, or video clip, to encode. The longest title is selected by default.\n\nBlu-ray and DVD sources often have multiple titles, the longest of which is typically the main feature."; ObjectID = "1541"; */
 "1541.ibShadowedToolTip" = "Titel oder Videoclip zum Enkodieren. Standardmäßig wird der längste Titel ausgewählt.
 
-Blu-ray und DVD haben meistens mehrere Titel, der längste ist für gewöhnlich der Hauptfilm.";
+Blu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlich der Hauptfilm.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1542"; */
 "1542.title" = "OtherViews";
@@ -93,9 +93,6 @@ Blu-ray und DVD haben meistens mehrere Titel, der längste ist für gewöhnlich 
 /* Class = "NSTabViewItem"; label = "Chapters"; ObjectID = "1989"; */
 "1989.label" = "Kapitel";
 
-/* Class = "NSTabViewItem"; label = "Advanced"; ObjectID = "2015"; */
-"2015.label" = "Erweitert";
-
 /* Class = "NSTextFieldCell"; title = "DO NOT TRANSLATE THIS NIB FILE"; ObjectID = "4846"; */
 "4846.title" = "DO NOT TRANSLATE THIS NIB FILE";
 
@@ -106,7 +103,7 @@ Blu-ray und DVD haben meistens mehrere Titel, der längste ist für gewöhnlich 
 "4907.title" = "Titel:";
 
 /* Class = "NSTextFieldCell"; title = "Save As:"; ObjectID = "4913"; */
-"4913.title" = "Speichern als:";
+"4913.title" = "Speichern unter:";
 
 /* Class = "NSTextFieldCell"; title = "Duration:"; ObjectID = "4914"; */
 "4914.title" = "Dauer:";
@@ -151,22 +148,22 @@ Blu-ray und DVD haben meistens mehrere Titel, der längste ist für gewöhnlich 
 "5513.ibExternalAccessibilityDescription" = "Bereichsauswahl";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Source range selection. By default, all chapters are selected and the entire source is encoded."; ObjectID = "5513"; */
-"5513.ibShadowedToolTip" = "Bereichsauswahl der Quelle. Standardmäßig werden alle Kapitel ausgewählt und die gesammte Quelle enkodiert.";
+"5513.ibShadowedToolTip" = "Bereichsauswahl der Quelle. Standardmäßig werden alle Kapitel ausgewählt und die gesamte Quelle enkodiert.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "5515"; */
 "5515.title" = "OtherViews";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Start time in frames"; ObjectID = "5521"; */
-"5521.ibExternalAccessibilityDescription" = "Startzeit in Bildern";
+"5521.ibExternalAccessibilityDescription" = "Startzeit in Einzelbildern";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "First frame to encode."; ObjectID = "5521"; */
-"5521.ibShadowedToolTip" = "Erste Bilder zum Enkodieren.";
+"5521.ibShadowedToolTip" = "Erstes Einzelbilder zum Enkodieren.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "End time in frames"; ObjectID = "5523"; */
-"5523.ibExternalAccessibilityDescription" = "Endzeit in Bildern";
+"5523.ibExternalAccessibilityDescription" = "Endzeit in Einzelbildern";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Last frame to encode."; ObjectID = "5523"; */
-"5523.ibShadowedToolTip" = "Letzte Bilder zum Enkodieren.";
+"5523.ibShadowedToolTip" = "Letzte Einzelbilder zum Enkodieren.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Reload the encoding settings for the currently selected preset. Modifications will be discarded."; ObjectID = "AhR-pK-Oz4"; */
 "AhR-pK-Oz4.ibShadowedToolTip" = "Läd die Enkodiereinstellungen der momentan ausgewählte Voreinstellung neu. Änderungen werden verworfen.";

--- a/macosx/de.lproj/Preferences.strings
+++ b/macosx/de.lproj/Preferences.strings
@@ -11,7 +11,7 @@
 "292.title" = "Auto";
 
 /* Class = "NSButtonCell"; title = "Automatically name output files"; ObjectID = "302"; */
-"302.title" = "Zieldatei automatisch benennen";
+"302.title" = "Ausgabedateien automatisch benennen";
 
 /* Class = "NSTextFieldCell"; title = "When Done:"; ObjectID = "304"; */
 "304.title" = "Wenn fertig:";
@@ -190,9 +190,6 @@
 /* Class = "NSTextFieldCell"; title = "Drag labels to Format to compose a naming format."; ObjectID = "dQ6-Dh-9sD"; */
 "dQ6-Dh-9sD.title" = "Labels in das Formatfenster ziehen um das Benennungsschema festzulegen.";
 
-/* Class = "NSButtonCell"; title = "Show Advanced Options Panel (deprecated)"; ObjectID = "Du1-9x-nHn"; */
-"Du1-9x-nHn.title" = "Erweiterte Optionen anzeigen (überholt)";
-
 /* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "None"; ObjectID = "f36-PN-c5F"; */
 "f36-PN-c5F.ibShadowedIsNilPlaceholder" = "Keine";
 
@@ -212,7 +209,7 @@
 "lgn-RF-k0d.title" = "Alte Aktivitätsprotokolle nach 30 Tagen löschen";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Minimum free space on destination disk."; ObjectID = "PaR-zw-opS"; */
-"PaR-zw-opS.ibShadowedToolTip" = "Minimaler freier Speicherplatte auf dem Zielvolume.";
+"PaR-zw-opS.ibShadowedToolTip" = "Minimaler freier Speicherplatz auf dem Zielvolume in GB.";
 
 /* Class = "NSButtonCell"; title = "Replace underscores with spaces"; ObjectID = "pUi-lK-cHw"; */
 "pUi-lK-cHw.title" = "Unterstriche durch Leerzeichen ersetzen";
@@ -223,13 +220,8 @@
 /* Class = "NSButtonCell"; title = "Remove common punctuation"; ObjectID = "wo5-iR-2mb"; */
 "wo5-iR-2mb.title" = "Punktationen entfernen";
 
-/* Class = "NSButton"; ibShadowedToolTip = "Show the Advanced Options Panel for x264 settings.\n\nThis setting is no longer supported and may be removed in a future version. Use at your own risk!"; ObjectID = "ybi-46-yhY"; */
-"ybi-46-yhY.ibShadowedToolTip" = "Zeige die Erweiterten Optionen zur x264-Einstellung.
-
-Diese Einstellungen werden nicht mehr unterstützt und in einer zukünftigen Version entfernt. Benutzung auf eigene Gefahr!";
-
 /* Class = "NSButtonCell"; title = "Pause queue if disk space is lower than:"; ObjectID = "yG9-mz-tqQ"; */
-"yG9-mz-tqQ.title" = "Warteschlange anhalten wenn der verfügbare Speicherplatz kleiner ist als:";
+"yG9-mz-tqQ.title" = "Warteschlange anhalten wenn der verfügbare Speicherplatz kleiner ist als (GB):";
 
 /* Class = "NSButtonCell"; title = "Show Open Source panel"; ObjectID = "Zqz-Kn-xOS"; */
 "Zqz-Kn-xOS.title" = "Öffnen-Dialog anzeigen";

--- a/macosx/de.lproj/Video.strings
+++ b/macosx/de.lproj/Video.strings
@@ -68,7 +68,7 @@ x264 ist verlustfrei bei RF 0.";
 "hib-wi-BDx.title" = "Profil:";
 
 /* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "iab-iA-j04"; */
-"iab-iA-j04.title" = "Voreinstellungen:";
+"iab-iA-j04.title" = "Voreinstellung:";
 
 /* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "auto"; ObjectID = "ioS-p7-9Ri"; */
 "ioS-p7-9Ri.ibShadowedIsNilPlaceholder" = "Auto";
@@ -107,9 +107,6 @@ Syntax: option-1=foo:opt2=bar,baz";
 /* Class = "NSTextFieldCell"; title = "RF:"; ObjectID = "rRB-9F-pHn"; */
 "rRB-9F-pHn.title" = "RF:";
 
-/* Class = "NSButtonCell"; title = "Use Advanced Options Panel"; ObjectID = "sa6-r3-eVr"; */
-"sa6-r3-eVr.title" = "Erweiterte Optionen verwenden";
-
 /* Class = "NSTextFieldCell"; title = "Framerate (FPS):"; ObjectID = "SJc-tv-AMH"; */
 "SJc-tv-AMH.title" = "Bildfrequenz (BpS):";
 
@@ -136,11 +133,6 @@ Syntax: option-1=foo:opt2=bar,baz";
 
 /* Class = "NSButtonCell"; title = "Constant Quality"; ObjectID = "ZjL-cY-O5f"; */
 "ZjL-cY-O5f.title" = "Konstante Qualität";
-
-/* Class = "NSButton"; ibShadowedToolTip = "Use the Advanced Options Panel for x264 settings.\n\nThis setting is no longer supported and may be removed in a future version. Use at your own risk!"; ObjectID = "Zs7-1Y-50A"; */
-"Zs7-1Y-50A.ibShadowedToolTip" = "Verwende das Panel für die erweiterten x264-Videoeinstellungen.
-
-Diese Einstellung wird nicht mehr unterstützt und möglicherweise in einer zukünftigen Version entfernt. Benutzung auf eigene Gefahr!";
 
 /* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "zSD-4Y-1cI"; */
 "zSD-4Y-1cI.title" = "Abstimmung:";


### PR DESCRIPTION
Update german localization to Transifex status of December 2018.
For details see #1698.

**Description of Change:**
This will bring the german localization of the MacGUI in line with the Transifex status of today.




**Test on:**

- [ X] macOS 10.13+