### PR TITLE
contrib: Update to libopus 1.3.1

### DIFF
--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBOPUS,libopus))
 $(eval $(call import.CONTRIB.defs,LIBOPUS))
 
-LIBOPUS.FETCH.url     = https://download.handbrake.fr/contrib/opus-1.3.tar.gz
-LIBOPUS.FETCH.url    += https://archive.mozilla.org/pub/opus/opus-1.3.tar.gz
-LIBOPUS.FETCH.sha256  = 4f3d69aefdf2dbaf9825408e452a8a414ffc60494c70633560700398820dc550
+LIBOPUS.FETCH.url     = https://download.handbrake.fr/contrib/opus-1.3.1.tar.gz
+LIBOPUS.FETCH.url    += https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz
+LIBOPUS.FETCH.sha256  = 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs


### PR DESCRIPTION
Release notes: https://opus-codec.org/release/stable/2019/04/12/libopus-1_3_1.html

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
