### PR TITLE
Create separate fake iso639 "any" entry

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3056,7 +3056,7 @@ void ghb_init_lang_list(GtkTreeView *tv, signal_user_data_t *ud)
     for (iso639 = lang_get_any(); iso639 != NULL;
          iso639 = lang_get_next(iso639))
     {
-        int          index = lang_lookup_index(iso639->iso639_1);
+        int          index = lang_lookup_index(iso639->iso639_2);
         const char * lang;
         if (iso639->native_name != NULL && iso639->native_name[0] != 0)
         {

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -2002,16 +2002,16 @@ language_opts_set(signal_user_data_t *ud, const gchar *name,
     (void)data; // Silence "unused variable" warning
     GtkTreeIter iter;
     GtkListStore *store;
-    gint ii;
 
     GtkComboBox *combo = GTK_COMBO_BOX(GHB_WIDGET(ud->builder, name));
     store = GTK_LIST_STORE(gtk_combo_box_get_model (combo));
     gtk_list_store_clear(store);
     const iso639_lang_t *iso639;
-    for (iso639 = lang_get_next(NULL), ii = 0; iso639 != NULL;
-         iso639 = lang_get_next(iso639), ii++)
+    for (iso639 = lang_get_next(NULL); iso639 != NULL;
+         iso639 = lang_get_next(iso639))
     {
-        gchar *lang;
+        int     index = lang_lookup_index(iso639->iso639_1);
+        gchar * lang;
 
         if (iso639->native_name[0] != 0)
             lang = g_strdup_printf("<small>%s</small>", iso639->native_name);
@@ -2023,7 +2023,7 @@ language_opts_set(signal_user_data_t *ud, const gchar *name,
                            0, lang,
                            1, TRUE,
                            2, iso639->iso639_2,
-                           3, (gdouble)ii,
+                           3, (gdouble)index,
                            -1);
         g_free(lang);
     }
@@ -3048,22 +3048,17 @@ void ghb_init_lang_list(GtkTreeView *tv, signal_user_data_t *ud)
 {
     GtkTreeIter    iter;
     GtkTreeStore * ts;
-    int            ii;
 
     ghb_init_lang_list_model(tv);
     ts = GTK_TREE_STORE(gtk_tree_view_get_model(tv));
 
     const iso639_lang_t *iso639;
-    for (iso639 = lang_get_next(NULL), ii = 0; iso639 != NULL;
-         iso639 = lang_get_next(iso639), ii++)
+    for (iso639 = lang_get_any(); iso639 != NULL;
+         iso639 = lang_get_next(iso639))
     {
+        int          index = lang_lookup_index(iso639->iso639_1);
         const char * lang;
-        if (ii == 0)
-        {
-            lang = _("Any");
-        }
-        else if (iso639->native_name != NULL &&
-                 iso639->native_name[0] != 0)
+        if (iso639->native_name != NULL && iso639->native_name[0] != 0)
         {
             lang = iso639->native_name;
         }
@@ -3072,7 +3067,7 @@ void ghb_init_lang_list(GtkTreeView *tv, signal_user_data_t *ud)
             lang = iso639->eng_name;
         }
         gtk_tree_store_append(ts, &iter, NULL);
-        gtk_tree_store_set(ts, &iter, 0, lang, 1, ii, -1);
+        gtk_tree_store_set(ts, &iter, 0, lang, 1, index, -1);
     }
 }
 

--- a/libhb/lang.h
+++ b/libhb/lang.h
@@ -44,6 +44,15 @@ int lang_to_code(const iso639_lang_t *lang);
 iso639_lang_t * lang_for_english( const char * english );
 
 /*
+ * Get fake iso639 cooresponding to "Any"
+ * "Any" is used when a match for any language is desired.
+ *
+ * Calling lang_get_next() with pointer returned by lang_get_any()
+ * returns the first entry in the languages list
+ */
+const iso639_lang_t* lang_get_any(void);
+
+/*
  * Get the next language in the list.
  * Returns NULL if there are no more languages.
  * Pass NULL to get the first language in the list.

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -860,11 +860,13 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
         add_audio_for_lang(list, preset, title, mux, copy_mask, fallback,
                            lang, behavior, mode, track_dict);
     }
-    // If no audios found, try "und" language option
+    // If no audios found, try "any" language option
+    // This can happen if AudioLanguageList is empty or if no audio
+    // matches the users preferred languages in AudioLanguageList
     if (hb_value_array_len(list) <= 0)
     {
         add_audio_for_lang(list, preset, title, mux, copy_mask, fallback,
-                           "und", behavior, mode, track_dict);
+                           "any", behavior, mode, track_dict);
     }
     hb_dict_free(&track_dict);
     return 0;
@@ -1161,6 +1163,7 @@ int hb_preset_job_add_subtitles(hb_handle_t *h, int title_index,
         }
         if (count <= 0)
         {
+            // No matching language.  Try "Unknown" language
             add_subtitle_for_lang(list, title, mux, "und", &behavior);
         }
     }

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -860,13 +860,11 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
         add_audio_for_lang(list, preset, title, mux, copy_mask, fallback,
                            lang, behavior, mode, track_dict);
     }
-    // If no audios found, try "any" language option
-    // This can happen if AudioLanguageList is empty or if no audio
-    // matches the users preferred languages in AudioLanguageList
-    if (hb_value_array_len(list) <= 0)
+    // If AudioLanguageList is empty, try "any" language option
+    if (count <= 0)
     {
         add_audio_for_lang(list, preset, title, mux, copy_mask, fallback,
-                           "any", 1, mode, track_dict);
+                           "any", behavior, mode, track_dict);
     }
     hb_dict_free(&track_dict);
     return 0;

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -866,7 +866,7 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
     if (hb_value_array_len(list) <= 0)
     {
         add_audio_for_lang(list, preset, title, mux, copy_mask, fallback,
-                           "any", behavior, mode, track_dict);
+                           "any", 1, mode, track_dict);
     }
     hb_dict_free(&track_dict);
     return 0;

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -11,6 +11,7 @@
 #include "hb.h"
 #include "hb_dict.h"
 #include "plist.h"
+#include "lang.h"
 
 #if HB_PROJECT_FEATURE_QSV
 #include "qsv_common.h"
@@ -401,8 +402,9 @@ static hb_dict_t * source_audio_track_used(hb_dict_t *track_dict, int track)
 static int find_audio_track(const hb_title_t *title,
                             const char *lang, int start, int behavior)
 {
-    hb_audio_config_t * audio;
-    int ii, count;
+    hb_audio_config_t   * audio;
+    int                   ii, count;
+    const iso639_lang_t * lang_any = lang_get_any();
 
     count = hb_list_count(title->list_audio);
     for (ii = start; ii < count; ii++)
@@ -416,7 +418,8 @@ static int find_audio_track(const hb_title_t *title,
         if ((behavior == 2 ||
              audio->lang.attributes == HB_AUDIO_ATTR_NONE ||
              (audio->lang.attributes & HB_AUDIO_ATTR_REGULAR_MASK)) &&
-            (!strcmp(lang, audio->lang.iso639_2) || !strcmp(lang, "und")))
+            (!strcmp(lang, audio->lang.iso639_2) ||
+             !strcmp(lang, lang_any->iso639_2)))
         {
             return ii;
         }
@@ -871,14 +874,16 @@ int hb_preset_job_add_audio(hb_handle_t *h, int title_index,
 static int find_subtitle_track(const hb_title_t *title,
                                const char *lang, int start)
 {
-    hb_subtitle_t * subtitle;
-    int ii, count;
+    hb_subtitle_t       * subtitle;
+    int                   ii, count;
+    const iso639_lang_t * lang_any = lang_get_any();
 
     count = hb_list_count(title->list_subtitle);
     for (ii = start; ii < count; ii++)
     {
         subtitle = hb_list_item(title->list_subtitle, ii);
-        if (!strcmp(lang, subtitle->iso639_2) || !strcmp(lang, "und"))
+        if (!strcmp(lang, subtitle->iso639_2) ||
+            !strcmp(lang, lang_any->iso639_2))
         {
             return ii;
         }
@@ -1082,14 +1087,16 @@ int hb_preset_job_add_subtitles(hb_handle_t *h, int title_index,
 
 
     // Add tracks for all languages in the language list
-    hb_value_array_t *lang_list = hb_dict_get(preset, "SubtitleLanguageList");
+    hb_value_array_t * lang_list = hb_dict_get(preset, "SubtitleLanguageList");
+    const iso639_lang_t * lang_any  = lang_get_any();
+    const char          * pref_lang = lang_any->iso639_2;
+
     count = hb_value_array_len(lang_list);
-    const char *pref_lang = "und";
     if (count > 0)
     {
         pref_lang = hb_value_get_string(hb_value_array_get(lang_list, 0));
     }
-    if (!strcmp(pref_lang, "und"))
+    if (!strcmp(pref_lang, lang_any->iso639_2))
     {
         if (first_audio_lang != NULL)
         {

--- a/macosx/HBLanguagesSelection.m
+++ b/macosx/HBLanguagesSelection.m
@@ -68,8 +68,8 @@
         NSMutableArray<HBLang *> *internal = [[NSMutableArray alloc] init];
         NSMutableArray<HBLang *> *selected = [[NSMutableArray alloc] init];
 
-        const iso639_lang_t *lang = lang_get_next(NULL);
-        for (lang = lang_get_next(lang); lang != NULL; lang = lang_get_next(lang))
+        const iso639_lang_t *lang;
+        for (lang = lang_get_any(); lang != NULL; lang = lang_get_next(lang))
         {
             NSString *nativeLanguage = strlen(lang->native_name) ? @(lang->native_name) : @(lang->eng_name);
 
@@ -86,15 +86,6 @@
             }
             
         }
-
-        // Add the (Any) item.
-        HBLang *item = [[HBLang alloc] initWithLanguage:NSLocalizedString(@"(Any)", @"Language selection")
-                                            iso639_2code:@"und"];
-        if ([languages containsObject:item.iso639_2])
-        {
-            item.isSelected = YES;
-        }
-        [internal insertObject:item atIndex:0];
 
         // Insert the selected items
         // in the original order.


### PR DESCRIPTION
Allows us to distinguish a selection of "any" which means match any
language from "und" which means the language is not known.

Fixes https://github.com/HandBrake/HandBrake/issues/731

I think I've correctly modified OSX code to handle the changes.  Someone should review and test.
Windows probably needs some additional tweaks.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
