### PR TITLE
audio_resample: set input and output samplerate

### DIFF
--- a/libhb/audio_resample.h
+++ b/libhb/audio_resample.h
@@ -37,6 +37,7 @@ typedef struct
 
     struct
     {
+        int sample_rate;
         uint64_t channel_layout;
         double lfe_mix_level;
         double center_mix_level;
@@ -46,6 +47,7 @@ typedef struct
 
     struct
     {
+        int sample_rate;
         int channels;
         uint64_t channel_layout;
         double lfe_mix_level;
@@ -56,6 +58,7 @@ typedef struct
 
     struct
     {
+        int sample_rate;
         int channels;
         int sample_size;
         uint64_t channel_layout;
@@ -72,6 +75,7 @@ typedef struct
  * as the output characteristics (no conversion needed).
  */
 hb_audio_resample_t* hb_audio_resample_init(enum AVSampleFormat sample_fmt,
+                                            int sample_rate,
                                             int hb_amixdown, int normalize_mix);
 
 /* The following functions set the audio input characteristics.
@@ -90,6 +94,9 @@ void                 hb_audio_resample_set_mix_levels(hb_audio_resample_t *resam
 
 void                 hb_audio_resample_set_sample_fmt(hb_audio_resample_t *resample,
                                                       enum AVSampleFormat sample_fmt);
+
+void                 hb_audio_resample_set_sample_rate(hb_audio_resample_t *resample,
+                                                       int sample_rate);
 
 /* Update an hb_audio_resample_t.
  *

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -206,8 +206,13 @@ static int decavcodecaInit( hb_work_object_t * w, hb_job_t * job )
     /* Downmixing & sample_fmt conversion */
     if (!(w->audio->config.out.codec & HB_ACODEC_PASS_FLAG))
     {
+        // Currently, samplerate conversion is performed in sync.c
+        // So set output samplerate to input samplerate
+        // This should someday get reworked to be part of an audio
+        // filter pipleine.
         pv->resample =
             hb_audio_resample_init(AV_SAMPLE_FMT_FLT,
+                                   w->audio->config.in.samplerate,
                                    w->audio->config.out.mixdown,
                                    w->audio->config.out.normalize_mix_level);
         if (pv->resample == NULL)
@@ -2274,6 +2279,8 @@ static void decodeAudio(hb_work_private_t *pv, packet_info_t * packet_info)
             hb_audio_resample_set_channel_layout(pv->resample, channel_layout);
             hb_audio_resample_set_sample_fmt(pv->resample,
                                              pv->frame->format);
+            hb_audio_resample_set_sample_rate(pv->resample,
+                                             pv->frame->sample_rate);
             if (hb_audio_resample_update(pv->resample))
             {
                 hb_log("decavcodec: hb_audio_resample_update() failed");

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -166,8 +166,12 @@ static int declpcmInit( hb_work_object_t * w, hb_job_t * job )
     pv->job = job;
 
     pv->next_pts = (int64_t)AV_NOPTS_VALUE;
+    // Currently, samplerate conversion is performed in sync.c
+    // So set output samplerate to input samplerate
+    // This should someday get reworked to be part of an audio filter pipleine.
     pv->resample =
         hb_audio_resample_init(AV_SAMPLE_FMT_FLT,
+                               w->audio->config.in.samplerate,
                                w->audio->config.out.mixdown,
                                w->audio->config.out.normalize_mix_level);
     if (pv->resample == NULL)
@@ -333,6 +337,8 @@ static hb_buffer_t *Decode( hb_work_object_t *w )
 
     hb_audio_resample_set_channel_layout(pv->resample,
                                          hdr2layout[pv->nchannels - 1]);
+    hb_audio_resample_set_sample_rate(pv->resample,
+                                      pv->samplerate);
     if (hb_audio_resample_update(pv->resample))
     {
         hb_log("declpcm: hb_audio_resample_update() failed");

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -249,13 +249,13 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                        context->channel_layout, 0);
         av_opt_set_int(pv->swresample, "out_channel_layout",
                        context->channel_layout, 0);
+        av_opt_set_int(pv->swresample, "in_sample_rate",
+                       context->sample_rate, 0);
+        av_opt_set_int(pv->swresample, "out_sample_rate",
+                       context->sample_rate, 0);
         if (hb_audio_dither_is_supported(audio->config.out.codec))
         {
             // dithering needs the sample rate
-            av_opt_set_int(pv->swresample, "in_sample_rate",
-                           context->sample_rate, 0);
-            av_opt_set_int(pv->swresample, "out_sample_rate",
-                           context->sample_rate, 0);
             av_opt_set_int(pv->swresample, "dither_method",
                            audio->config.out.dither_method, 0);
         }


### PR DESCRIPTION
It appears ffmpeg has changed swresample to require setting input and output samplerate even when *not* changing the samplerate.  This patch should prepare us for when we update to the latest ffmpeg release.

Fixes https://github.com/HandBrake/HandBrake/issues/2124

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

It should be sufficient to test doing mixdowns with a few sources. 

If anyone has a source with DVD lpcm, I have not tested that yet.  DVD lpcm has it's own decoder in declpcm.c so needs testing.  All other audio goes through decavcodec.c which I've tested on Linux.
