### PR TITLE
Change behavior of --all-audio option

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -3608,7 +3608,7 @@ static hb_dict_t * PreparePreset(const char *preset_name)
     }
 
     // Audio overrides
-    if (atracks == NULL && (
+    if (atracks == NULL && audio_all != 1 && (
         acodecs                   != NULL ||
         abitrates                 != NULL ||
         arates                    != NULL ||
@@ -3623,6 +3623,8 @@ static hb_dict_t * PreparePreset(const char *preset_name)
     {
         // No explicit audio tracks, but track settings modified.
         // Modify the presets audio settings.
+        //
+        // Note that --all-audio is explicitely asking for all tracks
         hb_value_array_t *list;
         list = hb_dict_get(preset, "AudioList");
         if (list == NULL)
@@ -4564,11 +4566,12 @@ PrepareJob(hb_handle_t *h, hb_title_t *title, hb_dict_t *preset_dict)
     hb_dict_t *audio_dict;
 
     /* Grab audio tracks */
-    if (atracks != NULL)
+    if (atracks != NULL || audio_all == 1)
     {
         int track_count;
         int ii;
-        if (atracks[0] != NULL && strcasecmp("none", atracks[0]))
+        if (atracks != NULL && atracks[0] != NULL &&
+            strcasecmp("none", atracks[0]))
         {
             // First "track" is not "none", add tracks
             for (ii = 0; atracks[ii] != NULL; ii++)


### PR DESCRIPTION
**Description of Change:**
Fixes https://github.com/HandBrake/HandBrake/issues/1898

The first patch addresses a bug that causes the failure to encode that is seen in the above issue. But this is only part of the problem.

The second commit addresses unintuitive behavior of --all-audio when additional audio command line override values are given.

Currently the overrides are being added to the preset's audio encoder list which results in additional tracks in the output that the user did not expect.  So instead, treat --all-audio as an implicit list of all tracks and apply overrides to the job after the preset has been processed.


**Test on:**
- [x] CLI
