### PR TITLE
added encoder to auto-name options

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1246,6 +1246,13 @@ set_destination_settings(signal_user_data_t *ud, GhbValue *settings)
                 p += strlen("{creation-time}");
                 g_free(val);
             }
+            else if (!strncasecmp(p, "{encoder}", strlen("{encoder}")))
+            {
+                const gchar *encoder;
+                encoder = ghb_dict_get_string(settings, "VideoEncoder");
+                g_string_append_printf(str, "%s", encoder);
+                p += strlen("{encoder}");
+            }
             else if (!strncasecmp(p, "{quality}", strlen("{quality}")))
             {
                 if (ghb_dict_get_bool(settings, "vquality_type_constant"))


### PR DESCRIPTION
**Description of Change:**
Added the code to automatically replace an `{encoder}` tag in automatic file naming.
Adresses part of [#1692](https://github.com/HandBrake/HandBrake/issues/1692).

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux