### PR TITLE
libhb: Only display audio source bitrates greater than one

### DIFF
--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1375,11 +1375,15 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_buffer_t * b)
         }
     }
 
-    // Append input bitrate in kbps to the end of the description
-    char in_bitrate_str[19];
-    snprintf(in_bitrate_str, 18, " (%d kbps)", audio->config.in.bitrate / 1000);
-    strncat(audio->config.lang.description, in_bitrate_str, 
-            sizeof(audio->config.lang.description) - strlen(audio->config.lang.description) - 1);
+    // Append input bitrate in kbps to the end of the description if greater than 1
+    // ffmpeg may report some audio bitrates as 1, not an issue
+    if (audio->config.in.bitrate > 1) 
+    {
+        char in_bitrate_str[19];
+        snprintf(in_bitrate_str, 18, " (%d kbps)", audio->config.in.bitrate / 1000);
+        strncat(audio->config.lang.description, in_bitrate_str, 
+                sizeof(audio->config.lang.description) - strlen(audio->config.lang.description) - 1);
+    }
 
     hb_log( "scan: audio 0x%x: %s, rate=%dHz, bitrate=%d %s", audio->id,
             info.name, audio->config.in.samplerate, audio->config.in.bitrate,


### PR DESCRIPTION
**Description of Change:**

Resolves #1944

Fixes issue where audio source bitrates display as 0 kbps because ffmpeg reports them as 1 bps.

**Test on:**

- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

![capture](https://user-images.githubusercontent.com/3466262/53670521-0115dd00-3c49-11e9-9085-9b67d59094c3.JPG)
