### PR TITLE
fix dts timestamps with videotoolbox h.265

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -653,9 +653,19 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     pv->context = context;
 
     job->areBframes = 0;
-    if ( context->has_b_frames )
+    if (context->has_b_frames > 0)
     {
-        job->areBframes = 1;
+        if (job->vcodec == HB_VCODEC_FFMPEG_VT_H265)
+        {
+            // VT appears to enable b-pyramid by default and there
+            // is no documented way of modifying this behaviour or
+            // querying if it is enabled.
+            job->areBframes = 2;
+        }
+        else
+        {
+            job->areBframes = context->has_b_frames;
+        }
     }
 
     if (context->extradata != NULL)

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -530,6 +530,8 @@ void hb_display_job_info(hb_job_t *job)
                 case HB_VCODEC_FFMPEG_VCE_H265:
                 case HB_VCODEC_FFMPEG_NVENC_H264:
                 case HB_VCODEC_FFMPEG_NVENC_H265:
+                case HB_VCODEC_FFMPEG_VT_H264:
+                case HB_VCODEC_FFMPEG_VT_H265:
                     hb_log("     + profile: %s", job->encoder_profile);
                 default:
                     break;
@@ -548,6 +550,9 @@ void hb_display_job_info(hb_job_t *job)
                 case HB_VCODEC_FFMPEG_VCE_H265:
                 case HB_VCODEC_FFMPEG_NVENC_H264:
                 case HB_VCODEC_FFMPEG_NVENC_H265:
+                case HB_VCODEC_FFMPEG_VT_H264:
+                // VT h.265 currently only supports auto level
+                // case HB_VCODEC_FFMPEG_VT_H265:
                     hb_log("     + level:   %s", job->encoder_level);
                 default:
                     break;


### PR DESCRIPTION
**Description of Change:**
Assume b-pyramid (2 frame init-delay) with VT h.265.
Fixes https://github.com/HandBrake/HandBrake/issues/1689

**Test on:**
- [ ] macOS 10.13+
