### PR TITLE
contrib: Update x265 to 3.1

### DIFF
--- a/contrib/x265/module.defs
+++ b/contrib/x265/module.defs
@@ -2,11 +2,11 @@ __deps__ := X265_8 X265_10 X265_12
 $(eval $(call import.MODULE.defs,X265,x265,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,X265))
 
-X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.0.tar.gz
-X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.0.tar.gz
-X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.0.tar.gz
-X265.FETCH.sha256  = c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662
-X265.EXTRACT.tarbase = x265_3.0
+X265.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.1.tar.gz
+X265.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.1.tar.gz
+X265.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.1.tar.gz
+X265.FETCH.sha256  = 39807e6ec6fc1e385829a882f5bdee1ed12b358b2d56918d6ddcefac054fd605
+X265.EXTRACT.tarbase = x265_3.1
 
 # Silence "warning: overriding recipe for target" messages
 X265.FETCH.target =

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -2,11 +2,11 @@ __deps__ := X265_8
 $(eval $(call import.MODULE.defs,X265_10,x265_10,$(__deps__),x265))
 $(eval $(call import.CONTRIB.defs,X265_10))
 
-X265_10.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.0.tar.gz
-X265_10.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.0.tar.gz
-X265_10.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.0.tar.gz
-X265_10.FETCH.sha256  = c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662
-X265_10.EXTRACT.tarbase = x265_3.0
+X265_10.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.1.tar.gz
+X265_10.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.1.tar.gz
+X265_10.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.1.tar.gz
+X265_10.FETCH.sha256  = 39807e6ec6fc1e385829a882f5bdee1ed12b358b2d56918d6ddcefac054fd605
+X265_10.EXTRACT.tarbase = x265_3.1
 
 # Silence "warning: overriding recipe for target" messages
 X265_10.FETCH.target =

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -2,11 +2,11 @@ __deps__ := X265_8
 $(eval $(call import.MODULE.defs,X265_12,x265_12,$(__deps__),x265))
 $(eval $(call import.CONTRIB.defs,X265_12))
 
-X265_12.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.0.tar.gz
-X265_12.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.0.tar.gz
-X265_12.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.0.tar.gz
-X265_12.FETCH.sha256  = c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662
-X265_12.EXTRACT.tarbase = x265_3.0
+X265_12.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.1.tar.gz
+X265_12.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.1.tar.gz
+X265_12.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.1.tar.gz
+X265_12.FETCH.sha256  = 39807e6ec6fc1e385829a882f5bdee1ed12b358b2d56918d6ddcefac054fd605
+X265_12.EXTRACT.tarbase = x265_3.1
 
 # Silence "warning: overriding recipe for target" messages
 X265_12.FETCH.target =

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -2,11 +2,11 @@ __deps__ :=
 $(eval $(call import.MODULE.defs,X265_8,x265_8,$(__deps__),x265))
 $(eval $(call import.CONTRIB.defs,X265_8))
 
-X265_8.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.0.tar.gz
-X265_8.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.0.tar.gz
-X265_8.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.0.tar.gz
-X265_8.FETCH.sha256  = c5b9fc260cabbc4a81561a448f4ce9cad7218272b4011feabc3a6b751b2f0662
-X265_8.EXTRACT.tarbase = x265_3.0
+X265_8.FETCH.url     = https://download.handbrake.fr/contrib/x265_3.1.tar.gz
+X265_8.FETCH.url    += https://bitbucket.org/multicoreware/x265/downloads/x265_3.1.tar.gz
+X265_8.FETCH.url    += https://download.videolan.org/pub/videolan/x265/x265_3.1.tar.gz
+X265_8.FETCH.sha256  = 39807e6ec6fc1e385829a882f5bdee1ed12b358b2d56918d6ddcefac054fd605
+X265_8.EXTRACT.tarbase = x265_3.1
 
 X265_8.build_dir             = 8bit
 X265_8.CONFIGURE.exe         = cmake


### PR DESCRIPTION
Updates x265 to 3.1

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux