### PR TITLE
make: Fix Py3 compatibility and version.txt handling

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -718,7 +718,8 @@ class RepoProbe( ShellProbe ):
 
     def _parseSession( self ):
         for line in self.session:
-            line = line.decode('utf-8')
+            if isinstance(line, bytes):
+                line = line.decode('utf-8')
 
             ## grok fields
             m = re.match( '([^\=]+)\=(.*)', line )
@@ -785,7 +786,7 @@ class RepoProbe( ShellProbe ):
                     self.session = in_file.readlines()
                 if self.session:
                     self._parseSession()
-            if self.hash is not empty and self.hash is not 'deadbeaf':
+            if self.hash and self.hash != 'deadbeaf':
                 cfg.infof( '(pass)\n' )
             else:
                 cfg.infof( '(fail)\n' )


### PR DESCRIPTION
Recent changes to make the configure script run on Python 3 by handling bytes versus strings have introduced (or exposed preexisting) bugs to the Flatpak build process. This contribution fixes the handling of the `version.txt` file.

**Description of Bug:**
The Flatpak build script depends on a generated .tar.bz2 archive of the HandBrake source code -- exported without the `.git` directory -- so version information can only be read by the configure script from `version.txt`.

https://github.com/HandBrake/HandBrake/blob/f60354ef7ece3c69a0c6e83021778c28270b2880/pkg/module.rules#L15-L22
See also
https://github.com/HandBrake/HandBrake/blob/f60354ef7ece3c69a0c6e83021778c28270b2880/pkg/linux/module.rules#L75-L76

However, the fallback code in `make/configure.py` which parses `version.txt` no longer behaves as expected when running on Python 3. That is because of two bugs:

1. `in_file.readlines()` produces a list of strings, which do not require further UTF-8 decoding, but 5bff83c1da2d99da99fab70cb8b9ae13717a4323 introduced `line = line.decode('utf-8')`. [That line of code](https://github.com/HandBrake/HandBrake/blob/f60354ef7ece3c69a0c6e83021778c28270b2880/make/configure.py#L721) is necessary when parsing Popen-piped output from executing `repo-info.sh` but cannot execute when reading from `version.txt` because `line` is already a string without the `.decode()` method.
2. [Preexisting code checked if the version hash string had a value](https://github.com/HandBrake/HandBrake/blob/f60354ef7ece3c69a0c6e83021778c28270b2880/make/configure.py#L788) by checking `is not empty` and then comparing it with the default string of "deadbeaf" -- but this does not produce the desired behavior.

~~~
Traceback (most recent call last):
  File "../make/configure.py", line 1613, in <module>
    action.run()
  File "../make/configure.py", line 289, in run
    self._actionEnd()
  File "../make/configure.py", line 263, in _actionEnd
    self._failSession()
  File "../make/configure.py", line 795, in _failSession
    if self.hash is not empty and self.hash is not 'deadbeaf':
NameError: name 'empty' is not defined
~~~

**Description of Change:**
The first fix addresses the problem that `readlines()` gives back a list of strings that cannot be further decoded. The second fix addresses the `self.hash` emptiness check. If a string is not empty, `if self.hash` will check that it's non-empty; the second string comparison is done with the `!=` operator.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] Automated CI script with Fedora and latest flatpak-builder, which previously functioned correctly until the introduction of the Python 3 compatibility commits

**Log file output (If relevant):**
Before this patch -- a modified verbose version of configure.py which dumps the exceptions without suppressing them reveals:

~~~
========================================================================
Building module handbrake in /builds/frederickding/HandBrake/build/.flatpak-builder/build/handbrake-1
========================================================================
argv in Configure.__init__:../make/configure.py --prefix=/app --flatpak --disable-gtk-update-checks --verbose dir in Configure.__init__: ../makesrc_dir in Configure.__init__: ..probe: host tuple...(pass) x86_64-pc-linux-gnu
  + ../make/config.guess
  : b'x86_64-pc-linux-gnu'
compute: available architectures...(pass) x86_64
  : <NO-OUTPUT>
find: ar...(pass) /usr/bin/ar
  : name[0] = ar
find: cp...(pass) /usr/bin/cp
  : name[0] = cp
find: gcc...(pass) /usr/bin/gcc
  : name[0] = gcc
find: gmake...(pass) /usr/bin/make
  : name[0] = gmake
  : name[1] = make
find: gm4...(pass) /usr/bin/m4
  : name[0] = gm4
  : name[1] = m4
find: mkdir...(pass) /usr/bin/mkdir
  : name[0] = mkdir
find: gpatch...(pass) /usr/bin/patch
  : name[0] = gpatch
  : name[1] = patch
find: rm...(pass) /usr/bin/rm
  : name[0] = rm
find: ranlib...(pass) /usr/bin/ranlib
  : name[0] = ranlib
find: strip...(pass) /usr/bin/strip
  : name[0] = strip
find: gtar...(pass) /usr/bin/tar
  : name[0] = gtar
  : name[1] = tar
find: nasm...(pass) /usr/bin/nasm
  : name[0] = nasm
find: autoconf...(pass) /usr/bin/autoconf
  : name[0] = autoconf
find: automake...(pass) /usr/bin/automake
  : name[0] = automake
find: cmake...(pass) /usr/bin/cmake
  : name[0] = cmake
find: libtool...(pass) /usr/bin/libtool
  : name[0] = libtool
find: pkg-config...(pass) /usr/bin/pkg-config
  : name[0] = pkg-config
find: xcodebuild...(fail) not found
  : name[0] = xcodebuild
find: lipo...(fail) not found
  : name[0] = lipo
find: python3...(pass) /usr/bin/python3
  : name[0] = python3
compute: build tuple...(pass) x86_64-pc-linux-gnu
  : <NO-OUTPUT>
probe: number of CPU cores...(pass) 1
  : <NO-OUTPUT>
probe: repo info...(fail) code 128
  + ../scripts/repo-info.sh ..
  : b'fatal: not a git repository (or any parent up to mount point /run/build)'
  : b'Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).'
  : b'fatal: not a git repository (or any parent up to mount point /run/build)'
  : b'Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set).'
  : b'Not a valid repository.'
probe: version.txt...
../version.txt
(exception fail)
Traceback (most recent call last):
  File "../make/configure.py", line 1612, in <module>
    action.run()
  File "../make/configure.py", line 289, in run
    self._actionEnd()
  File "../make/configure.py", line 263, in _actionEnd
    self._failSession()
  File "../make/configure.py", line 793, in _failSession
    self._parseSession()
  File "../make/configure.py", line 726, in _parseSession
    line = line.decode('utf-8')
AttributeError: 'str' object has no attribute 'decode'
Error: module handbrake: Child process exited with code 1
make: *** [../pkg/linux/module.rules:76: /builds/frederickding/HandBrake/build/pkg/flatpak/HandBrake-20190227214027-8afb87b-master-test2-build-x86_64.flatpak] Error 1
~~~