### PR TITLE
make: Fix Linux build output being on a single line

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -1427,6 +1427,8 @@ class Launcher:
         except Exception as x:
             cfg.errln( 'launch failure: %s', x )
         for line in pipe.stdout:
+            if not isinstance(line, str):
+                line = line.decode()
             self.echof( '%s', line )
         pipe.wait()
 


### PR DESCRIPTION
**Description of Change:**

In the configure.py script, most of the stdout lines being sent from the make subprocess call are
bytestrings, causing the newlines in those bytestrings to inevitably be pointless.

I added a conditional decode step in the case that we do get bytestrings from the piped stdout.

Resolves #2011 



**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

![resolvedCapture](https://user-images.githubusercontent.com/3466262/55203137-c39d6480-51a0-11e9-8712-516c7fe0ffe7.JPG)
