### PR TITLE
encavcodec: Make VCE h.265 encoder emit an IDR for every GOP

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -562,6 +562,12 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         }
     }
 
+    // Make VCE h.265 encoder emit an IDR for every GOP
+    if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265)
+    {
+        av_dict_set(&av_opts, "gops_per_idr", "1", 0);
+    }
+
     if( job->pass_id == HB_PASS_ENCODE_1ST ||
         job->pass_id == HB_PASS_ENCODE_2ND )
     {


### PR DESCRIPTION
**Description of Change:**
Potential fix for seeking/scrubbing of VCE h.265 encoded video
May fix https://github.com/HandBrake/HandBrake/issues/1561
Also see discussion https://github.com/HandBrake/HandBrake/pull/1801

**Test on:**

- [ ] Windows 10+  (via MinGW)
