### PR TITLE
Add a --enable-hardening flag to enable stack protection and enhanced…

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -415,6 +415,11 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
         hb_log(" - %s", cpu_type);
     }
     hb_log(" - logical processor count: %d", hb_get_cpu_count());
+    
+    /* Print hardening status in all scan and encode logs */
+#ifdef USE_HARDEN
+    hb_log(" - hardening is enabled");
+#endif
 
 #ifdef USE_QSV
     if (!is_hardware_disabled())

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -95,6 +95,10 @@ ifeq (1,$(FEATURE.x265))
     LIBHB.GCC.D += USE_X265
 endif
 
+ifeq (1,$(BUILD.harden))
+    LIBHB.GCC.D += USE_HARDEN
+endif
+
 ifeq (1,$(COMPAT.strtok_r))
     LIBHB.GCC.D += HB_NEED_STRTOK_R
 endif

--- a/make/configure.py
+++ b/make/configure.py
@@ -1294,6 +1294,8 @@ def createCLI( cross = None ):
         xcconfigMode.cli_add_argument( grp, '--xcode-config' )
         grp.add_argument( '--minver', default=None, action='store', metavar='VER',
             help='specify deployment target for Xcode builds' )
+        grp.add_argument( '--enable-hardening', dest="enable_build_harden", default=None, action='store_true',
+            help='enable buffer overflow protection' )
         cli.add_argument_group( grp )
 
     ## add tool locations
@@ -1780,6 +1782,7 @@ int main()
 
     doc.add( 'BUILD.date',   time.strftime('%c', now) ),
     doc.add( 'BUILD.arch',   arch.mode.mode )
+    doc.add( 'BUILD.harden', int( options.enable_build_harden != None))
 
     doc.addBlank()
     doc.add( 'SRC',     cfg.src_final )
@@ -1942,6 +1945,7 @@ int main()
     stdout.write( ' (%s)\n' % note_unsupported ) if not (build.system == 'linux' or build.system == 'mingw') else stdout.write( '\n' )
     stdout.write( 'Enable VCE:         %s' % options.enable_vce )
     stdout.write( ' (%s)\n' % note_unsupported ) if not build.system == 'mingw' else stdout.write( '\n' )
+    stdout.write( 'Enable buffer overflow protection: %s\n' % options.enable_build_harden )
 
     if options.launch:
         stdout.write( '%s\n' % ('-' * 79) )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1280,6 +1280,8 @@ def createCLI( cross = None ):
     arch.mode.cli_add_argument( grp, '--arch' )
     grp.add_argument( '--cross', default=None, action='store', metavar='SPEC',
         help='specify GCC cross-compilation spec' )
+    grp.add_argument( '--enable-hardening', dest="enable_build_harden", default=None, action='store_true',
+        help='enable buffer overflow protection' )
     cli.add_argument_group( grp )
 
     ## add Xcode options
@@ -1294,8 +1296,6 @@ def createCLI( cross = None ):
         xcconfigMode.cli_add_argument( grp, '--xcode-config' )
         grp.add_argument( '--minver', default=None, action='store', metavar='VER',
             help='specify deployment target for Xcode builds' )
-        grp.add_argument( '--enable-hardening', dest="enable_build_harden", default=None, action='store_true',
-            help='enable buffer overflow protection' )
         cli.add_argument_group( grp )
 
     ## add tool locations

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -78,6 +78,12 @@ ifeq ($(BUILD.machine),$(filter $(BUILD.machine),i686 x86_64))
 else
     GCC.args.extra = $(CFLAGS) $(CPPFLAGS)
 endif
+# If hardening is enabled -D_FORTIFY_SOURCE=2 adds compile-time protection and run-time
+# checking against static sized buffer overflow flaws. -fstack-protector-strong enables
+# stack canaries to detect stack buffer overflows (stack overwrites).
+ifeq (1,$(BUILD.harden))
+    GCC.args.extra += $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2
+endif
 GCC.args.extra.h_o     =
 GCC.args.extra.c_o     =
 GCC.args.extra.dylib   = $(LDFLAGS)


### PR DESCRIPTION
… buffer overflow protection

This is the PR for #2027. It adds a --enable-hardening flag. If you decide you want to enable it by default, without an option, this can be changed.
On macOS I've verified that the flag works (in GNUmakefile its 1 or 0) and, that the build is working properly.

**Description of Change:**
Adds a --enable-hardening flag to enable -D_FORTIFY_SOURCE=2 for compile-time protection and run-time checking against static sized buffer overflow flaws. -fstack-protector-strong enables stack canaries to detect stack buffer overflows (stack overwrites).



**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux