### PR TITLE
GHB: Sanitize generated preset export filenames

### DIFF
--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -2062,6 +2062,8 @@ preset_export_action_cb(GSimpleAction *action, GVariant *param,
         exportDir = ".";
     }
     filename = g_strdup_printf("%s.json", name);
+    // Sanitize generated filename
+    g_strdelimit(filename, GHB_UNSAFE_FILENAME_CHARS, '_');
     gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(dialog), exportDir);
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), filename);
     g_free(filename);
@@ -2929,4 +2931,3 @@ preset_widget_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_widget_to_setting(ud->settings, widget);
     ghb_check_dependency(ud, widget, NULL);
 }
-

--- a/gtk/src/values.h
+++ b/gtk/src/values.h
@@ -28,6 +28,8 @@
 #include <glib-object.h>
 #include "hb_dict.h"
 
+#define GHB_UNSAFE_FILENAME_CHARS "/:<>\"\\|?*"
+
 #define GHB_DICT    HB_VALUE_TYPE_DICT
 #define GHB_ARRAY   HB_VALUE_TYPE_ARRAY
 #define GHB_STRING  HB_VALUE_TYPE_STRING


### PR DESCRIPTION

**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Export filenames for presets default to "name.json". But since the preset name allows characters which are problematic in filenames, we add a define for `GHB_UNSAFE_FILENAME_CHARS` in `values.h`, and use `g_strdelimit()` to replace each occurrence with an underscore.

Fixes #1871

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**

After patching:

![screenshot from 2019-02-05 17-21-58](https://user-images.githubusercontent.com/538020/52308482-6d176500-296b-11e9-939e-b82eac80b5c6.png)

![screenshot from 2019-02-05 17-22-08](https://user-images.githubusercontent.com/538020/52308790-43127280-296c-11e9-9db0-ad3380d1f17e.png)

(Note: The contrived preset name I created also fails to display in the main window dropbox after selection, presumably because of some of the illegal characters in its name, indicating that preset names themselves could probably do with some input-sanitizing. But, despite not being displayed, the preset is selected and used, and can be exported as indicated.)