### PR TITLE
libhb: eliminate file path length limits

### DIFF
--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -38,7 +38,7 @@ static int title_info_compare_mpls(const void *, const void *);
  ***********************************************************************
  *
  **********************************************************************/
-hb_bd_t * hb_bd_init( hb_handle_t *h, char * path )
+hb_bd_t * hb_bd_init( hb_handle_t *h, const char * path )
 {
     hb_bd_t * d;
     int ii;
@@ -281,14 +281,12 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
 
     if (d->disc_info->disc_name != NULL && d->disc_info->disc_name[0] != 0)
     {
-        strncpy(title->name, d->disc_info->disc_name, sizeof(title->name));
-        title->name[sizeof(title->name) - 1] = 0;
+        title->name = strdup(d->disc_info->disc_name);
     }
     else if (d->disc_info->udf_volume_id != NULL &&
              d->disc_info->udf_volume_id[0] != 0)
     {
-        strncpy(title->name, d->disc_info->udf_volume_id, sizeof(title->name));
-        title->name[sizeof(title->name) - 1] = 0;
+        title->name = strdup(d->disc_info->udf_volume_id);
     }
     else
     {
@@ -300,7 +298,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
                 p_last = &p_cur[1];
             }
         }
-        snprintf(title->name, sizeof( title->name ), "%s", p_last);
+        title->name = strdup(p_last);
         char *dot_term = strrchr(title->name, '.');
         if (dot_term)
             *dot_term = '\0';

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -297,13 +297,13 @@ void hb_image_close(hb_image_t **_image);
 struct hb_subtitle_config_s
 {
     enum subdest { RENDERSUB, PASSTHRUSUB } dest;
-    int  force;
-    int  default_track; 
+    int       force;
+    int       default_track; 
     
     /* SRT subtitle tracks only */
-    char src_filename[256];
-    char src_codeset[40];
-    int64_t offset;
+    const char * src_filename;
+    char         src_codeset[40];
+    int64_t      offset;
 };
 
 /*******************************************************************************
@@ -456,7 +456,7 @@ struct hb_title_set_s
 {
     hb_list_t   * list_title;
     int           feature;    // Detected DVD feature title
-    char          path[1024];
+    const char  * path;
 };
 
 typedef enum
@@ -1044,8 +1044,8 @@ struct hb_title_s
 {
     enum { HB_DVD_TYPE, HB_BD_TYPE, HB_STREAM_TYPE, HB_FF_STREAM_TYPE } type;
     uint32_t        reg_desc;
-    char            path[1024];
-    char            name[1024];
+    const char    * path;
+    const char    * name;
     int             index;
     int             playlist;
     int             angle_count;

--- a/libhb/dvd.h
+++ b/libhb/dvd.h
@@ -96,7 +96,7 @@ union hb_dvd_s
 
 struct hb_dvd_func_s
 {
-    hb_dvd_t *    (* init)        ( hb_handle_t *, char * );
+    hb_dvd_t *    (* init)        ( hb_handle_t *, const char * );
     void          (* close)       ( hb_dvd_t ** );
     char        * (* name)        ( char * );
     int           (* title_count) ( hb_dvd_t * );

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -19,7 +19,7 @@
 #define DVD_READ_CACHE 1
 
 static char        * hb_dvdnav_name( char * path );
-static hb_dvd_t    * hb_dvdnav_init( hb_handle_t * h, char * path );
+static hb_dvd_t    * hb_dvdnav_init( hb_handle_t * h, const char * path );
 static int           hb_dvdnav_title_count( hb_dvd_t * d );
 static hb_title_t  * hb_dvdnav_title_scan( hb_dvd_t * d, int t, uint64_t min_duration );
 static int           hb_dvdnav_start( hb_dvd_t * d, hb_title_t *title, int chapter );
@@ -150,7 +150,7 @@ fail:
  ***********************************************************************
  *
  **********************************************************************/
-static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, char * path )
+static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, const char * path )
 {
     hb_dvd_t * e;
     hb_dvdnav_t * d;
@@ -445,7 +445,8 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
     hb_chapter_t     * chapter;
     hb_dvd_chapter_t * dvd_chapter;
     int                count;
-    const char       * name;
+    const char       * title_string;
+    char               name[1024];
     unsigned char      unused[1024];
     const char       * codec_name;
 
@@ -453,30 +454,33 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
 
     title = hb_title_init( d->path, t );
     title->type = HB_DVD_TYPE;
-    if (dvdnav_get_title_string(d->dvdnav, &name) == DVDNAV_STATUS_OK)
+    if (dvdnav_get_title_string(d->dvdnav, &title_string) == DVDNAV_STATUS_OK)
     {
-        strncpy(title->name, name, sizeof(title->name) - 1);
-        title->name[sizeof(title->name) - 1] = 0;
+        title->name = strdup(title_string);
     }
 
-    if (strlen(title->name) == 0)
+    if (title->name == NULL || title->name[0] == 0)
     {
-        if( DVDUDFVolumeInfo( d->reader, title->name, sizeof( title->name ),
-                             unused, sizeof( unused ) ) )
+        free((char*)title->name);
+        if (DVDUDFVolumeInfo(d->reader, name, sizeof(name),
+                             unused, sizeof(unused)))
         {
-
-        char * p_cur, * p_last = d->path;
-        for( p_cur = d->path; *p_cur; p_cur++ )
-        {
-            if( IS_DIR_SEP(p_cur[0]) && p_cur[1] )
+            char * p_cur, * p_last = d->path;
+            for( p_cur = d->path; *p_cur; p_cur++ )
             {
-                p_last = &p_cur[1];
+                if( IS_DIR_SEP(p_cur[0]) && p_cur[1] )
+                {
+                    p_last = &p_cur[1];
+                }
             }
+            title->name = strdup(p_last);
+            char *dot_term = strrchr(title->name, '.');
+            if (dot_term)
+                *dot_term = '\0';
         }
-        snprintf( title->name, sizeof( title->name ), "%s", p_last );
-        char *dot_term = strrchr(title->name, '.');
-        if (dot_term)
-            *dot_term = '\0';
+        else
+        {
+            title->name = strdup(name);
         }
     }
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -365,7 +365,7 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     hb_title_t * title;
 
     // Check if scanning is necessary.
-    if (!strcmp(h->title_set.path, path))
+    if (h->title_set.path != NULL && !strcmp(h->title_set.path, path))
     {
         // Current title_set path matches requested path.
         // Check if the requested title has already been scanned.
@@ -408,6 +408,8 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
         hb_list_rem( h->title_set.list_title, title );
         hb_title_close( &title );
     }
+    free((char*)h->title_set.path);
+    h->title_set.path = NULL;
 
     /* Print CPU info here so that it's in all scan and encode logs */
     const char *cpu_name = hb_get_cpu_name();
@@ -435,7 +437,8 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
 
 void hb_force_rescan( hb_handle_t * h )
 {
-    h->title_set.path[0] = 0;
+    free((char*)h->title_set.path);
+    h->title_set.path = NULL;
 }
 
 /**
@@ -1642,6 +1645,8 @@ void hb_close( hb_handle_t ** _h )
         hb_title_close( &title );
     }
     hb_list_close( &h->title_set.list_title );
+    free((char*)h->title_set.path);
+    h->title_set.path = NULL;
 
     hb_list_close( &h->jobs );
     hb_lock_close( &h->state_lock );

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -903,11 +903,13 @@ char* hb_job_to_json( const hb_job_t * job )
 
 // These functions exist only to perform type checking when using
 // json_unpack_ex().
+typedef const char * const_str_t;
+
 static double*      unpack_f(double *f)     { return f; }
 static int*         unpack_i(int *i)        { return i; }
 static json_int_t*  unpack_I(json_int_t *i) { return i; }
 static int *        unpack_b(int *b)        { return b; }
-static const char** unpack_s(const char **s){ return s; }
+static const_str_t* unpack_s(const_str_t *s){ return s; }
 static json_t**     unpack_o(json_t** o)    { return o; }
 
 void hb_json_job_scan( hb_handle_t * h, const char * json_job )
@@ -1613,8 +1615,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             }
             else if (importfile != NULL)
             {
-                strncpy(sub_config.src_filename, importfile, 255);
-                sub_config.src_filename[255] = 0;
+                sub_config.src_filename = importfile;
 
                 const char * lang = "und";
                 const char * srtcodeset = "UTF-8";

--- a/libhb/internal.h
+++ b/libhb/internal.h
@@ -323,7 +323,7 @@ typedef struct hb_bd_s hb_bd_t;
 typedef union  hb_dvd_s hb_dvd_t;
 typedef struct hb_stream_s hb_stream_t;
 
-hb_dvd_t *   hb_dvd_init( hb_handle_t * h, char * path );
+hb_dvd_t *   hb_dvd_init( hb_handle_t * h, const char * path );
 int          hb_dvd_title_count( hb_dvd_t * );
 hb_title_t * hb_dvd_title_scan( hb_dvd_t *, int title, uint64_t min_duration );
 int          hb_dvd_start( hb_dvd_t *, hb_title_t *title, int chapter );
@@ -337,7 +337,7 @@ int          hb_dvd_angle_count( hb_dvd_t * d );
 void         hb_dvd_set_angle( hb_dvd_t * d, int angle );
 int          hb_dvd_main_feature( hb_dvd_t * d, hb_list_t * list_title );
 
-hb_bd_t     * hb_bd_init( hb_handle_t *h, char * path );
+hb_bd_t     * hb_bd_init( hb_handle_t *h, const char * path );
 int           hb_bd_title_count( hb_bd_t * d );
 hb_title_t  * hb_bd_title_scan( hb_bd_t * d, int t, uint64_t min_duration );
 int           hb_bd_start( hb_bd_t * d, hb_title_t *title );
@@ -353,7 +353,7 @@ int           hb_bd_main_feature( hb_bd_t * d, hb_list_t * list_title );
 
 hb_stream_t * hb_bd_stream_open( hb_handle_t *h, hb_title_t *title );
 void hb_ts_stream_reset(hb_stream_t *stream);
-hb_stream_t * hb_stream_open(hb_handle_t *h, char * path,
+hb_stream_t * hb_stream_open(hb_handle_t *h, const char * path,
                              hb_title_t *title, int scan);
 void		 hb_stream_close( hb_stream_t ** );
 hb_title_t * hb_stream_title_scan( hb_stream_t *, hb_title_t *);

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -295,12 +295,12 @@ static void ScanFunc( void * _data )
     }
     if (hb_list_count(data->title_set->list_title) > 0)
     {
-        strncpy(data->title_set->path, data->path, 1024);
-        data->title_set->path[1023] = 0;
+        data->title_set->path = strdup(data->path);
     }
     else
     {
-        data->title_set->path[0] = 0;
+        free((char*)data->title_set->path);
+        data->title_set->path = NULL;
     }
 
 finish:

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -813,7 +813,7 @@ static void prune_streams(hb_stream_t *d)
  *
  **********************************************************************/
 hb_stream_t *
-hb_stream_open(hb_handle_t *h, char *path, hb_title_t *title, int scan)
+hb_stream_open(hb_handle_t *h, const char *path, hb_title_t *title, int scan)
 {
     if (title == NULL)
     {
@@ -1052,9 +1052,11 @@ hb_title_t * hb_stream_title_scan(hb_stream_t *stream, hb_title_t * title)
     title->type = HB_STREAM_TYPE;
 
     // Copy part of the stream path to the title name
-    char *sep = hb_strr_dir_sep(stream->path);
+    char * name = stream->path;
+    char * sep  = hb_strr_dir_sep(stream->path);
     if (sep)
-        strcpy(title->name, sep+1);
+        name = sep + 1;
+    title->name = strdup(name);
     char *dot_term = strrchr(title->name, '.');
     if (dot_term)
         *dot_term = '\0';
@@ -5632,9 +5634,11 @@ static hb_title_t *ffmpeg_title_scan( hb_stream_t *stream, hb_title_t *title )
     title->type = HB_FF_STREAM_TYPE;
 
     // Copy part of the stream path to the title name
-    char *sep = hb_strr_dir_sep(stream->path);
+    char * name = stream->path;
+    char * sep = hb_strr_dir_sep(stream->path);
     if (sep)
-        strcpy(title->name, sep+1);
+        name = sep + 1;
+    title->name = strdup(name);
     char *dot_term = strrchr(title->name, '.');
     if (dot_term)
         *dot_term = '\0';

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -263,8 +263,7 @@
                     sub_config.offset = subTrack.offset;
 
                     // we need to strncpy file name and codeset
-                    strncpy(sub_config.src_filename, subTrack.fileURL.fileSystemRepresentation, 255);
-                    sub_config.src_filename[255] = 0;
+                    sub_config.src_filename = subTrack.fileURL.fileSystemRepresentation;
                     strncpy(sub_config.src_codeset, subTrack.charCode.UTF8String, 39);
                     sub_config.src_codeset[39] = 0;
 


### PR DESCRIPTION
Changes file path arrays to file path pointers and allocates space as needed for long paths.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
