### PR TITLE
contrib: Update to libsamplerate 0.1.9-49-ga2eb281.

### DIFF
--- a/contrib/libsamplerate/module.defs
+++ b/contrib/libsamplerate/module.defs
@@ -1,12 +1,12 @@
 $(eval $(call import.MODULE.defs,LIBSAMPLERATE,libsamplerate))
 $(eval $(call import.CONTRIB.defs,LIBSAMPLERATE))
 
-# libsamplerate 0.1.9-31-g292789a
-LIBSAMPLERATE.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68.tar.gz
-LIBSAMPLERATE.FETCH.url   += https://github.com/erikd/libsamplerate/archive/02ebb9f0fc4d67cb3f1ac4c2283664340510fd68.tar.gz
-LIBSAMPLERATE.FETCH.sha256 = 5fc80ce7cd961f09ac4274fe57e4cd563209d5b1c549d8ff2d82b7091835310c
-LIBSAMPLERATE.EXTRACT.basename = libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68.tar.gz
-LIBSAMPLERATE.EXTRACT.tarbase  = libsamplerate-02ebb9f0fc4d67cb3f1ac4c2283664340510fd68
+# libsamplerate 0.1.9-49-ga2eb281
+LIBSAMPLERATE.FETCH.url    = https://download.handbrake.fr/handbrake/contrib/libsamplerate-a2eb2814150a4ada0b49ea3cc5e51170572fc606.tar.gz
+LIBSAMPLERATE.FETCH.url   += https://github.com/erikd/libsamplerate/archive/a2eb2814150a4ada0b49ea3cc5e51170572fc606.tar.gz
+LIBSAMPLERATE.FETCH.sha256 = b8228e8bdbd754e95146745f85e37a25fb43d626cca7f785f3fd8e0a1c1f5f22
+LIBSAMPLERATE.EXTRACT.basename = libsamplerate-a2eb2814150a4ada0b49ea3cc5e51170572fc606.tar.gz
+LIBSAMPLERATE.EXTRACT.tarbase  = libsamplerate-a2eb2814150a4ada0b49ea3cc5e51170572fc606
 
 LIBSAMPLERATE.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;
 


### PR DESCRIPTION
Please upload tarball as `libsamplerate-a2eb2814150a4ada0b49ea3cc5e51170572fc606.tar.gz` and verify checksum.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux