### PR TITLE
Feature flag export

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -23,7 +23,7 @@
 #include "qsv_common.h"
 #endif
 
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
 #include "x265.h"
 #endif
 
@@ -318,7 +318,7 @@ static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
         case HB_VCODEC_FFMPEG_VP9:
             return 1;
 
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
         case HB_VCODEC_X265_8BIT:
         case HB_VCODEC_X265_10BIT:
         case HB_VCODEC_X265_12BIT:
@@ -1480,7 +1480,7 @@ const char* const* hb_video_encoder_get_presets(int encoder)
         case HB_VCODEC_X264_10BIT:
             return x264_preset_names;
 
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
         case HB_VCODEC_X265_8BIT:
         case HB_VCODEC_X265_10BIT:
         case HB_VCODEC_X265_12BIT:
@@ -1500,7 +1500,7 @@ const char* const* hb_video_encoder_get_tunes(int encoder)
         case HB_VCODEC_X264_10BIT:
             return x264_tune_names;
 
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
         case HB_VCODEC_X265_8BIT:
         case HB_VCODEC_X265_10BIT:
         case HB_VCODEC_X265_12BIT:

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -398,7 +398,7 @@ static int hb_audio_encoder_is_enabled(int encoder)
             return 1;
 #endif
 
-#ifdef USE_FFMPEG_AAC
+#if HB_PROJECT_FEATURE_FFMPEG_AAC
         case HB_ACODEC_FFAAC:
             return avcodec_find_encoder_by_name("aac") != NULL;
 #endif

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -31,7 +31,7 @@
 #include <windows.h>
 #endif
 
-#ifdef USE_NVENC
+#if HB_PROJECT_FEATURE_NVENC
 #include "nvenc_common.h"
 #endif
 
@@ -291,7 +291,7 @@ static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
                 return hb_vce_h265_available();
 #endif
 
-#ifdef USE_NVENC
+#if HB_PROJECT_FEATURE_NVENC
             case HB_VCODEC_FFMPEG_NVENC_H264:
                 return hb_nvenc_h264_available();
             case HB_VCODEC_FFMPEG_NVENC_H265:

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -34,8 +34,7 @@
 #if HB_PROJECT_FEATURE_NVENC
 #include "nvenc_common.h"
 #endif
-
-#ifdef USE_VCE
+#if HB_PROJECT_FEATURE_VCE
 #include "vce_common.h"
 #endif
 
@@ -284,7 +283,7 @@ static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
 #endif
 
         switch (encoder){
-#ifdef USE_VCE
+#if HB_PROJECT_FEATURE_VCE
             case HB_VCODEC_FFMPEG_VCE_H264:
                return hb_vce_h264_available();
             case HB_VCODEC_FFMPEG_VCE_H265:
@@ -1537,7 +1536,7 @@ const char* const* hb_video_encoder_get_profiles(int encoder)
         case HB_VCODEC_X265_16BIT:
             return hb_h265_profile_names_16bit;
 
-#ifdef USE_VCE
+#if HB_PROJECT_FEATURE_VCE
         case HB_VCODEC_FFMPEG_VCE_H264:
             return hb_vce_h264_profile_names;
         case HB_VCODEC_FFMPEG_VCE_H265:
@@ -1571,7 +1570,7 @@ const char* const* hb_video_encoder_get_levels(int encoder)
         case HB_VCODEC_FFMPEG_VT_H264:
             return hb_h264_level_names;
 
-#ifdef USE_VCE
+#if HB_PROJECT_FEATURE_VCE
      case HB_VCODEC_FFMPEG_VCE_H264:
             return hb_vce_h264_level_names; // Not quite the same as x264
 #endif

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -19,7 +19,7 @@
 #include "h264_common.h"
 #include "h265_common.h"
 #include "encx264.h"
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #endif
 
@@ -276,7 +276,7 @@ static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
     // Hardware Encoders
     if (!disable_hardware)
     {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         if (encoder & HB_VCODEC_QSV_MASK)
         {
             return hb_qsv_video_encoder_is_enabled(encoder);
@@ -1330,7 +1330,7 @@ const hb_rate_t* hb_audio_bitrate_get_next(const hb_rate_t *last)
 void hb_video_quality_get_limits(uint32_t codec, float *low, float *high,
                                  float *granularity, int *direction)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (codec & HB_VCODEC_QSV_MASK)
     {
         return hb_qsv_video_quality_get_limits(codec, low, high, granularity,
@@ -1413,7 +1413,7 @@ void hb_video_quality_get_limits(uint32_t codec, float *low, float *high,
 
 const char* hb_video_quality_get_name(uint32_t codec)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (codec & HB_VCODEC_QSV_MASK)
     {
         return hb_qsv_video_quality_get_name(codec);
@@ -1445,7 +1445,7 @@ int hb_video_encoder_get_depth(int encoder)
 {
     switch (encoder)
     {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         case HB_VCODEC_QSV_H265_10BIT:
 #endif
         case HB_VCODEC_X264_10BIT:
@@ -1462,7 +1462,7 @@ int hb_video_encoder_get_depth(int encoder)
 
 const char* const* hb_video_encoder_get_presets(int encoder)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (encoder & HB_VCODEC_QSV_MASK)
     {
         return hb_qsv_preset_get_names();
@@ -1514,7 +1514,7 @@ const char* const* hb_video_encoder_get_tunes(int encoder)
 
 const char* const* hb_video_encoder_get_profiles(int encoder)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (encoder & HB_VCODEC_QSV_MASK)
     {
         return hb_qsv_profile_get_names(encoder);
@@ -1556,7 +1556,7 @@ const char* const* hb_video_encoder_get_profiles(int encoder)
 
 const char* const* hb_video_encoder_get_levels(int encoder)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (encoder & HB_VCODEC_QSV_MASK)
     {
         return hb_qsv_level_get_names(encoder);
@@ -3804,7 +3804,7 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->list_attachment = hb_attachment_list_copy( title->list_attachment );
     job->metadata = hb_metadata_copy( title->metadata );
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     job->qsv.enc_info.is_init_done = 0;
     job->qsv.async_depth           = HB_QSV_ASYNC_DEPTH_DEFAULT;
     job->qsv.decode                = !!(title->video_decode_support &
@@ -4170,7 +4170,7 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             filter = &hb_filter_grayscale;
             break;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         case HB_FILTER_QSV:
             filter = &hb_filter_qsv;
             break;

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -10,6 +10,7 @@
 #ifndef HB_COMMON_H
 #define HB_COMMON_H
 
+#include "project.h"
 #include "hbtypes.h"
 #include "hb_dict.h"
 #include <math.h>
@@ -1432,7 +1433,7 @@ char * hb_x264_param_unparse(int bit_depth, const char *x264_preset,
 // x264 option name/synonym helper
 const char * hb_x264_encopt_name( const char * name );
 
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
 // x265 option name/synonym helper
 const char * hb_x265_encopt_name( const char * name );
 #endif

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -103,7 +103,7 @@ typedef enum
 #include "audio_remap.h"
 #include "libavutil/channel_layout.h"
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_libav.h"
 #endif
 
@@ -700,7 +700,7 @@ struct hb_job_s
     {
         int decode;
         int async_depth;
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         hb_qsv_context *ctx;
 #endif
         // shared encoding parameters

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -47,7 +47,7 @@
 #include "lang.h"
 #include "audio_resample.h"
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #endif
 
@@ -139,7 +139,7 @@ struct hb_work_private_s
     hb_audio_resample_t  * resample;
     int                    drop_samples;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     // QSV-specific settings
     struct
     {
@@ -361,7 +361,7 @@ static void closePrivData( hb_work_private_t ** ppv )
         }
         if ( pv->context && pv->context->codec )
         {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
             /*
              * FIXME: knowingly leaked.
              *
@@ -967,7 +967,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
     reordered_data_t * reordered = NULL;
     hb_buffer_t      * out;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     // no need to copy the frame data when decoding with QSV to opaque memory
     if (pv->qsv.decode &&
         pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY)
@@ -1120,7 +1120,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     hb_filter_init_t   filter_init;
     enum AVPixelFormat pix_fmt;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (pv->qsv.decode &&
         pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY)
     {
@@ -1345,7 +1345,7 @@ static int decodeFrame( hb_work_private_t * pv, packet_info_t * packet_info )
         return 0;
     }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (pv->qsv.decode &&
         pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY &&
         pv->job->qsv.ctx == NULL && pv->video_codec_opened > 0)
@@ -1398,7 +1398,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
         pv->next_pts = 0;
     hb_buffer_list_clear(&pv->list);
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if ((pv->qsv.decode = hb_qsv_decode_is_enabled(job)))
     {
         pv->qsv.codec_name = hb_qsv_decode_get_codec_name(w->codec_param);
@@ -1429,7 +1429,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
         pv->threads = HB_FFMPEG_THREADS_AUTO;
     }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (pv->qsv.decode)
     {
         pv->codec = avcodec_find_decoder_by_name(pv->qsv.codec_name);
@@ -1457,7 +1457,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
         avcodec_parameters_to_context(pv->context,
                                   ic->streams[pv->title->video_id]->codecpar);
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         if (pv->qsv.decode &&
             pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY)
         {
@@ -1474,7 +1474,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
             av_dict_set( &av_opts, "flags", "output_corrupt", 0 );
         }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         if (pv->qsv.decode && pv->context->codec_id == AV_CODEC_ID_HEVC)
         {
             av_dict_set( &av_opts, "load_plugin", "hevc_hw", 0 );
@@ -1590,7 +1590,7 @@ static int decodePacket( hb_work_object_t * w )
         pv->context->error_concealment = FF_EC_GUESS_MVS|FF_EC_DEBLOCK;
 
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         if (pv->qsv.decode &&
             pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY)
         {
@@ -2080,7 +2080,7 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
 
     info->video_decode_support = HB_DECODE_SUPPORT_SW;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (avcodec_find_decoder_by_name(hb_qsv_decode_get_codec_name(pv->context->codec_id)))
     {
         switch (pv->context->codec_id)

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -26,7 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \* ********************************************************************* */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "hb.h"
 #include "nal_units.h"
@@ -2023,4 +2025,4 @@ fail:
     return HB_WORK_ERROR;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -6,7 +6,10 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
-#ifdef USE_X265
+
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_X265
 
 #include "hb.h"
 #include "hb_dict.h"

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -8,7 +8,7 @@
  */
 
 #include "hb.h"
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_libav.h"
 #endif
 
@@ -496,7 +496,7 @@ hb_buffer_t * hb_buffer_dup( const hb_buffer_t * src )
             hb_buffer_init_planes( buf );
     }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     memcpy(&buf->qsv_details, &src->qsv_details, sizeof(src->qsv_details));
 #endif
 
@@ -719,7 +719,7 @@ void hb_buffer_close( hb_buffer_t ** _b )
 
     while( b )
     {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         // Reclaim QSV resources before dropping the buffer.
         // when decoding without QSV, the QSV atom will be NULL.
         if (b->qsv_details.qsv_atom != NULL && b->qsv_details.ctx != NULL)

--- a/libhb/h265_common.h
+++ b/libhb/h265_common.h
@@ -10,6 +10,8 @@
 #ifndef HB_H265_COMMON_H
 #define HB_H265_COMMON_H
 
+#include "project.h"
+
 // inspired by libavcodec/hevc.h
 // in HEVC, all "random access point" NAL units are keyframes
 #define HB_HEVC_NALU_KEYFRAME(nal_unit_type) (((nal_unit_type) >= 16) && ((nal_unit_type) <= 23))
@@ -20,7 +22,7 @@ static const char * const hb_h265_profile_names_8bit[]      = {
     "auto", "main", "mainstillpicture", NULL, };
 static const char * const hb_h265_profile_names_10bit[]     = {
     "auto", "main10", "main10-intra", NULL, };
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 static const char * const hb_h265_qsv_profile_names_10bit[] = {
     "auto", "main10", NULL, };
 #endif

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1703,7 +1703,7 @@ int hb_global_init()
     hb_register(&hb_enctheora);
     hb_register(&hb_encvorbis);
     hb_register(&hb_encx264);
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
     hb_register(&hb_encx265);
 #endif
 #ifdef USE_QSV

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -15,7 +15,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #endif
 
@@ -416,7 +416,7 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     }
     hb_log(" - logical processor count: %d", hb_get_cpu_count());
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (!is_hardware_disabled())
     {
         /* Print QSV info here so that it's in all scan and encode logs */
@@ -1661,7 +1661,7 @@ int hb_global_init()
         return -1;
     }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (!disable_hardware) 
     {
         result = hb_qsv_info_init();
@@ -1706,7 +1706,7 @@ int hb_global_init()
 #if HB_PROJECT_FEATURE_X265
     hb_register(&hb_encx265);
 #endif
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (!disable_hardware) 
     {
         hb_register(&hb_encqsv);

--- a/libhb/hb_dict.c
+++ b/libhb/hb_dict.c
@@ -826,7 +826,7 @@ hb_dict_t * hb_encopts_to_dict(const char * encopts, int encoder)
                 // x264 has multiple names for some options
                 if (encoder & HB_VCODEC_X264_MASK)
                     name = hb_x264_encopt_name(name);
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
                 // x265 has multiple names for some options
                 if (encoder & HB_VCODEC_X265_MASK)
                     name = hb_x265_encopt_name(name);

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -7,9 +7,13 @@
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+#ifndef HB_INTERNAL_H
+#define HB_INTERNAL_H
+
+#include "project.h"
 #include "hbffmpeg.h"
 #include "extras/cl.h"
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_libav.h"
 #endif
 
@@ -142,7 +146,7 @@ struct hb_buffer_s
         int           size;
     } plane[4]; // 3 Color components + alpha
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     struct qsv
     {
         void           * qsv_atom;
@@ -470,7 +474,7 @@ extern hb_filter_object_t hb_filter_avfilter;
 extern hb_filter_object_t hb_filter_mt_frame;
 extern hb_filter_object_t hb_filter_colorspace;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 extern hb_filter_object_t hb_filter_qsv;
 extern hb_filter_object_t hb_filter_qsv_pre;
 extern hb_filter_object_t hb_filter_qsv_post;
@@ -533,3 +537,4 @@ void                 hb_chapter_dequeue(hb_chapter_queue_t *q, hb_buffer_t *b);
 #define HB_FONT_SANS "sans-serif"
 #endif
 
+#endif // HB_INTERNAL_H

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -42,9 +42,6 @@ LIBHB.out += $(LIBHB.a)
 
 ###############################################################################
 
-ifeq (1,$(FEATURE.ffmpeg_aac))
-LIBHB.GCC.D += USE_FFMPEG_AAC
-endif
 LIBHB.GCC.D += __LIBHB__ USE_PTHREAD
 LIBHB.GCC.I += $(LIBHB.build/) $(CONTRIB.build/)include
 

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -80,7 +80,7 @@ else
 endif
 
 ifeq (1,$(FEATURE.qsv))
-    LIBHB.GCC.D += USE_QSV HAVE_THREADS=1
+    LIBHB.GCC.D += HAVE_THREADS=1
 endif
 
 ifeq (1,$(FEATURE.vce))

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -87,10 +87,6 @@ ifeq (1,$(FEATURE.vce))
     LIBHB.GCC.D += USE_VCE
 endif
 
-ifeq (1,$(FEATURE.nvenc))
-    LIBHB.GCC.D += USE_NVENC
-endif
-
 ifeq (1,$(COMPAT.strtok_r))
     LIBHB.GCC.D += HB_NEED_STRTOK_R
 endif

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -91,10 +91,6 @@ ifeq (1,$(FEATURE.nvenc))
     LIBHB.GCC.D += USE_NVENC
 endif
 
-ifeq (1,$(FEATURE.x265))
-    LIBHB.GCC.D += USE_X265
-endif
-
 ifeq (1,$(COMPAT.strtok_r))
     LIBHB.GCC.D += HB_NEED_STRTOK_R
 endif

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -83,10 +83,6 @@ ifeq (1,$(FEATURE.qsv))
     LIBHB.GCC.D += HAVE_THREADS=1
 endif
 
-ifeq (1,$(FEATURE.vce))
-    LIBHB.GCC.D += USE_VCE
-endif
-
 ifeq (1,$(COMPAT.strtok_r))
     LIBHB.GCC.D += HB_NEED_STRTOK_R
 endif

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -10,7 +10,7 @@
 #include "hbffmpeg.h"
 #include "hb.h"
 
-#ifdef USE_NVENC
+#if HB_PROJECT_FEATURE_NVENC
 #include <ffnvcodec/nvEncodeAPI.h>
 #include <ffnvcodec/dynlink_loader.h>
 #endif 
@@ -19,7 +19,7 @@ int hb_check_nvenc_available();
 
 int hb_nvenc_h264_available()
 {
-    #ifdef USE_NVENC
+    #if HB_PROJECT_FEATURE_NVENC
         return hb_check_nvenc_available();
     #else
         return 0;
@@ -28,7 +28,7 @@ int hb_nvenc_h264_available()
 
 int hb_nvenc_h265_available()
 {
-    #ifdef USE_NVENC
+    #if HB_PROJECT_FEATURE_NVENC
         return hb_check_nvenc_available();
     #else
         return 0;
@@ -42,7 +42,7 @@ int hb_check_nvenc_available()
         return 0;
     } 
     
-    #ifdef USE_NVENC
+    #if HB_PROJECT_FEATURE_NVENC
         uint32_t nvenc_ver;
         void *context = NULL;
         NvencFunctions *nvenc_dl = NULL;

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -8,11 +8,12 @@
  * http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+#include "project.h"
 #include "hb_dict.h"
 #include "param.h"
 #include "common.h"
 #include "colormap.h"
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #endif
 #include <regex.h>
@@ -183,7 +184,7 @@ static hb_filter_param_t deinterlace_presets[] =
     { 3, "Default",            "default",      "mode=3"         },
     { 2, "Skip Spatial Check", "skip-spatial", "mode=1"         },
     { 5, "Bob",                "bob",          "mode=7"         },
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     { 6, "QSV",                "qsv",          "mode=11"        },
 #endif
     { 0,  NULL,                NULL,           NULL             },
@@ -240,7 +241,7 @@ static filter_param_map_t param_map[] =
 
 void hb_param_configure_qsv(void)
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (!hb_qsv_available())
     {
         memset(&deinterlace_presets[4], 0, sizeof(hb_filter_param_t));

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -7,6 +7,8 @@
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
+#include "project.h"
+
 #ifdef SYS_MINGW
 #define _WIN32_WINNT 0x600
 #endif
@@ -70,7 +72,7 @@
 #include <linux/cdrom.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include <libdrm/drm.h>
 #endif
 #elif defined( SYS_OPENBSD )
@@ -1513,7 +1515,7 @@ char * hb_strndup(const char * src, size_t len)
 #endif
 }
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #ifdef SYS_LINUX
 
 #define MAX_NODES             16
@@ -1686,7 +1688,7 @@ void hb_display_close(hb_display_t ** _d)
 }
 
 #endif // SYS_LINUX
-#else // !USE_QSV
+#else // !HB_PROJECT_FEATURE_QSV
 
 hb_display_t * hb_display_init(const char         *  driver_name,
                                const char * const * interface_names)
@@ -1699,4 +1701,4 @@ void hb_display_close(hb_display_t ** _d)
     (void)_d;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/ports.h
+++ b/libhb/ports.h
@@ -24,7 +24,9 @@
 #define IS_DIR_SEP(c) (c == '/')
 #endif
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 #include "mfx/mfxstructures.h"
 #ifdef SYS_LINUX
 #include <va/va_drm.h>
@@ -41,7 +43,7 @@ extern const char* DRM_INTEL_DRIVER_NAME;
 typedef struct
 {
     void          * handle;
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     mfxHandleType   mfxType;
 
 #ifdef SYS_LINUX

--- a/libhb/project.h.m4
+++ b/libhb/project.h.m4
@@ -39,18 +39,18 @@ dnl
 <<#>>define HB_PROJECT_HOST_TITLE                "__HOST_title"
 <<#>>define HB_PROJECT_HOST_ARCH                 "__HOST_arch"
 
-<<#>>define HB_PROJECT_FEATURE_asm               __FEATURE_asm
-<<#>>define HB_PROJECT_FEATURE_fdk_aac           __FEATURE_fdk_aac
-<<#>>define HB_PROJECT_FEATURE_ffmpeg_aac        __FEATURE_ffmpeg_aac
-<<#>>define HB_PROJECT_FEATURE_flatpak           __FEATURE_flatpak
-<<#>>define HB_PROJECT_FEATURE_gtk               __FEATURE_gtk
-<<#>>define HB_PROJECT_FEATURE_gtk_mingw         __FEATURE_gtk_mingw
-<<#>>define HB_PROJECT_FEATURE_gtk_update_checks __FEATURE_gtk_update_checks
-<<#>>define HB_PROJECT_FEATURE_gst               __FEATURE_gst
-<<#>>define HB_PROJECT_FEATURE_nvenc             __FEATURE_nvenc
-<<#>>define HB_PROJECT_FEATURE_qsv               __FEATURE_qsv
-<<#>>define HB_PROJECT_FEATURE_vce               __FEATURE_vce
-<<#>>define HB_PROJECT_FEATURE_x265              __FEATURE_x265
-<<#>>define HB_PROJECT_FEATURE_numa              __FEATURE_numa
+<<#>>define HB_PROJECT_FEATURE_ASM               __FEATURE_asm
+<<#>>define HB_PROJECT_FEATURE_FDK_AAC           __FEATURE_fdk_aac
+<<#>>define HB_PROJECT_FEATURE_FFMPEG_AAC        __FEATURE_ffmpeg_aac
+<<#>>define HB_PROJECT_FEATURE_FLATPAK           __FEATURE_flatpak
+<<#>>define HB_PROJECT_FEATURE_GTK               __FEATURE_gtk
+<<#>>define HB_PROJECT_FEATURE_GTK_MINGW         __FEATURE_gtk_mingw
+<<#>>define HB_PROJECT_FEATURE_GTK_UPDATE_CHECKS __FEATURE_gtk_update_checks
+<<#>>define HB_PROJECT_FEATURE_GST               __FEATURE_gst
+<<#>>define HB_PROJECT_FEATURE_NVENC             __FEATURE_nvenc
+<<#>>define HB_PROJECT_FEATURE_QSV               __FEATURE_qsv
+<<#>>define HB_PROJECT_FEATURE_VCE               __FEATURE_vce
+<<#>>define HB_PROJECT_FEATURE_X265              __FEATURE_x265
+<<#>>define HB_PROJECT_FEATURE_NUMA              __FEATURE_numa
 
 #endif /* HB_PROJECT_PROJECT_H */

--- a/libhb/project.h.m4
+++ b/libhb/project.h.m4
@@ -6,37 +6,51 @@ dnl
 #ifndef HB_PROJECT_H
 #define HB_PROJECT_H
 
-<<#>>define HB_PROJECT_TITLE           "__HB_title"
-<<#>>define HB_PROJECT_NAME            "__HB_name"
-<<#>>define HB_PROJECT_NAME_LOWER      "__HB_name_lower"
-<<#>>define HB_PROJECT_NAME_UPPER      "__HB_name_upper"
-<<#>>define HB_PROJECT_URL_WEBSITE     "__HB_url_website"
-<<#>>define HB_PROJECT_URL_COMMUNITY   "__HB_url_community"
-<<#>>define HB_PROJECT_URL_IRC         "__HB_url_irc"
-<<#>>define HB_PROJECT_URL_APPCAST     "__HB_url_appcast"
-<<#>>define HB_PROJECT_VERSION_MAJOR   __HB_version_major
-<<#>>define HB_PROJECT_VERSION_MINOR   __HB_version_minor
-<<#>>define HB_PROJECT_VERSION_POINT   __HB_version_point
-<<#>>define HB_PROJECT_VERSION         "__HB_version"
-<<#>>define HB_PROJECT_VERSION_HEX     0x<<>>__HB_version_hex<<>>LL
-<<#>>define HB_PROJECT_BUILD           __HB_build
-<<#>>define HB_PROJECT_REPO_URL        "__HB_repo_url"
-<<#>>define HB_PROJECT_REPO_TAG        "__HB_repo_tag"
-<<#>>define HB_PROJECT_REPO_REV        __HB_repo_rev
-<<#>>define HB_PROJECT_REPO_HASH       "__HB_repo_hash"
-<<#>>define HB_PROJECT_REPO_BRANCH     "__HB_repo_branch"
-<<#>>define HB_PROJECT_REPO_REMOTE     "__HB_repo_remote"
-<<#>>define HB_PROJECT_REPO_TYPE       "__HB_repo_type"
-<<#>>define HB_PROJECT_REPO_OFFICIAL   __HB_repo_official
-<<#>>define HB_PROJECT_REPO_DATE       "__HB_repo_date"
+<<#>>define HB_PROJECT_TITLE                     "__HB_title"
+<<#>>define HB_PROJECT_NAME                      "__HB_name"
+<<#>>define HB_PROJECT_NAME_LOWER                "__HB_name_lower"
+<<#>>define HB_PROJECT_NAME_UPPER                "__HB_name_upper"
+<<#>>define HB_PROJECT_URL_WEBSITE               "__HB_url_website"
+<<#>>define HB_PROJECT_URL_COMMUNITY             "__HB_url_community"
+<<#>>define HB_PROJECT_URL_IRC                   "__HB_url_irc"
+<<#>>define HB_PROJECT_URL_APPCAST               "__HB_url_appcast"
+<<#>>define HB_PROJECT_VERSION_MAJOR             __HB_version_major
+<<#>>define HB_PROJECT_VERSION_MINOR             __HB_version_minor
+<<#>>define HB_PROJECT_VERSION_POINT             __HB_version_point
+<<#>>define HB_PROJECT_VERSION                   "__HB_version"
+<<#>>define HB_PROJECT_VERSION_HEX               0x<<>>__HB_version_hex<<>>LL
+<<#>>define HB_PROJECT_BUILD                     __HB_build
+<<#>>define HB_PROJECT_REPO_URL                  "__HB_repo_url"
+<<#>>define HB_PROJECT_REPO_TAG                  "__HB_repo_tag"
+<<#>>define HB_PROJECT_REPO_REV                  __HB_repo_rev
+<<#>>define HB_PROJECT_REPO_HASH                 "__HB_repo_hash"
+<<#>>define HB_PROJECT_REPO_BRANCH               "__HB_repo_branch"
+<<#>>define HB_PROJECT_REPO_REMOTE               "__HB_repo_remote"
+<<#>>define HB_PROJECT_REPO_TYPE                 "__HB_repo_type"
+<<#>>define HB_PROJECT_REPO_OFFICIAL             __HB_repo_official
+<<#>>define HB_PROJECT_REPO_DATE                 "__HB_repo_date"
 
-<<#>>define HB_PROJECT_HOST_SPEC       "__HOST_spec"
-<<#>>define HB_PROJECT_HOST_MACHINE    "__HOST_machine"
-<<#>>define HB_PROJECT_HOST_VENDOR     "__HOST_vendor"
-<<#>>define HB_PROJECT_HOST_SYSTEM     "__HOST_system"
-<<#>>define HB_PROJECT_HOST_SYSTEMF    "__HOST_systemf"
-<<#>>define HB_PROJECT_HOST_RELEASE    "__HOST_release"
-<<#>>define HB_PROJECT_HOST_TITLE      "__HOST_title"
-<<#>>define HB_PROJECT_HOST_ARCH       "__HOST_arch"
+<<#>>define HB_PROJECT_HOST_SPEC                 "__HOST_spec"
+<<#>>define HB_PROJECT_HOST_MACHINE              "__HOST_machine"
+<<#>>define HB_PROJECT_HOST_VENDOR               "__HOST_vendor"
+<<#>>define HB_PROJECT_HOST_SYSTEM               "__HOST_system"
+<<#>>define HB_PROJECT_HOST_SYSTEMF              "__HOST_systemf"
+<<#>>define HB_PROJECT_HOST_RELEASE              "__HOST_release"
+<<#>>define HB_PROJECT_HOST_TITLE                "__HOST_title"
+<<#>>define HB_PROJECT_HOST_ARCH                 "__HOST_arch"
+
+<<#>>define HB_PROJECT_FEATURE_asm               __FEATURE_asm
+<<#>>define HB_PROJECT_FEATURE_fdk_aac           __FEATURE_fdk_aac
+<<#>>define HB_PROJECT_FEATURE_ffmpeg_aac        __FEATURE_ffmpeg_aac
+<<#>>define HB_PROJECT_FEATURE_flatpak           __FEATURE_flatpak
+<<#>>define HB_PROJECT_FEATURE_gtk               __FEATURE_gtk
+<<#>>define HB_PROJECT_FEATURE_gtk_mingw         __FEATURE_gtk_mingw
+<<#>>define HB_PROJECT_FEATURE_gtk_update_checks __FEATURE_gtk_update_checks
+<<#>>define HB_PROJECT_FEATURE_gst               __FEATURE_gst
+<<#>>define HB_PROJECT_FEATURE_nvenc             __FEATURE_nvenc
+<<#>>define HB_PROJECT_FEATURE_qsv               __FEATURE_qsv
+<<#>>define HB_PROJECT_FEATURE_vce               __FEATURE_vce
+<<#>>define HB_PROJECT_FEATURE_x265              __FEATURE_x265
+<<#>>define HB_PROJECT_FEATURE_numa              __FEATURE_numa
 
 #endif /* HB_PROJECT_PROJECT_H */

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -7,7 +7,9 @@
  * For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include <stdio.h>
 #include <string.h>
@@ -2247,4 +2249,4 @@ int hb_qsv_available()
     return 0;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/qsv_common.h
+++ b/libhb/qsv_common.h
@@ -12,7 +12,9 @@
 
 int            hb_qsv_available();
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "mfx/mfxvideo.h"
 #include "mfx/mfxplugin.h"
@@ -193,5 +195,5 @@ const char* hb_qsv_impl_get_via_name(int impl);
 
 void hb_qsv_force_workarounds(); // for developers only
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV
 #endif // HB_QSV_COMMON_H

--- a/libhb/qsv_filter.c
+++ b/libhb/qsv_filter.c
@@ -26,7 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \* ********************************************************************* */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "hb.h"
 #include "hbffmpeg.h"
@@ -671,5 +673,5 @@ static int hb_qsv_filter_work( hb_filter_object_t * filter,
     return HB_FILTER_OK;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV
 

--- a/libhb/qsv_filter.h
+++ b/libhb/qsv_filter.h
@@ -29,6 +29,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef QSV_FILTER_H
 #define QSV_FILTER_H
 
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 void qsv_filter_close( hb_qsv_context* qsv, HB_QSV_STAGE_TYPE vpp_type );
+#endif
 
 #endif // QSV_FILTER_H

--- a/libhb/qsv_filter_pp.c
+++ b/libhb/qsv_filter_pp.c
@@ -26,7 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \* ********************************************************************* */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "hb.h"
 #include "hbffmpeg.h"
@@ -930,4 +932,4 @@ int process_filter(qsv_filter_task_t* task, void* params){
     return sts;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/qsv_filter_pp.h
+++ b/libhb/qsv_filter_pp.h
@@ -29,6 +29,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef QSV_FILTER_PP_H
 #define QSV_FILTER_PP_H
 
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
+
 #include "mfx/mfxplugin.h"
 
 struct qsv_filter_task_s;
@@ -109,4 +113,5 @@ mfxStatus lock_frame(mfxFrameAllocator *,mfxFrameSurface1*);
 mfxStatus unlock_frame(mfxFrameAllocator *,mfxFrameSurface1*);
 
 
+#endif // HB_PROJECT_FEATURE_QSV
 #endif //QSV_FILTER_PP_H

--- a/libhb/qsv_libav.c
+++ b/libhb/qsv_libav.c
@@ -26,7 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \* ********************************************************************* */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "hbffmpeg.h"
 #include "qsv_libav.h"
@@ -605,4 +607,4 @@ void hb_qsv_wait_on_sync(hb_qsv_context *qsv, hb_qsv_stage *stage)
         }
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/qsv_memory.c
+++ b/libhb/qsv_memory.c
@@ -26,7 +26,9 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 \* ********************************************************************* */
 
-#ifdef USE_QSV
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
 
 #include "hb.h"
 #include "hbffmpeg.h"
@@ -121,4 +123,4 @@ int qsv_yuv420_to_nv12(struct SwsContext* sws_context,mfxFrameSurface1* dst, hb_
     return ret;
 }
 
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/qsv_memory.h
+++ b/libhb/qsv_memory.h
@@ -29,6 +29,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #ifndef QSV_MEMORY_H
 #define QSV_MEMORY_H
 
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_QSV
+
 #include "mfx/mfxplugin.h"
 #include "qsv_libav.h"
 
@@ -52,4 +56,5 @@ typedef struct{
 int qsv_nv12_to_yuv420(struct SwsContext* sws_context,hb_buffer_t* dst, mfxFrameSurface1* src,mfxCoreInterface *core);
 int qsv_yuv420_to_nv12(struct SwsContext* sws_context,mfxFrameSurface1* dst, hb_buffer_t* src);
 
+#endif // HB_PROJECT_FEATURE_QSV
 #endif // QSV_MEMORY_H

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -7,7 +7,9 @@
  * For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-#ifdef USE_VCE
+#include "project.h"
+
+#if HB_PROJECT_FEATURE_VCE
 #include "AMF/core/Factory.h"
 #include "AMF/components/VideoEncoderVCE.h"
 #include "AMF/components/VideoEncoderHEVC.h"
@@ -116,7 +118,7 @@ int hb_vce_h265_available()
     return (check_component_available(AMFVideoEncoder_HEVC) == AMF_OK) ? 1 : 0;
 }
 
-#else // !USE_VCE
+#else // !HB_PROJECT_FEATURE_VCE
 
 int hb_vce_h264_available()
 {
@@ -128,4 +130,4 @@ int hb_vce_h265_available()
     return 0;
 }
 
-#endif // USE_VCE
+#endif // HB_PROJECT_FEATURE_VCE

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -116,7 +116,7 @@ int hb_vce_h265_available()
     return (check_component_available(AMFVideoEncoder_HEVC) == AMF_OK) ? 1 : 0;
 }
 
-#else
+#else // !USE_VCE
 
 int hb_vce_h264_available()
 {
@@ -128,4 +128,4 @@ int hb_vce_h265_available()
     return 0;
 }
 
-#endif // USE_QSV
+#endif // USE_VCE

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -256,7 +256,7 @@ hb_work_object_t* hb_video_encoder(hb_handle_t *h, int vcodec)
         case HB_VCODEC_THEORA:
             w = hb_get_work(h, WORK_ENCTHEORA);
             break;
-#ifdef USE_X265
+#if HB_PROJECT_FEATURE_X265
         case HB_VCODEC_X265_8BIT:
         case HB_VCODEC_X265_10BIT:
         case HB_VCODEC_X265_12BIT:

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -274,7 +274,7 @@ hb_work_object_t* hb_video_encoder(hb_handle_t *h, int vcodec)
             w->codec_param = AV_CODEC_ID_HEVC;
             break;
 #endif
-#ifdef USE_NVENC
+#if HB_PROJECT_FEATURE_NVENC
         case HB_VCODEC_FFMPEG_NVENC_H264:
             w = hb_get_work(h, WORK_ENCAVCODEC);
             w->codec_param = AV_CODEC_ID_H264;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -12,7 +12,7 @@
 #include "decomb.h"
 #include "hbavfilter.h"
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #include "qsv_filter_pp.h"
 #endif
@@ -421,7 +421,7 @@ void hb_display_job_info(hb_job_t *job)
 
     hb_log(" * video track");
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (hb_qsv_decode_is_enabled(job))
     {
         hb_log("   + decoder: %s",
@@ -1204,7 +1204,7 @@ static int sanitize_audio(hb_job_t *job)
 
 static int sanitize_qsv( hb_job_t * job )
 {
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #if 0 // TODO: re-implement QSV VPP filtering and QSV zerocopy path
     int i;
 
@@ -1368,7 +1368,7 @@ static int sanitize_qsv( hb_job_t * job )
         }
     }
 #endif // QSV VPP filtering and QSV zerocopy path
-#endif // USE_QSV
+#endif // HB_PROJECT_FEATURE_QSV
 
     return 0;
 }
@@ -1550,7 +1550,7 @@ static void do_job(hb_job_t *job)
     hb_reduce(&job->vrate.num, &job->vrate.den,
                job->vrate.num,  job->vrate.den);
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #if 0 // TODO: re-implement QSV zerocopy path
     if (hb_qsv_decode_is_enabled(job) && (job->vcodec & HB_VCODEC_QSV_MASK))
     {
@@ -2043,13 +2043,13 @@ static void filter_loop( void * _f )
 
         buf_out = NULL;
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         hb_buffer_t *last_buf_in = buf_in;
 #endif
 
         f->status = f->work( f, &buf_in, &buf_out );
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
         if (f->status == HB_FILTER_DELAY &&
             last_buf_in->qsv_details.filter_details != NULL && buf_out == NULL)
         {

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -264,7 +264,7 @@ hb_work_object_t* hb_video_encoder(hb_handle_t *h, int vcodec)
             w = hb_get_work(h, WORK_ENCX265);
             break;
 #endif
-#ifdef USE_VCE
+#if HB_PROJECT_FEATURE_VCE
         case HB_VCODEC_FFMPEG_VCE_H264:
             w = hb_get_work(h, WORK_ENCAVCODEC);
             w->codec_param = AV_CODEC_ID_H264;

--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -33,11 +33,6 @@ MACOSX.map.g.max  = debug
 MACOSX.xcconfig = $(foreach x,$(XCODE.xcconfig),-xcconfig $(MACOSX.src/)xcconfig/$(x))
 MACOSX.sdk      = $(foreach sdk,$(GCC.sysroot),-sdk $(sdk))
 
-## some optional features use ifdef directives outside of libhb (e.g. CLI)
-ifeq (1,$(FEATURE.x265))
-    MACOSX.GCC.D += -DUSE_X265
-endif
-
 ## extra CFLAGS: macro definitions
 MACOSX.extra_cflags = OTHER_CFLAGS='$(MACOSX.GCC.D)'
 

--- a/make/configure.py
+++ b/make/configure.py
@@ -1956,7 +1956,7 @@ int main()
     doc.add( 'PREFIX/', cfg.prefix_final + os.sep )
 
     doc.addBlank()
-    doc.add( 'FEATURE.asm',        'disabled' )
+    doc.add( 'FEATURE.asm',        int( 0 ))
     doc.add( 'FEATURE.fdk_aac',    int( options.enable_fdk_aac ))
     doc.add( 'FEATURE.ffmpeg_aac', int( options.enable_ffmpeg_aac ))
     doc.add( 'FEATURE.flatpak',    int( options.flatpak ))

--- a/test/module.defs
+++ b/test/module.defs
@@ -30,18 +30,6 @@ ifeq ($(HOST.system),linux)
 endif
 endif
 
-ifeq (1,$(FEATURE.vce))
-    TEST.GCC.D += USE_VCE
-endif
-
-ifeq (1,$(FEATURE.nvenc))
-    TEST.GCC.D += USE_NVENC
-endif
-
-ifeq (1,$(FEATURE.x265))
-    TEST.GCC.D += USE_X265
-endif
-
 ifeq (1,$(FEATURE.flatpak))
     TEST.GCC.l += glib-2.0
 endif

--- a/test/module.defs
+++ b/test/module.defs
@@ -24,7 +24,6 @@ ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
 endif
 
 ifeq (1,$(FEATURE.qsv))
-    TEST.GCC.D += USE_QSV HAVE_THREADS=1
     TEST.GCC.l += mfx
 ifeq ($(HOST.system),linux)
     TEST.GCC.l += va va-drm

--- a/test/test.c
+++ b/test/test.c
@@ -34,7 +34,7 @@
 #include "lang.h"
 #include "parsecsv.h"
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
 #endif
 
@@ -190,7 +190,7 @@ static int      start_at_frame = 0;
 static int64_t  stop_at_pts    = 0;
 static int      stop_at_frame = 0;
 static uint64_t min_title_duration = 10;
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 static int      qsv_async_depth    = -1;
 static int      qsv_decode         = -1;
 #endif
@@ -1901,7 +1901,7 @@ static void ShowHelp()
 "\n"
     );
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
 if (hb_qsv_available())
 {
     fprintf( out,
@@ -2163,7 +2163,7 @@ static int ParseOptions( int argc, char ** argv )
             { "verbose",     optional_argument, NULL,    'v' },
             { "no-dvdnav",   no_argument,       NULL,    DVDNAV },
 
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
             { "qsv-baseline",         no_argument,       NULL,        QSV_BASELINE,       },
             { "qsv-async-depth",      required_argument, NULL,        QSV_ASYNC_DEPTH,    },
             { "qsv-implementation",   required_argument, NULL,        QSV_IMPLEMENTATION, },
@@ -3053,7 +3053,7 @@ static int ParseOptions( int argc, char ** argv )
             case MIN_DURATION:
                 min_title_duration = strtol( optarg, NULL, 0 );
                 break;
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
             case QSV_BASELINE:
                 hb_qsv_force_workarounds();
                 break;
@@ -4122,7 +4122,7 @@ static hb_dict_t * PreparePreset(const char *preset_name)
         hb_dict_set(preset, "VideoColorMatrixCodeOverride",
                     hb_value_int(color_matrix_code));
     }
-#ifdef USE_QSV
+#if HB_PROJECT_FEATURE_QSV
     if (qsv_async_depth >= 0)
     {
         hb_dict_set(preset, "VideoQSVAsyncDepth",


### PR DESCRIPTION
**Description of Change:**
Exports all FEATURE flags to project.h where they can be used directly in code instead of indirectly through gcc command line defines.

Uses the FEATURE defines in code and removes the extra gcc definitions

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
