### PR TITLE
qsv: adding LowPower encode support for HEVC

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1248,8 +1248,9 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     }
 
     // log code path and main output settings
-    hb_log("encqsvInit: using %s path",
-           pv->is_sys_mem ? "encode-only" : "full QSV");
+    hb_log("encqsvInit: using %s%s path",
+           pv->is_sys_mem ? "encode-only" : "full QSV",
+           videoParam.mfx.LowPower == MFX_CODINGOPTION_ON ? " (LowPower)" : "" );
     hb_log("encqsvInit: %s %s profile @ level %s",
            hb_qsv_codec_name  (videoParam.mfx.CodecId),
            hb_qsv_profile_name(videoParam.mfx.CodecId, videoParam.mfx.CodecProfile),

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -261,8 +261,6 @@ const char* hb_get_cpu_platform_name()
 {
     switch (hb_cpu_info.platform)
     {
-        // Intel 64 and IA-32 Architectures Software Developer's Manual, Vol. 3C
-        // Table 35-1: CPUID Signature Values of DisplayFamily_DisplayModel
         case HB_CPU_PLATFORM_INTEL_BNL:
             return "Intel microarchitecture Bonnell";
         case HB_CPU_PLATFORM_INTEL_SNB:
@@ -281,6 +279,8 @@ const char* hb_get_cpu_platform_name()
             return "Intel microarchitecture Airmont";
         case HB_CPU_PLATFORM_INTEL_KBL:
             return "Intel microarchitecture Kaby Lake";
+        case HB_CPU_PLATFORM_INTEL_ICL:
+            return "Intel microarchitecture Ice Lake";
         default:
             return NULL;
     }
@@ -319,8 +319,8 @@ static void init_cpu_info()
         family = ((eax >> 8) & 0xf) + ((eax >> 20) & 0xff);
         model  = ((eax >> 4) & 0xf) + ((eax >> 12) & 0xf0);
 
-        // Intel 64 and IA-32 Architectures Software Developer's Manual, Vol. 3C
-        // Table 35-1: CPUID Signature Values of DisplayFamily_DisplayModel
+        // Intel 64 and IA-32 Architectures Software Developer's Manual, Volume 4/January 2019
+        // Table 2-1. CPUID Signature Values of DisplayFamily_DisplayModel
         switch (family)
         {
             case 0x06:
@@ -371,6 +371,8 @@ static void init_cpu_info()
                     case 0x9E:
                         hb_cpu_info.platform = HB_CPU_PLATFORM_INTEL_KBL;
                         break;
+                    case 0x7E:
+                        hb_cpu_info.platform = HB_CPU_PLATFORM_INTEL_ICL;
                     default:
                         break;
                 }

--- a/libhb/ports.h
+++ b/libhb/ports.h
@@ -73,6 +73,7 @@ enum hb_cpu_platform
     HB_CPU_PLATFORM_INTEL_CHT,
     HB_CPU_PLATFORM_INTEL_SKL,
     HB_CPU_PLATFORM_INTEL_KBL,
+    HB_CPU_PLATFORM_INTEL_ICL,
 };
 int         hb_get_cpu_count(void);
 int         hb_get_cpu_platform(void);

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1763,7 +1763,12 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(qsv, "Decode",
                     hb_value_xform(value, HB_VALUE_TYPE_BOOL));
     }
-    if ((value = hb_dict_get(preset, "VideoQSVAsyncDepth")) != NULL)
+    if ((value = hb_dict_get(preset, "VideoQSVLowPower")) != NULL)
+    {
+        hb_dict_set(qsv, "LowPower",
+                    hb_value_xform(value, HB_VALUE_TYPE_BOOL));
+    }
+     if ((value = hb_dict_get(preset, "VideoQSVAsyncDepth")) != NULL)
     {
         hb_dict_set(qsv, "AsyncDepth",
                     hb_value_xform(value, HB_VALUE_TYPE_INT));

--- a/libhb/qsv_common.h
+++ b/libhb/qsv_common.h
@@ -48,6 +48,7 @@ typedef struct hb_qsv_info_s
 #define HB_QSV_CAP_MSDK_API_1_6      (1LL <<  0)
     // H.264, H.265: B-frames can be used as references
 #define HB_QSV_CAP_B_REF_PYRAMID     (1LL <<  1)
+#define HB_QSV_CAP_LOWPOWER_ENCODE   (1LL <<  2)
     // mfxExtVideoSignalInfo
 #define HB_QSV_CAP_VUI_VSINFO        (1LL <<  3)
     // optional rate control methods


### PR DESCRIPTION
Adding support of LowPower/VDENC encoding for appropriate HW generation.

CLI usage: -x “lowpower=1”
GUI usage: at Video tab and “Extra Options”: lowpower=1


