### PR TITLE
lapsharp: blank frame buffer stride region

### DIFF
--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -597,6 +597,34 @@ hb_buffer_t * hb_frame_buffer_init( int pix_fmt, int width, int height )
     return buf;
 }
 
+void hb_frame_buffer_blank_stride(hb_buffer_t * buf)
+{
+    int pp, xx, yy, stride;
+
+    for (pp = 0; pp < 4; pp++)
+    {
+        if (buf->plane[pp].data != NULL)
+        {
+            stride = buf->plane[pp].stride;
+            for (yy = 0; yy < buf->plane[pp].height; yy++)
+            {
+                for (xx = buf->plane[pp].width; xx < stride; xx++)
+                {
+                    *(buf->plane[pp].data + (yy * stride) + xx) = 0x80;
+                }
+            }
+            for (yy = buf->plane[pp].height;
+                 yy < buf->plane[pp].height_stride; yy++)
+            {
+                for (xx = 0; xx < stride; xx++)
+                {
+                    *(buf->plane[pp].data + (yy * stride) + xx) = 0x80;
+                }
+            }
+        }
+    }
+}
+
 // this routine reallocs a buffer for an uncompressed YUV420 video frame
 // with dimensions width x height.
 void hb_video_buffer_realloc( hb_buffer_t * buf, int width, int height )

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -161,6 +161,7 @@ void hb_buffer_pool_free( void );
 hb_buffer_t * hb_buffer_init( int size );
 hb_buffer_t * hb_buffer_eof_init( void );
 hb_buffer_t * hb_frame_buffer_init( int pix_fmt, int w, int h);
+void          hb_frame_buffer_blank_stride(hb_buffer_t * buf);
 void          hb_buffer_init_planes( hb_buffer_t * b );
 void          hb_buffer_realloc( hb_buffer_t *, int size );
 void          hb_video_buffer_realloc( hb_buffer_t * b, int w, int h );

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -162,6 +162,7 @@ hb_buffer_t * hb_buffer_init( int size );
 hb_buffer_t * hb_buffer_eof_init( void );
 hb_buffer_t * hb_frame_buffer_init( int pix_fmt, int w, int h);
 void          hb_frame_buffer_blank_stride(hb_buffer_t * buf);
+void          hb_frame_buffer_mirror_stride(hb_buffer_t * buf);
 void          hb_buffer_init_planes( hb_buffer_t * b );
 void          hb_buffer_realloc( hb_buffer_t *, int size );
 void          hb_video_buffer_realloc( hb_buffer_t * b, int w, int h );

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -283,6 +283,7 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
         return HB_FILTER_DONE;
     }
 
+    hb_frame_buffer_blank_stride(in);
     out = hb_frame_buffer_init(in->f.fmt, in->f.width, in->f.height);
 
     int c;

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -283,7 +283,7 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
         return HB_FILTER_DONE;
     }
 
-    hb_frame_buffer_blank_stride(in);
+    hb_frame_buffer_mirror_stride(in);
     out = hb_frame_buffer_init(in->f.fmt, in->f.width, in->f.height);
 
     int c;


### PR DESCRIPTION
Zero is not black.  Stride is used in computations and is assumed black.

Fixes https://github.com/HandBrake/HandBrake/issues/1751

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

