### PR TITLE
scan: only apply min duration filter to BD and DVD

### DIFF
--- a/gtk/src/ghb.m4
+++ b/gtk/src/ghb.m4
@@ -6572,7 +6572,7 @@ filter_output([
                           <object class="GtkLabel" id="label70">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Filter short titles (seconds)</property>
+                            <property name="label" translatable="yes">Filter short DVD and Blu-ray titles (seconds)</property>
                             <property name="use_markup">True</property>
                           </object>
                           <packing>

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -120,7 +120,7 @@ int hb_batch_title_count( hb_batch_t * d )
 /***********************************************************************
  * hb_batch_title_scan
  **********************************************************************/
-hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t, uint64_t min_duration )
+hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t )
 {
 
     hb_title_t   * title;
@@ -145,11 +145,6 @@ hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t, uint64_t min_duration )
 
     title = hb_stream_title_scan( stream, title );
     hb_stream_close( &stream );
-    if( title != NULL && title->duration < min_duration )
-    {
-        hb_log( "batch: ignoring title (too short)" );
-        hb_title_close(&title);
-    }
 
     return title;
 }

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -301,8 +301,7 @@ typedef struct hb_batch_s hb_batch_t;
 hb_batch_t  * hb_batch_init( hb_handle_t *h, char * path );
 void          hb_batch_close( hb_batch_t ** _d );
 int           hb_batch_title_count( hb_batch_t * d );
-hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t,
-                                   uint64_t min_duration );
+hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t );
 
 /***********************************************************************
  * dvd.c

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -155,7 +155,7 @@ static void ScanFunc( void * _data )
         if( data->title_index )
         {
             /* Scan this title only */
-            title = hb_batch_title_scan(data->batch, data->title_index, 0);
+            title = hb_batch_title_scan(data->batch, data->title_index);
             if ( title )
             {
                 hb_list_add( data->title_set->list_title, title );
@@ -169,8 +169,7 @@ static void ScanFunc( void * _data )
                 hb_title_t * title;
 
                 UpdateState1(data, i + 1);
-                title = hb_batch_title_scan(data->batch, i + 1,
-                                            data->min_title_duration);
+                title = hb_batch_title_scan(data->batch, i + 1);
                 if ( title != NULL )
                 {
                     hb_list_add( data->title_set->list_title, title );


### PR DESCRIPTION
Fixes https://github.com/HandBrake/HandBrake/issues/1590

**Description of Change:**
Don't discard titles less than min-duration when doing batch file scan

I updated the preference option in LinGui to indicate that the value only applies to DVD and Blu-ray.  The other GUIs should do the same.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

