### PR TITLE
Fix handling of variable frame rate video timestamps in a/v sync thread.

### DIFF
--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -1143,7 +1143,10 @@ static void fixStreamTimestamps( sync_stream_t * stream )
     }
     else if (stream->type == SYNC_TYPE_VIDEO)
     {
-        dejitterVideo(stream);
+        if (stream->common->job->cfr==1)
+        {
+            dejitterVideo(stream);
+        }
         fixVideoOverlap(stream);
     }
     else if (stream->type == SYNC_TYPE_SUBTITLE)


### PR DESCRIPTION
Only allow dejitter to align video frames with uniform timestamps when encoding with a constant target video frame rate. By definition any type of variable frame rate is not aligned with uniform offset timestamps.

It's easy to see the effects this has by taking a variable frame rate mkv file t.mkv and runnning the following shell script. This should return all 0's post patch but random offsets pre-patch. It will be most consistent for input vfr timeseries that are always near to a constant number of frames every second or few seconds.

```
./HandBrakeCLI -i t.mkv -o t_out.mkv -e x264 -a none --vfr
mkvextract t.mkv timestamps_v2 0:t.txt
mkvextract t_out.mkv timestamps_v2 0:t_out.txt
awk '{getline t<"t.txt"; print $0-t}' t_out.txt
```

It's hard to construct a case where this has profound effects, but I've seen it  throw off video audio alignment quite badly for a VFR video that was actually two CFR videos with different timestamps (thus throwing off the average frame rate calculation).

Testing was with the above script on a fair quantity of video files of both CFR and VFR form and with outputs in both CFR and VFR.

**Test On:**

- [x] Windows 10+ (via MinGW)
- [x] Debian Linux
