### PR TITLE
Disable libsamplerate examples if no Alsa lib

### DIFF
--- a/contrib/libsamplerate/A00-disable-examples-if-no-alsa.patch
+++ b/contrib/libsamplerate/A00-disable-examples-if-no-alsa.patch
@@ -1,0 +1,44 @@
+diff -ur libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68.orig/Makefile.am libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68/Makefile.am
+--- libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68.orig/Makefile.am	2001-09-17 00:00:00 -0000
++++ libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68/Makefile.am	2018-04-21 12:49:45 +0200
+@@ -57,6 +57,8 @@ dist_html_DATA = doc/SRC.png doc/SRC.css doc/index.html doc/license.html doc/his
+ # examples/ #
+ #############
+ 
++if HAVE_LIBSNDFILE
++if HAVE_LIBALSA
+ noinst_PROGRAMS = examples/varispeed-play examples/timewarp-file
+ 
+ examples_varispeed_play_SOURCES = examples/varispeed-play.c examples/audio_out.c examples/audio_out.h
+@@ -66,6 +68,8 @@ examples_varispeed_play_LDADD = src/libsamplerate.la $(SNDFILE_LIBS) $(ALSA_LIBS
+ examples_timewarp_file_SOURCES = examples/timewarp-file.c
+ examples_timewarp_file_CFLAGS = $(SNDFILE_CFLAGS) $(ALSA_CFLAGS)
+ examples_timewarp_file_LDADD = src/libsamplerate.la $(SNDFILE_LIBS) $(ALSA_LIBS)
++endif
++endif
+ 
+ ##########
+ # tests/ #
+@@ -146,6 +150,10 @@ tests_multichan_throughput_test_SOURCES = tests/multichan_throughput_test.c test
+ tests_multichan_throughput_test_CFLAGS = $(FFTW3_CFLAGS)
+ tests_multichan_throughput_test_LDADD = src/libsamplerate.la $(FFTW3_LIBS)
+ 
++if HAVE_LIBSNDFILE
++check_PROGRAMS += tests/src-evaluate
++
+ tests_src_evaluate_SOURCES = tests/src-evaluate.c tests/calc_snr.c tests/util.c
+ tests_src_evaluate_CFLAGS = $(SNDFILE_CFLAGS) $(FFTW3_CFLAGS)
+ tests_src_evaluate_LDADD = $(SNDFILE_LIBS) $(FFTW3_LIBS)
++endif
+diff --git a/configure.ac b/configure.ac
+index 0edbf3a..a714f7b 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -199,6 +199,7 @@ AS_IF([test "x$enable_alsa" != "xno"], [
+ 					])
+ 			])
+ 	])
++AM_CONDITIONAL([HAVE_LIBALSA], [test "x$enable_alsa" = "xyes"])
+ 
+ dnl ====================================================================================
+ dnl  Check for libfftw3 which is required for the test and example programs.


### PR DESCRIPTION
**Description of Change:**

Addresses #1798

This fixes cross compilation for Windows and (apparently?) Gentoo.

The patchfile is derrived from an upstream fix in a newer version of libsamplerate:

https://github.com/erikd/libsamplerate/pull/38

libsamplerate's examples/ dir contains code that is not portable.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
