### PR TITLE
Add fast AV1 decoding/source file support via dav1d

### DIFF
--- a/THANKS.markdown
+++ b/THANKS.markdown
@@ -8,6 +8,7 @@ HandBrake uses many cool libraries from the GNU/Linux world. We thank them and t
 - [libass](https://github.com/libass/libass)
 - [libbluray](https://www.videolan.org/developers/libbluray.html)
 - [libbzip2](http://bzip.org/)
+- [libdav1d](https://code.videolan.org/videolan/dav1d)
 - [libdvdnav](https://dvdnav.mplayerhq.hu/)
 - [libdvdread](https://dvdnav.mplayerhq.hu/)
 - [libfdk-aac](https://sourceforge.net/projects/opencore-amr/)

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := BZIP2 ZLIB FDKAAC LIBVPX LAME LIBOPUS LIBSPEEX XZ
+__deps__ := BZIP2 ZLIB FDKAAC LIBDAV1D LIBVPX LAME LIBOPUS LIBSPEEX XZ
 ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBMFX
 endif
@@ -55,6 +55,8 @@ FFMPEG.CONFIGURE.extra = \
     --enable-encoder=libvpx_vp8 \
     --enable-encoder=libvpx_vp9 \
     --disable-decoder=*_crystalhd \
+    --enable-libdav1d \
+    --enable-decoder=libdav1d \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"
 

--- a/contrib/libdav1d/A00-add-cross-file.patch
+++ b/contrib/libdav1d/A00-add-cross-file.patch
@@ -1,0 +1,19 @@
+diff -Naur /dev/null dav1d-f1b756ef5bdc0bb759b2b140f15362fec024c1ff/x86_64-w64-mingw32.meson
+--- /dev/null	2019-02-01 11:36:25.027425148 -0500
++++ dav1d-f1b756ef5bdc0bb759b2b140f15362fec024c1ff/x86_64-w64-mingw32.meson	2019-02-01 12:10:45.582462644 -0500
+@@ -0,0 +1,15 @@
++[binaries]
++c = 'x86_64-w64-mingw32-gcc'
++cpp = 'x86_64-w64-mingw32-g++'
++ar = 'x86_64-w64-mingw32-ar'
++strip = 'x86_64-w64-mingw32-strip'
++windres = 'x86_64-w64-mingw32-windres'
++
++[properties]
++c_link_args = ['-static-libgcc']
++
++[host_machine]
++system = 'windows'
++cpu_family = 'x86_64'
++cpu = 'x86_64'
++endian = 'little'

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,0 +1,27 @@
+$(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
+$(eval $(call import.CONTRIB.defs,LIBDAV1D))
+
+LIBDAV1D.FETCH.url     = https://code.videolan.org/videolan/dav1d/-/archive/0.4.0/dav1d-0.4.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = 18bf96c5168b8c704422387620fefaa953e8dbd4eacb0f0796c03d6e741f8924
+
+LIBDAV1D.build_dir     = build/
+
+LIBDAV1D.CONFIGURE.exe    = $(MESON.exe)
+LIBDAV1D.CONFIGURE.deps   =
+LIBDAV1D.CONFIGURE.shared =
+LIBDAV1D.CONFIGURE.host   =
+LIBDAV1D.CONFIGURE.build  =
+LIBDAV1D.CONFIGURE.static = -Ddefault_library=static
+LIBDAV1D.CONFIGURE.extra  = --libdir=$(call fn.ABSOLUTE,$(CONTRIB.build/))lib/ --buildtype=release
+LIBDAV1D.CONFIGURE.env    =
+
+ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
+    LIBDAV1D.CONFIGURE.extra += --cross-file=$(call fn.ABSOLUTE,$(LIBDAV1D.EXTRACT.dir/))x86_64-w64-mingw32.meson
+endif
+
+LIBDAV1D.BUILD.make       = $(NINJA.exe)
+LIBDAV1D.BUILD.extra      = -v
+
+LIBDAV1D.INSTALL.make     = $(NINJA.exe)
+
+LIBDAV1D.CLEAN.make       = $(NINJA.exe)

--- a/contrib/libdav1d/module.rules
+++ b/contrib/libdav1d/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBDAV1D))
+$(eval $(call import.CONTRIB.rules,LIBDAV1D))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -199,7 +199,7 @@ PKG_CHECK_MODULES(GHB, [$GHB_PACKAGES])
 
 GHB_CFLAGS="$HBINC $GHB_CFLAGS"
 
-HB_LIBS="-lhandbrake -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
+HB_LIBS="-lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
 
 if test "x$use_fdk_aac" = "xyes" ; then
     HB_LIBS="$HB_LIBS -lfdk-aac"

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,7 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX FFMPEG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBSAMPLERATE LIBTHEORA LIBVORBIS LIBOGG \
     LIBXML2 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON \
-    HARFBUZZ LIBOPUS LIBSPEEX
+    HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     __deps__ += FONTCONFIG
@@ -103,7 +103,7 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 LIBHB.dll.libs = $(foreach n, \
         ass avformat avfilter avcodec avutil swresample postproc dvdnav dvdread \
         freetype mp3lame swscale vpx theora vorbis vorbisenc ogg \
-        x264 xml2 bluray jansson harfbuzz opus speex, \
+        x264 xml2 bluray jansson harfbuzz opus speex dav1d, \
         $(CONTRIB.build/)lib/lib$(n).a )
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -296,6 +296,8 @@
 		A9F217E61E2F934C00C10C6E /* container-migration.plist in Resources */ = {isa = PBXBuildFile; fileRef = A9F217E51E2F934C00C10C6E /* container-migration.plist */; };
 		A9F472891976B7F30009EC65 /* HBSubtitlesDefaultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F472871976B7F30009EC65 /* HBSubtitlesDefaultsController.m */; };
 		A9F7102619A475EC00F61301 /* HBDockTile.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F7102519A475EC00F61301 /* HBDockTile.m */; };
+		D0DC8F682331573500C12A24 /* libdav1d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0DC8F672331573500C12A24 /* libdav1d.a */; };
+		D0DC8F69233159C700C12A24 /* libdav1d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0DC8F672331573500C12A24 /* libdav1d.a */; };
 		D86C9DD51C6D372500F06F1B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86C9DD41C6D372500F06F1B /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -801,6 +803,7 @@
 		A9F7102519A475EC00F61301 /* HBDockTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HBDockTile.m; sourceTree = "<group>"; };
 		D062DF6422FAE05700A65A9E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/HBQueueTableViewController.strings; sourceTree = "<group>"; };
 		D062DF6522FAE06000A65A9E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/HBQueueInfoViewController.strings; sourceTree = "<group>"; };
+		D0DC8F672331573500C12A24 /* libdav1d.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdav1d.a; path = external/contrib/lib/libdav1d.a; sourceTree = "BUILT_PRODUCTS_DIR"; };
 		D86C9DD41C6D372500F06F1B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -828,6 +831,7 @@
 				27D6C74814B102DA00B785E4 /* libavformat.a in Frameworks */,
 				27D6C74A14B102DA00B785E4 /* libavutil.a in Frameworks */,
 				27D6C74C14B102DA00B785E4 /* libbluray.a in Frameworks */,
+				D0DC8F682331573500C12A24 /* libdav1d.a in Frameworks */,
 				27D6C75014B102DA00B785E4 /* libdvdnav.a in Frameworks */,
 				27D6C75214B102DA00B785E4 /* libdvdread.a in Frameworks */,
 				1C53DE8C20BD598D006BBCA8 /* libspeex.a in Frameworks */,
@@ -895,6 +899,7 @@
 				A91CE2B61C7DABBC0068F46F /* libavformat.a in Frameworks */,
 				A91CE2B81C7DABBC0068F46F /* libavutil.a in Frameworks */,
 				A91CE2B91C7DABBC0068F46F /* libbluray.a in Frameworks */,
+				D0DC8F69233159C700C12A24 /* libdav1d.a in Frameworks */,
 				A91CE2BA1C7DABBC0068F46F /* libdvdnav.a in Frameworks */,
 				A91CE2BB1C7DABBC0068F46F /* libdvdread.a in Frameworks */,
 				1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */,
@@ -1013,6 +1018,7 @@
 		273F203414ADBAC30021BE6D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D0DC8F672331573500C12A24 /* libdav1d.a */,
 				A9A25D9B21182741005A8A0F /* CoreMedia.framework */,
 				A9AB9AA721181CC700BB3C7E /* CoreVideo.framework */,
 				A9AB9AA4211819A500BB3C7E /* VideoToolbox.framework */,

--- a/make/configure.py
+++ b/make/configure.py
@@ -1562,7 +1562,9 @@ try:
             gmake  = ToolProbe( 'GMAKE.exe',      'make',       'gmake', 'make', abort=True )
 
         m4         = ToolProbe( 'M4.exe',         'm4',         'gm4', 'm4', abort=True )
+        meson      = ToolProbe( 'MESON.exe',      'meson',      'meson', abort=True )
         mkdir      = ToolProbe( 'MKDIR.exe',      'mkdir',      'mkdir', abort=True )
+        ninja      = ToolProbe( 'NINJA.exe',      'ninja',      'ninja', abort=True )
         patch      = ToolProbe( 'PATCH.exe',      'patch',      'gpatch', 'patch', abort=True )
         rm         = ToolProbe( 'RM.exe',         'rm',         'rm', abort=True )
         ranlib     = ToolProbe( 'RANLIB.exe',     'ranlib',     'ranlib', abort=True )

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -46,6 +46,7 @@ ifeq (1,$(FEATURE.x265))
     MODULES += contrib/x265_12bit
 endif
 
+MODULES += contrib/libdav1d
 MODULES += contrib/ffmpeg
 MODULES += contrib/libdvdread
 MODULES += contrib/libdvdnav

--- a/scripts/mac-toolchain-build
+++ b/scripts/mac-toolchain-build
@@ -34,7 +34,7 @@ function mac_toolchain_build {
         MAKEJOBS="4"
     fi
     SUDO=
-    TOTAL=6
+    TOTAL=8
 
     # functions
     function print_fail_and_exit {
@@ -88,6 +88,12 @@ function mac_toolchain_build {
     echo -en "${CREL}"
     printf "Downloading [%02i/%02i] %s " "6" "${TOTAL}" "nasm 2.14.02"
     curl -Lf --connect-timeout 30 https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.bz2 -o "nasm-2.14.02.tar.bz2" >/dev/null 2>&1 || print_fail_and_exit
+    echo -en "${CREL}"
+    printf "Downloading [%02i/%02i] %s " "7" "${TOTAL}" "ninja 1.9.0"
+    curl -Lf --connect-timeout 30 https://github.com/ninja-build/ninja/archive/v1.9.0.tar.gz -o "ninja-1.9.0.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
+    echo -en "${CREL}"
+    printf "Downloading [%02i/%02i] %s " "8" "${TOTAL}" "meson 0.51.2"
+    curl -Lf --connect-timeout 30 https://github.com/mesonbuild/meson/archive/0.51.2.tar.gz -o "meson-0.51.2.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
     printf "Downloading [%02i/%02i] complete.\n" "${TOTAL}" "${TOTAL}"
 
@@ -157,9 +163,28 @@ function mac_toolchain_build {
     ${SUDO} make install >>../nasm-2.14.02.log 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
 
+    # ninja
+    cd "${TEMP_DIR}"
+    printf "Building    [%02i/%02i] %s " "7" "${TOTAL}" "ninja 1.9.0"
+    [[ "${SUDO}" != "" ]] && ${SUDO} -v
+    tar -xf ninja-1.9.0.tar.gz >/dev/null 2>&1 || print_fail_and_exit
+    cd ninja-1.9.0 >/dev/null 2>&1 || print_fail_and_exit
+    ./configure.py --bootstrap >../ninja-1.9.0.log 2>&1 || print_fail_and_exit
+    ${SUDO} mv ninja /usr/local/bin >>../ninja-1.9.0.log 2>&1 || print_fail_and_exit
+    echo -en "${CREL}"
+
+    # meson
+    cd "${TEMP_DIR}"
+    printf "Building    [%02i/%02i] %s " "8" "${TOTAL}" "meson 0.51.2"
+    [[ "${SUDO}" != "" ]] && ${SUDO} -v
+    tar -xf meson-0.51.2.tar.gz >/dev/null 2>&1 || print_fail_and_exit
+    cd meson-0.51.2 >/dev/null 2>&1 || print_fail_and_exit
+    ${SUDO} python3 setup.py install >>../meson-0.51.2.log 2>&1 || print_fail_and_exit
+    echo -en "${CREL}"
+
     # done
     printf "Building    [%02i/%02i] complete.\n" "${TOTAL}" "${TOTAL}"
-    rm -rf "${TEMP_DIR}"
+    ${SUDO} rm -rf "${TEMP_DIR}"
     if [[ "${PREFIX}" != "/usr/local" ]]; then
         echo "bin: ${PREFIX}/bin"
         echo "  add to your shell startup script (${HOME}/.bash_profile):"

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
         dvdread fribidi \
         swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
-        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma
+        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma dav1d
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     TEST.GCC.l += fontconfig


### PR DESCRIPTION
**Description of Change:**

This simply attempts to compile ffmpeg with libdav1d support that's cross-compile friendly.

Fixes #1737, partially solves #457 (decode).

I chose libdav1d as its the _de facto_ decoder which is faster than the reference library, libaom. It appears to be the horse everyone is betting on and is financially supported by the Alliance for Open Media/AOM.

It also appears to be more stable, using various Netflix test AV1 files, it doesn't hang on some of them like libaom does. And is of course faster.

~~In order to compile ffmpeg with libdav1d support, I needed to get on the nightly release. I chose the latest master snapshot and removed the patches that were merged in the upstream.~~ With ffmpeg 4.2 released, libdav1d was supported officially.

It uses the `meson` build system though, which means that's a new package requirement for compiling Handbrake from source. If the maintainers approve this, I'll add the appropriate HandBrake-docs PR.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux