### PR TITLE
Enable FFmpeg libaom-av1 decoder

### DIFF
--- a/THANKS.markdown
+++ b/THANKS.markdown
@@ -5,6 +5,7 @@
 HandBrake uses many cool libraries from the GNU/Linux world. We thank them and their authors.
 
 - [ffmpeg](https://ffmpeg.org/)
+- [libaom](https://aomedia.googlesource.com/aom/)
 - [libass](https://github.com/libass/libass)
 - [libbluray](https://www.videolan.org/developers/libbluray.html)
 - [libbzip2](http://bzip.org/)

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := BZIP2 ZLIB FDKAAC LIBVPX LAME LIBOPUS LIBSPEEX XZ
+__deps__ := BZIP2 ZLIB FDKAAC LIBVPX LIBAOM LAME LIBOPUS LIBSPEEX XZ
 ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBMFX
 endif
@@ -55,6 +55,9 @@ FFMPEG.CONFIGURE.extra = \
     --disable-decoder=libvpx_* \
     --enable-encoder=libvpx_vp8 \
     --enable-encoder=libvpx_vp9 \
+    --enable-libaom \
+    --enable-decoder=libaom-av1 \
+    --disable-encoder=libaom-av1 \
     --disable-decoder=*_crystalhd \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"


### PR DESCRIPTION
Adds the libaom decoder to the FFmpeg build process. Should fix #1737 and partly #457.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
