### PR TITLE
Check if libnuma is installed actually

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -186,7 +186,9 @@ if test "x$use_fdk_aac" = "xyes" ; then
 fi
 
 if test "x$use_x265" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lx265 -lnuma"
+    HB_LIBS="$HB_LIBS -lx265"
+    AC_CHECK_LIB([numa], [numa_available], [HB_LIBS="$HB_LIBS -lnuma"], [])
+
 fi
 
 if test "x$use_qsv" = "xyes" ; then


### PR DESCRIPTION
**Description of Change:**

Build fails on FreeBSD as follows.

```
  : libtool: link: /usr/bin/c++ -g -O2 -D_ENABLE_GST -Wl,--export-dynamic -Wl,--exclude-libs -Wl,ALL -Wl,-S -g0 -O3 -o ghb callbacks.o queuehandler.o videohandler.o audiohandler.o subtitlehandler.o main.o settings.o resources.o presets.o preview.o data_res.o ui_res.o icon_res.o icons.o values.o appcast.o plist.o hb-backend.o renderer_button.o ghbcellrenderertext.o ghb-dvd.o marshalers.o -Wl,--export-dynamic -pthread  -L/home/yuichiro/HandBrake/build//libhb -L/home/yuichiro/HandBrake/build//contrib/lib -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc /home/yuichiro/HandBrake/build/contrib/lib/libdvdnav.a -L/home/yuichiro/HandBrake/build/contrib/lib -L/usr/local/lib /home/yuichiro/HandBrake/build/contrib/lib/libdvdread.a -lmp3lame -lvorbis -lvorbisenc -logg -lsamplerate -lx264 -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 /home/yuichiro/HandBrake/build/contrib/lib/libbluray.a -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma /home/yuichiro/HandBrake/build/contrib/lib/libfdk-aac.a -lm -lx265 -lnuma -lgtk-3 -lgdk-3 -lpangocairo-1.0 -lpango-1.0 -latk-1.0 -lcairo-gobject -lcairo -lpthread -lgdk_pixbuf-2.0 -lgthread-2.0 -lgio-2.0 -lgmodule-2.0 -lgstvideo-1.0 -lgstaudio-1.0 -lgstbase-1.0 -lgstpbutils-1.0 -lgstreamer-1.0 -lgobject-2.0 -lglib-2.0 -lintl -pthread
  : ld: error: unable to find library -lnuma
  : c++: error: linker command failed with exit code 1 (use -v to see invocation)
  : gmake[3]: *** [Makefile:619: ghb] Error 1
  : gmake[3]: Leaving directory '/home/yuichiro/HandBrake/build/gtk/src'
  : gmake[2]: *** [Makefile:451: all-recursive] Error 1
  : gmake[2]: Leaving directory '/home/yuichiro/HandBrake/build/gtk'
  : gmake[1]: *** [Makefile:383: all] Error 2
  : gmake[1]: Leaving directory '/home/yuichiro/HandBrake/build/gtk'
  : gmake: *** [../gtk/module.rules:31: gtk.build] Error 2
```

Unfortunately, libnuma is not supported on FreeBSD.
I would like to check if libnuma is installed actually by configure script.
This pull request works on my `FreeBSD 13.0-CURRENT r346074 GENERIC-NODEBUG`.
I believe this will work on Linux.
Please check this PR on Linux machines.



**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] FreeBSD

**Screenshots (If relevant):**


**Log file output (If relevant):**
