### PR TITLE
MacGui: update German localization (housekeeping #1)

### DIFF
--- a/macosx/HandBrakeKit/de.lproj/Localizable.strings
+++ b/macosx/HandBrakeKit/de.lproj/Localizable.strings
@@ -39,7 +39,7 @@
 ", Web Optimized" = ", Web-optimiert";
 
 /* HBStateFormatter -> work pass type format */
-"(subtitle scan)" = "(Untertitelscan)";
+"(subtitle scan)" = "(Untertitelüberprüfung)";
 
 /* Title short description -> video format */
 "%.6g FPS" = "%.6g BpS";
@@ -211,7 +211,7 @@
 "MP4 File" = "MP4-Datei";
 
 /* HBStateFormatter -> pass display name */
-"Muxing…" = "Multiplexen…";
+"Muxing…" = "Multiplexen …";
 
 /* HBFilters -> filter display name */
 "NLMeans" = "NLMeans";
@@ -227,7 +227,7 @@
 "Off" = "Aus";
 
 /* Video description */
-"Options: %@" = "Optionen: %@";
+"Options: %@" = "Einstellungen: %@";
 
 /* HBStateFormatter -> work pass number format */
 "Pass %d %@ of %d, %.2f %%" = "Durchgang %1$d %2$@ von %3$d, %4$.2f %% ";
@@ -266,10 +266,10 @@
 "Same as source (variable)" = "Wie die Quelle (variabel)";
 
 /* HBStateFormatter -> scan pass format */
-"Scanning title %d of %d, preview %d…" = "Titel %1$d von %2$d scannen, Vorschau  %3$d…";
+"Scanning title %d of %d, preview %d…" = "Titel %1$d von %2$d überprüfen, Vorschau  %3$d …";
 
 /* HBStateFormatter -> scan pass format */
-"Scanning title %d of %d…" = "Titel %1$d von %2$d scannen…";
+"Scanning title %d of %d…" = "Titel %1$d von %2$d überprüfen …";
 
 /* HBStateFormatter -> search pass display name */
 "Searching for start point:  %.2f %%" = "Nach Startpunkt suchen: %.2f %%";
@@ -312,7 +312,7 @@
 "VFR" = "VFR";
 
 /* Video description */
-"Video Options:" = "Videooptionen:";
+"Video Options:" = "Videoeinstellungen:";
 
 /* Video description */
 "Video:" = "Video:";

--- a/macosx/de.lproj/AddPreset.strings
+++ b/macosx/de.lproj/AddPreset.strings
@@ -8,7 +8,7 @@
 "75B-xq-Qbe.title" = "Bildgröße:";
 
 /* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "a0j-nw-n23"; */
-"a0j-nw-n23.title" = "Auswahlverhalten…";
+"a0j-nw-n23.title" = "Auswahlverhalten …";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Selection Behavior determines the track(s) and settings used when the preset is selected."; ObjectID = "aez-2b-JXx"; */
 "aez-2b-JXx.ibShadowedToolTip" = "Das Auswahlverhalten bestimmt die Spur(en) und Einstellungen die verwendet werden, wenn die Voreinstellung ausgewählt wird.";
@@ -47,7 +47,7 @@
 "jhj-Et-ncF.title" = "Voreinstellungsname:";
 
 /* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "LPX-Rc-KLa"; */
-"LPX-Rc-KLa.title" = "Verhalten wählen…";
+"LPX-Rc-KLa.title" = "Auswahlverhalten …";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "PictureHeight"; ObjectID = "Mga-dS-8BF"; */
 "Mga-dS-8BF.ibExternalAccessibilityDescription" = "Bildhöhe";
@@ -68,7 +68,7 @@
 "qsA-gt-zdK.title" = "OtherViews";
 
 /* Class = "NSMenuItem"; title = "New Category…"; ObjectID = "Sf8-HP-mhE"; */
-"Sf8-HP-mhE.title" = "Neue Kategorie…";
+"Sf8-HP-mhE.title" = "Neue Kategorie …";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "tQ1-PN-kvh"; */
 "tQ1-PN-kvh.title" = "OtherViews";

--- a/macosx/de.lproj/Audio.strings
+++ b/macosx/de.lproj/Audio.strings
@@ -26,7 +26,7 @@
 "AMA-Ul-v2f.title" = "Alle Spuren hinzufügen";
 
 /* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "aYF-d5-Ya6"; */
-"aYF-d5-Ya6.title" = "Verhalten auswählen…";
+"aYF-d5-Ya6.title" = "Auswahlverhalten …";
 
 /* Class = "NSSliderCell"; ibExternalAccessibilityDescription = "Gain"; ObjectID = "BBQ-FP-aQN"; */
 "BBQ-FP-aQN.ibExternalAccessibilityDescription" = "Verstärkung";
@@ -120,7 +120,7 @@ Werte größer als 1 erhöht weiter die Lautstärke von leisen Stellen. Werte gr
 "sq7-Ux-T6D.title" = "Neu laden";
 
 /* Class = "NSMenuItem"; title = "Selection Behavior…"; ObjectID = "TK6-fY-4Sk"; */
-"TK6-fY-4Sk.title" = "Verhalten wählen…";
+"TK6-fY-4Sk.title" = "Auswahlverhalten …";
 
 /* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Codec"; ObjectID = "tYY-w7-ZIq"; */
 "tYY-w7-ZIq.ibExternalAccessibilityDescription" = "Codec";

--- a/macosx/de.lproj/ChaptersTitles.strings
+++ b/macosx/de.lproj/ChaptersTitles.strings
@@ -17,7 +17,7 @@
 "G9p-Cg-wyC.title" = "1";
 
 /* Class = "NSButtonCell"; title = "Export Chapters…"; ObjectID = "h0O-zg-OF9"; */
-"h0O-zg-OF9.title" = "Kapitel exportieren…";
+"h0O-zg-OF9.title" = "Kapitel exportieren …";
 
 /* Class = "NSTableView"; ibExternalAccessibilityDescription = "Chapter titles"; ObjectID = "InF-gR-Lia"; */
 "InF-gR-Lia.ibExternalAccessibilityDescription" = "Kapiteltitel";
@@ -35,7 +35,7 @@
 "pAo-XM-bvP.title" = "Text Cell";
 
 /* Class = "NSButtonCell"; title = "Import Chapters…"; ObjectID = "PM3-Ue-0kW"; */
-"PM3-Ue-0kW.title" = "Kapitel importieren…";
+"PM3-Ue-0kW.title" = "Kapitel importieren …";
 
 /* Class = "NSTableColumn"; headerCell.title = "Duration"; ObjectID = "QVB-Cw-DJD"; */
 "QVB-Cw-DJD.headerCell.title" = "Dauer";

--- a/macosx/de.lproj/HBFiltersViewController.strings
+++ b/macosx/de.lproj/HBFiltersViewController.strings
@@ -84,7 +84,7 @@ Bob versucht besser Bewegungen zu erhalten, mit kleinen Einbußen in der Auflös
 "Da7-pY-5vu.title" = "Eigene:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Detelecine removes comb artifacts that are the result of telecine, a process for converting film frame rates to television frame rates."; ObjectID = "DER-tS-cLx"; */
-"DER-tS-cLx.ibShadowedToolTip" = "Detelecine entfernt Kammartefakte, Resultat der optischen Abtastung, ein Prozess um Filmbilder in Fernsehbilder umzuwandeln.";
+"DER-tS-cLx.ibShadowedToolTip" = "Detelecine entfernt Kammartefakte, ein Resultat der optischen Abtastung (Telecine), ein Prozess um Bildraten optischer Filme in Fernsehbildraten umzuwandeln.";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Rotate the picture clockwise in 90 degree increments."; ObjectID = "dsH-ZQ-dBs"; */
 "dsH-ZQ-dBs.ibShadowedToolTip" = "Dreht das Bild im Uhrzeigersinn in 90°-Schritten.";

--- a/macosx/de.lproj/HBPictureHUDController.strings
+++ b/macosx/de.lproj/HBPictureHUDController.strings
@@ -11,7 +11,7 @@
 "KrC-nR-rYk.title" = "OtherViews";
 
 /* Class = "NSTextFieldCell"; title = "sec"; ObjectID = "ksF-Ma-hB1"; */
-"ksF-Ma-hB1.title" = "Sek";
+"ksF-Ma-hB1.title" = "Sek.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Show picture settings."; ObjectID = "mV7-hU-tMt"; */
 "mV7-hU-tMt.ibShadowedToolTip" = "Zeige die Bildeinstellungen";

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -8,10 +8,10 @@
 "--:--" = "--:--";
 
 /* Preview -> size info label */
-"(%.0f%% actual size)" = "(%.0f%% aktuelle Größe)";
+"(%.0f%% actual size)" = "(%.0f%% effektive Größe)";
 
 /* Preview -> size info label */
-"(Actual size)" = "(Aktuelle Größe)";
+"(Actual size)" = "(Effektive Größe)";
 
 /* Language selection */
 "(Any)" = "(Beliebig)";
@@ -30,7 +30,7 @@
 "A file already exists at the selected destination." = "Am ausgewählten Ziel existiert schon eine Datei.";
 
 /* Picture HUD -> scale button */
-"Actual Scale" = "Aktuelle Skalierung";
+"Actual Scale" = "Ursprüngliche Skalierung";
 
 /* Queue undo action name */
 "Add Job To Queue" = "Aufgabe zu Warteschlange hinzufügen";
@@ -219,7 +219,7 @@
 
 /* Queue Done Alert -> shut down second button
    Queue Done Alert -> sleep second button */
-"Preferences…" = "Einstellungen…";
+"Preferences…" = "Einstellungen …";
 
 /* Preview -> progress formatter title */
 "preview" = "Vorschau";
@@ -238,7 +238,7 @@
 
 /* Queue done alert message
    Queue notification alert message */
-"Put down that cocktail…" = "Stellen Sie den Cocktail ab…";
+"Put down that cocktail…" = "Stellen Sie den Cocktail ab …";
 
 /* Quit Alert -> first button */
 "Quit" = "Beenden";

--- a/macosx/de.lproj/MainMenu.strings
+++ b/macosx/de.lproj/MainMenu.strings
@@ -2,7 +2,7 @@
 "0te-ai-fgD.title" = "Dienste";
 
 /* Class = "NSMenuItem"; title = "Rename Preset…"; ObjectID = "1GQ-n3-jfY"; */
-"1GQ-n3-jfY.title" = "Voreinstellung umbenennen…";
+"1GQ-n3-jfY.title" = "Voreinstellung umbenennen …";
 
 /* Class = "NSMenuItem"; title = "Video"; ObjectID = "6rE-SM-AGi"; */
 "6rE-SM-AGi.title" = "Video";
@@ -44,7 +44,7 @@
 "1192.title" = "Fenster";
 
 /* Class = "NSMenuItem"; title = "Open Source…"; ObjectID = "1198"; */
-"1198.title" = "Quelle öffnen…";
+"1198.title" = "Quelle öffnen …";
 
 /* Class = "NSMenuItem"; title = "File"; ObjectID = "1200"; */
 "1200.title" = "Ablage";
@@ -65,7 +65,7 @@
 "1433.title" = "Online-Community-Forum";
 
 /* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "1445"; */
-"1445.title" = "Einstellungen…";
+"1445.title" = "Einstellungen …";
 
 /* Class = "NSMenuItem"; title = "Edit"; ObjectID = "1795"; */
 "1795.title" = "Bearbeiten";
@@ -95,7 +95,7 @@
 "1804.title" = "Auswahl anzeigen";
 
 /* Class = "NSMenuItem"; title = "Find…"; ObjectID = "1805"; */
-"1805.title" = "Suchen…";
+"1805.title" = "Suchen …";
 
 /* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "1806"; */
 "1806.title" = "Weitersuchen (vorwärts)";
@@ -113,7 +113,7 @@
 "1811.title" = "Rechtschreibung und Grammatik";
 
 /* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "1812"; */
-"1812.title" = "Rechtschreibung…";
+"1812.title" = "Rechtschreibung …";
 
 /* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "1813"; */
 "1813.title" = "Rechtschreibung prüfen";
@@ -158,7 +158,7 @@
 "1950.title" = "Offizielle Voreinstellungen zurücksetzen";
 
 /* Class = "NSMenuItem"; title = "New Preset…"; ObjectID = "1955"; */
-"1955.title" = "Neue Voreinstellung sichern…";
+"1955.title" = "Neue Voreinstellung sichern …";
 
 /* Class = "NSMenuItem"; title = "Online Documentation"; ObjectID = "1985"; */
 "1985.title" = "Online-Dokumentation";
@@ -188,22 +188,22 @@
 "2508.title" = "Schließen";
 
 /* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "4964"; */
-"4964.title" = "Auf Updates prüfen…";
+"4964.title" = "Auf Updates prüfen …";
 
 /* Class = "NSMenuItem"; title = "Preview Window"; ObjectID = "5157"; */
 "5157.title" = "Vorschau";
 
 /* Class = "NSMenuItem"; title = "Export…"; ObjectID = "5188"; */
-"5188.title" = "Exportieren…";
+"5188.title" = "Exportieren …";
 
 /* Class = "NSMenuItem"; title = "Import…"; ObjectID = "5192"; */
-"5192.title" = "Importieren…";
+"5192.title" = "Importieren …";
 
 /* Class = "NSMenuItem"; title = "Show All"; ObjectID = "5280"; */
 "5280.title" = "Alle einblenden";
 
 /* Class = "NSMenuItem"; title = "Add Titles To Queue…"; ObjectID = "5897"; */
-"5897.title" = "Titel zur Warteschlange hinzufügen…";
+"5897.title" = "Titel zur Warteschlange hinzufügen …";
 
 /* Class = "NSMenuItem"; title = "Audio"; ObjectID = "brQ-mu-8JM"; */
 "brQ-mu-8JM.title" = "Audio";
@@ -230,7 +230,7 @@
 "Jef-U4-eQT.title" = "Bild";
 
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "KKV-n0-Fmr"; */
-"KKV-n0-Fmr.title" = "Werkzeugleiste anpassen…";
+"KKV-n0-Fmr.title" = "Werkzeugleiste anpassen …";
 
 /* Class = "NSMenuItem"; title = "Chapters"; ObjectID = "lCU-PH-gal"; */
 "lCU-PH-gal.title" = "Kapitel";

--- a/macosx/de.lproj/MainWindow.strings
+++ b/macosx/de.lproj/MainWindow.strings
@@ -2,10 +2,10 @@
 "0UB-bG-kwS.label" = "Filter";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Save New Preset…"; ObjectID = "2vD-zN-YMe"; */
-"2vD-zN-YMe.ibShadowedToolTip" = "Neue Voreinstellung speichern…";
+"2vD-zN-YMe.ibShadowedToolTip" = "Neue Voreinstellung speichern …";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Title to scan."; ObjectID = "3w9-Iu-3u2"; */
-"3w9-Iu-3u2.ibShadowedToolTip" = "Titel zum durchsuchen";
+"3w9-Iu-3u2.ibShadowedToolTip" = "Titel zum überprüfen.";
 
 /* Class = "NSTextFieldCell"; title = "0"; ObjectID = "6E4-AG-PEh"; */
 "6E4-AG-PEh.title" = "0";
@@ -32,7 +32,7 @@
 "38K-hd-P5J.toolTip" = "Alle Titel zur Warteschlange hinzufügen";
 
 /* Class = "NSMenuItem"; title = "Add Titles To Queue…"; ObjectID = "046-kc-MnL"; */
-"046-kc-MnL.title" = "Titel zur Warteschlange hinzufügen…";
+"046-kc-MnL.title" = "Titel zur Warteschlange hinzufügen …";
 
 /* Class = "NSTabViewItem"; label = "Audio"; ObjectID = "1475"; */
 "1475.label" = "Audio";
@@ -112,7 +112,7 @@ Blu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlic
 "4915.title" = "00:00:00";
 
 /* Class = "NSButtonCell"; title = "Browse…"; ObjectID = "4920"; */
-"4920.title" = "Wählen…";
+"4920.title" = "Wählen …";
 
 /* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "4923"; */
 "4923.title" = "Voreinstellung:";
@@ -199,7 +199,7 @@ Blu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlic
 "dK4-jt-v4K.toolTip" = "Vorschau zeigen";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Scan only the specified title instead of all titles."; ObjectID = "DN4-48-aOI"; */
-"DN4-48-aOI.ibShadowedToolTip" = "Nur den ausgewählten statt allen Titeln durchsuchen.";
+"DN4-48-aOI.ibShadowedToolTip" = "Nur den ausgewählten statt alle Titel überprüfen.";
 
 /* Class = "NSToolbarItem"; label = "Add To Queue"; ObjectID = "DZZ-Fe-wjw"; */
 "DZZ-Fe-wjw.label" = "Zur Warteschlange hinzufügen";
@@ -229,7 +229,7 @@ Blu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlic
 "INL-y9-Gwp.title" = "Alle Titel zur Warteschlange hinzufügen";
 
 /* Class = "NSButtonCell"; title = "Save New Preset…"; ObjectID = "IOU-3L-nvB"; */
-"IOU-3L-nvB.title" = "Neue Voreinstellung speichern…";
+"IOU-3L-nvB.title" = "Neue Voreinstellung speichern …";
 
 /* Class = "NSTextFieldCell"; title = "Range:"; ObjectID = "IxV-PW-oYh"; */
 "IxV-PW-oYh.title" = "Bereich:";

--- a/macosx/de.lproj/Preferences.strings
+++ b/macosx/de.lproj/Preferences.strings
@@ -35,7 +35,7 @@
 "351.title" = "Protokoll:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Number of picture previews to scan. Higher values may increase automatic cropping accuracy at the expense of title scan time."; ObjectID = "352"; */
-"352.ibShadowedToolTip" = "Anzahl der zu durchsuchenden Vorschaubilder. Höhere Werte verbessern die Genauigkeit der automatischen Bildbeschneidung auf Kosten einer längeren Scanzeit.";
+"352.ibShadowedToolTip" = "Anzahl der zu überprüfenden Vorschaubilder. Höhere Werte verbessern die Genauigkeit der automatischen Bildbeschneidung auf Kosten einer längeren Scanzeit.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "354"; */
 "354.title" = "OtherViews";
@@ -119,7 +119,7 @@
 "449.title" = "Keine";
 
 /* Class = "NSButtonCell"; title = "Browse…"; ObjectID = "451"; */
-"451.title" = "Auswählen…";
+"451.title" = "Auswählen …";
 
 /* Class = "NSButtonCell"; title = "Play System Alert Sound"; ObjectID = "458"; */
 "458.title" = "Systemton abspielen";
@@ -182,7 +182,7 @@
 "519.title" = "60";
 
 /* Class = "NSTextFieldCell"; title = "Title Scan:"; ObjectID = "c0L-TU-WML"; */
-"c0L-TU-WML.title" = "Titelscan:";
+"c0L-TU-WML.title" = "Titelüberprüfung:";
 
 /* Class = "NSTextFieldCell"; title = "x264 Encoder:"; ObjectID = "cqp-xU-GOe"; */
 "cqp-xU-GOe.title" = "x264-Enkoder:";

--- a/macosx/de.lproj/Presets.strings
+++ b/macosx/de.lproj/Presets.strings
@@ -26,7 +26,7 @@
 "LQk-kD-5sj.title" = "Voreinstellungsmenüoptionen";
 
 /* Class = "NSMenuItem"; title = "Import…"; ObjectID = "LUl-ag-Iu6"; */
-"LUl-ag-Iu6.title" = "Importieren…";
+"LUl-ag-Iu6.title" = "Importieren …";
 
 /* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "oBC-Nh-TwB"; */
 "oBC-Nh-TwB.title" = "Table View Cell";
@@ -43,11 +43,11 @@
 Überschreibt alle Enkodiereinstellungen. Die Einstellungen können noch feinjustiert werden nachdem eine Voreinstellung ausgewählt wurde.";
 
 /* Class = "NSMenuItem"; title = "Export…"; ObjectID = "xEQ-Un-J0n"; */
-"xEQ-Un-J0n.title" = "Exportieren…";
+"xEQ-Un-J0n.title" = "Exportieren …";
 
 /* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Additional Options"; ObjectID = "Ybq-Zt-sta"; */
-"Ybq-Zt-sta.ibExternalAccessibilityDescription" = "Zusätzliche Optionen";
+"Ybq-Zt-sta.ibExternalAccessibilityDescription" = "Zusätzliche Einstellungen";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Show additional options."; ObjectID = "Ybq-Zt-sta"; */
-"Ybq-Zt-sta.ibShadowedToolTip" = "Zeige zusätzliche Optionen.";
+"Ybq-Zt-sta.ibShadowedToolTip" = "Zeige zusätzliche Einstellungen.";
 

--- a/macosx/de.lproj/Subtitles.strings
+++ b/macosx/de.lproj/Subtitles.strings
@@ -101,10 +101,10 @@
 "ooy-Sh-Edm.title" = "Check";
 
 /* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "oxg-bs-1si"; */
-"oxg-bs-1si.title" = "Auswahlverhalten…";
+"oxg-bs-1si.title" = "Auswahlverhalten …";
 
 /* Class = "NSMenuItem"; title = "Selection Behavior…"; ObjectID = "pwm-PV-1x4"; */
-"pwm-PV-1x4.title" = "Verhalten wählen…";
+"pwm-PV-1x4.title" = "Auswahlverhalten …";
 
 /* Class = "NSTextFieldCell"; title = "Text"; ObjectID = "QRj-KI-a03"; */
 "QRj-KI-a03.title" = "Text";

--- a/macosx/de.lproj/SubtitlesDefaults.strings
+++ b/macosx/de.lproj/SubtitlesDefaults.strings
@@ -63,10 +63,10 @@ Es kann nur jeweils ein Untertitel eingebrannt werden.";
 "mvw-Hg-JFM.title" = "Keine";
 
 /* Class = "NSTextFieldCell"; title = "Only one subtitles burn-in option will be applied, starting with the first (top)."; ObjectID = "N4s-K9-RwM"; */
-"N4s-K9-RwM.title" = "Nur eine Untertitel-Einbrennoption wird angewendet, angefangen mit der obersten.";
+"N4s-K9-RwM.title" = "Nur eine Untertitel-Einbrenneinstellung wird angewendet, angefangen mit der ersten (obersten).";
 
 /* Class = "NSTextFieldCell"; title = "Options:"; ObjectID = "NJl-q3-zXL"; */
-"NJl-q3-zXL.title" = "Optionen:";
+"NJl-q3-zXL.title" = "Einstellungen:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Track Selection Behavior.\n\nNone will not select any audio tracks by default.\n\nFirst Matching Selected Languages adds the first audio track matching each of the selected languages present in the source.\n\nAll Matching Selected Languages adds all audio tracks matching each of the selected languages present in the source."; ObjectID = "oiD-QI-wly"; */
 "oiD-QI-wly.ibShadowedToolTip" = "Verhalten der Spurauswahl.

--- a/macosx/de.lproj/Video.strings
+++ b/macosx/de.lproj/Video.strings
@@ -8,7 +8,7 @@
 "6Dd-IP-Pwt.title" = "Konstante Bildfrequenz";
 
 /* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "7bP-tR-sAX"; */
-"7bP-tR-sAX.title" = "Enkoderoptionen:";
+"7bP-tR-sAX.title" = "Enkodereinstellungen:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "7CG-ga-88H"; */
 "7CG-ga-88H.title" = "OtherViews";
@@ -77,7 +77,7 @@ x264 ist verlustfrei bei RF 0.";
 "Jj0-Qw-HF8.title" = "OtherViews";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Additional video encoder options. For advanced use only.\n\nSyntax: option-1=foo:opt2=bar"; ObjectID = "mL3-yC-hUj"; */
-"mL3-yC-hUj.ibShadowedToolTip" = "Zusätzliche Videoenkodieroptionen. Für erfahrene Anwender.
+"mL3-yC-hUj.ibShadowedToolTip" = "Zusätzliche Videoenkodiereinstellungen. Für erfahrene Anwender.
 
 Syntax: option-1=foo:opt2=bar";
 
@@ -88,7 +88,7 @@ Syntax: option-1=foo:opt2=bar";
 "nPA-nO-Eik.title" = "Enkodierung in 2 Durchgängen";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Additional video encoder options. For advanced use only.\n\nSyntax: option-1=foo:opt2=bar,baz"; ObjectID = "oJk-ur-wgc"; */
-"oJk-ur-wgc.ibShadowedToolTip" = "Zusätzliche Videoenkodieroptionen. Für erfahrene Anwender.
+"oJk-ur-wgc.ibShadowedToolTip" = "Zusätzliche Videoenkodiereinstellungen. Für erfahrene Anwender.
 
 Syntax: option-1=foo:opt2=bar,baz";
 
@@ -120,10 +120,10 @@ Syntax: option-1=foo:opt2=bar,baz";
 "vSc-VB-NEv.title" = "Ersten Durchgang beschleunigen";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Displays all internal video encoder options."; ObjectID = "wk1-2U-z4i"; */
-"wk1-2U-z4i.ibShadowedToolTip" = "Zeigt alle internen Videoenkodieroptionen.";
+"wk1-2U-z4i.ibShadowedToolTip" = "Zeigt alle internen Videoenkodiereinstellungen.";
 
 /* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "XIe-8Z-tIF"; */
-"XIe-8Z-tIF.title" = "Enkoderoptionen:";
+"XIe-8Z-tIF.title" = "Enkodereinstellungen:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video encoder. Determines video type and settings used during encoding."; ObjectID = "xwK-Yu-a1e"; */
 "xwK-Yu-a1e.ibShadowedToolTip" = "Videoenkoder. Legt den Videotyp und die Einstellungen während des Enkodierens fest.";
@@ -138,7 +138,7 @@ Syntax: option-1=foo:opt2=bar,baz";
 "zSD-4Y-1cI.title" = "Abstimmung:";
 
 /* Class = "NSTextFieldCell"; title = "Additional Options:"; ObjectID = "ZSm-03-g0B"; */
-"ZSm-03-g0B.title" = "Zusätzliche Optionen:";
+"ZSm-03-g0B.title" = "Zusätzliche Einstellungen:";
 
 /* Class = "NSButtonCell"; title = "Variable Framerate"; ObjectID = "zZo-75-1WG"; */
 "zZo-75-1WG.title" = "Variable Bildfrequenz";


### PR DESCRIPTION
This is the housekeeping #1 2019 set of German macOS localization changes from Transifex. This patch includes some community feedbacks from my german Mac user forum. One user pointed out, there is a rule in german orthography to put a space between a word and the ellipsis ... which is also how Apple is doing on macOS.
https://www.duden.de/sprachwissen/rechtschreibregeln/auslassungspunkte
I fixed this. I also fixed one mistranslation, improved some wordings and better aligned the strings between Mac and Windows.
It does not include any new string for e.g. the recent changes to the subtitles, just fixes and corrections.