### PR TITLE
scripts: Update mac-toolchain-build

### DIFF
--- a/scripts/mac-toolchain-build
+++ b/scripts/mac-toolchain-build
@@ -74,11 +74,11 @@ function mac_toolchain_build {
     printf "Downloading [%02i/%02i] %s " "1" "${TOTAL}" "autoconf 2.69"
     curl -Lf --connect-timeout 30 https://ftp.gnu.org/gnu/autoconf/autoconf-2.69.tar.gz -o "autoconf-2.69.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
-    printf "Downloading [%02i/%02i] %s " "2" "${TOTAL}" "automake 1.15.1"
-    curl -Lf --connect-timeout 30 https://ftp.gnu.org/gnu/automake/automake-1.15.1.tar.gz -o "automake-1.15.1.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
+    printf "Downloading [%02i/%02i] %s " "2" "${TOTAL}" "automake 1.16.1"
+    curl -Lf --connect-timeout 30 https://ftp.gnu.org/gnu/automake/automake-1.16.1.tar.gz -o "automake-1.16.1.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
-    printf "Downloading [%02i/%02i] %s " "3" "${TOTAL}" "cmake 3.9.6"
-    curl -Lf --connect-timeout 30 https://cmake.org/files/v3.9/cmake-3.9.6.tar.gz -o "cmake-3.9.6.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
+    printf "Downloading [%02i/%02i] %s " "3" "${TOTAL}" "cmake 3.14.5"
+    curl -Lf --connect-timeout 30 https://cmake.org/files/v3.14/cmake-3.14.5.tar.gz -o "cmake-3.14.5.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
     printf "Downloading [%02i/%02i] %s " "4" "${TOTAL}" "libtool 2.4.6"
     curl -Lf --connect-timeout 30 https://ftp.gnu.org/gnu/libtool/libtool-2.4.6.tar.gz -o "libtool-2.4.6.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
@@ -86,8 +86,8 @@ function mac_toolchain_build {
     printf "Downloading [%02i/%02i] %s " "5" "${TOTAL}" "pkg-config 0.29.2"
     curl -Lf --connect-timeout 30 https://pkg-config.freedesktop.org/releases/pkg-config-0.29.2.tar.gz -o "pkg-config-0.29.2.tar.gz" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
-    printf "Downloading [%02i/%02i] %s " "6" "${TOTAL}" "nasm 2.13.02"
-    curl -Lf --connect-timeout 30 https://www.nasm.us/pub/nasm/releasebuilds/2.13.02/nasm-2.13.02.tar.bz2 -o "nasm-2.13.02.tar.bz2" >/dev/null 2>&1 || print_fail_and_exit
+    printf "Downloading [%02i/%02i] %s " "6" "${TOTAL}" "nasm 2.14.02"
+    curl -Lf --connect-timeout 30 https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.bz2 -o "nasm-2.14.02.tar.bz2" >/dev/null 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
     printf "Downloading [%02i/%02i] complete.\n" "${TOTAL}" "${TOTAL}"
 
@@ -104,25 +104,25 @@ function mac_toolchain_build {
 
     # automake
     cd "${TEMP_DIR}"
-    printf "Building    [%02i/%02i] %s " "2" "${TOTAL}" "automake 1.15.1"
+    printf "Building    [%02i/%02i] %s " "2" "${TOTAL}" "automake 1.16.1"
     [[ "${SUDO}" != "" ]] && ${SUDO} -v
-    tar -xf automake-1.15.1.tar.gz >/dev/null 2>&1 || print_fail_and_exit
-    cd automake-1.15.1 >/dev/null 2>&1 || print_fail_and_exit
-    ./configure --prefix="${PREFIX}" >../automake-1.15.1.log 2>&1 || print_fail_and_exit
-    make --jobs="${MAKEJOBS}" >>../automake-1.15.1.log 2>&1 || print_fail_and_exit
-    ${SUDO} make install >>../automake-1.15.1.log 2>&1 || print_fail_and_exit
+    tar -xf automake-1.16.1.tar.gz >/dev/null 2>&1 || print_fail_and_exit
+    cd automake-1.16.1 >/dev/null 2>&1 || print_fail_and_exit
+    ./configure --prefix="${PREFIX}" >../automake-1.16.1.log 2>&1 || print_fail_and_exit
+    make --jobs="${MAKEJOBS}" >>../automake-1.16.1.log 2>&1 || print_fail_and_exit
+    ${SUDO} make install >>../automake-1.16.1.log 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
 
     # cmake
     cd "${TEMP_DIR}"
     echo "You may safely dismiss and ignore any prompt to install Java."
-    printf "Building    [%02i/%02i] %s " "3" "${TOTAL}" "cmake 3.9.6"
+    printf "Building    [%02i/%02i] %s " "3" "${TOTAL}" "cmake 3.14.5"
     [[ "${SUDO}" != "" ]] && ${SUDO} -v
-    tar -xf cmake-3.9.6.tar.gz >/dev/null 2>&1 || print_fail_and_exit
-    cd cmake-3.9.6 >/dev/null 2>&1 || print_fail_and_exit
-    ./configure --prefix="${PREFIX}" --no-qt-gui --system-curl >../cmake-3.9.6.log 2>&1 || print_fail_and_exit
-    make --jobs="${MAKEJOBS}" >>../cmake-3.9.6.log 2>&1 || print_fail_and_exit
-    ${SUDO} make install >>../cmake-3.9.6.log 2>&1 || print_fail_and_exit
+    tar -xf cmake-3.14.5.tar.gz >/dev/null 2>&1 || print_fail_and_exit
+    cd cmake-3.14.5 >/dev/null 2>&1 || print_fail_and_exit
+    ./configure --prefix="${PREFIX}" --no-qt-gui --system-curl >../cmake-3.14.5.log 2>&1 || print_fail_and_exit
+    make --jobs="${MAKEJOBS}" >>../cmake-3.14.5.log 2>&1 || print_fail_and_exit
+    ${SUDO} make install >>../cmake-3.14.5.log 2>&1 || print_fail_and_exit
 
     # libtool
     cd "${TEMP_DIR}"
@@ -148,13 +148,13 @@ function mac_toolchain_build {
 
     # nasm
     cd "${TEMP_DIR}"
-    printf "Building    [%02i/%02i] %s " "6" "${TOTAL}" "nasm 2.13.02"
+    printf "Building    [%02i/%02i] %s " "6" "${TOTAL}" "nasm 2.14.02"
     [[ "${SUDO}" != "" ]] && ${SUDO} -v
-    tar -xf nasm-2.13.02.tar.bz2 >/dev/null 2>&1 || print_fail_and_exit
-    cd nasm-2.13.02 >/dev/null 2>&1 || print_fail_and_exit
-    ./configure --prefix="${PREFIX}" --enable-sections --enable-lto >../nasm-2.13.02.log 2>&1 || print_fail_and_exit
-    make --jobs="${MAKEJOBS}" AR=ar RANLIB=ranlib >>../nasm-2.13.02.log 2>&1 || print_fail_and_exit
-    ${SUDO} make install >>../nasm-2.13.02.log 2>&1 || print_fail_and_exit
+    tar -xf nasm-2.14.02.tar.bz2 >/dev/null 2>&1 || print_fail_and_exit
+    cd nasm-2.14.02 >/dev/null 2>&1 || print_fail_and_exit
+    ./configure --prefix="${PREFIX}" --enable-sections --enable-lto >../nasm-2.14.02.log 2>&1 || print_fail_and_exit
+    make --jobs="${MAKEJOBS}" AR=ar RANLIB=ranlib >>../nasm-2.14.02.log 2>&1 || print_fail_and_exit
+    ${SUDO} make install >>../nasm-2.14.02.log 2>&1 || print_fail_and_exit
     echo -en "${CREL}"
 
     # done


### PR DESCRIPTION
Update mac-toolchain-build to newest versions of automake, cmake and nasm 

**Description of Change:**

Update automake 1.15.1 -> 1.16.1
Update cmake 3.9.6 -> 3.14.5
Update  nasm 2.13.02 -> 2.14.02

I've tested this for several weeks now (the script and building of HB) and could not see any issue. I had been preparing this patch for several months, but found it better to wait until all versions reached a stable level (and now before the release of cmake 3.15.0, this seems the case).

- [x] macOS 10.14