### PR TITLE
encx265: set level

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -547,6 +547,9 @@ void hb_display_job_info(hb_job_t *job)
             {
                 case HB_VCODEC_X264_8BIT:
                 case HB_VCODEC_X264_10BIT:
+                case HB_VCODEC_X265_8BIT:
+                case HB_VCODEC_X265_10BIT:
+                case HB_VCODEC_X265_12BIT:
                 case HB_VCODEC_QSV_H264:
                 case HB_VCODEC_QSV_H265:
                 case HB_VCODEC_QSV_H265_10BIT:


### PR DESCRIPTION
It seems the encoder level has been supported in x265 since May 2014,
just a few months after initial support for x265 was added to
HandBrake :\

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
