### PR TITLE
LinGui: make QSV encoding actually work

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -35,7 +35,6 @@ FFMPEG.CONFIGURE.extra = \
     --disable-muxers \
     --disable-network \
     --disable-hwaccels \
-    --disable-vaapi \
     --disable-vdpau \
     --disable-encoders \
     --enable-libmp3lame \
@@ -58,6 +57,12 @@ FFMPEG.CONFIGURE.extra = \
     --disable-decoder=*_crystalhd \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"
+
+ifeq (1-linux,$(FEATURE.qsv)-$(BUILD.system))
+FFMPEG.CONFIGURE.extra += --enable-vaapi
+else
+FFMPEG.CONFIGURE.extra += --disable-vaapi
+endif
 
 ifeq (1,$(FEATURE.fdk_aac))
 FFMPEG.CONFIGURE.extra += \

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -59,9 +59,10 @@ FFMPEG.CONFIGURE.extra = \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"
 
 ifeq (1-linux,$(FEATURE.qsv)-$(BUILD.system))
-FFMPEG.CONFIGURE.extra += --enable-vaapi
+    FFMPEG.CONFIGURE.extra += --enable-vaapi
+    FFMPEG.CONFIGURE.extra += --disable-xlib
 else
-FFMPEG.CONFIGURE.extra += --disable-vaapi
+    FFMPEG.CONFIGURE.extra += --disable-vaapi
 endif
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -212,7 +212,7 @@ if test "x$use_x265" = "xyes" ; then
 fi
 
 if test "x$use_qsv" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lmfx"
+    HB_LIBS="$HB_LIBS -lmfx -lva -lva-drm"
 fi
 if test "x$PYTHON" != "x" ; then
     HB_PYTHON="$PYTHON"

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -70,6 +70,7 @@
 #include <linux/cdrom.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
+#include <libdrm/drm.h>
 #elif defined( SYS_OPENBSD )
 #include <sys/dvdio.h>
 #include <fcntl.h>
@@ -1505,3 +1506,150 @@ char * hb_strndup(const char * src, size_t len)
     return strndup(src, len);
 #endif
 }
+
+#ifdef USE_QSV
+#ifdef SYS_LINUX
+
+#define MAX_NODES             16
+#define DRI_RENDER_NODE_START 128
+#define DRI_RENDER_NODE_LAST  (DRI_RENDER_NODE_START + MAX_NODES - 1)
+#define DRI_CARD_NODE_START   0
+#define DRI_CARD_NODE_LAST    (DRI_CARD_NODE_START + MAX_NODES - 1)
+
+const char* DRI_PATH = "/dev/dri/";
+const char* DRI_NODE_RENDER = "renderD";
+const char* DRI_NODE_CARD = "card";
+
+static int try_adapter(const char * name, const char * dir,
+                const char * prefix, int node_start, int node_last)
+{
+    int             node;
+    int             len        = strlen(name);
+    char          * driverName = malloc(len + 1);
+    drm_version_t   version = {};
+
+    version.name_len = len + 1;
+    version.name     = driverName;
+    for (node = node_start; node <= node_last; node++)
+    {
+        char * adapter = hb_strdup_printf("%s%s%d", dir, prefix, node);
+        int    fd      = open(adapter, O_RDWR);
+
+        free(adapter);
+        if (fd < 0)
+        {
+            continue;
+        }
+
+        if (!ioctl(fd, DRM_IOCTL_VERSION, &version) &&
+            version.name_len == len && !strncmp(driverName, name, len))
+        {
+            free(driverName);
+            return fd;
+        }
+        close(fd);
+    }
+
+    free(driverName);
+    return -1;
+}
+
+static int open_adapter(const char * name)
+{
+    int fd = try_adapter(name, DRI_PATH, DRI_NODE_RENDER,
+                         DRI_RENDER_NODE_START, DRI_RENDER_NODE_LAST);
+    if (fd < 0)
+    {
+        fd = try_adapter(name, DRI_PATH, DRI_NODE_CARD,
+                         DRI_CARD_NODE_START, DRI_CARD_NODE_LAST);
+    }
+    return fd;
+}
+
+hb_display_t * hb_display_init(const char * driver_name,
+                               const char * interface_name)
+{
+    hb_display_t * hbDisplay = calloc(sizeof(hb_display_t), 1);
+
+    hbDisplay->vaDisplay = NULL;
+    hbDisplay->vaFd      = open_adapter(driver_name);
+    if (hbDisplay->vaFd < 0)
+    {
+        hb_deep_log( 3, "hb_va_display_init: no display found" );
+        free(hbDisplay);
+        return NULL;
+    }
+
+    setenv("LIBVA_DRIVER_NAME", interface_name, 1);
+    hbDisplay->vaDisplay = vaGetDisplayDRM(hbDisplay->vaFd);
+    if (hbDisplay->vaDisplay == NULL)
+    {
+        close(hbDisplay->vaFd);
+        free(hbDisplay);
+        return NULL;
+    }
+
+    int major = 0, minor = 0;
+    VAStatus vaRes = vaInitialize(hbDisplay->vaDisplay, &major, &minor);
+    if (vaRes != VA_STATUS_SUCCESS)
+    {
+        vaTerminate(hbDisplay->vaDisplay);
+        close(hbDisplay->vaFd);
+        free(hbDisplay);
+        return NULL;
+    }
+    hbDisplay->handle = hbDisplay->vaDisplay;
+    hbDisplay->mfxType = MFX_HANDLE_VA_DISPLAY;
+
+    return hbDisplay;
+}
+
+void hb_display_close(hb_display_t ** _d)
+{
+    hb_display_t * hbDisplay = *_d;
+
+    if (hbDisplay == NULL)
+    {
+        return;
+    }
+    if (hbDisplay->vaDisplay)
+    {
+        vaTerminate(hbDisplay->vaDisplay);
+    }
+    if (hbDisplay->vaFd >= 0)
+    {
+        close(hbDisplay->vaFd);
+    }
+    free(hbDisplay);
+
+    *_d = NULL;
+}
+
+#else // !SYS_LINUX
+
+hb_display_t * hb_display_init(const char * driver_name,
+                               const char * interface_name)
+{
+    return NULL;
+}
+
+void hb_display_close(hb_display_t ** _d)
+{
+    (void)_d;
+}
+
+#endif // SYS_LINUX
+#else // !USE_QSV
+
+hb_display_t * hb_display_init(const char * driver_name,
+                               const char * interface_name)
+{
+    return NULL;
+}
+
+void hb_display_close(hb_display_t ** _d)
+{
+    (void)_d;
+}
+
+#endif // USE_QSV

--- a/libhb/ports.h
+++ b/libhb/ports.h
@@ -24,6 +24,36 @@
 #define IS_DIR_SEP(c) (c == '/')
 #endif
 
+#ifdef USE_QSV
+#include "mfx/mfxstructures.h"
+#ifdef SYS_LINUX
+#include <va/va_drm.h>
+#endif
+#endif
+
+/************************************************************************
+ * HW accel display
+ ***********************************************************************/
+#ifdef SYS_LINUX
+extern const char* DRM_INTEL_DRIVER_NAME;
+#endif // SYS_LINUX
+
+typedef struct
+{
+    void          * handle;
+#ifdef USE_QSV
+    mfxHandleType   mfxType;
+
+#ifdef SYS_LINUX
+    int             vaFd;
+    VADisplay       vaDisplay;
+#endif // SYS_LINUX
+#endif
+} hb_display_t;
+
+hb_display_t * hb_display_init(const char * driver_name,
+                               const char * interface_name);
+void           hb_display_close(hb_display_t ** _d);
 
 /************************************************************************
  * CPU info utilities

--- a/libhb/qsv_common.h
+++ b/libhb/qsv_common.h
@@ -68,6 +68,7 @@ typedef struct hb_qsv_info_s
 } hb_qsv_info_t;
 
 /* Intel Quick Sync Video utilities */
+hb_display_t * hb_qsv_display_init(void);
 int            hb_qsv_video_encoder_is_enabled(int encoder);
 int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -60,7 +60,10 @@
         {
             "name": "handbrake",
             "no-autogen": true,
-            "config-opts": ["--flatpak", "--disable-gtk-update-checks"],
+            "config-opts": [
+                "--flatpak",
+                "--disable-gtk-update-checks"
+            ],
             "builddir": true,
             "post-install": ["install -d /app/extensions"],
             "sources": [

--- a/pkg/linux/flatpak/fr.handbrake.plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.plugin.IntelMediaSDK.json
@@ -1,0 +1,106 @@
+{
+    "app-id": "fr.handbrake.plugin.IntelMediaSDK",
+    "branch": "1",
+    "runtime": "fr.handbrake.ghb",
+    "runtime-version": "development",
+    "sdk": "org.freedesktop.Sdk//18.08",
+    "build-extension": true,
+    "separate-locales": false,
+    "appstream-compose": false,
+    "modules": [
+        {
+            "name": "intel-gmmlib",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/intel/gmmlib/archive/intel-gmmlib-18.4.1.tar.gz",
+                    "sha256": "7970a8ae4e16efb98f38fbbc0346eea03227fc4462a9bd8e8077277cc3430a84"
+                }
+            ],
+            "buildsystem": "cmake",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "make-args": [
+                    "VERBOSE=1"
+                ],
+                "make-install-args": [
+                    "VERBOSE=1"
+                ]
+            }
+        },
+        {
+            "name": "libva",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/intel/libva/releases/download/2.4.0/libva-2.4.0.tar.bz2",
+                    "sha256": "99263056c21593a26f2ece812aee6fe60142b49e6cd46cb33c8dddf18fc19391"
+                }
+            ],
+            "no-autogen": true,
+            "config-opts": ["--with-drivers-path=/app/extensions/IntelMediaSDK/lib/dri"],
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK"
+            }
+        },
+        {
+            "name": "libva-utils",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/intel/libva-utils/releases/download/2.4.0/libva-utils-2.4.0.tar.bz2",
+                    "sha256": "5b7d1954b40fcb2c0544be20125c71a0852049715ab85a3e8aba60434a40c6b3"
+                }
+            ],
+            "no-autogen": true,
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+            }
+        },
+        {
+            "name": "intel-media-driver",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/VCDP/media-driver/archive/intel-media-kbl-19.1.0.tar.gz",
+                    "sha256": "d494f8cf395e9996beda9846afdc736998de6978481aab0e483d818a0c836d66"
+                }
+            ],
+            "buildsystem": "cmake",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+            }
+        },
+        {
+            "name": "mediasdk",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/Intel-Media-SDK/MediaSDK/archive/MSS-KBL-2019-R1.tar.gz",
+                    "sha256": "ec3d23a2ca4f18144b52d2257b3050ba0f9a98f2688418dd40e8335a215be765"
+                }
+            ],
+            "buildsystem": "cmake",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DMFX_ENABLE_SW_FALLBACK=OFF"
+            ],
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+            }
+        }
+    ]
+}
+

--- a/pkg/linux/module.defs
+++ b/pkg/linux/module.defs
@@ -18,28 +18,9 @@ else ifeq ($(HB.repo.branch),)
 else
     PKG.rpm.hb.version = $(tag).$(HB.repo.shorthash).$(HB.repo.branch)
 endif
-ifeq ($(HB.repo.type),release)
-    PKG.flatpak.branch = stable
-else
-    PKG.flatpak.branch = development
-endif
 
 ifneq ($(PGP_ID),)
     PGPSIGN = --gpg-sign=$(PGP_ID)
-endif
-
-ifeq (1,$(FEATURE.qsv))
-    FPQSV = -q
-endif
-
-ifneq ($(FP_RUNTIME),)
-    FPRUNTIME = -r $(FP_RUNTIME)
-endif
-
-ifneq ($(HB_URL),)
-ifneq ($(HB_SHA256),)
-	FLATHUB_MANIFEST = $(PKG.gui.flathub.manifest) $(PKG.cli.flathub.manifest)
-endif
 endif
 
 ###############################################################################
@@ -55,7 +36,6 @@ PKG.rpm.src.tar.bz2 = $(STAGE.out.src.abs/)rpm/$(PKG.rpm.basename).tar.bz2
 STAGE.out.rpm.src/ = $(STAGE.out.src.abs/)rpm/
 
 PKG.debian  = $(PKG.in.abs/)linux/debian
-PKG.flatpak/  = $(PKG.in.abs/)linux/flatpak/
 PKG.cli.deb = $(PKG.out.abs/)$(HB.name)-$(HB.debversion)-Ubuntu_CLI_$(BUILD.machine).deb
 PKG.gui.deb = $(PKG.out.abs/)$(HB.name)-$(HB.debversion)-Ubuntu_GUI_$(BUILD.machine).deb
 PKG.deb.basename = $(HB.name.lower)-$(HB.debversion)
@@ -69,18 +49,6 @@ PKG.gui.tmp.deb = $(PKG.out.abs/)$(HB.name.lower)-gtk_$(HB.debversion)_$(PKG.deb
 PKG.native.rpm.stamp = $(RPM.out/).rpm.stamp
 PKG.rpm.stamp = $(PKG.out.abs/).rpm.stamp
 
-PKG.out.flatpak/ = $(PKG.out.abs/)flatpak/
-STAGE.out.flatpak/ = $(STAGE.out.abs/)flatpak/
-PKG.gui.flathub.manifest = $(PKG.out.flatpak/)fr.handbrake.ghb.json
-PKG.cli.flathub.manifest = $(PKG.out.flatpak/)/fr.handbrake.HandBrakeCLI.json
-PKG.gui.manifest.flatpak = $(PKG.flatpak/)fr.handbrake.ghb.json
-PKG.cli.manifest.flatpak = $(PKG.flatpak/)fr.handbrake.HandBrakeCLI.json
-PKG.gui.build.flatpak = $(STAGE.out.flatpak/)$(HB.name)-$(HB.version)-$(BUILD.machine).build
-PKG.cli.build.flatpak = $(STAGE.out.flatpak/)$(HB.name)CLI-$(HB.version)-$(BUILD.machine).build
-PKG.repo.flatpak = $(PKG.out.flatpak/)$(HB.name)-Flatpak.repo
-PKG.cli.flatpak = $(PKG.out.flatpak/)$(HB.name)CLI-$(HB.version)-$(BUILD.machine).flatpak
-PKG.gui.flatpak = $(PKG.out.flatpak/)$(HB.name)-$(HB.version)-$(BUILD.machine).flatpak
-
 PKG.gui.native.rpm = $(RPM.out/)RPMS/$(PKG.rpm.machine)/$(HB.name.lower)-gui-$(PKG.rpm.hb.version)-$(PKG.release)$(PKG.rpm.dist).$(PKG.rpm.machine).rpm
 PKG.cli.native.rpm = $(RPM.out/)RPMS/$(PKG.rpm.machine)/$(HB.name.lower)-cli-$(PKG.rpm.hb.version)-$(PKG.release)$(PKG.rpm.dist).$(PKG.rpm.machine).rpm
 
@@ -90,6 +58,66 @@ RPM.out  = $(STAGE.out.abs/)rpm
 RPM.out/ = $(RPM.out)/
 RPMROOT.out  = $(STAGE.out.abs/)rpmroot
 RPMROOT.out/ = $(RPMROOT.out)/
+
+###############################################################################
+# Flatpak
+###############################################################################
+
+ifeq (1,$(FEATURE.qsv))
+    FPQSV = -q
+endif
+
+ifneq ($(FP_RUNTIME),)
+    FPRUNTIME = -r $(FP_RUNTIME)
+endif
+
+ifeq ($(HB.repo.type),release)
+    PKG.branch.flatpak = stable
+else
+    PKG.branch.flatpak = development
+endif
+PKG.plugin.version.flatpak = 1
+
+PKG.flatpak/  = $(PKG.in.abs/)linux/flatpak/
+
+PKG.out.flatpak/ = $(PKG.out.abs/)flatpak/
+STAGE.out.flatpak/ = $(STAGE.out.abs/)flatpak/
+
+PKG.repo.flatpak = $(PKG.out.flatpak/)$(HB.name)-Flatpak.repo
+
+PKG.gui.name.flatpak = fr.handbrake.ghb
+PKG.gui.manifest.flathub = $(PKG.out.flatpak/)$(PKG.gui.name.flatpak).json
+PKG.gui.template.flatpak = $(PKG.flatpak/)$(PKG.gui.name.flatpak).json
+PKG.gui.manifest.flatpak = $(STAGE.out.flatpak/)$(PKG.gui.name.flatpak).json
+PKG.gui.build.flatpak = $(STAGE.out.flatpak/)$(PKG.gui.name.flatpak)-$(HB.version)-$(BUILD.machine).build
+PKG.gui.flatpak = $(PKG.out.flatpak/)$(PKG.gui.name.flatpak)-$(HB.version)-$(BUILD.machine).flatpak
+
+PKG.cli.name.flatpak = fr.handbrake.HandBrakeCLI
+PKG.cli.manifest.flathub = $(PKG.out.flatpak/)$(PKG.cli.name.flatpak).json
+PKG.cli.template.flatpak = $(PKG.flatpak/)$(PKG.cli.name.flatpak).json
+PKG.cli.manifest.flatpak = $(STAGE.out.flatpak/)$(PKG.cli.name.flatpak).json
+PKG.cli.build.flatpak = $(STAGE.out.flatpak/)$(PKG.cli.name.flatpak)-$(HB.version)-$(BUILD.machine).build
+PKG.cli.flatpak = $(PKG.out.flatpak/)$(PKG.cli.name.flatpak)-$(HB.version)-$(BUILD.machine).flatpak
+
+PKG.mediasdk.name.flatpak = fr.handbrake.plugin.IntelMediaSDK
+PKG.mediasdk.manifest.flathub = $(PKG.out.flatpak/)$(PKG.mediasdk.name.flatpak).json
+PKG.mediasdk.template.flatpak = $(PKG.flatpak/)$(PKG.mediasdk.name.flatpak).json
+PKG.mediasdk.manifest.flatpak = $(STAGE.out.flatpak/)$(PKG.mediasdk.name.flatpak).json
+PKG.mediasdk.build.flatpak = $(STAGE.out.flatpak/)$(PKG.mediasdk.name.flatpak)-$(HB.version)-$(BUILD.machine).build
+PKG.mediasdk.flatpak = $(PKG.out.flatpak/)$(PKG.mediasdk.name.flatpak)-$(HB.version)-$(BUILD.machine).flatpak
+
+PKG.all.flatpak = $(PKG.gui.flatpak) $(PKG.cli.flatpak)
+ifeq (1,$(FEATURE.qsv))
+    PKG.all.flatpak += $(PKG.mediasdk.flatpak)
+endif
+
+PKG.plugins.flatpak = $(PKG.mediasdk.flatpak)
+
+ifneq ($(HB_URL),)
+ifneq ($(HB_SHA256),)
+	FLATHUB_MANIFEST = $(PKG.gui.manifest.flathub) $(PKG.cli.manifest.flathub)
+endif
+endif
 
 ###############################################################################
 

--- a/pkg/linux/module.defs
+++ b/pkg/linux/module.defs
@@ -28,6 +28,10 @@ ifneq ($(PGP_ID),)
     PGPSIGN = --gpg-sign=$(PGP_ID)
 endif
 
+ifeq (1,$(FEATURE.qsv))
+    FPQSV = -q
+endif
+
 ifneq ($(FP_RUNTIME),)
     FPRUNTIME = -r $(FP_RUNTIME)
 endif

--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -63,23 +63,23 @@ $(PKG.rpm.stamp): $(PKG.native.rpm.stamp)
 #
 $(PKG.gui.flathub.manifest):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.gui.flathub.manifest)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.gui.flathub.manifest)
 
 $(PKG.cli.flathub.manifest):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.cli.flathub.manifest)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.cli.flathub.manifest)
 
 $(PKG.gui.flatpak): GNUmakefile $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.ghb.json
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.ghb.json
 	flatpak-builder --default-branch=$(PKG.flatpak.branch) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.ghb.json
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) fr.handbrake.ghb $(PKG.flatpak.branch)
 
 $(PKG.cli.flatpak): GNUmakefile $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
 	flatpak-builder --default-branch=$(PKG.flatpak.branch) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) fr.handbrake.HandBrakeCLI $(PKG.flatpak.branch)
 

--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -1,4 +1,5 @@
-pkg.create.flatpak:: contrib.fetch $(PKG.gui.flatpak) $(PKG.cli.flatpak) $(FLATHUB_MANIFEST)
+pkg.create.flatpak:: contrib.fetch $(PKG.all.flatpak)
+pkg.create.plugins.flatpak:: $(PKG.plugins.flatpak)
 pkg.create.flathub:: $(FLATHUB_MANIFEST)
 pkg.create.deb:: $(PKG.gui.deb) $(PKG.cli.deb)
 pkg.create.rpm:: $(PKG.rpm.stamp)
@@ -61,27 +62,37 @@ $(PKG.rpm.stamp): $(PKG.native.rpm.stamp)
 #
 # Flatpak binary package rules
 #
-$(PKG.gui.flathub.manifest):
+$(PKG.gui.manifest.flathub):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.gui.flathub.manifest)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.gui.manifset.flathub)
 
-$(PKG.cli.flathub.manifest):
+$(PKG.cli.manifest.flathub):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.cli.flathub.manifest)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))") $(FPRUNTIME) $(PKG.cli.manifest.flathub)
 
-$(PKG.gui.flatpak): GNUmakefile $(PKG.src.tar.bz2)
+$(PKG.gui.flatpak): GNUmakefile $(PKG.gui.template.flatpak) $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.ghb.json
-	flatpak-builder --default-branch=$(PKG.flatpak.branch) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.ghb.json
-	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) fr.handbrake.ghb $(PKG.flatpak.branch)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.gui.manifest.flatpak)
+	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(PKG.gui.manifest.flatpak)
+	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) $(PKG.gui.name.flatpak) $(PKG.branch.flatpak)
 
-$(PKG.cli.flatpak): GNUmakefile $(PKG.src.tar.bz2)
+$(PKG.cli.flatpak): GNUmakefile $(PKG.cli.template.flatpak) $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.manifest.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
-	flatpak-builder --default-branch=$(PKG.flatpak.branch) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(STAGE.out.flatpak/)fr.handbrake.HandBrakeCLI.json
-	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) fr.handbrake.HandBrakeCLI $(PKG.flatpak.branch)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.cli.manifest.flatpak)
+	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(PKG.cli.manifest.flatpak)
+	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) $(PKG.cli.name.flatpak) $(PKG.branch.flatpak)
+
+$(PKG.mediasdk.flatpak): GNUmakefile $(PKG.mediasdk.template.flatpak) $(PKG.gui.flatpak)
+	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
+	$(MKDIR.exe) -p $(PKG.out.flatpak/)
+	$(SRC/)scripts/create_flatpak_manifest.py -p -r $(PKG.branch.flatpak) -t $(PKG.mediasdk.template.flatpak) $(PKG.mediasdk.manifest.flatpak)
+	-flatpak --user remove --noninteractive $(PKG.gui.name.flatpak)//$(PKG.branch.flatpak)
+	flatpak --user install --noninteractive $(PKG.gui.flatpak)
+	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.mediasdk.build.flatpak) $(PKG.mediasdk.manifest.flatpak)
+	flatpak build-bundle --runtime $(PKG.repo.flatpak) $(PKG.mediasdk.flatpak) $(PKG.mediasdk.name.flatpak) $(PKG.plugin.version.flatpak)
+	-flatpak --user remove --noninteractive $(PKG.gui.name.flatpak)//$(PKG.branch.flatpak)
 
 #
 # Debian binary package rules

--- a/test/module.defs
+++ b/test/module.defs
@@ -25,6 +25,7 @@ endif
 
 ifeq (1,$(FEATURE.qsv))
     TEST.GCC.D += USE_QSV HAVE_THREADS=1
+    TEST.GCC.l += mfx
 ifeq ($(BUILD.system),linux)
     TEST.GCC.l += va va-drm
 endif


### PR DESCRIPTION
Assuming you built HandBrake with 'configure --enable-qsv' and you have
built and installed Intel MediaSDK in a directory that is in your LD search
path, the QSV encoders now work.  HW decode is not supported.

**Description of Change:**
A VA display must be initialized and given to libmfx after MFXInit() and before anything else.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] Ubuntu Linux

Should be tested on windows since I changed things slightly in the windows code path.