### PR TITLE
MacGui: update German localization (Feb 2019)

### DIFF
--- a/macosx/HandBrakeKit/de.lproj/Localizable.strings
+++ b/macosx/HandBrakeKit/de.lproj/Localizable.strings
@@ -2,14 +2,24 @@
 " - fastdecode" = "- Schnelldekodierung";
 
 /* HBStateFormatter -> work time format */
-" (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)" = " (%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$dh%4$dm%5$ds)";
+" (%.2f fps, avg %.2f fps, ETA %02d:%02d:%02d)" = " (%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$dh:%4$dmin:%5$dsec)";
 
 /* HBStateFormatter -> search time format
    HBStateFormatter -> work time format */
-" (ETA %02dh%02dm%02ds)" = " (ETA %1$dh%2$dm%3$ds)";
+" (ETA %02d:%02d:%02d)" = " (ETA %1$dh:%2$dmin:%3$dsec)";
+
+/* Title description */
+" (Title %d, %@, %@) ▸ %@
+" = " (Titel %1$d, %2$@, %3$@) ▸ %4$@
+";
+
+/* Title description */
+" (Title %d, %@) ▸ %@
+" = " (Titel %1$d, %2$@) ▸ %3$@
+";
 
 /* Dimensions description */
-" Keep Aspect Ratio" = "Seitenverhältnis beibehalten";
+" Keep Aspect Ratio" = " Bildformat erhalten";
 
 /* Title short description -> audio format */
 ", %d audio tracks" = ", %d Tonspuren";
@@ -32,8 +42,14 @@
 /* Format description */
 ", Chapter Markers" = ", Kapitelmarker";
 
+/* HBPicture -> summary */
+", Crop: %@ %d/%d/%d/%d" = ", Beschneiden: %1$@ %2$d/%3$d/%4$d/%5$d";
+
 /* Format description */
 ", iPod 5G Support" = ", iPod 5G-Unterstützung";
+
+/* HBPicture -> summary */
+", Modulus: %d" = ", Modulus: %d";
 
 /* Format description */
 ", Web Optimized" = ", Web-optimiert";
@@ -46,6 +62,18 @@
 
 /* Audio description */
 "%@ ▸ Encoder: %@" = "%1$@ ▸ Enkodierer: %2$@";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d" = "%1$@Anzeige: %2$dx%3$d";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d, Anamorphic: %dx%d Auto" = "%1$@Anzeige: %2$dx%3$d, Anamorphisch: %4$dx%5$d Auto";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d, Anamorphic: %dx%d Custom" = "%1$@Anzeige: %2$dx%3$d, Anamorphisch: %4$dx%5$d Eigene";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d, Anamorphic: %dx%d Loose" = "%1$@Anzeige: %2$dx%3$d, Anamorphisch: %4$dx%5$d Loose";
 
 /* HBPicture -> short info */
 "%dx%d Storage, %dx%d Display" = "%1$d x %2$d Original, %3$d x %4$d Anzeige";
@@ -73,6 +101,9 @@
 
 /* Audio description */
 "Audio:" = "Audio:";
+
+/* HBPicture -> summary */
+"Auto" = "Auto";
 
 /* Video description */
 "Bitrate: %d kbps" = "Bitrate: %d kbps";
@@ -102,12 +133,23 @@
 /* HBJob -> video short description framerate */
 "CRF" = "CRF";
 
+/* HBFilters -> custom display name
+   HBPicture -> summary */
+"Custom" = "Eigene";
+
 /* Filters description
    HBJob -> filters short description */
 "Deblock" = "Deblock";
 
 /* HBFilters -> filter display name */
 "Decomb" = "Decomb";
+
+/* HBJob -> invalid Decomb custom settings error recovery suggestion */
+"Decomb syntax: mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
+
+Decomb default: mode=7" = "Decomb-Syntax: mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
+
+Decomb-Standard: mode=7";
 
 /* Subtitles description */
 "Default" = "Standard";
@@ -141,7 +183,7 @@
 "Filters:" = "Filter:";
 
 /* Subtitles description */
-"Forced Only" = "Nur erzwungene";
+"Forced Only" = "Erzwungene";
 
 /* HBSubtitles -> search pass name */
 "Foreign Audio Search" = "Fremdsprachentonsuche";
@@ -167,6 +209,13 @@
 
 /* HBFilters -> filter display name */
 "HQDN3D" = "HQDN3D";
+
+/* HBJob -> invalid name error recovery suggestion */
+"HQDN3D syntax: y-spatial=y:cb-spatial=c:cr-spatial=c:y-temporal=y:cb-temporal=c:cr-temporal=c
+
+Default settings: y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-temporal=3:cr-temporal=3" = "HQDN3D-Syntax: y-spatial=y:cb-spatial=c:cr-spatial=c:y-temporal=y:cb-temporal=c:cr-temporal=c
+
+Standardeinstellungen: y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-temporal=3:cr-temporal=3";
 
 /* HBFilters -> invalid comb detect custom string description */
 "Invalid custom comb detect settings." = "Ungültige benutzerdefinierte Comb Detect-Einstellungen.";
@@ -198,6 +247,13 @@
 /* HBFilters -> filter display name */
 "Lapsharp" = "Lapsharp";
 
+/* HBJob -> invalid lapsharp custom settings error recovery suggestion */
+"Lapsharp syntax: y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
+
+Lapsharp default: y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap" = "Lapsharp-Syntax: y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
+
+Lapsharp-Standard: y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap";
+
 /* Video description */
 "Level: %@" = "Level: %@";
 
@@ -208,9 +264,6 @@
 "MKV File" = "MKV-Datei";
 
 /* HBJob -> Format display name */
-"WebM File" = "WebM-Datei";
-
-/* HBJob -> Format display name */
 "MP4 File" = "MP4-Datei";
 
 /* HBStateFormatter -> pass display name */
@@ -218,6 +271,13 @@
 
 /* HBFilters -> filter display name */
 "NLMeans" = "NLMeans";
+
+/* HBJob -> invalid name error recovery suggestion */
+"NLMeans syntax: y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t
+
+Default settings: y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0" = "NLMeans-Syntax: y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t
+
+Standardeinstellungen: y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0";
 
 /* HBAudio -> none track name
    HBJob -> filters short description
@@ -286,8 +346,25 @@
 /* Filters description */
 "Sharpen" = "Schärfen";
 
+/* HBPicture -> short info */
+"Source: %dx%d, " = "Original: %1$dx%2$d, ";
+
 /* Subtitles description */
 "Subtitles:" = "Untertitel:";
+
+/* HBJob -> invalid comb detect custom settings error recovery suggestion */
+"Syntax: mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d
+
+Default: mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16" = "Syntax: mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d
+
+Standardeinstellungen: mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16";
+
+/* HBJob -> invalid detelecine custom settings error recovery suggestion */
+"Syntax: skip-left=s:skip-right=s:skip-top=s:skip-bottom=s:strict-breaks=s:plane=p:parity=p:disable=d
+
+Default: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0" = "Syntax: skip-left=s:skip-right=s:skip-top=s:skip-bottom=s:strict-breaks=s:plane=p:parity=p:disable=d
+
+Standardeinstellungen: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0";
 
 /* HBJob -> invalid name error recovery suggestion */
 "The file name can't contain the / character." = "Der Dateinamen darf kein Zeichen / enthalten.";
@@ -311,6 +388,13 @@
 /* HBFilters -> filter display name */
 "Unsharp" = "Unscharf Maskieren";
 
+/* HBJob -> invalid unsharp custom settings error recovery suggestion */
+"Unsharp syntax: y-strength=y:y-size=y:cb-strength=c:cb-size=c:cr-strength=c:cr-size=c
+
+Unsharp default: y-strength=0.25:y-size=7:cb-strength=0.25:cb-size=7" = "Unscharf Maskieren-Syntax: y-strength=y:y-size=y:cb-strength=c:cb-size=c:cr-strength=c:cr-size=c
+
+Unscharf Maskieren-Standardeinstellungen: y-strength=0.25:y-size=7:cb-strength=0.25:cb-size=7";
+
 /* HBJob -> video short description framerate */
 "VFR" = "VFR";
 
@@ -320,6 +404,16 @@
 /* Video description */
 "Video:" = "Video:";
 
+/* HBJob -> Format display name */
+"WebM File" = "WebM-Datei";
+
 /* HBFilters -> filter display name */
 "Yadif" = "Yadif";
+
+/* HBJob -> invalid Yadif custom settings error recovery suggestion */
+"Yadif syntax: mode=m:parity=p
+
+Yadif default: mode=3" = "Yadif-Syntax: mode=m:parity=p
+
+Yadif-Standardeinstellungen: mode=3";
 

--- a/macosx/de.lproj/ExceptionAlert.strings
+++ b/macosx/de.lproj/ExceptionAlert.strings
@@ -1,0 +1,15 @@
+/* Class = "NSWindow"; title = "Internal Error"; ObjectID = "1"; */
+"1.title" = "Interner Fehler";
+
+/* Class = "NSTextFieldCell"; title = "An internal error has occurred. You can choose to continue in an unstable state, or crash."; ObjectID = "10"; */
+"10.title" = "Ein interner Fehler ist aufgetreten. Soll in einem instabilen Modus fortgefahren werden oder soll das Programm abstürzen?";
+
+/* Class = "NSTextFieldCell"; title = "Reason contents go here."; ObjectID = "12"; */
+"12.title" = "Der Grund folgt hier.";
+
+/* Class = "NSButtonCell"; title = "Crash"; ObjectID = "14"; */
+"14.title" = "Abstürzen";
+
+/* Class = "NSButtonCell"; title = "Continue"; ObjectID = "16"; */
+"16.title" = "Fortfahren";
+

--- a/macosx/de.lproj/HBPictureViewController.strings
+++ b/macosx/de.lproj/HBPictureViewController.strings
@@ -155,6 +155,9 @@ Eigene: Erlaubt benutzerdefinierte Einstellungen.";
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "und-OA-MLn"; */
 "und-OA-MLn.title" = "OtherViews";
 
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = " "; ObjectID = "uqQ-uA-3xF"; */
+"uqQ-uA-3xF.ibExternalAccessibilityDescription" = "0b36a71978ca057bf0594fec41410ec0_tr";
+
 /* Class = "NSMenuItem"; title = "16"; ObjectID = "uTT-yC-MFJ"; */
 "uTT-yC-MFJ.title" = "16";
 

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -1,5 +1,5 @@
 /* Preview -> size info label */
-" Scaled To Screen" = "An Bildschirm anpassen";
+" Scaled To Screen" = " An Bildschirm anpassen";
 
 /* No comment provided by engineer. */
 "- --:--" = "- --:--";
@@ -80,6 +80,9 @@
 /* Toolbar Open/Cancel Item */
 "Cancel Scanning Source" = "Quelle überprüfen abbrechen";
 
+/* Preferences -> Output Name Token */
+"Chapters" = "Kapitel";
+
 /* Main Window -> Destination open panel */
 "Choose" = "Auswählen";
 
@@ -89,11 +92,20 @@
 /* Copy Protection Alert -> message */
 "Copy-Protected sources are not supported." = "Kopiergeschützte Quellen werden nicht unterstützt.";
 
+/* Preferences -> Output Name Token */
+"Creation-Date" = "Erstellungsdatum";
+
+/* Preferences -> Output Name Token */
+"Creation-Time" = "Erstellungsuhrzeit";
+
 /* Touch bar */
 "Current Time" = "Momentane Zeit";
 
 /* Add preset window -> picture setting */
 "Custom" = "Eigene";
+
+/* Preferences -> Output Name Token */
+"Date" = "Datum";
 
 /* Delete preset alert -> first button */
 "Delete Preset" = "Voreinstellung löschen";
@@ -240,6 +252,9 @@
    Queue notification alert message */
 "Put down that cocktail…" = "Stellen Sie den Cocktail ab …";
 
+/* Preferences -> Output Name Token */
+"Quality/Bitrate" = "Qualität/Bitrate";
+
 /* Quit Alert -> first button */
 "Quit" = "Beenden";
 
@@ -278,9 +293,6 @@
 /* Touch bar */
 "Show Activity Window" = "Aktivitätsfenster zeigen";
 
-/* Video -> Advanced editor */
-"Show advanced editor" = "Erweiterte Optionen einblenden";
-
 /* Touch bar */
 "Show Preview Window" = "Vorschau zeigen";
 
@@ -289,6 +301,9 @@
 
 /* Touch bar */
 "Slider" = "Schieberegler";
+
+/* Preferences -> Output Name Token */
+"Source" = "Quelle";
 
 /* Add preset window -> picture setting */
 "Source Maximum" = "Quellenmaximum";
@@ -365,6 +380,12 @@
 
 /* Invalid destination alert -> informative text */
 "This is not a valid destination directory!" = "Dies ist kein gültiges Zielverzeichnis.";
+
+/* Preferences -> Output Name Token */
+"Time" = "Zeit";
+
+/* Preferences -> Output Name Token */
+"Title" = "Titel";
 
 /* Video -> Framerate */
 "Variable Framerate" = "Variable Bildfrequenz";

--- a/macosx/de.lproj/MainMenu.strings
+++ b/macosx/de.lproj/MainMenu.strings
@@ -4,8 +4,8 @@
 /* Class = "NSMenuItem"; title = "Rename Preset…"; ObjectID = "1GQ-n3-jfY"; */
 "1GQ-n3-jfY.title" = "Voreinstellung umbenennen …";
 
-/* Class = "NSMenuItem"; title = "Video"; ObjectID = "6rE-SM-AGi"; */
-"6rE-SM-AGi.title" = "Video";
+/* Class = "NSMenuItem"; title = "Filters"; ObjectID = "6rE-SM-AGi"; */
+"6rE-SM-AGi.title" = "Filter";
 
 /* Class = "NSMenuItem"; title = "Summary"; ObjectID = "9ie-b7-RaS"; */
 "9ie-b7-RaS.title" = "Zusammenfassung";
@@ -226,8 +226,8 @@
 /* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "IsV-5A-bqx"; */
 "IsV-5A-bqx.title" = "Werkzeugleiste zeigen";
 
-/* Class = "NSMenuItem"; title = "Picture"; ObjectID = "Jef-U4-eQT"; */
-"Jef-U4-eQT.title" = "Bild";
+/* Class = "NSMenuItem"; title = "Video"; ObjectID = "Jef-U4-eQT"; */
+"Jef-U4-eQT.title" = "Video";
 
 /* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "KKV-n0-Fmr"; */
 "KKV-n0-Fmr.title" = "Werkzeugleiste anpassen …";

--- a/macosx/de.lproj/MainWindow.strings
+++ b/macosx/de.lproj/MainWindow.strings
@@ -264,6 +264,9 @@ Blu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlic
 /* Class = "NSTextFieldCell"; title = "To:"; ObjectID = "rfK-nQ-Aq2"; */
 "rfK-nQ-Aq2.title" = "Zielort:";
 
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = " "; ObjectID = "sbX-LU-uOW"; */
+"sbX-LU-uOW.ibShadowedIsNilPlaceholder" = "bae99e1761724952e7893d509131ea79_tr";
+
 /* Class = "NSToolbarItem"; label = "Pause"; ObjectID = "wTQ-KF-5KW"; */
 "wTQ-KF-5KW.label" = "Pause";
 

--- a/macosx/de.lproj/Preferences.strings
+++ b/macosx/de.lproj/Preferences.strings
@@ -124,11 +124,11 @@
 /* Class = "NSButtonCell"; title = "Play System Alert Sound"; ObjectID = "458"; */
 "458.title" = "Systemton abspielen";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "Minimum title duration in seconds. Shorter titles will be skipped."; ObjectID = "463"; */
-"463.ibShadowedToolTip" = "Minimale Zeit für den Titelscan in Sekunden. Kürzere Titel werden übersprungen.";
+/* Class = "NSTextField"; ibShadowedToolTip = "Minimum DVD and Blu-ray title duration in seconds. Shorter titles will be skipped."; ObjectID = "463"; */
+"463.ibShadowedToolTip" = "Minimale Dauer des DVD- und Blu-ray-Titels in Sekunden. Kürzere Titel werden übersprungen.";
 
-/* Class = "NSTextFieldCell"; title = "Minimum title duration to scan:"; ObjectID = "464"; */
-"464.title" = "Minimale Zeit für den Titelscan:";
+/* Class = "NSTextFieldCell"; title = "Ignore DVD and Blu-ray titles shorter than:"; ObjectID = "464"; */
+"464.title" = "DVD- und Blu-ray-Titel ignorieren, falls kürzer als:";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Minimum title duration in seconds. Shorter titles will be skipped."; ObjectID = "480"; */
 "480.ibShadowedToolTip" = "Minimale Dauer des Titels in Sekunden. Kürzere Titel werden übersprungen.";

--- a/macosx/de.lproj/Queue.strings
+++ b/macosx/de.lproj/Queue.strings
@@ -28,6 +28,12 @@
 /* Class = "NSMenuItem"; title = "Alert and Notification"; ObjectID = "aat-1N-Odn"; */
 "aat-1N-Odn.title" = "Hinweis mit Nachricht und Alarm";
 
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "anR-ZS-eOK"; */
+"anR-ZS-eOK.title" = "Table View Cell";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "F1i-sW-mz6"; */
+"F1i-sW-mz6.title" = "Table View Cell";
+
 /* Class = "NSMenuItem"; title = "Alert"; ObjectID = "fAD-ky-zo6"; */
 "fAD-ky-zo6.title" = "Hinweis mit Alarm";
 
@@ -39,6 +45,9 @@
 
 /* Class = "NSMenuItem"; title = "Notification"; ObjectID = "jDL-sB-8e3"; */
 "jDL-sB-8e3.title" = "Hinweis mit Nachricht";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "MWq-ie-HjX"; */
+"MWq-ie-HjX.title" = "Text Cell";
 
 /* Class = "NSMenuItem"; title = "Shut Down Computer"; ObjectID = "QmP-SQ-XKK"; */
 "QmP-SQ-XKK.title" = "Computer herunterfahren";

--- a/macosx/de.lproj/Subtitles.strings
+++ b/macosx/de.lproj/Subtitles.strings
@@ -1,23 +1,23 @@
 /* Class = "NSTableView"; ibExternalAccessibilityDescription = "Subtitles tracks"; ObjectID = "0yM-wE-D2x"; */
 "0yM-wE-D2x.ibExternalAccessibilityDescription" = "Untertitelspuren";
 
-/* Class = "NSTableColumn"; headerCell.title = "SRT Encoding"; ObjectID = "1Qg-We-ltR"; */
-"1Qg-We-ltR.headerCell.title" = "SRT-Enkodierung";
+/* Class = "NSTableColumn"; headerCell.title = "Encoding"; ObjectID = "1Qg-We-ltR"; */
+"1Qg-We-ltR.headerCell.title" = "Enkodierung";
 
 /* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "4PX-In-DpF"; */
 "4PX-In-DpF.title" = "Alle Spuren hinzufügen";
 
-/* Class = "NSTableColumn"; headerCell.title = "SRT Language"; ObjectID = "9ka-9O-WDj"; */
-"9ka-9O-WDj.headerCell.title" = "SRT-Sprache";
+/* Class = "NSTableColumn"; headerCell.title = "Language"; ObjectID = "9ka-9O-WDj"; */
+"9ka-9O-WDj.headerCell.title" = "Sprache";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "ABd-Ec-K2L"; */
 "ABd-Ec-K2L.title" = "OtherViews";
 
-/* Class = "NSTextField"; ibExternalAccessibilityDescription = "SRT Offset"; ObjectID = "aJi-zQ-0cg"; */
-"aJi-zQ-0cg.ibExternalAccessibilityDescription" = "SRT-Versatz";
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "SRT/SSA Offset"; ObjectID = "aJi-zQ-0cg"; */
+"aJi-zQ-0cg.ibExternalAccessibilityDescription" = "SRT/SSA-Versatz";
 
-/* Class = "NSTextField"; ibShadowedToolTip = "SRT Offset. Positive or negative offset in milliseconds (ms) for the selected SRT format source track. Not applicable to other formats."; ObjectID = "aJi-zQ-0cg"; */
-"aJi-zQ-0cg.ibShadowedToolTip" = "SRT-Versatz. Positiver oder negativer Versatz in Millisekunden (ms) der ausgewählten SRT-Spur. Nicht anwendbar bei anderen Formaten.";
+/* Class = "NSTextField"; ibShadowedToolTip = "Positive or negative offset in milliseconds (ms) for the selected SRT/SSA format source track. Not applicable to other formats."; ObjectID = "aJi-zQ-0cg"; */
+"aJi-zQ-0cg.ibShadowedToolTip" = "Positiver oder negativer Versatz in Millisekunden (ms) der ausgewählten SRT/SSA-Spur. Nicht anwendbar bei anderen Formaten.";
 
 /* Class = "NSMenuItem"; title = "Pop Up"; ObjectID = "cSW-OC-qKA"; */
 "cSW-OC-qKA.title" = "Pop Up";
@@ -28,8 +28,8 @@
 /* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "fAW-To-EeP"; */
 "fAW-To-EeP.title" = "Item 3";
 
-/* Class = "NSTableColumn"; headerCell.title = "SRT Offset"; ObjectID = "Fgh-pZ-6uu"; */
-"Fgh-pZ-6uu.headerCell.title" = "SRT-Versatz";
+/* Class = "NSTableColumn"; headerCell.title = "Offset"; ObjectID = "Fgh-pZ-6uu"; */
+"Fgh-pZ-6uu.headerCell.title" = "Versatz";
 
 /* Class = "NSTableColumn"; headerCell.title = "Burned In"; ObjectID = "fIe-Fg-ufj"; */
 "fIe-Fg-ufj.headerCell.title" = "Eingebrannte";
@@ -40,8 +40,8 @@
 /* Class = "NSTableColumn"; headerCell.title = "Default"; ObjectID = "fvq-pE-sOC"; */
 "fvq-pE-sOC.headerCell.title" = "Standard";
 
-/* Class = "NSMenuItem"; title = "Add External SRT…"; ObjectID = "fXD-7h-jMl"; */
-"fXD-7h-jMl.title" = "Externe SRTs hinzufügen…";
+/* Class = "NSMenuItem"; title = "Add External Subtitles Track…"; ObjectID = "fXD-7h-jMl"; */
+"fXD-7h-jMl.title" = "Externe Untertitelspur hinzufügen …";
 
 /* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "g4b-FM-qX4"; */
 "g4b-FM-qX4.title" = "Item 2";
@@ -53,7 +53,7 @@
 "HC5-ql-Vcr.ibExternalAccessibilityDescription" = "Nur erzwungene Untertitel";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Forced Only. Use only subtitles marked as “forced” in the selected source track."; ObjectID = "HC5-ql-Vcr"; */
-"HC5-ql-Vcr.ibShadowedToolTip" = "Nur erzwungene. Benutze nur Untertitel die in der ausgewählten Quelle als “erzwungen” markiert sind.";
+"HC5-ql-Vcr.ibShadowedToolTip" = "Erzwungene. Benutze nur Untertitel die in der ausgewählten Quelle als “erzwungen” markiert sind.";
 
 /* Class = "NSTextFieldCell"; title = "0"; ObjectID = "hhH-c3-gD0"; */
 "hhH-c3-gD0.title" = "0";
@@ -61,17 +61,17 @@
 /* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "HQq-Mp-4sI"; */
 "HQq-Mp-4sI.title" = "Item 2";
 
-/* Class = "NSMenuItem"; ibShadowedToolTip = "Add new SRT subtitle to the list."; ObjectID = "HW0-PS-t0U"; */
-"HW0-PS-t0U.ibShadowedToolTip" = "Füge neue SRT-Untertitel zur Liste hinzu.";
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Add new SRT/SSA subtitle to the list."; ObjectID = "HW0-PS-t0U"; */
+"HW0-PS-t0U.ibShadowedToolTip" = "Einen neuen SRT/SSA-Untertitel zur Liste hinzufügen.";
 
-/* Class = "NSMenuItem"; title = "Add External SRT…"; ObjectID = "HW0-PS-t0U"; */
-"HW0-PS-t0U.title" = "Externe SRT hinzufügen…";
+/* Class = "NSMenuItem"; title = "Add External Subtitles Track…"; ObjectID = "HW0-PS-t0U"; */
+"HW0-PS-t0U.title" = "Externe Untertitelspur hinzufügen …";
 
-/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT Language"; ObjectID = "Inz-O5-B8g"; */
-"Inz-O5-B8g.ibExternalAccessibilityDescription" = "SRT-Sprache";
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT/SSA Language"; ObjectID = "Inz-O5-B8g"; */
+"Inz-O5-B8g.ibExternalAccessibilityDescription" = "SRT/SSA-Sprache";
 
-/* Class = "NSPopUpButton"; ibShadowedToolTip = "SRT Language. Language of the selected SRT format source track. Not applicable to other formats."; ObjectID = "Inz-O5-B8g"; */
-"Inz-O5-B8g.ibShadowedToolTip" = "SRT-Sprache. Sprache der ausgewählten SRT-Spur der Quelle. Nicht verfügbar bei anderen Formaten.";
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Language of the selected SRT/SSA format source track. Not applicable to other formats."; ObjectID = "Inz-O5-B8g"; */
+"Inz-O5-B8g.ibShadowedToolTip" = "Sprache der ausgewählten SRT/SSA-Spur der Quelle. Nicht verfügbar bei anderen Formaten.";
 
 /* Class = "NSMenuItem"; title = "Reload"; ObjectID = "jcM-HL-QJ6"; */
 "jcM-HL-QJ6.title" = "Neu laden";
@@ -83,7 +83,7 @@
 "JLr-Qi-X0X.title" = "Check";
 
 /* Class = "NSTableColumn"; headerCell.title = "Forced Only"; ObjectID = "klV-Gy-igk"; */
-"klV-Gy-igk.headerCell.title" = "Nur erzwungene";
+"klV-Gy-igk.headerCell.title" = "Erzwungene";
 
 /* Class = "NSButton"; ibExternalAccessibilityDescription = "Default"; ObjectID = "mdO-Qu-3Pb"; */
 "mdO-Qu-3Pb.ibExternalAccessibilityDescription" = "Standard";
@@ -112,11 +112,11 @@
 /* Class = "NSButton"; ibShadowedToolTip = "Configure subtitle tracks Selection Behavior. These settings affect which tracks will be added to the subtitle tracks list, and the settings used for each track."; ObjectID = "QsM-28-Pya"; */
 "QsM-28-Pya.ibShadowedToolTip" = "Konfiguriert das Auswahlverhalten der Untertitelspuren. Diese Einstellungen bestimmen welche Spuren zur Liste der Untertitelspuren hinzugefügt werden und die Einstellungen welche für jede Spur benutzt werden.";
 
-/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT Character Encoding"; ObjectID = "QV0-kE-4yR"; */
-"QV0-kE-4yR.ibExternalAccessibilityDescription" = "SRT-Charakter-Enkodierung";
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT/SSA Character Encoding"; ObjectID = "QV0-kE-4yR"; */
+"QV0-kE-4yR.ibExternalAccessibilityDescription" = "SRT/SSA-Zeichenkodierung";
 
-/* Class = "NSPopUpButton"; ibShadowedToolTip = "SRT Encoding. Character encoding/codeset of the selected SRT format source track. Not applicable to other formats."; ObjectID = "QV0-kE-4yR"; */
-"QV0-kE-4yR.ibShadowedToolTip" = "SRT-Enkodierung. Charakter-Enkodierung und -Zeichensatz der ausgewählten SRT-Spur. Nicht verfügbar bei anderen Formaten";
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Character encoding/codeset of the selected SRT/SSA format source track. Not applicable to other formats."; ObjectID = "QV0-kE-4yR"; */
+"QV0-kE-4yR.ibShadowedToolTip" = "Zeichenkodierung/Codeliste des ausgewählten SRT/SSA-Spur der Quelle. Nicht verfügbar bei anderen Formaten.";
 
 /* Class = "NSMenuItem"; title = "Remove All Tracks"; ObjectID = "R8a-qg-ASg"; */
 "R8a-qg-ASg.title" = "Alle Spuren entfernen";


### PR DESCRIPTION
Latest Transifex sync of german macOS strings. Make HandBrake:master even with Transifex.
Tested on macOS Mojave.