### PR TITLE
Disable Hardware mode for hb_global_init

### DIFF
--- a/libhb/common.h
+++ b/libhb/common.h
@@ -334,7 +334,7 @@ struct hb_subtitle_config_s
  *
  */
 
-void hb_common_global_init(void);
+void hb_common_global_init(int);
 
 int              hb_video_framerate_get_from_name(const char *name);
 const char*      hb_video_framerate_get_name(int framerate);

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -68,6 +68,7 @@ struct hb_handle_s
 
 hb_work_object_t * hb_objects = NULL;
 int hb_instance_counter = 0;
+int disable_hardware = 0;
 
 static void thread_func( void * );
 
@@ -414,8 +415,11 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     hb_log(" - logical processor count: %d", hb_get_cpu_count());
 
 #ifdef USE_QSV
-    /* Print QSV info here so that it's in all scan and encode logs */
-    hb_qsv_info_print();
+    if (!is_hardware_disabled())
+    {
+        /* Print QSV info here so that it's in all scan and encode logs */
+        hb_qsv_info_print();
+    }
 #endif
 
     hb_log( "hb_scan: path=%s, title_index=%d", path, title_index );
@@ -1638,6 +1642,12 @@ void hb_close( hb_handle_t ** _h )
     *_h = NULL;
 }
 
+int hb_global_init_no_hardware()
+{
+    disable_hardware = 1;
+    hb_global_init();
+}
+
 int hb_global_init()
 {
     int result = 0;
@@ -1650,13 +1660,16 @@ int hb_global_init()
     }
 
 #ifdef USE_QSV
-    result = hb_qsv_info_init();
-    if (result < 0)
+    if (!disable_hardware) 
     {
-        hb_error("hb_qsv_info_init failed!");
-        return -1;
+        result = hb_qsv_info_init();
+        if (result < 0)
+        {
+            hb_error("hb_qsv_info_init failed!");
+            return -1;
+        }
+        hb_param_configure_qsv();
     }
-    hb_param_configure_qsv();
 #endif
 
     /* libavcodec */
@@ -1692,11 +1705,14 @@ int hb_global_init()
     hb_register(&hb_encx265);
 #endif
 #ifdef USE_QSV
-    hb_register(&hb_encqsv);
+    if (!disable_hardware) 
+    {
+        hb_register(&hb_encqsv);
+    }
 #endif
 
     hb_x264_global_init();
-    hb_common_global_init();
+    hb_common_global_init(disable_hardware);
 
     /*
      * Initialise buffer pool
@@ -1909,4 +1925,8 @@ void hb_system_sleep_prevent(hb_handle_t *h)
 hb_interjob_t * hb_interjob_get( hb_handle_t * h )
 {
     return h->interjob;
+}
+
+int is_hardware_disabled(void){
+    return disable_hardware;
 }

--- a/libhb/hb.h
+++ b/libhb/hb.h
@@ -134,6 +134,7 @@ void          hb_close( hb_handle_t ** );
 /* hb_global_init()
    Performs process initialization. */
 int           hb_global_init(void);
+int           hb_global_init_no_hardware();
 /* hb_global_close()
    Performs final cleanup for the process. */
 void          hb_global_close(void);
@@ -141,6 +142,8 @@ void          hb_global_close(void);
 /* hb_get_instance_id()
    Return the unique instance id of an libhb instance created by hb_init. */
 int hb_get_instance_id( hb_handle_t * h );
+
+int is_hardware_disabled(void);
 
 #ifdef __cplusplus
 }

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -8,6 +8,7 @@
  */
 
 #include "hbffmpeg.h"
+#include "hb.h"
 
 #ifdef USE_NVENC
 #include <ffnvcodec/nvEncodeAPI.h>
@@ -34,6 +35,11 @@ int hb_nvenc_h265_available()
 
 int hb_check_nvenc_available() 
 {
+    if (is_hardware_disabled())
+    {
+        return 0;
+    } 
+    
     #ifdef USE_NVENC
         uint32_t nvenc_ver;
         void *context;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -147,6 +147,11 @@ static int qsv_implementation_is_hardware(mfxIMPL implementation)
 
 int hb_qsv_available()
 {
+    if (is_hardware_disabled())
+    {
+        return 0;
+    } 
+    
     return ((hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0) |
             (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0) |
             (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265_10BIT) ? HB_VCODEC_QSV_H265_10BIT : 0));

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -98,11 +98,21 @@ clean:
 
 int hb_vce_h264_available()
 {
+    if (is_hardware_disabled())
+    {
+        return 0;
+    } 
+    
     return (check_component_available(AMFVideoEncoderVCE_AVC) == AMF_OK) ? 1 : 0;
 }
 
 int hb_vce_h265_available()
 {
+    if (is_hardware_disabled())
+    {
+        return 0;
+    } 
+    
     return (check_component_available(AMFVideoEncoder_HEVC) == AMF_OK) ? 1 : 0;
 }
 


### PR DESCRIPTION
**Description of Change:**

Add a hb_global_init_no_hardware that disables all the hardware encoder/decode init and check code. For users where drivers or other system issues prevent HandBrake from loading.

This is mostly for the WinGui to use as a "fallback" when something goes wrong on the system.  Seems there are a lot of dodgy drivers out there that are causing driver level crashes.  

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux  

