### PR TITLE
libhb: do not set HB_STATE_WORKDONE before all the work threads are closed

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -77,7 +77,7 @@ static void InitWorkState(hb_handle_t *h, int pass_id, int pass, int pass_count)
 
 }
 
-static void SetWorkdoneState(hb_job_t *job)
+static void SetWorkStateInfo(hb_job_t *job)
 {
     hb_state_t state;
 
@@ -88,7 +88,6 @@ static void SetWorkdoneState(hb_job_t *job)
     }
     hb_get_state2(job->h, &state);
 
-    state.state                     = HB_STATE_WORKDONE;
     state.param.working.error       = *job->done_error;
     state.param.working.sequence_id = job->sequence_id;
 
@@ -155,7 +154,7 @@ static void work_func( void * _work )
             do_job( job );
             *(work->current_job) = NULL;
         }
-        SetWorkdoneState(job);
+        SetWorkStateInfo(job);
 
         // Clean job passes
         for (pass = 0; pass < pass_count; pass++)


### PR DESCRIPTION
The MacGui uses a single hb instance for the queue, and when a job is done it calls hb_scan() and hb_start() again for the next job. If HB_STATE_WORKDONE is set before all the previous work threads and resources are cleared, the macgui might receive the HB_STATE_WORKDONE and call hb_scan() while the hb instance if closing the previous job work resources.
In #1823 activity logs you can see "libhb: work result = 0" is written after " macgui: QueueCore work done", and the only reason is that the macgui received a HB_STATE_WORKDONE state update before the hb instance has properly stopped the previous work.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux