### PR TITLE
stream: Improve probing of unknown streams

### DIFF
--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -735,6 +735,24 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
             goto fail;
     }
 
+    switch( vts->vtsi_mat->vts_video_attr.mpeg_version )
+    {
+        case 0:
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG1VIDEO;
+            break;
+        case 1:
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG2VIDEO;
+            break;
+        default:
+            hb_log("scan: unknown/reserved MPEG version %d",
+                    vts->vtsi_mat->vts_video_attr.mpeg_version);
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG2VIDEO;
+            break;
+    }
+
     hb_log("scan: aspect = %d:%d",
            title->container_dar.num, title->container_dar.den);
 

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -928,6 +928,24 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
             goto fail;
     }
 
+    switch( ifo->vtsi_mat->vts_video_attr.mpeg_version )
+    {
+        case 0:
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG1VIDEO;
+            break;
+        case 1:
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG2VIDEO;
+            break;
+        default:
+            hb_log("scan: unknown/reserved MPEG version %d",
+                    ifo->vtsi_mat->vts_video_attr.mpeg_version);
+            title->video_codec       = WORK_DECAVCODECV;
+            title->video_codec_param = AV_CODEC_ID_MPEG2VIDEO;
+            break;
+    }
+
     hb_log("scan: aspect = %d:%d",
            title->container_dar.num, title->container_dar.den);
 


### PR DESCRIPTION
Fixes detection of MPEG-1 in program streams
Assuming the problem in https://github.com/HandBrake/HandBrake/issues/1880 is really mpeg-1 in a VOB file, the first patch in this series should fix scanning of the VOB

The second patch in this series should fix scanning the mpeg-1 DVD.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

Other platforms shouldn't behave differently than Linux, but if you have some mpeg-1 and mpeg-2 PS and TS files you can test this against, it would be helpful.
