### PR TITLE
Add AV1 decoding/source file support

### DIFF
--- a/THANKS.markdown
+++ b/THANKS.markdown
@@ -5,6 +5,7 @@
 HandBrake uses many cool libraries from the GNU/Linux world. We thank them and their authors.
 
 - [ffmpeg](https://ffmpeg.org/)
+- [libaom](https://aomedia.googlesource.com/aom/)
 - [libass](https://github.com/libass/libass)
 - [libbluray](https://www.videolan.org/developers/libbluray.html)
 - [libbzip2](http://bzip.org/)

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := BZIP2 ZLIB FDKAAC LIBVPX LAME LIBOPUS LIBSPEEX XZ
+__deps__ := BZIP2 ZLIB FDKAAC LIBVPX LIBAOM LAME LIBOPUS LIBSPEEX XZ
 ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBMFX
 endif
@@ -55,6 +55,9 @@ FFMPEG.CONFIGURE.extra = \
     --disable-decoder=libvpx_* \
     --enable-encoder=libvpx_vp8 \
     --enable-encoder=libvpx_vp9 \
+    --enable-libaom \
+    --enable-decoder=libaom-av1 \
+    --enable-encoder=libaom-av1 \
     --disable-decoder=*_crystalhd \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"

--- a/contrib/libaom/A00-proper-version-detection.patch
+++ b/contrib/libaom/A00-proper-version-detection.patch
@@ -1,0 +1,13 @@
+diff -ur aom_v1.0.0-errata1.orig/CHANGELOG aom_v1.0.0-errata1/CHANGELOG
+--- aom_v1.0.0-errata1.orig/CHANGELOG	2017-05-12 17:11:38 -0700
++++ aom_v1.0.0-errata1/CHANGELOG	2019-01-31 10:31:11.216396293 -0500
+@@ -1,7 +1,5 @@
+-Next Release
+-  - Incompatible changes:
+-    The AV1 encoder's default keyframe interval changed to 128 from 9999.
+-    Support for armv6 was removed.
++2018-06-28 v1.0.0
++  AOMedia Codec Workgroup Approved version 1.0
+ 
+ 2016-04-07 v0.1.0 "AOMedia Codec 1"
+   This release is the first Alliance for Open Media codec.

--- a/contrib/libaom/module.defs
+++ b/contrib/libaom/module.defs
@@ -1,0 +1,71 @@
+$(eval $(call import.MODULE.defs,LIBAOM,libaom,PTHREADW32))
+$(eval $(call import.CONTRIB.defs,LIBAOM))
+
+# TODO: Mirror 1.0.0-errata1 on download.handbrake.fr
+LIBAOM.FETCH.url     = https://aomedia.googlesource.com/aom/+archive/add4b15580e410c00c927ee366fa65545045a5d9.tar.gz
+# Google's tgz seems to have its checksum change every time *shrug*
+# LIBAOM.FETCH.sha256  = 61efbfbeb540c4bf5611bb493035adf00563fad0fc21fe808b959133a08f9429
+
+# Custom extraction because of how aom needs cmake called in a special way
+define LIBAOM.EXTRACT
+    $(RM.exe) -fr $(LIBAOM.EXTRACT.dir/)
+    $(MKDIR.exe) -p $(LIBAOM.EXTRACT.dir/)
+    $(TAR.exe) xfC $(LIBAOM.FETCH.distfile) $(LIBAOM.EXTRACT.dir/)
+    $(TOUCH.exe) $@
+endef
+
+LIBAOM.CONFIGURE.dir         = contrib/libaom/build
+LIBAOM.CONFIGURE.exe         = cmake
+LIBAOM.CONFIGURE.args.prefix =
+LIBAOM.CONFIGURE.deps        =
+LIBAOM.CONFIGURE.static      =
+LIBAOM.CONFIGURE.shared      =
+LIBAOM.CONFIGURE.extra       =
+## find CMakeLists.txt
+LIBAOM.CONFIGURE.args.prefix += "$(call fn.ABSOLUTE,$(LIBAOM.EXTRACT.dir/)/)"
+
+LIBAOM.BUILD.dir             = contrib/libaom/build # aom wants `make` called inside its cmake directory
+LIBAOM.INSTALL.dir           = contrib/libaom/build
+
+ifneq (none,$(LIBAOM.GCC.g))
+    ifeq (darwin,$(BUILD.system))
+        LIBAOM.CONFIGURE.extra += -G Xcode
+        LIBAOM.CONFIGURE.extra += -DCMAKE_CONFIGURATION_TYPES=Debug
+    else
+        LIBAOM.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    endif
+endif
+
+ifeq (1,$(BUILD.cross))
+    ifeq (mingw,$(BUILD.system))
+        ifeq (x86_64,$(BUILD.machine))
+            LIBAOM.CONFIGURE.extra += -DCMAKE_TOOLCHAIN_FILE=build/cmake/toolchains/x86_64-mingw-gcc.cmake
+        else
+            LIBAOM.CONFIGURE.extra += -DCMAKE_TOOLCHAIN_FILE=build/cmake/toolchains/x86-mingw-gcc.cmake
+        endif
+    endif
+    ifeq (darwin,$(BUILD.system))
+        LIBAOM.CONFIGURE.extra += -DCMAKE_TOOLCHAIN_FILE=build/cmake/toolchains/x86-macos.cmake
+    endif
+    ifeq (linux,$(BUILD.system))
+        ifneq (x86_64,$(BUILD.machine))
+            LIBAOM.CONFIGURE.extra += -DCMAKE_TOOLCHAIN_FILE=build/cmake/toolchains/x86_64-mingw-gcc.cmake
+        endif
+    endif
+endif
+
+ifneq (none,$(LIBAOM.GCC.g))
+    LIBAOM.CONFIGURE.extra += -DAOM_TARGET_CPU=generic # aids in debugging for Visual Studio
+else
+    ifeq (x86_64,$(BUILD.machine))
+        LIBAOM.CONFIGURE.extra += -DAOM_TARGET_CPU=x86_64
+    else
+        LIBAOM.CONFIGURE.extra += -DAOM_TARGET_CPU=x86
+    endif
+endif
+
+## TODO: what do I do for INSTALL?
+LIBAOM.INSTALL.make = $(MV.exe)
+LIBAOM.INSTALL.args.dir = cd $(1);
+LIBAOM.INSTALL.extra = *.a ../lib/
+LIBAOM.INSTALL.args = @dir !make !extra

--- a/contrib/libaom/module.defs
+++ b/contrib/libaom/module.defs
@@ -20,7 +20,7 @@ LIBAOM.CONFIGURE.args.prefix =
 LIBAOM.CONFIGURE.deps        =
 LIBAOM.CONFIGURE.static      =
 LIBAOM.CONFIGURE.shared      =
-LIBAOM.CONFIGURE.extra       =
+LIBAOM.CONFIGURE.extra       = "-DCMAKE_INSTALL_PREFIX=$(call fn.ABSOLUTE,$(CONTRIB.build/))"
 ## find CMakeLists.txt
 LIBAOM.CONFIGURE.args.prefix += "$(call fn.ABSOLUTE,$(LIBAOM.EXTRACT.dir/)/)"
 
@@ -63,9 +63,3 @@ else
         LIBAOM.CONFIGURE.extra += -DAOM_TARGET_CPU=x86
     endif
 endif
-
-## TODO: what do I do for INSTALL?
-LIBAOM.INSTALL.make = $(MV.exe)
-LIBAOM.INSTALL.args.dir = cd $(1);
-LIBAOM.INSTALL.extra = *.a ../lib/
-LIBAOM.INSTALL.args = @dir !make !extra

--- a/contrib/libaom/module.rules
+++ b/contrib/libaom/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBAOM))
+$(eval $(call import.CONTRIB.rules,LIBAOM))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -179,7 +179,7 @@ PKG_CHECK_MODULES(GHB, [$GHB_PACKAGES])
 
 GHB_CFLAGS="$HBINC $GHB_CFLAGS"
 
-HB_LIBS="-lhandbrake -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
+HB_LIBS="-lhandbrake -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -laom -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
 
 case $host in
   *-*-mingw*)

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,7 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX FFMPEG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBSAMPLERATE LIBTHEORA LIBVORBIS LIBOGG \
     LIBXML2 PTHREADW32 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON \
-    HARFBUZZ LIBOPUS LIBSPEEX
+    HARFBUZZ LIBOPUS LIBSPEEX LIBAOM
 
 ifeq (,$(filter $(BUILD.system),darwin cygwin mingw))
     __deps__ += FONTCONFIG
@@ -117,7 +117,7 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 
 LIBHB.dll.libs = $(foreach n, \
         ass avformat avfilter avcodec avutil swresample postproc dvdnav dvdread \
-        freetype mp3lame samplerate swscale vpx theora vorbis vorbisenc ogg \
+        freetype mp3lame samplerate swscale vpx aom theora vorbis vorbisenc ogg \
         x264 xml2 bluray jansson harfbuzz opus speex, \
         $(CONTRIB.build/)lib/lib$(n).a )
 

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -29,6 +29,7 @@ ifneq (,$(filter $(BUILD.system),darwin cygwin mingw))
     MODULES += contrib/x264
     MODULES += contrib/jansson
     MODULES += contrib/libvpx
+    MODULES += contrib/libaom
 endif
 
 ifeq (1,$(FEATURE.flatpak))

--- a/pkg/linux/debian/control.bionic
+++ b/pkg/linux/debian/control.bionic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev libvpx-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libaom-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.cosmic
+++ b/pkg/linux/debian/control.cosmic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev libvpx-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libaom-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
         dvdread fribidi \
         samplerate swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
-        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma
+        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma aom
 
 ifeq (,$(filter $(BUILD.system),darwin cygwin mingw))
     TEST.GCC.l += fontconfig


### PR DESCRIPTION
**Description of Change:**

This simply _attempts_ to compile ffmpeg with libaom support that's cross-compile friendly.

Fixes #1737, partially solves #457, a rigorous redo of #1738 by @EwoutH.

I spent _faaaar_ too long trying to understand the custom build system handbrake has. I did my best but I'm sure I abused its intent with respect to libaom.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux