### PR TITLE
Add AVX2 optimizations to NLMeans.

### DIFF
--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -239,7 +239,7 @@ static void nlmeans_alloc(const uint8_t *src,
     const int bs = NLMEANS_ALIGN(bw);
     const int bh = src_h + 2 * border;
 
-    uint8_t *mem   = malloc(bs * bh * sizeof(uint8_t));
+    uint8_t *mem   = av_malloc(bs * bh * sizeof(uint8_t));
     uint8_t *image = mem + border + bs * border;
 
     // Copy main image
@@ -508,7 +508,7 @@ static void nlmeans_filter_edgeboost(const uint8_t *src,
     const int offset_max =   (kernel_size + 1) /2;
     uint16_t pixel1;
     uint16_t pixel2;
-    uint8_t *mask_mem = calloc(bs * bh, sizeof(uint8_t));
+    uint8_t *mask_mem = av_calloc(bs * bh, sizeof(uint8_t));
     uint8_t *mask = mask_mem + border + bs * border;
     for (int y = 0; y < h; y++)
     {
@@ -587,7 +587,7 @@ static void nlmeans_filter_edgeboost(const uint8_t *src,
         }
     }
 
-    free(mask_mem);
+    av_free(mask_mem);
 }
 
 static void nlmeans_prefilter(BorderedPlane *src,
@@ -619,7 +619,7 @@ static void nlmeans_prefilter(BorderedPlane *src,
         const int bh         = h + 2 * border;
 
         // Duplicate plane
-        uint8_t *mem_pre = malloc(bs * bh * sizeof(uint8_t));
+        uint8_t *mem_pre = av_malloc(bs * bh * sizeof(uint8_t));
         uint8_t *image_pre = mem_pre + border + bs * border;
         for (int y = 0; y < h; y++)
         {
@@ -787,7 +787,7 @@ static void nlmeans_plane(NLMeansFunctions *functions,
 
     // Allocate integral image
     const int integral_stride    = NLMEANS_ALIGN(dst_w) + 2 * NLMEANS_ALIGNMENT;
-    uint32_t* const integral_mem = calloc(integral_stride * (dst_h+1), sizeof(uint32_t));
+    uint32_t* const integral_mem = av_calloc(integral_stride * (dst_h+1), sizeof(uint32_t));
     uint32_t* const integral     = integral_mem + integral_stride + NLMEANS_ALIGNMENT;
 
     // Iterate through available frames
@@ -894,7 +894,7 @@ static void nlmeans_plane(NLMeansFunctions *functions,
     }
 
     free(tmp_data);
-    free(integral_mem);
+    av_free(integral_mem);
 
 }
 
@@ -1017,7 +1017,7 @@ static int nlmeans_init(hb_filter_object_t *filter,
     }
     hb_log("NLMeans using %i threads", pv->threads);
 
-    pv->frame = calloc(pv->threads + pv->max_frames, sizeof(Frame));
+    pv->frame = av_calloc(pv->threads + pv->max_frames, sizeof(Frame));
     for (int ii = 0; ii < pv->threads + pv->max_frames; ii++)
     {
         for (int c = 0; c < 3; c++)
@@ -1078,12 +1078,12 @@ static void nlmeans_close(hb_filter_object_t *filter)
             if (pv->frame[f].plane[c].mem_pre != NULL &&
                 pv->frame[f].plane[c].mem_pre != pv->frame[f].plane[c].mem)
             {
-                free(pv->frame[f].plane[c].mem_pre);
+                av_free(pv->frame[f].plane[c].mem_pre);
                 pv->frame[f].plane[c].mem_pre = NULL;
             }
             if (pv->frame[f].plane[c].mem != NULL)
             {
-                free(pv->frame[f].plane[c].mem);
+                av_free(pv->frame[f].plane[c].mem);
                 pv->frame[f].plane[c].mem = NULL;
             }
         }
@@ -1097,7 +1097,7 @@ static void nlmeans_close(hb_filter_object_t *filter)
         }
     }
 
-    free(pv->frame);
+    av_free(pv->frame);
     free(pv->thread_data);
     free(pv);
     filter->private_data = NULL;
@@ -1210,12 +1210,12 @@ static hb_buffer_t * nlmeans_filter(hb_filter_private_t *pv)
             if (pv->frame[t].plane[c].mem_pre != NULL &&
                 pv->frame[t].plane[c].mem_pre != pv->frame[t].plane[c].mem)
             {
-                free(pv->frame[t].plane[c].mem_pre);
+                av_free(pv->frame[t].plane[c].mem_pre);
                 pv->frame[t].plane[c].mem_pre = NULL;
             }
             if (pv->frame[t].plane[c].mem != NULL)
             {
-                free(pv->frame[t].plane[c].mem);
+                av_free(pv->frame[t].plane[c].mem);
                 pv->frame[t].plane[c].mem = NULL;
             }
         }

--- a/libhb/nlmeans.h
+++ b/libhb/nlmeans.h
@@ -8,6 +8,10 @@
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+#define NLMEANS_ALIGNMENT      32
+#define NLMEANS_ALIGN(x)       ((x + NLMEANS_ALIGNMENT-1) &~ (NLMEANS_ALIGNMENT-1))
+#define NLMEANS_ALIGN_HALF(x)  ((x + (NLMEANS_ALIGNMENT/2)-1) &~ ((NLMEANS_ALIGNMENT/2)-1))
+
 typedef struct
 {
     void (*build_integral)(uint32_t *integral,

--- a/libhb/nlmeans_x86.c
+++ b/libhb/nlmeans_x86.c
@@ -32,13 +32,14 @@ static void build_integral_avx2(uint32_t *integral,
 {
     const __m256i zero = _mm256_set1_epi8(0);
     const int bw = w + 2 * border;
+    const int bs = NLMEANS_ALIGN(bw);
 
     for (int y = 0; y < dst_h; y++)
     {
         __m256i prevadd = _mm256_set1_epi32(0);
 
-        const uint8_t *p1 = src_pre + y*bw;
-        const uint8_t *p2 = compare_pre + (y+dy)*bw + dx;
+        const uint8_t *p1 = src_pre + y*bs;
+        const uint8_t *p2 = compare_pre + (y+dy)*bs + dx;
         uint32_t *out = integral + (y*integral_stride);
 
         for (int x = 0; x < dst_w; x += 32)
@@ -167,13 +168,14 @@ static void build_integral_sse2(uint32_t *integral,
 {
     const __m128i zero = _mm_set1_epi8(0);
     const int bw = w + 2 * border;
+    const int bs = NLMEANS_ALIGN(bw);
 
     for (int y = 0; y < dst_h; y++)
     {
         __m128i prevadd = _mm_set1_epi32(0);
 
-        const uint8_t *p1 = src_pre + y*bw;
-        const uint8_t *p2 = compare_pre + (y+dy)*bw + dx;
+        const uint8_t *p1 = src_pre + y*bs;
+        const uint8_t *p2 = compare_pre + (y+dy)*bs + dx;
         uint32_t *out = integral + (y*integral_stride);
 
         for (int x = 0; x < dst_w; x += 16)

--- a/libhb/nlmeans_x86.c
+++ b/libhb/nlmeans_x86.c
@@ -12,10 +12,145 @@
 
 #if defined(ARCH_X86)
 
-#include <emmintrin.h>
+#include <immintrin.h>
 
 #include "libavutil/cpu.h"
 #include "nlmeans.h"
+
+static void build_integral_avx2(uint32_t *integral,
+                                int       integral_stride,
+                          const uint8_t  *src,
+                          const uint8_t  *src_pre,
+                          const uint8_t  *compare,
+                          const uint8_t  *compare_pre,
+                                int       w,
+                                int       border,
+                                int       dst_w,
+                                int       dst_h,
+                                int       dx,
+                                int       dy)
+{
+    const __m256i zero = _mm256_set1_epi8(0);
+    const int bw = w + 2 * border;
+
+    for (int y = 0; y < dst_h; y++)
+    {
+        __m256i prevadd = _mm256_set1_epi32(0);
+
+        const uint8_t *p1 = src_pre + y*bw;
+        const uint8_t *p2 = compare_pre + (y+dy)*bw + dx;
+        uint32_t *out = integral + (y*integral_stride);
+
+        for (int x = 0; x < dst_w; x += 32)
+        {
+            __m256i pa, pb;
+            __m256i pla, plb;
+            __m256i ldiff, lldiff, lhdiff;
+            __m256i ltmp,htmp;
+            __m256i ladd,hadd;
+            __m256i pha,phb;
+            __m256i hdiff,hldiff,hhdiff;
+            __m256i l2tmp,h2tmp;
+
+            pa = _mm256_loadu_si256((__m256i*)p1);      // Load source  pixels into register 1
+            pb = _mm256_loadu_si256((__m256i*)p2);      // Load compare pixels into register 2
+
+            // Low
+            pla = _mm256_unpacklo_epi8(pa,zero);        // Unpack and interleave source  low with zeros
+            plb = _mm256_unpacklo_epi8(pb,zero);        // Unpack and interleave compare low with zeros
+
+            ldiff = _mm256_sub_epi16(pla,plb);          // Diff source and compare lows (subtract)
+            ldiff = _mm256_mullo_epi16(ldiff,ldiff);    // Square low diff (multiply at 32-bit precision)
+
+            lldiff = _mm256_unpacklo_epi16(ldiff,zero); // Unpack and interleave diff low  with zeros
+            lhdiff = _mm256_unpackhi_epi16(ldiff,zero); // Unpack and interleave diff high with zeros
+
+            ltmp = _mm256_slli_si256(lldiff, 4);        // Temp shift diff low left 4 bytes
+            lldiff = _mm256_add_epi32(lldiff, ltmp);    // Add above to diff low
+            ltmp = _mm256_slli_si256(lldiff, 8);        // Temp shift diff low left 8 bytes
+            lldiff = _mm256_add_epi32(lldiff, ltmp);    // Add above to diff low
+            lldiff = _mm256_add_epi32(lldiff, prevadd); // Add previous total to diff low
+
+            ladd = _mm256_shuffle_epi32(lldiff, 0xff);  // Shuffle diff low
+
+            htmp = _mm256_slli_si256(lhdiff, 4);        // Temp shift diff high left 4 bytes
+            lhdiff = _mm256_add_epi32(lhdiff, htmp);    // Add above to diff high
+            htmp = _mm256_slli_si256(lhdiff, 8);        // Temp shift diff high left 8 bytes
+            lhdiff = _mm256_add_epi32(lhdiff, htmp);    // Add above to diff high
+            lhdiff = _mm256_add_epi32(lhdiff, ladd);    // Add shuffled diff low to diff high
+
+            prevadd = _mm256_shuffle_epi32(lhdiff, 0xff); // Shuffle diff high
+
+            // High
+            pha = _mm256_unpackhi_epi8(pa,zero);        // Unpack and interleave source  high with zeros
+            phb = _mm256_unpackhi_epi8(pb,zero);        // Unpack and interleave compare high with zeros
+
+            hdiff = _mm256_sub_epi16(pha,phb);          // Diff source and compare highs (subtract)
+            hdiff = _mm256_mullo_epi16(hdiff,hdiff);    // Square high diff (multiply at 32-bit precision)
+
+            hldiff = _mm256_unpacklo_epi16(hdiff,zero); // Unpack and interleave diff low  with zeros
+            hhdiff = _mm256_unpackhi_epi16(hdiff,zero); // Unpack and interleave diff high with zeros
+
+            l2tmp = _mm256_slli_si256(hldiff, 4);       // Temp shift diff low 4 bytes
+            hldiff = _mm256_add_epi32(hldiff, l2tmp);   // Add above to diff low
+            l2tmp = _mm256_slli_si256(hldiff, 8);       // Temp shift diff low left 8 bytes
+            hldiff = _mm256_add_epi32(hldiff, l2tmp);   // Add above to diff low
+            hldiff = _mm256_add_epi32(hldiff, prevadd); // Add previous total to diff low
+
+            hadd = _mm256_shuffle_epi32(hldiff, 0xff);  // Shuffle diff low
+
+            h2tmp = _mm256_slli_si256(hhdiff, 4);       // Temp shift diff high left 4 bytes
+            hhdiff = _mm256_add_epi32(hhdiff, h2tmp);   // Add above to diff high
+            h2tmp = _mm256_slli_si256(hhdiff, 8);       // Temp shift diff high left 8 bytes
+            hhdiff = _mm256_add_epi32(hhdiff, h2tmp);   // Add above to diff high
+            hhdiff = _mm256_add_epi32(hhdiff, hadd);    // Add shuffled diff low to diff high
+
+            prevadd = _mm256_shuffle_epi32(hhdiff, 0xff); // Shuffle diff high
+
+            // Store, lane:0
+            _mm_store_si128((__m128i*)(out),    _mm256_extractf128_si256(lldiff,0)); // Store low  diff low  in memory
+            _mm_store_si128((__m128i*)(out+4),  _mm256_extractf128_si256(lhdiff,0)); // Store low  diff high in memory
+            _mm_store_si128((__m128i*)(out+8),  _mm256_extractf128_si256(hldiff,0)); // Store high diff low  in memory
+            _mm_store_si128((__m128i*)(out+12), _mm256_extractf128_si256(hhdiff,0)); // Store high diff high in memory
+
+            // Cross lanes for (out-1)
+            lldiff = _mm256_add_epi32(lldiff,_mm256_permutevar8x32_epi32(hhdiff, _mm256_set_epi32(3,3,3,3,3,3,3,3)));
+            lhdiff = _mm256_add_epi32(lhdiff,_mm256_permutevar8x32_epi32(hhdiff, _mm256_set_epi32(3,3,3,3,3,3,3,3)));
+            hldiff = _mm256_add_epi32(hldiff,_mm256_permutevar8x32_epi32(hhdiff, _mm256_set_epi32(3,3,3,3,3,3,3,3)));
+            hhdiff = _mm256_add_epi32(hhdiff,_mm256_permutevar8x32_epi32(hhdiff, _mm256_set_epi32(3,3,3,3,3,3,3,3)));
+
+            // Store, lane:1
+            _mm_store_si128((__m128i*)(out+16), _mm256_extractf128_si256(lldiff,1)); // Store low  diff low  in memory
+            _mm_store_si128((__m128i*)(out+20), _mm256_extractf128_si256(lhdiff,1)); // Store low  diff high in memory
+            _mm_store_si128((__m128i*)(out+24), _mm256_extractf128_si256(hldiff,1)); // Store high diff low  in memory
+            _mm_store_si128((__m128i*)(out+28), _mm256_extractf128_si256(hhdiff,1)); // Store high diff high in memory
+
+            // Adjust prevadd for next iteration
+            prevadd = _mm256_permutevar8x32_epi32(hhdiff, _mm256_set_epi32(7,7,7,7,7,7,7,7));
+            prevadd = _mm256_blend_epi32(prevadd, zero, 0xf0);
+
+            // Increment
+            out += 32;
+            p1  += 32;
+            p2  += 32;
+        }
+
+        if (y > 0)
+        {
+            out = integral + y*integral_stride;
+
+            for (int x = 0; x < dst_w; x += 32)
+            {
+                *((__m256i*)out)      = _mm256_add_epi32(*(__m256i*)(out-integral_stride),    *(__m256i*)(out));
+                *((__m256i*)(out+8))  = _mm256_add_epi32(*(__m256i*)(out+8-integral_stride),  *(__m256i*)(out+8));
+                *((__m256i*)(out+16)) = _mm256_add_epi32(*(__m256i*)(out+16-integral_stride), *(__m256i*)(out+16));
+                *((__m256i*)(out+24)) = _mm256_add_epi32(*(__m256i*)(out+24-integral_stride), *(__m256i*)(out+24));
+
+                out += 32;
+            }
+        }
+    }
+}
 
 static void build_integral_sse2(uint32_t *integral,
                                 int       integral_stride,
@@ -145,7 +280,12 @@ static void build_integral_sse2(uint32_t *integral,
 
 void nlmeans_init_x86(NLMeansFunctions *functions)
 {
-    if (av_get_cpu_flags() & AV_CPU_FLAG_SSE2)
+    if (av_get_cpu_flags() & AV_CPU_FLAG_AVX2)
+    {
+        functions->build_integral = build_integral_avx2;
+        hb_log("NLMeans using AVX2 optimizations");
+    }
+    else if (av_get_cpu_flags() & AV_CPU_FLAG_SSE2)
     {
         functions->build_integral = build_integral_sse2;
         hb_log("NLMeans using SSE2 optimizations");

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -73,8 +73,8 @@ GCC.args.L         = -L$(1)
 GCC.args.l         = -l$(1)
 GCC.args.end       = -Wl,--end-group
 
-ifeq ($(BUILD.machine),$(filter $(BUILD.machine),i686 x86_64))
-    GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2
+ifeq (x86_64,$(BUILD.machine))
+    GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2 -mavx -mavx2 -mno-sse2avx
 else
     GCC.args.extra = $(CFLAGS) $(CPPFLAGS)
 endif

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -74,7 +74,7 @@ GCC.args.l         = -l$(1)
 GCC.args.end       = -Wl,--end-group
 
 ifeq (x86_64,$(BUILD.machine))
-    GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2 -mavx -mavx2 -mno-sse2avx
+    GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2 -mavx -mavx2
 else
     GCC.args.extra = $(CFLAGS) $(CPPFLAGS)
 endif


### PR DESCRIPTION
Building this code will produce a HandBrake binary that only runs on AVX2 capable processors. We need to do some work to the build system to improve this, so that only CPU feature-specific code gets compiled this way, and the rest generically. Kona started on this a few years back; the code is a bit dated now but perhaps useful for study: https://github.com/KonaBlend/HandBrake/commits/arch

Unfortunately, I have not been able to demonstrate a significant speedup. Feel free to benchmark and post results here. Do not benchmark against 1.2.0, because it will be slower due to the number of threads used with high core counts. Benchmark master with and without this patch. Takk.