### PR TITLE
Switch hardening default from None to False

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -1381,7 +1381,7 @@ def createCLI( cross = None ):
     arch.mode.cli_add_argument( grp, '--arch' )
     grp.add_argument( '--cross', default=None, action='store', metavar='SPEC',
         help='specify GCC cross-compilation spec' )
-    grp.add_argument( '--enable-hardening', dest="enable_host_harden", default=None, action='store_true',
+    grp.add_argument( '--enable-hardening', dest="enable_host_harden", default=False, action='store_true',
         help='enable buffer overflow protection' )
     cli.add_argument_group( grp )
 
@@ -1932,7 +1932,7 @@ int main()
         doc.add( 'HOST.cross.prefix', '' )
 
     doc.add( 'HOST.arch',   arch.mode.mode )
-    doc.add( 'HOST.harden', int( options.enable_host_harden != None))
+    doc.add( 'HOST.harden', int( options.enable_host_harden) )
 
     doc.addBlank()
     doc.add( 'SRC',     cfg.src_final )


### PR DESCRIPTION
In https://github.com/HandBrake/HandBrake/pull/2040#discussion_r275171237 it was mentioned, `options.enable_build_harden` should not be `None`. But without the `None` it didn't build at all. I've recently learned why. If `default` is set to the boolean value `False`, then the `None` can be removed. This makes it possible to apply the review comment from bradleysepos.