### PR TITLE
MacGui: update german localization.

### DIFF
--- a/macosx/HandBrakeKit/de.lproj/Localizable.strings
+++ b/macosx/HandBrakeKit/de.lproj/Localizable.strings
@@ -1,12 +1,12 @@
 /* Video description */
-" - fastdecode" = "- Schnelldekodierung";
+" - fastdecode" = "- Schnelldecodierung";
 
 /* HBStateFormatter -> work time format */
-" (%.2f fps, avg %.2f fps, ETA %02d:%02d:%02d)" = " (%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$dh:%4$dmin:%5$dsec)";
+" (%.2f fps, avg %.2f fps, ETA %@)" = "(%1$.2f BpS, im Mittel %2$.2f BpS, ETA %3$@)";
 
 /* HBStateFormatter -> search time format
    HBStateFormatter -> work time format */
-" (ETA %02d:%02d:%02d)" = " (ETA %1$dh:%2$dmin:%3$dsec)";
+" (ETA %@)" = " (ETA %@)";
 
 /* Title description */
 " (Title %d, %@, %@) ▸ %@\n" = " (Titel %1$d, %2$@, %3$@) ▸ %4$@\n";
@@ -57,7 +57,7 @@
 "%.6g FPS" = "%.6g BpS";
 
 /* Audio description */
-"%@ ▸ Encoder: %@" = "%1$@ ▸ Enkodierer: %2$@";
+"%@ ▸ Encoder: %@" = "%1$@ ▸ Encoder: %2$@";
 
 /* HBPicture -> short info */
 "%@Output: %dx%d" = "%1$@Anzeige: %2$dx%3$d";
@@ -166,10 +166,10 @@
 "DRC: %.2f" = "DRC: %.2f";
 
 /* Video description */
-"Encoder: %@, " = "Enkodierer: %@,";
+"Encoder: %@, " = "Encoder: %@,";
 
 /* HBStateFormatter -> work pass display name */
-"Encoding %@ " = "Enkodiere %@";
+"Encoding %@ " = "Encodiere %@";
 
 /* Filters description */
 "Filters:" = "Filter:";
@@ -238,6 +238,12 @@
 /* HBJob -> invalid lapsharp custom settings error recovery suggestion */
 "Lapsharp syntax: y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c\n\nLapsharp default: y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap" = "Lapsharp-Syntax: y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c\n\nLapsharp-Standard: y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap";
 
+/* HBFilters -> invalid deblock custom string description */
+"Invalid deblock custom settings." = "Ungültige benutzerdefinierte Deblock-Einstellungen.";
+
+/* HBFilters -> invalid deblock custom string description */
+"Deblock syntax: strength=s:thresh=t:blocksize=b" = "Deblock-Syntax: strength=s:thresh=t:blocksize=b";
+
 /* Video description */
 "Level: %@" = "Level: %@";
 
@@ -259,13 +265,15 @@
 /* HBJob -> invalid name error recovery suggestion */
 "NLMeans syntax: y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t\n\nDefault settings: y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0" = "NLMeans-Syntax: y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t\n\nStandardeinstellungen: y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0";
 
+/* HBVideo -> tune */
+"none" = "Keine";
+
 /* HBAudio -> none track name
    HBJob -> filters short description
    HBSubtitles -> none track name */
 "None" = "Ohne";
 
 /* HBFilters -> filter display name
-   HBFilters -> filter summary
    HBFilters -> off display name */
 "Off" = "Aus";
 
@@ -339,7 +347,10 @@
 "Syntax: skip-left=s:skip-right=s:skip-top=s:skip-bottom=s:strict-breaks=s:plane=p:parity=p:disable=d\n\nDefault: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0" = "Syntax: skip-left=s:skip-right=s:skip-top=s:skip-bottom=s:strict-breaks=s:plane=p:parity=p:disable=d\n\nStandardeinstellungen: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0";
 
 /* HBJob -> invalid name error recovery suggestion */
-"The file name can't contain the / character." = "Der Dateinamen darf kein Zeichen / enthalten.";
+"The file name can't be empty." = "Der Dateiname darf nicht leer sein.";
+
+/* HBJob -> invalid name error recovery suggestion */
+"The file name can't contain the / character." = "Der Dateiname darf kein /-Zeichen enthalten.";
 
 /* Preset -> import error description */
 "The preset \"%@\" could not be imported." = "Die Voreinstellung \"%@\" konnte nicht importiert werden.";
@@ -374,6 +385,9 @@
 
 /* HBJob -> Format display name */
 "WebM File" = "WebM-Datei";
+
+/* HBFilters -> filter display name */
+"Yadif" = "Yadif";
 
 /* HBJob -> invalid Yadif custom settings error recovery suggestion */
 "Yadif syntax: mode=m:parity=p\n\nYadif default: mode=3" = "Yadif-Syntax: mode=m:parity=p\n\nYadif-Standardeinstellungen: mode=3";

--- a/macosx/de.lproj/Audio.strings
+++ b/macosx/de.lproj/Audio.strings
@@ -68,7 +68,7 @@
 "LLW-KN-65P.ibExternalAccessibilityDescription" = "Abmischung";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Mixdown type. Controls how multi-channel audio is mixed into fewer channels, or whether the original channels are preserved.\n\nDolby Surround and Dolby Pro Logic II convert multi-channel audio to stereo and matrix encode additional channels for surround reproduction on compatible equipment, while maintaining stereo compatibility."; ObjectID = "LLW-KN-65P"; */
-"LLW-KN-65P.ibShadowedToolTip" = "Abmischungstyp. Kontrolliert wie Mehrkanalaudio in weniger Kanäle gemischt wird oder ob die originalen Kanäle behalten werden.\n\nDolby Surround und Dolby Pro Logic II konvertiert Mehrkanalaudio in Stereo und enkodiert zusätzliche Kanäle für Surroundreproduktion auf kompatiblen Geräten, die Stereokompatibilität wird beibehalten.";
+"LLW-KN-65P.ibShadowedToolTip" = "Abmischungstyp. Kontrolliert wie Mehrkanalaudio in weniger Kanäle gemischt wird oder ob die originalen Kanäle behalten werden.\n\nDolby Surround und Dolby Pro Logic II konvertiert Mehrkanalaudio in Stereo und encodiert zusätzliche Kanäle für Surroundreproduktion auf kompatiblen Geräten, die Stereokompatibilität wird beibehalten.";
 
 /* Class = "NSTableColumn"; headerCell.title = "Codec"; ObjectID = "lnO-sZ-6xv"; */
 "lnO-sZ-6xv.headerCell.title" = "Codec";
@@ -119,7 +119,7 @@
 "tYY-w7-ZIq.ibExternalAccessibilityDescription" = "Codec";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder."; ObjectID = "tYY-w7-ZIq"; */
-"tYY-w7-ZIq.ibShadowedToolTip" = "Audioenkoder.";
+"tYY-w7-ZIq.ibShadowedToolTip" = "Audioencoder.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Configure audio tracks Selection Behavior. These settings affect which tracks will be added to the audio tracks list, and the settings used for each track."; ObjectID = "vFP-nq-IQg"; */
 "vFP-nq-IQg.ibShadowedToolTip" = "Konfiguriert das Auswahlverhalten der Tonspur. Diese Einstellungen bestimmen welche Spuren zur Tonspurliste hinzugefügt werden und die Einstellungen welche für jede Spur benutzt werden.";

--- a/macosx/de.lproj/AudioDefaults.strings
+++ b/macosx/de.lproj/AudioDefaults.strings
@@ -14,10 +14,10 @@
 "6lx-af-rBL.ibExternalAccessibilityDescription" = "Codec";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder."; ObjectID = "6lx-af-rBL"; */
-"6lx-af-rBL.ibShadowedToolTip" = "Audioenkoder.";
+"6lx-af-rBL.ibShadowedToolTip" = "Audioencoder.";
 
 /* Class = "NSTextFieldCell"; title = "Audio encoder settings for each selected track:"; ObjectID = "007-WM-RmC"; */
-"007-WM-RmC.title" = "Audioenkodereinstellungen für jede ausgewählte Spur:";
+"007-WM-RmC.title" = "Audioencodereinstellungen für jede ausgewählte Spur:";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "7sl-o7-pUh"; */
 "7sl-o7-pUh.title" = "Text Cell";
@@ -26,7 +26,7 @@
 "8mC-Wx-myL.title" = "DTS";
 
 /* Class = "NSButtonCell"; title = "Use only first encoder for secondary audio"; ObjectID = "66v-2g-DHn"; */
-"66v-2g-DHn.title" = "Nur ersten Kodierer für sekundäres Audio verwenden";
+"66v-2g-DHn.title" = "Nur ersten Encoder für sekundäres Audio verwenden";
 
 /* Class = "NSTextFieldCell"; title = "Passthru Fallback:"; ObjectID = "AQe-Sg-Qgh"; */
 "AQe-Sg-Qgh.title" = "Passthru-Fallback:";
@@ -95,7 +95,7 @@
 "igm-hS-rrD.ibExternalAccessibilityDescription" = "Abmischung";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Mixdown type. Controls how multi-channel audio is mixed into fewer channels, or whether the original channels are preserved.\n\nDolby Surround and Dolby Pro Logic II convert multi-channel audio to stereo and matrix encode additional channels for surround reproduction on compatible equipment, while maintaining stereo compatibility."; ObjectID = "igm-hS-rrD"; */
-"igm-hS-rrD.ibShadowedToolTip" = "Abmischungstyp. Kontrolliert wie Mehrkanalaudio in weniger Kanäle gemischt wird oder ob die originalen Kanäle behalten werden.\n\nDolby Dolby Surround und Dolby Pro Logic II konvertiert Mehrkanalaudio in Stereo und enkodiert zusätzliche Kanäle für Surroundreproduktion auf kompatiblen Geräten, die Stereokompatibilität wird beibehalten.";
+"igm-hS-rrD.ibShadowedToolTip" = "Abmischungstyp. Kontrolliert wie Mehrkanalaudio in weniger Kanäle gemischt wird oder ob die originalen Kanäle behalten werden.\n\nDolby Dolby Surround und Dolby Pro Logic II konvertiert Mehrkanalaudio in Stereo und encodiert zusätzliche Kanäle für Surroundreproduktion auf kompatiblen Geräten, die Stereokompatibilität wird beibehalten.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports DTS-HD. This permits DTS-HD passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "IxI-o9-jMs"; */
 "IxI-o9-jMs.ibShadowedToolTip" = "Dies aktivieren, wenn das Abspielgerät DTS-HD unterstützt. Dies erlaubt das Durchschleifen von DTS-HD, wenn das automatische Durchschleifen aktiviert ist.";
@@ -116,7 +116,7 @@
 "Kwy-lU-VuU.title" = "OtherViews";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder to use when a track suitable for passthru is unavailable."; ObjectID = "LdN-Cx-ZJY"; */
-"LdN-Cx-ZJY.ibShadowedToolTip" = "Audioenkoder der verwendet werden soll, wenn eine Spur für das Durchschleifen (Passthru) nicht verfügbar ist.";
+"LdN-Cx-ZJY.ibShadowedToolTip" = "Audioencoder der verwendet werden soll, wenn eine Spur für das Durchschleifen (Passthru) nicht verfügbar ist.";
 
 /* Class = "NSButtonCell"; title = "DTS-HD"; ObjectID = "LX6-kc-5vq"; */
 "LX6-kc-5vq.title" = "DTS-HD";
@@ -185,7 +185,7 @@
 "u9h-dn-wcK.title" = "E-AC3";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Only the primary audio track will be encoded with the full encoder list. All additional audio tracks will be encoded with first encoder only."; ObjectID = "uF5-6E-EIe"; */
-"uF5-6E-EIe.ibShadowedToolTip" = "Nur die primäre Tonspur wird mit der kompletten Audioliste enkodiert. Alle zusätzlichen Tonspuren werden nur mit dem ersten Enkoder enkodiert.";
+"uF5-6E-EIe.ibShadowedToolTip" = "Nur die primäre Tonspur wird mit der kompletten Audioliste encodiert. Alle zusätzlichen Tonspuren werden nur mit dem ersten Encoder encodiert.";
 
 /* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "uFK-z7-8Yj"; */
 "uFK-z7-8Yj.title" = "Text Cell";

--- a/macosx/de.lproj/HBFiltersViewController.strings
+++ b/macosx/de.lproj/HBFiltersViewController.strings
@@ -34,17 +34,23 @@
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Sharpen filter preset. Sets the strength of the filter."; ObjectID = "bac-vC-bD4"; */
 "bac-vC-bD4.ibShadowedToolTip" = "Voreinstellungen des Schärfefilters. Stellt die Stärke des Filters ein.";
 
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Deblock Preset"; ObjectID = "bz8-FC-vYp"; */
+"bz8-FC-vYp.ibExternalAccessibilityDescription" = "Deblock-Voreinstellung";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Deblock reduces blocky artifacts caused by low quality video compression."; ObjectID = "bz8-FC-vYp"; */
+"bz8-FC-vYp.ibShadowedToolTip" = "Deblock reduziert Blockartefakte, die durch Videokompression niedriger Qualität entstehen.";
+
+/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "b6A-ax-2Ed"; */
+"b6A-ax-2Ed.title" = "OtherViews";
+
 /* Class = "NSMenuItem"; title = "180°"; ObjectID = "bEe-EV-Q73"; */
 "bEe-EV-Q73.title" = "180°";
 
-/* Class = "NSTextFieldCell"; title = "Off"; ObjectID = "CIX-Cq-deK"; */
-"CIX-Cq-deK.title" = "Aus";
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Sharpen Tune"; ObjectID = "bRd-Km-Wa8"; */
+"bRd-Km-Wa8.ibExternalAccessibilityDescription" = "Voreinstellung des Entrauschfilters";
 
-/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Denoise Preset"; ObjectID = "cTy-PO-BSd"; */
-"cTy-PO-BSd.ibExternalAccessibilityDescription" = "Voreinstellung des Entrauschfilters";
-
-/* Class = "NSPopUpButton"; ibShadowedToolTip = "Denoise filter preset. Sets the strength of the filter."; ObjectID = "cTy-PO-BSd"; */
-"cTy-PO-BSd.ibShadowedToolTip" = "Voreinstellung des Entrauschfilters. Beeinflusst die Stärke des Filters.";
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Deblock tune. Further adjusts the Deblock preset to optimize settings for specific scenarios."; ObjectID = "bRd-Km-Wa8"; */
+"bRd-Km-Wa8.ibShadowedToolTip" = "Voreinstellung des Entrauschfilters. Beeinflusst die Stärke des Filters.";
 
 /* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "Da7-pY-5vu"; */
 "Da7-pY-5vu.title" = "Eigene:";
@@ -100,11 +106,17 @@
 /* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "N6B-kA-kMA"; */
 "N6B-kA-kMA.title" = "Abstimmung:";
 
+/* Class = "NSTextField"; ibShadowedToolTip = "Custom Deblock parameters.\n\nstrength=s:thresh=t:blocksize=b"; ObjectID = "DI9-Ed-acp"; */
+"DI9-Ed-acp.ibShadowedToolTip" = "Eigene Deblock-Parameter. \n\nstrength=s:thresh=t:blocksize=b:";
+
 /* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "n6U-tH-vo0"; */
 "n6U-tH-vo0.title" = "Eigene:";
 
 /* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "oqh-kd-lEw"; */
 "oqh-kd-lEw.title" = "Eigene:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "xqk-dM-L3o"; */
+"xqk-dM-L3o.title" = "Eigene:";
 
 /* Class = "NSMenuItem"; title = "90°"; ObjectID = "OyA-fK-x19"; */
 "OyA-fK-x19.title" = "90°";
@@ -136,17 +148,20 @@
 /* Class = "NSTextField"; ibShadowedToolTip = "Custom Interlace Detection parameters.\n\nSyntax: mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d\n\nDefault: mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16"; ObjectID = "rPg-F2-gtl"; */
 "rPg-F2-gtl.ibShadowedToolTip" = "Eigene Parameter der Interlace-Erkennung.\n\nSyntax: mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d\n\nStandard: mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16";
 
+/* Class = "NSMenu"; title = "OtherViews"; ObjectID = "rfp-ah-CVB"; */
+"rfp-ah-CVB.title" = "OtherViews";
+
 /* Class = "NSTextFieldCell"; title = "Denoise:"; ObjectID = "Rxe-Xm-vXj"; */
 "Rxe-Xm-vXj.title" = "Entrauschen:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "tAS-YR-VfA"; */
 "tAS-YR-VfA.title" = "OtherViews";
 
-/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "Off"; ObjectID = "tG7-P3-mWx"; */
-"tG7-P3-mWx.ibShadowedIsNilPlaceholder" = "Aus";
-
 /* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "tje-4P-jKt"; */
 "tje-4P-jKt.title" = "Abstimmung:";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "ydN-tP-vpt"; */
+"ydN-tP-vpt.title" = "Abstimmung:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "tlc-kS-W8X"; */
 "tlc-kS-W8X.title" = "OtherViews";
@@ -156,9 +171,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Color:"; ObjectID = "uDH-ts-vs5"; */
 "uDH-ts-vs5.title" = "Farbe:";
-
-/* Class = "NSSlider"; ibShadowedToolTip = "Deblock reduces blocky artifacts caused by low quality video compression."; ObjectID = "VHj-6u-NVp"; */
-"VHj-6u-NVp.ibShadowedToolTip" = "Deblock reduziert Blockartefakte, die durch Videokompression niedriger Qualität entstehen.";
 
 /* Class = "NSTextFieldCell"; title = "Deinterlace:"; ObjectID = "VsK-mC-9Pj"; */
 "VsK-mC-9Pj.title" = "Deinterlace:";

--- a/macosx/de.lproj/HBPictureHUDController.strings
+++ b/macosx/de.lproj/HBPictureHUDController.strings
@@ -2,10 +2,10 @@
 "12K-c3-Z7A.ibShadowedToolTip" = "Vorschau an den Bildschirm anpassen";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Encode and play a preview video using current settings."; ObjectID = "16b-R9-bBU"; */
-"16b-R9-bBU.ibShadowedToolTip" = "Enkodiert und zeigt eine Vorschau mit den momentanen Einstellungen.";
+"16b-R9-bBU.ibShadowedToolTip" = "Encodiert und zeigt eine Vorschau mit den momentanen Einstellungen.";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Duration to encode in seconds."; ObjectID = "ASA-X8-16P"; */
-"ASA-X8-16P.ibShadowedToolTip" = "Dauer des Enkodierens in Sekunden";
+"ASA-X8-16P.ibShadowedToolTip" = "Dauer des Encodierens in Sekunden";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "KrC-nR-rYk"; */
 "KrC-nR-rYk.title" = "OtherViews";

--- a/macosx/de.lproj/HBPictureViewController.strings
+++ b/macosx/de.lproj/HBPictureViewController.strings
@@ -26,7 +26,7 @@
 "9hH-As-JSa.ibExternalAccessibilityDescription" = "Speicherbreite";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Video storage width. This is the number of pixels wide to be encoded. Storage width may differ from display width depending on anamorphic settings."; ObjectID = "9hH-As-JSa"; */
-"9hH-As-JSa.ibShadowedToolTip" = "Videospeicherbreite. Ist die Breite in Pixel in die das Video enkodiert werden soll. Diese Anzeigegröße kann von der Originalgröße abweichen, abhängig von den anamorphischen Einstellungen.";
+"9hH-As-JSa.ibShadowedToolTip" = "Videospeicherbreite. Ist die Breite in Pixel in die das Video encodiert werden soll. Diese Anzeigegröße kann von der Originalgröße abweichen, abhängig von den anamorphischen Einstellungen.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop top"; ObjectID = "41c-48-2XJ"; */
 "41c-48-2XJ.ibExternalAccessibilityDescription" = "Oben beschneiden";
@@ -62,7 +62,7 @@
 "Hkl-7Z-J2e.ibExternalAccessibilityDescription" = "Speicherhöhe";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Video storage height. This is the number of pixels tall to be encoded. Storage height may differ from display height depending on anamorphic settings."; ObjectID = "Hkl-7Z-J2e"; */
-"Hkl-7Z-J2e.ibShadowedToolTip" = "Videospeicherhöhe. Die Anzahl der Pixel der Höhe in der das Video enkodiert wird. Diese Anzeigegröße kann von der Originalgröße abweichen, abhängig von den anamorphischen Einstellungen.";
+"Hkl-7Z-J2e.ibShadowedToolTip" = "Videospeicherhöhe. Die Anzahl der Pixel der Höhe in der das Video encodiert wird. Diese Anzeigegröße kann von der Originalgröße abweichen, abhängig von den anamorphischen Einstellungen.";
 
 /* Class = "NSTextFieldCell"; title = "x"; ObjectID = "hN1-S9-zl8"; */
 "hN1-S9-zl8.title" = "x";

--- a/macosx/de.lproj/HBSummaryViewController.strings
+++ b/macosx/de.lproj/HBSummaryViewController.strings
@@ -17,7 +17,7 @@
 "Jaw-pH-rhf.ibExternalAccessibilityDescription" = "Größenübersicht";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Optimize MP4 for progressive download. After encoding, data is reorganized and rewritten to allow immediate playback over a network, without needing to download the entire file."; ObjectID = "lUi-Oc-208"; */
-"lUi-Oc-208.ibShadowedToolTip" = "Optimiert MP4 für den schrittweißen Download. Nach der Enkodierung werden die Daten so umgeschrieben, dass ein direktes Abspielen übers Internet ermöglicht wird ohne den gesamten Film herunterladen zu müssen.";
+"lUi-Oc-208.ibShadowedToolTip" = "Optimiert MP4 für den schrittweißen Download. Nach der Encodierung werden die Daten so umgeschrieben, dass ein direktes Abspielen übers Internet ermöglicht wird ohne den gesamten Film herunterladen zu müssen.";
 
 /* Class = "NSView"; ibExternalAccessibilityDescription = "Preview"; ObjectID = "m5a-0z-QQ4"; */
 "m5a-0z-QQ4.ibExternalAccessibilityDescription" = "Vorschau";

--- a/macosx/de.lproj/Localizable.strings
+++ b/macosx/de.lproj/Localizable.strings
@@ -20,10 +20,10 @@
 "(Modified)" = "(Modifiziert)";
 
 /* Queue status */
-"%d encode pending" = "%d Enkodierung anstehend";
+"%d encode pending" = "%d Encodierung anstehend";
 
 /* Queue status */
-"%d encodes pending" = "%d Enkodierungen anstehend";
+"%d encodes pending" = "%d Encodierungen anstehend";
 
 /* Destination same as source alert -> message
    File already exists alert -> message */
@@ -87,7 +87,7 @@
 "Choose" = "Auswählen";
 
 /* Queue Alert -> cancel rip first button */
-"Continue Encoding" = "Enkodierung fortsetzen";
+"Continue Encoding" = "Encodierung fortsetzen";
 
 /* Copy Protection Alert -> message */
 "Copy-Protected sources are not supported." = "Kopiergeschützte Quellen werden nicht unterstützt.";
@@ -121,16 +121,16 @@
 "Done" = "Fertig";
 
 /* Queue status */
-"Encode Canceled." = "Enkodierung abgebrochen.";
+"Encode Canceled." = "Encodierung abgebrochen.";
 
 /* Queue done notification failed message */
-"Encode failed" = "Enkodierung fehlgeschlagen";
+"Encode failed" = "Encodierung fehlgeschlagen";
 
 /* Queue status */
-"Encode Failed." = "Enkodierung fehlgeschlagen.";
+"Encode Failed." = "Encodierung fehlgeschlagen.";
 
 /* Queue status */
-"Encode Finished." = "Enkodierung beendet.";
+"Encode Finished." = "Encodierung beendet.";
 
 /* Export presets save panel title */
 "Export presets" = "Voreinstellungen exportieren";
@@ -151,7 +151,7 @@
 "HandBrake can't playback this combination of video/audio/container format. Do you want to open it in an external player?" = "HandBrake kann die Kombination aus Audio/Video/Kontainer-Format nicht wiedergeben. Soll es extern geöffnet werden?";
 
 /* Quit Alert -> informative text */
-"If you quit HandBrake your current encode will be reloaded into your queue at next launch. Do you want to quit anyway?" = "Wenn Sie HandBrake nun beenden werden Ihre momentanen Enkodierungen beim nächsten Start wieder in die Warteschlange geladen. Wollen Sie trotzdem beenden?";
+"If you quit HandBrake your current encode will be reloaded into your queue at next launch. Do you want to quit anyway?" = "Wenn Sie HandBrake nun beenden werden Ihre momentanen Encodierungen beim nächsten Start wieder in die Warteschlange geladen. Wollen Sie trotzdem beenden?";
 
 /* Import preset open panel title */
 "Import presets" = "Voreinstellungen importieren";
@@ -164,7 +164,7 @@
 
 /* Queue Edit Alert -> stop and edit first button
    Queue Stop Alert -> stop and remove first button */
-"Keep Encoding" = "Enkodierung beibehalten";
+"Keep Encoding" = "Encodierung beibehalten";
 
 /* Touch bar */
 "Live Preview" = "Live-Vorschau";
@@ -176,7 +176,7 @@
 "Move Jobs in Queue" = "Aufgaben zu Warteschlange hinzufügen";
 
 /* Queue status */
-"No encode pending" = "Keine Enkodierungen anstehend";
+"No encode pending" = "Keine Encodierungen anstehend";
 
 /* Preview -> accessibility label */
 "No image" = "Kein Bild";
@@ -211,10 +211,10 @@
 /* Queue -> pause/resume menu
    Toolbar Pause Item
    Touch bar */
-"Pause Encoding" = "Enkodierung anhalten";
+"Pause Encoding" = "Encodierung anhalten";
 
 /* Touch bar */
-"Pause/Resume Encoding" = "Enkodierung Pausieren/Fortsetzen";
+"Pause/Resume Encoding" = "Encodierung Pausieren/Fortsetzen";
 
 /* Video -> Framerate */
 "Peak Framerate (VFR)" = "Maximale Bildfrequenz (VFR)";
@@ -272,14 +272,14 @@
 
 /* Queue -> pause/resume men
    Toolbar Pause Item */
-"Resume Encoding" = "Enkodierung fortsetzen";
+"Resume Encoding" = "Encodierung fortsetzen";
 
 /* Picture HUD -> scale button
    Touch bar */
 "Scale To Screen" = "An Bildschirm anpassen";
 
 /* Queue Alert -> cancel rip informative text */
-"Select Continue Encoding to dismiss this dialog without making changes." = "Enkodierung fortsetzen wählen um diesen Dialog ohne weitere Änderungen zu schließen.";
+"Select Continue Encoding to dismiss this dialog without making changes." = "Encodierung fortsetzen wählen um diesen Dialog ohne weitere Änderungen zu schließen.";
 
 /* Preferences -> send to app destination open panel */
 "Select the desired external application" = "Die gewünschte externe Anwendung auswählen";
@@ -314,13 +314,13 @@
 /* Menu Start/Stop Item
    Queue -> start/stop menu
    Toolbar Start/Stop Item */
-"Start Encoding" = "Enkodierung starten";
+"Start Encoding" = "Encodierung starten";
 
 /* Toolbar Start/Stop Item */
 "Start Queue" = "Warteschlange starten";
 
 /* Touch bar */
-"Start/Stop Encoding" = "Enkodierung Starten/Abbrechen";
+"Start/Stop Encoding" = "Encodierung Starten/Abbrechen";
 
 /* Toolbar Start/Stop Item */
 "Stop" = "Stop";
@@ -333,28 +333,28 @@
 
 /* Queue -> start/stop menu
    Toolbar Start/Stop Item */
-"Stop Encoding" = "Enkodierung stoppen";
+"Stop Encoding" = "Encodierung stoppen";
 
 /* Queue Stop Alert -> stop and remove second button */
-"Stop Encoding and Delete" = "Enkodierung stoppen und löschen";
+"Stop Encoding and Delete" = "Encodierung stoppen und löschen";
 
 /* Queue Edit Alert -> stop and edit second button */
-"Stop Encoding and Edit" = "Enkodierung stoppen und ändern";
+"Stop Encoding and Edit" = "Encodierung stoppen und ändern";
 
 /* Queue Edit Alert -> stop and edit message */
-"Stop This Encode and Edit It?" = "Die Enkodierung stoppen und ändern?";
+"Stop This Encode and Edit It?" = "Die Encodierung stoppen und ändern?";
 
 /* Queue Stop Alert -> stop and remove message */
-"Stop This Encode and Remove It?" = "Die Enkodierung stoppen und entfernen?";
+"Stop This Encode and Remove It?" = "Die Encodierung stoppen und entfernen?";
 
 /* Player HUD -> subtitles menu */
 "Subtitles" = "Untertitel";
 
 /* Queue Done Alert -> shut down message */
-"The computer will shut down after encoding is done." = "Der Computer wird nach Beendigung der Enkodierung heruntergefahren.";
+"The computer will shut down after encoding is done." = "Der Computer wird nach Beendigung der Encodierung heruntergefahren.";
 
 /* Queue Done Alert -> sleep message */
-"The computer will sleep after encoding is done." = "Der Computer wird nach Beendigung der Enkodierung in den Ruhezustand versetzt.";
+"The computer will sleep after encoding is done." = "Der Computer wird nach Beendigung der Encodierung in den Ruhezustand versetzt.";
 
 /* Chapters import -> invalid CSV recovery suggestion */
 "The CSV file is not a valid chapters CSV file." = "Die CSV-Datei ist keine gültige Kapitel-Datei.";
@@ -394,16 +394,16 @@
 "Warning!" = "Warnung!";
 
 /* Queue Alert -> cancel rip message */
-"You are currently encoding. What would you like to do?" = "Sie sind momentan am enkodieren. Was wollen Sie tun?";
+"You are currently encoding. What would you like to do?" = "Sie sind momentan am encodieren. Was wollen Sie tun?";
 
 /* Delete preset alert -> informative text */
 "You can't undo this action." = "Diese Aktion kann nicht rückgängig gemacht werden.";
 
 /* Queue Done Alert -> shut down informative text */
-"You have selected to shut down the computer after encoding. To turn off shut down, go to the HandBrake preferences." = "Sie haben ausgewählt den Computer nach der Enkodierung herunterzufahren. Um das Herunterfahren abzustellen gehen Sie in die HandBrake-Einstellungen.";
+"You have selected to shut down the computer after encoding. To turn off shut down, go to the HandBrake preferences." = "Sie haben ausgewählt den Computer nach der Encodierung herunterzufahren. Um das Herunterfahren abzustellen gehen Sie in die HandBrake-Einstellungen.";
 
 /* Queue Done Alert -> sleep informative text */
-"You have selected to sleep the computer after encoding. To turn off sleeping, go to the HandBrake preferences." = "Sie haben ausgewählt den Computer nach der Enkodierung in den Ruhezustand zu setzen. Um den Ruhezustand abzustellen gehen Sie in die HandBrake-Einstellungen.";
+"You have selected to sleep the computer after encoding. To turn off sleeping, go to the HandBrake preferences." = "Sie haben ausgewählt den Computer nach der Encodierung in den Ruhezustand zu setzen. Um den Ruhezustand abzustellen gehen Sie in die HandBrake-Einstellungen.";
 
 /* Queue -> disk almost full alert informative text */
 "You need to make more space available on your destination disk." = "Der Speicherplatz auf dem Zielmedium ist nicht ausreichend.";
@@ -412,15 +412,15 @@
 "Your destination disk is almost full." = "Ihr Ziel-Speichermedium ist fast voll.";
 
 /* Queue done notification message */
-"Your encode %@ couldn't be completed." = "Die Enkodierung %@ konnte nicht ausgeführt werden.";
+"Your encode %@ couldn't be completed." = "Die Encodierung %@ konnte nicht ausgeführt werden.";
 
 /* Queue done notification message */
-"Your encode %@ is done!" = "Die Enkodierung %@ ist fertig!";
+"Your encode %@ is done!" = "Die Encodierung %@ ist fertig!";
 
 /* Queue done alert informative text */
-"Your HandBrake queue is done!" = "Alle Aufgaben in Ihrer HandBrake-Warteschlange wurde erfolgreich ausgeführt!";
+"Your HandBrake queue is done!" = "Alle Aufgaben in Ihrer HandBrake-Warteschlange wurden erfolgreich ausgeführt!";
 
 /* Queue Edit Alert -> stop and edit informative text
    Queue Stop Alert -> stop and remove informative text */
-"Your movie will be lost if you don't continue encoding." = "Ihr Film wird verloren gehen, wenn Sie die Enkodierung nicht fortsetzen.";
+"Your movie will be lost if you don't continue encoding." = "Ihr Film wird verloren gehen, wenn Sie die Encodierung nicht fortsetzen.";
 

--- a/macosx/de.lproj/MainMenu.strings
+++ b/macosx/de.lproj/MainMenu.strings
@@ -8,7 +8,7 @@
 "6rE-SM-AGi.title" = "Filter";
 
 /* Class = "NSMenuItem"; title = "Summary"; ObjectID = "9ie-b7-RaS"; */
-"9ie-b7-RaS.title" = "Zusammenfassung";
+"9ie-b7-RaS.title" = "Übersicht";
 
 /* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
 "29.title" = "Hauptmenü";
@@ -146,7 +146,7 @@
 "1822.title" = "Einsetzen und Stil anpassen";
 
 /* Class = "NSMenuItem"; title = "Presets View"; ObjectID = "1884"; */
-"1884.title" = "Voreinstellungsansicht";
+"1884.title" = "Voreinstellungen";
 
 /* Class = "NSMenuItem"; title = "Presets"; ObjectID = "1948"; */
 "1948.title" = "Voreinstellungen";
@@ -176,13 +176,13 @@
 "2443.title" = "Zur Warteschlange hinzufügen";
 
 /* Class = "NSMenuItem"; title = "Start Encoding"; ObjectID = "2444"; */
-"2444.title" = "Enkodierung stoppen";
+"2444.title" = "Encodierung stoppen";
 
 /* Class = "NSMenuItem"; title = "Queue"; ObjectID = "2445"; */
 "2445.title" = "Warteschlange";
 
 /* Class = "NSMenuItem"; title = "Pause Encoding"; ObjectID = "2494"; */
-"2494.title" = "Enkodierung pausieren";
+"2494.title" = "Encodierung pausieren";
 
 /* Class = "NSMenuItem"; title = "Close Window"; ObjectID = "2508"; */
 "2508.title" = "Schließen";

--- a/macosx/de.lproj/MainWindow.strings
+++ b/macosx/de.lproj/MainWindow.strings
@@ -50,7 +50,7 @@
 "1539.ibShadowedToolTip" = "Name der Quelle.";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Title, or video clip, to encode. The longest title is selected by default.\n\nBlu-ray and DVD sources often have multiple titles, the longest of which is typically the main feature."; ObjectID = "1541"; */
-"1541.ibShadowedToolTip" = "Titel oder Videoclip zum Enkodieren. Standardmäßig wird der längste Titel ausgewählt.\n\nBlu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlich der Hauptfilm.";
+"1541.ibShadowedToolTip" = "Titel oder Videoclip zum Encodieren. Standardmäßig wird der längste Titel ausgewählt.\n\nBlu-rays und DVDs haben meistens mehrere Titel, der längste ist für gewöhnlich der Hauptfilm.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1542"; */
 "1542.title" = "OtherViews";
@@ -59,7 +59,7 @@
 "1545.ibExternalAccessibilityDescription" = "Erstes Kapitel";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "First chapter to encode."; ObjectID = "1545"; */
-"1545.ibShadowedToolTip" = "Erstes Kapitel zum Enkodieren.";
+"1545.ibShadowedToolTip" = "Erstes Kapitel zum Encodieren.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1546"; */
 "1546.title" = "OtherViews";
@@ -68,7 +68,7 @@
 "1548.ibExternalAccessibilityDescription" = "Letztes Kapitel";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Last chapter to encode."; ObjectID = "1548"; */
-"1548.ibShadowedToolTip" = "Letztes Kapitel zum Enkodieren.";
+"1548.ibShadowedToolTip" = "Letztes Kapitel zum Encodieren.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "1549"; */
 "1549.title" = "OtherViews";
@@ -119,7 +119,7 @@
 "4923.title" = "Voreinstellung:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video angle to encode. Only applicable to multi-angle DVD and Blu-ray."; ObjectID = "5181"; */
-"5181.ibShadowedToolTip" = "Videowinkel zum Enkodieren. Nur auswählbar bei DVD und Blu-ray mit Mehrfachwinkelaufnahmen.";
+"5181.ibShadowedToolTip" = "Videowinkel zum Encodieren. Nur auswählbar bei DVD und Blu-ray mit Mehrfachwinkelaufnahmen.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "5183"; */
 "5183.title" = "OtherViews";
@@ -134,13 +134,13 @@
 "5491.ibExternalAccessibilityDescription" = "Startzeit in Sekunden";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "First second to encode."; ObjectID = "5491"; */
-"5491.ibShadowedToolTip" = "Erste Sekunden zum Enkodieren.";
+"5491.ibShadowedToolTip" = "Erste Sekunden zum Encodieren.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "End time in seconds"; ObjectID = "5493"; */
 "5493.ibExternalAccessibilityDescription" = "Endzeit in Sekunden";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Last second to encode."; ObjectID = "5493"; */
-"5493.ibShadowedToolTip" = "Letzte Sekunden zum Enkodieren.";
+"5493.ibShadowedToolTip" = "Letzte Sekunden zum Encodieren.";
 
 /* Class = "NSTextFieldCell"; title = "–"; ObjectID = "5506"; */
 "5506.title" = "–";
@@ -149,7 +149,7 @@
 "5513.ibExternalAccessibilityDescription" = "Bereichsauswahl";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Source range selection. By default, all chapters are selected and the entire source is encoded."; ObjectID = "5513"; */
-"5513.ibShadowedToolTip" = "Bereichsauswahl der Quelle. Standardmäßig werden alle Kapitel ausgewählt und die gesamte Quelle enkodiert.";
+"5513.ibShadowedToolTip" = "Bereichsauswahl der Quelle. Standardmäßig werden alle Kapitel ausgewählt und die gesamte Quelle encodiert.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "5515"; */
 "5515.title" = "OtherViews";
@@ -158,16 +158,16 @@
 "5521.ibExternalAccessibilityDescription" = "Startzeit in Einzelbildern";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "First frame to encode."; ObjectID = "5521"; */
-"5521.ibShadowedToolTip" = "Erstes Einzelbilder zum Enkodieren.";
+"5521.ibShadowedToolTip" = "Erstes Einzelbilder zum Encodieren.";
 
 /* Class = "NSTextField"; ibExternalAccessibilityDescription = "End time in frames"; ObjectID = "5523"; */
 "5523.ibExternalAccessibilityDescription" = "Endzeit in Einzelbildern";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Last frame to encode."; ObjectID = "5523"; */
-"5523.ibShadowedToolTip" = "Letzte Einzelbilder zum Enkodieren.";
+"5523.ibShadowedToolTip" = "Letzte Einzelbilder zum Encodieren.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Reload the encoding settings for the currently selected preset. Modifications will be discarded."; ObjectID = "AhR-pK-Oz4"; */
-"AhR-pK-Oz4.ibShadowedToolTip" = "Läd die Enkodiereinstellungen der momentan ausgewählte Voreinstellung neu. Änderungen werden verworfen.";
+"AhR-pK-Oz4.ibShadowedToolTip" = "Läd die Encodiereinstellungen der momentan ausgewählte Voreinstellung neu. Änderungen werden verworfen.";
 
 /* Class = "NSTabViewItem"; label = "Summary"; ObjectID = "BA0-eg-2Ka"; */
 "BA0-eg-2Ka.label" = "Übersicht";
@@ -179,10 +179,10 @@
 "byg-kj-sEM.label" = "Start";
 
 /* Class = "NSToolbarItem"; paletteLabel = "Start Encoding"; ObjectID = "byg-kj-sEM"; */
-"byg-kj-sEM.paletteLabel" = "Enkodierung starten";
+"byg-kj-sEM.paletteLabel" = "Encodierung starten";
 
 /* Class = "NSToolbarItem"; toolTip = "Start Encoding"; ObjectID = "byg-kj-sEM"; */
-"byg-kj-sEM.toolTip" = "Enkodierung starten";
+"byg-kj-sEM.toolTip" = "Encodierung starten";
 
 /* Class = "NSButtonCell"; title = "Reload"; ObjectID = "cgS-BU-Nfd"; */
 "cgS-BU-Nfd.title" = "Neu laden";
@@ -200,7 +200,7 @@
 "dK4-jt-v4K.toolTip" = "Vorschau zeigen";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Scan only the specified title instead of all titles."; ObjectID = "DN4-48-aOI"; */
-"DN4-48-aOI.ibShadowedToolTip" = "Nur den ausgewählten statt alle Titel überprüfen.";
+"DN4-48-aOI.ibShadowedToolTip" = "Nur den ausgewählten, statt alle Titel überprüfen.";
 
 /* Class = "NSToolbarItem"; label = "Add To Queue"; ObjectID = "DZZ-Fe-wjw"; */
 "DZZ-Fe-wjw.label" = "Zur Warteschlange hinzufügen";
@@ -215,7 +215,7 @@
 "eij-Sn-QmJ.label" = "Bildgröße";
 
 /* Class = "NSButtonCell"; title = "Scan only title:"; ObjectID = "eQA-t2-FcV"; */
-"eQA-t2-FcV.title" = "Nur Titel überprüfen:";
+"eQA-t2-FcV.title" = "Überprüfe nur Titel:";
 
 /* Class = "NSToolbarItem"; label = "Queue"; ObjectID = "HCx-ku-nF7"; */
 "HCx-ku-nF7.label" = "Warteschlange";
@@ -269,8 +269,8 @@
 "wTQ-KF-5KW.label" = "Pause";
 
 /* Class = "NSToolbarItem"; paletteLabel = "Pause Encoding"; ObjectID = "wTQ-KF-5KW"; */
-"wTQ-KF-5KW.paletteLabel" = "Enkodierung pausieren";
+"wTQ-KF-5KW.paletteLabel" = "Encodierung pausieren";
 
 /* Class = "NSToolbarItem"; toolTip = "Pause Encoding"; ObjectID = "wTQ-KF-5KW"; */
-"wTQ-KF-5KW.toolTip" = "Enkodierung pausieren";
+"wTQ-KF-5KW.toolTip" = "Encodierung pausieren";
 

--- a/macosx/de.lproj/Preferences.strings
+++ b/macosx/de.lproj/Preferences.strings
@@ -89,16 +89,16 @@
 "389.title" = "OtherViews";
 
 /* Class = "NSMenuItem"; title = "0.20"; ObjectID = "390"; */
-"390.title" = "0.20";
+"390.title" = "0,20";
 
 /* Class = "NSMenuItem"; title = "0.25"; ObjectID = "391"; */
-"391.title" = "0.25";
+"391.title" = "0,25";
 
 /* Class = "NSMenuItem"; title = "0.50"; ObjectID = "393"; */
-"393.title" = "0.50";
+"393.title" = "0,50";
 
 /* Class = "NSMenuItem"; title = "1.0"; ObjectID = "394"; */
-"394.title" = "1.0";
+"394.title" = "1,0";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Determines the granularity of the x264 Constant Quality control. Smaller values allow for finer quality increments."; ObjectID = "395"; */
 "395.ibShadowedToolTip" = "Legt die Granularität des x264-Qualitätsreglers fest. Kleinere Werte erlauben feinere Einstellungen.";
@@ -185,7 +185,7 @@
 "c0L-TU-WML.title" = "Titelüberprüfung:";
 
 /* Class = "NSTextFieldCell"; title = "x264 Encoder:"; ObjectID = "cqp-xU-GOe"; */
-"cqp-xU-GOe.title" = "x264-Enkoder:";
+"cqp-xU-GOe.title" = "x264-Encoder:";
 
 /* Class = "NSTextFieldCell"; title = "Drag labels to Format to compose a naming format."; ObjectID = "dQ6-Dh-9sD"; */
 "dQ6-Dh-9sD.title" = "Labels in das Formatfenster ziehen um das Benennungsschema festzulegen.";

--- a/macosx/de.lproj/Presets.strings
+++ b/macosx/de.lproj/Presets.strings
@@ -38,7 +38,7 @@
 "uad-bt-uKD.ibExternalAccessibilityDescription" = "Voreinstellungen";
 
 /* Class = "NSScrollView"; ibShadowedToolTip = "Presets are groups of encode settings tailored for specific scenarios. Select the one closest matching your intent.\n\nOverrides all encode settings. Settings may be further adjusted after selecting a preset."; ObjectID = "uad-bt-uKD"; */
-"uad-bt-uKD.ibShadowedToolTip" = "Voreinstellungen sind eine Gruppe von Enkodiereinstellungen, zugeschnitten auf ein bestimmtes Szenario. Es ist die Voreinstellung auszuwählen, die am besten zu den jeweiligen Bedürfnissen passt.\n\nÜberschreibt alle Enkodiereinstellungen. Die Einstellungen können noch feinjustiert werden nachdem eine Voreinstellung ausgewählt wurde.";
+"uad-bt-uKD.ibShadowedToolTip" = "Voreinstellungen sind eine Gruppe von Encodereinstellungen, zugeschnitten auf ein bestimmtes Szenario. Es ist die Voreinstellung auszuwählen, die am besten zu den jeweiligen Bedürfnissen passt.\n\nÜberschreibt alle Encodereinstellungen. Die Einstellungen können noch feinjustiert werden nachdem eine Voreinstellung ausgewählt wurde.";
 
 /* Class = "NSMenuItem"; title = "Export…"; ObjectID = "xEQ-Un-J0n"; */
 "xEQ-Un-J0n.title" = "Exportieren …";

--- a/macosx/de.lproj/Queue.strings
+++ b/macosx/de.lproj/Queue.strings
@@ -5,7 +5,7 @@
 "2637.title" = "Anstehende Aufgaben";
 
 /* Class = "NSTextFieldCell"; title = "There are no jobs currently encoding"; ObjectID = "2647"; */
-"2647.title" = "Momentan stehen keine Enkodierungsaufgaben an";
+"2647.title" = "Momentan stehen keine Encodierungsaufgaben an";
 
 /* Class = "NSMenuItem"; title = "Edit Job Settings"; ObjectID = "2650"; */
 "2650.title" = "Aufgabeneinstellungen bearbeiten";
@@ -23,7 +23,7 @@
 "a3c-kV-98E.paletteLabel" = "Wenn fertig";
 
 /* Class = "NSToolbarItem"; toolTip = "Action to perform when encoding is complete."; ObjectID = "a3c-kV-98E"; */
-"a3c-kV-98E.toolTip" = "Aktion die ausgeführt werden soll, sobald die Enkodierung abgeschlossen ist.";
+"a3c-kV-98E.toolTip" = "Aktion die ausgeführt werden soll, sobald die Encodierung abgeschlossen ist.";
 
 /* Class = "NSMenuItem"; title = "Alert and Notification"; ObjectID = "aat-1N-Odn"; */
 "aat-1N-Odn.title" = "Hinweis mit Nachricht und Alarm";
@@ -59,7 +59,7 @@
 "s7o-pK-heI.paletteLabel" = "Pause/Fortfahren";
 
 /* Class = "NSToolbarItem"; toolTip = "Pause Encoding"; ObjectID = "s7o-pK-heI"; */
-"s7o-pK-heI.toolTip" = "Enkodierung anhalten";
+"s7o-pK-heI.toolTip" = "Encodierung anhalten";
 
 /* Class = "NSMenuItem"; title = "Do Nothing"; ObjectID = "sm5-26-sAg"; */
 "sm5-26-sAg.title" = "Nichts machen";
@@ -71,7 +71,7 @@
 "SX6-mq-Hck.paletteLabel" = "Start/Abbrechen";
 
 /* Class = "NSToolbarItem"; toolTip = "Start Encoding"; ObjectID = "SX6-mq-Hck"; */
-"SX6-mq-Hck.toolTip" = "Enkodierung starten";
+"SX6-mq-Hck.toolTip" = "Encodierung starten";
 
 /* Class = "NSMenuItem"; title = "Clear Selected Job"; ObjectID = "Wfz-Kj-Vtx"; */
 "Wfz-Kj-Vtx.title" = "Ausgewählte Aufgabe löschen";

--- a/macosx/de.lproj/Subtitles.strings
+++ b/macosx/de.lproj/Subtitles.strings
@@ -2,7 +2,7 @@
 "0yM-wE-D2x.ibExternalAccessibilityDescription" = "Untertitelspuren";
 
 /* Class = "NSTableColumn"; headerCell.title = "Encoding"; ObjectID = "1Qg-We-ltR"; */
-"1Qg-We-ltR.headerCell.title" = "Enkodierung";
+"1Qg-We-ltR.headerCell.title" = "Encodierung";
 
 /* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "4PX-In-DpF"; */
 "4PX-In-DpF.title" = "Alle Spuren hinzufügen";

--- a/macosx/de.lproj/Video.strings
+++ b/macosx/de.lproj/Video.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Fast Decode"; ObjectID = "5De-nU-l3h"; */
-"5De-nU-l3h.title" = "Schnelle Dekodierung";
+"5De-nU-l3h.title" = "Schnelle Decodierung";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "6Cs-jo-8Q6"; */
 "6Cs-jo-8Q6.title" = "OtherViews";
@@ -8,7 +8,7 @@
 "6Dd-IP-Pwt.title" = "Konstante Bildfrequenz";
 
 /* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "7bP-tR-sAX"; */
-"7bP-tR-sAX.title" = "Enkodereinstellungen:";
+"7bP-tR-sAX.title" = "Encodereinstellungen:";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "7CG-ga-88H"; */
 "7CG-ga-88H.title" = "OtherViews";
@@ -23,13 +23,13 @@
 "A4U-3F-pYq.title" = "x264-Voreinstellungen";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video encoder tune. Further adjusts encoder preset to optimize settings for specific scenarios."; ObjectID = "A7d-wM-Xmp"; */
-"A7d-wM-Xmp.ibShadowedToolTip" = "Videoenkoderabstimmung. Zur weiteren Einstellung des Enkoders um die Einstellung an bestimmte Szenarien anzupassen.";
+"A7d-wM-Xmp.ibShadowedToolTip" = "Videoencoderabstimmung. Zur weiteren Einstellung des Encoders um die Einstellung an bestimmte Szenarien anzupassen.";
 
 /* Class = "NSSlider"; ibShadowedToolTip = "Video encoder preset. Adjusts encoder settings to balance compression efficiency and encoding speed. Slower encoder presets may use settings that are less compatible with certain devices."; ObjectID = "Biw-5K-pPD"; */
-"Biw-5K-pPD.ibShadowedToolTip" = "Videoenkodervoreinstellungen. Stellt die Enkodiereinstellungen so ein, dass Kompressionseffizienz und Geschwindigkeit im Gleichgewicht sind. Voreinstellungen mit langsamer Geschwindigkeit sind evtl. nicht kompatibel mit manchen Geräten.";
+"Biw-5K-pPD.ibShadowedToolTip" = "Videoencodervoreinstellungen. Stellt die Encodiereinstellungen so ein, dass Kompressionseffizienz und Geschwindigkeit im Gleichgewicht sind. Voreinstellungen mit langsamer Geschwindigkeit sind evtl. nicht kompatibel mit manchen Geräten.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "2-pass encoding analyzes the entire source video before encoding. The information gathered enables the encoder to make more informed decisions about quality and data rate in Average Bitrate mode."; ObjectID = "bnV-aE-FVh"; */
-"bnV-aE-FVh.ibShadowedToolTip" = "Die Enkodierung in zwei Durchgängen analysiert das Video vor dem Enkodieren. Die daraus gewonnenen Informationen ermöglichen es dem Enkoder bessere Entscheidungen bezüglich Qualität und Datenrate im Modus mit durchschnittlicher Bitrate zu treffen.";
+"bnV-aE-FVh.ibShadowedToolTip" = "Die Encodierung in zwei Durchgängen analysiert das Video vor dem Encodieren. Die daraus gewonnenen Informationen ermöglichen es dem Encoder bessere Entscheidungen bezüglich Qualität und Datenrate im Modus mit durchschnittlicher Bitrate zu treffen.";
 
 /* Class = "NSTextFieldCell"; title = "0"; ObjectID = "bvD-W7-O0N"; */
 "bvD-W7-O0N.title" = "0";
@@ -44,7 +44,7 @@
 "c27-4i-SiJ.ibShadowedNotApplicablePlaceholder" = "0";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video encoder profile. Sets and ensures compliance with the specified video compression standard profile. Overrides all other settings."; ObjectID = "CPP-lh-FbN"; */
-"CPP-lh-FbN.ibShadowedToolTip" = "Videoenkoderprofil. Garantiert die Erfüllung bestimmter Videostandardprofile. Überschreibt alle anderen Einstellungen.";
+"CPP-lh-FbN.ibShadowedToolTip" = "Videoencoderprofil. Garantiert die Erfüllung bestimmter Videostandardprofile. Überschreibt alle anderen Einstellungen.";
 
 /* Class = "NSTextFieldCell"; title = "Quality:"; ObjectID = "F3s-qR-qeE"; */
 "F3s-qR-qeE.title" = "Qualität:";
@@ -54,9 +54,6 @@
 
 /* Class = "NSSlider"; ibShadowedToolTip = "Constant Quality varies bitrate to ensure visual quality remains relatively consistent throughout the video.\n\nAdjust the quality slider to the right to increase quality or to the left to decrease quality, in small increments of plus or minus 1-2.\n\nRecommended values for the x264 and x265 encoders are RF 18-28. Higher quality settings may produce extremely large files.\n\nx264 is lossless at RF 0."; ObjectID = "GPu-Ht-bKg"; */
 "GPu-Ht-bKg.ibShadowedToolTip" = "Konstante Qualität variiert die Bitrate um eine gleichbleibende visuelle Qualität über das ganze Video zu garantieren.\n\nWird der Qualitätsregler nach rechts bewegt erhöht sich die Qualität, nach links erniedrigt sie sich.\n\nEmpfohlene Werte für x264 und x265 sind zwischen RF 18-28. Höhere Qualitätseinstellungen produzieren evtl. sehr große Dateien.\n\nx264 ist verlustfrei bei RF 0.";
-
-/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "none"; ObjectID = "gu5-Qw-6oi"; */
-"gu5-Qw-6oi.ibShadowedIsNilPlaceholder" = "Keine";
 
 /* Class = "NSTextFieldCell"; title = "Profile:"; ObjectID = "hib-wi-BDx"; */
 "hib-wi-BDx.title" = "Profil:";
@@ -71,22 +68,22 @@
 "Jj0-Qw-HF8.title" = "OtherViews";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Additional video encoder options. For advanced use only.\n\nSyntax: option-1=foo:opt2=bar"; ObjectID = "mL3-yC-hUj"; */
-"mL3-yC-hUj.ibShadowedToolTip" = "Zusätzliche Videoenkodiereinstellungen. Für erfahrene Anwender.\n\nSyntax: option-1=foo:opt2=bar";
+"mL3-yC-hUj.ibShadowedToolTip" = "Zusätzliche Videoencodiereinstellungen. Für erfahrene Anwender.\n\nSyntax: option-1=foo:opt2=bar";
 
 /* Class = "NSTextFieldCell"; title = "Video Encoder:"; ObjectID = "Mrb-6Q-0YM"; */
-"Mrb-6Q-0YM.title" = "Videoenkoder:";
+"Mrb-6Q-0YM.title" = "Videoencoder:";
 
 /* Class = "NSButtonCell"; title = "2-pass encoding"; ObjectID = "nPA-nO-Eik"; */
-"nPA-nO-Eik.title" = "Enkodierung in 2 Durchgängen";
+"nPA-nO-Eik.title" = "Encodierung in 2 Durchgängen";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Additional video encoder options. For advanced use only.\n\nSyntax: option-1=foo:opt2=bar,baz"; ObjectID = "oJk-ur-wgc"; */
-"oJk-ur-wgc.ibShadowedToolTip" = "Zusätzliche Videoenkodiereinstellungen. Für erfahrene Anwender.\n\nSyntax: option-1=foo:opt2=bar,baz";
+"oJk-ur-wgc.ibShadowedToolTip" = "Zusätzliche Videoencodiereinstellungen. Für erfahrene Anwender.\n\nSyntax: option-1=foo:opt2=bar,baz";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Turbo first pass speeds up the first pass of a 2-pass encode for a slight penalty to analysis."; ObjectID = "olm-zg-k9Y"; */
-"olm-zg-k9Y.ibShadowedToolTip" = "Der beschleunigte erste Durchgang beschleunigt die Enkodierung in zwei Durchgängen, ist aber mit einer etwas schlechteren Analyseleistung behaftet.";
+"olm-zg-k9Y.ibShadowedToolTip" = "Der beschleunigte erste Durchgang beschleunigt die Encodierung in zwei Durchgängen, ist aber mit einer etwas schlechteren Analyseleistung behaftet.";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video encoder level. Sets and ensures compliance with the specified video compression standard level. Overrides all other settings."; ObjectID = "P7c-Zk-G99"; */
-"P7c-Zk-G99.ibShadowedToolTip" = "Videoenkoderstufe. Garantiert die Erfüllung bestimmter Videostandardprofile. Überschreibt alle anderen Einstellungen.";
+"P7c-Zk-G99.ibShadowedToolTip" = "Videoencoderstufe. Garantiert die Erfüllung bestimmter Videostandardprofile. Überschreibt alle anderen Einstellungen.";
 
 /* Class = "NSMenu"; title = "OtherViews"; ObjectID = "pPu-oR-2R8"; */
 "pPu-oR-2R8.title" = "OtherViews";
@@ -110,16 +107,16 @@
 "vSc-VB-NEv.title" = "Ersten Durchgang beschleunigen";
 
 /* Class = "NSTextField"; ibShadowedToolTip = "Displays all internal video encoder options."; ObjectID = "wk1-2U-z4i"; */
-"wk1-2U-z4i.ibShadowedToolTip" = "Zeigt alle internen Videoenkodiereinstellungen.";
+"wk1-2U-z4i.ibShadowedToolTip" = "Zeigt alle internen Videoencodiereinstellungen.";
 
 /* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "XIe-8Z-tIF"; */
-"XIe-8Z-tIF.title" = "Enkodereinstellungen:";
+"XIe-8Z-tIF.title" = "Encodereinstellungen:";
 
 /* Class = "NSPopUpButton"; ibShadowedToolTip = "Video encoder. Determines video type and settings used during encoding."; ObjectID = "xwK-Yu-a1e"; */
-"xwK-Yu-a1e.ibShadowedToolTip" = "Videoenkoder. Legt den Videotyp und die Einstellungen während des Enkodierens fest.";
+"xwK-Yu-a1e.ibShadowedToolTip" = "Videoencoder. Legt den Videotyp und die Einstellungen während des Encodierens fest.";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Fast Decode uses settings that reduce CPU usage during playback of the encoded video. Useful for devices that struggle to play video without stuttering."; ObjectID = "z7F-H2-Vfr"; */
-"z7F-H2-Vfr.ibShadowedToolTip" = "Die Schnelle Dekodierung benutzt Einstellungen um die Prozessorauslastung beim Abspielen des enkodierten Videos zu reduzieren. Nützlich bei leistungsschwachen Abspielgeräten, bei denen das Video sonst nicht ruckelfrei läuft.";
+"z7F-H2-Vfr.ibShadowedToolTip" = "Die schnelle Decodierung benutzt Einstellungen um die Prozessorauslastung beim Abspielen des encodierten Videos zu reduzieren. Nützlich bei leistungsschwachen Abspielgeräten, bei denen das Video sonst nicht ruckelfrei läuft.";
 
 /* Class = "NSButtonCell"; title = "Constant Quality"; ObjectID = "ZjL-cY-O5f"; */
 "ZjL-cY-O5f.title" = "Konstante Qualität";


### PR DESCRIPTION
Bring german strings in sync with Transifex and add new deblock strings.

I changed "Decodieren" according to the recommendation of the German Duden® Spelling Dictionary (and the notification in Transifex). I changed some spelling mistakes. And I added some new strings from recent code changes. All changes are a sync from Transifex (apart from the deblock strings).