### PR TITLE
libhb: Display audo source bitrate

### DIFF
--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1376,6 +1376,12 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_buffer_t * b)
         }
     }
 
+    // Append input bitrate in kbps to the end of the description
+    char in_bitrate_str[19];
+    snprintf(in_bitrate_str, 18, " (%d kbps)", audio->config.in.bitrate / 1000);
+    strncat(audio->config.lang.description, in_bitrate_str, 
+            sizeof(audio->config.lang.description) - strlen(audio->config.lang.description) - 1);
+
     hb_log( "scan: audio 0x%x: %s, rate=%dHz, bitrate=%d %s", audio->id,
             info.name, audio->config.in.samplerate, audio->config.in.bitrate,
             audio->config.lang.description );


### PR DESCRIPTION
**Description of Change:**

As per #1718 , adds source audio bitrate to audio track description in Audio tab.
I chose to display it in kbps to match the output bitrate format. 

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

![1718_commit](https://user-images.githubusercontent.com/3466262/52391235-35dbad80-2a6a-11e9-9cb5-c83f49c9ff13.JPG)

**Log file output (If relevant):**
