### PR TITLE
Fix some typos

### DIFF
--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -771,7 +771,7 @@ hb_buffer_t * hb_bd_read( hb_bd_t * d )
 
                 case BD_EVENT_PLAYITEM:
                     discontinuity = 1;
-                    hb_deep_log(2, "bd: Playitem %u", event.param);
+                    hb_deep_log(2, "bd: Play item %u", event.param);
                     break;
 
                 case BD_EVENT_STILL:

--- a/libhb/comb_detect.c
+++ b/libhb/comb_detect.c
@@ -1281,7 +1281,7 @@ static int comb_detect_init( hb_filter_object_t * filter,
         if (taskset_init( &pv->mask_filter_taskset, pv->cpu_count,
                           sizeof( decomb_thread_arg_t ) ) == 0)
         {
-            hb_error( "maske filter could not initialize taskset" );
+            hb_error( "mask filter could not initialize taskset" );
         }
 
         decomb_prev_thread_args = NULL;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1931,7 +1931,7 @@ int hb_mixdown_has_remix_support(int mixdown, uint64_t layout)
                     (layout & AV_CH_LAYOUT_SURROUND) == AV_CH_LAYOUT_SURROUND);
 
         // stereo + either of side or back left/right, back center
-        // also, allow Dolby Surrounbd output if the input is already Dolby
+        // also, allow Dolby Surround output if the input is already Dolby
         case HB_AMIXDOWN_DOLBY:
         case HB_AMIXDOWN_DOLBYPLII:
             return ((layout & AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||

--- a/libhb/deccc608sub.c
+++ b/libhb/deccc608sub.c
@@ -297,7 +297,7 @@ static int get_char_in_utf8(unsigned char *buffer, unsigned char c)
             *buffer = 0xc3;
             *(buffer+1) = 0x9a;
             return 2;
-        case 0x94: // capital letter U with diaresis
+        case 0x94: // capital letter U with diaeresis
             *buffer = 0xc3;
             *(buffer+1) = 0x9c;
             return 2;
@@ -333,10 +333,10 @@ static int get_char_in_utf8(unsigned char *buffer, unsigned char c)
         case 0x9d: // Full stop (.)
             *buffer = 0x2e;
             return 1;
-        case 0x9e: // Quoatation mark
+        case 0x9e: // Quotation mark
             *buffer = 0x22;
             return 1;
-        case 0x9f: // Quoatation mark
+        case 0x9f: // Quotation mark
             *buffer = 0x22;
             return 1;
         case 0xa0: // uppercase A, grave accent
@@ -359,11 +359,11 @@ static int get_char_in_utf8(unsigned char *buffer, unsigned char c)
             *buffer = 0xc3;
             *(buffer+1) = 0x8a;
             return 2;
-        case 0xa5: // capital letter E with diaresis
+        case 0xa5: // capital letter E with diaeresis
             *buffer = 0xc3;
             *(buffer+1) = 0x8b;
             return 2;
-        case 0xa6: // lowercase letter e with diaresis
+        case 0xa6: // lowercase letter e with diaeresis
             *buffer = 0xc3;
             *(buffer+1) = 0xab;
             return 2;
@@ -371,11 +371,11 @@ static int get_char_in_utf8(unsigned char *buffer, unsigned char c)
             *buffer = 0xc3;
             *(buffer+1) = 0x8e;
             return 2;
-        case 0xa8: // uppercase I, with diaresis
+        case 0xa8: // uppercase I, with diaeresis
             *buffer = 0xc3;
             *(buffer+1) = 0x8f;
             return 2;
-        case 0xa9: // lowercase i, with diaresis
+        case 0xa9: // lowercase i, with diaeresis
             *buffer = 0xc3;
             *(buffer+1) = 0xaf;
             return 2;

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -23,7 +23,7 @@ struct hb_work_private_s
     int         scr_sequence;
 
     /* the following is frame info for the frame we're currently accumulating */
-    uint64_t    duration;   /* frame duratin (in 90KHz ticks) */
+    uint64_t    duration;   /* frame duration (in 90KHz ticks) */
     uint32_t    offset;     /* where in buf frame starts */
     uint32_t    samplerate; /* sample rate in bits/sec */
     uint8_t     nchannels;

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -1100,7 +1100,7 @@ static int hb_decomb_init( hb_filter_object_t * filter,
             if( !pv->cx2 || !pv->cy2 || !pv->cxy || !pv->tmpc )
                 hb_error("EEDI2: failed to malloc derivative arrays");
             else
-                hb_log("EEDI2: successfully mallloced derivative arrays");
+                hb_log("EEDI2: successfully malloced derivative arrays");
         }
 
         for( ii = 0; ii < 3; ii++ )

--- a/libhb/decpgssub.c
+++ b/libhb/decpgssub.c
@@ -19,7 +19,7 @@ struct hb_work_private_s
     // all the packets we see until libav returns a subtitle with
     // the information we need.
     hb_buffer_list_t list_pass;
-    // It is possible for multiple subtitles to be enncapsulated in
+    // It is possible for multiple subtitles to be encapsulated in
     // one packet.  This won't happen for PGS subs, but may for other
     // types of subtitles.  Since I plan to generalize this code to handle
     // other than PGS, we will need to keep a list of all subtitles seen

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -326,7 +326,7 @@ static int get_line( hb_work_private_t * pv, char *buf, int size )
     int i;
     char c;
 
-    // clear remnants of the previous line before progessing a new one
+    // clear remnants of the previous line before processing a new one
     memset(buf, '\0', size);
 
     /* Find newline in converted UTF-8 buffer */

--- a/libhb/decssasub.c
+++ b/libhb/decssasub.c
@@ -424,7 +424,7 @@ static int decssaWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
     }
 
     // Not much to do here.  ffmpeg already supplies SSA subtitles in the
-    // requried matroska packet format.
+    // required matroska packet format.
     //
     // We require string termination of the buffer
     hb_buffer_realloc(in, ++in->size);

--- a/libhb/decvobsub.c
+++ b/libhb/decvobsub.c
@@ -630,7 +630,7 @@ static hb_buffer_t * Decode( hb_work_object_t * w )
     if ( ParseControls( w ) )
     {
         /*
-         * Coudln't parse the info
+         * Couldn't parse the info
          */
         hb_deep_log( 2, "decvobsub: Could not parse info!" );
 

--- a/libhb/eedi2.h
+++ b/libhb/eedi2.h
@@ -7,10 +7,10 @@
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
  
-// Used to order a sequeunce of metrics for median filtering
+// Used to order a sequence of metrics for median filtering
 void eedi2_sort_metrics( int *order, const int length );
 
-// Aping some Windows API funcctions AviSynth seems to like
+// Aping some Windows API functions AviSynth seems to like
 // Taken from here: http://www.gidforums.com/t-8543.html
 void *eedi2_aligned_malloc(size_t size, size_t align_size);
 void eedi2_aligned_free(void *ptr);

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -749,7 +749,7 @@ static void compute_dts_offset( hb_work_private_t * pv, hb_buffer_t * buf )
 //
 // Where pts0 - ptsN are in decoded monotonically increasing presentation
 // order and delay == pts1 (1 being the number of frames the decoder must
-// delay before it has suffecient information to decode). The number of
+// delay before it has sufficient information to decode). The number of
 // frames to delay is set by job->areBframes, so it is configurable.
 // This guarantees that DTS <= PTS for any frame.
 //

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1143,7 +1143,7 @@ void hb_set_anamorphic_size2(hb_geometry_t *src_geo,
     hb_limit_rational64(&dst_par_num, &dst_par_den,
                         dst_par_num, dst_par_den, 65535);
 
-    // If the user is directling updating PAR, don't override his values.
+    // If the user is directing updating PAR, don't override his values.
     // I.e. don't even reduce the values.
     hb_reduce(&out_par.num, &out_par.den, dst_par_num, dst_par_den);
     if (geo->mode == HB_ANAMORPHIC_CUSTOM && !keep_display_aspect &&

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -969,7 +969,7 @@ static int validate_audio_codec_mux(int codec, int mux, int track)
 
 /**
  * Convert a json string representation of a job to an hb_job_t
- * @param h        - Pointer to the hb_hanle_t hb instance which contains the
+ * @param h        - Pointer to the hb_handle_t hb instance which contains the
  *                   title that the job refers to.
  * @param json_job - Pointer to json string representation of a job
  */

--- a/libhb/mt_frame_filter.c
+++ b/libhb/mt_frame_filter.c
@@ -7,7 +7,7 @@
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
 
-/* This is a psuedo-filter that wraps other filters to provide frame
+/* This is a pseudo-filter that wraps other filters to provide frame
  * based multi-threading of the wrapped filter. The sub-filter must
  * operate on each frame independently with no context carried over
  * from one frame to the next. */

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -1203,7 +1203,7 @@ static int avformatMux(hb_mux_object_t *m, hb_mux_data_t *track, hb_buffer_t *bu
         // if it sees a negative dts, it applies an offset to both pts
         // and dts to make it positive.  This offset breaks chapter
         // start times and A/V sync.  libav also requires that dts is
-        // "monotically increasing", which means it last_dts <= next_dts.
+        // "monotonically increasing", which means it last_dts <= next_dts.
         // It also uses dts to determine track interleaving, so we need
         // to provide some reasonable dts value.
         // So when renderOffset < 0, set to 0 for mkv.

--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -409,7 +409,7 @@ static int muxWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             if ( mf_full( track ) )
             {
                 // If the track's fifo is still full, advance
-                // the currint interleave point and try again.
+                // the current interleave point and try again.
                 hb_bitvec_cpy(mux->rdy, mux->allRdy);
                 break;
             }

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1126,7 +1126,7 @@ int hb_preset_job_add_subtitles(hb_handle_t *h, int title_index,
     if (first_audio_lang != NULL &&
         foreign_audio_search && !strncmp(first_audio_lang, pref_lang, 4))
     {
-        // First audio lang matches the preferred subittle lang.
+        // First audio lang matches the preferred subtitle lang.
         // Preset says to add search for foreign audio subtitles.
         int burn = burn_foreign || behavior.burn_first;
         // If not burning, make this the default track.
@@ -3323,7 +3323,7 @@ hb_value_t * hb_presets_update_version(hb_value_t *presets)
                 hb_value_incref(presets);
                 return presets;
             }
-            // Unrecoginzable preset file format
+            // Unrecognizable preset file format
             return NULL;
         }
     }
@@ -3698,13 +3698,13 @@ static int hb_presets_add_internal(hb_value_t *preset)
     int index = hb_value_array_len(hb_presets);
     if (hb_value_type(preset) == HB_VALUE_TYPE_DICT)
     {
-        // A standalone preset or folder of presets.  Add to preset array.
+        // A standalone preset or folder of presets. Add to preset array.
         hb_value_array_append(hb_presets, hb_value_dup(preset));
         added++;
     }
     else if (hb_value_type(preset) == HB_VALUE_TYPE_ARRAY)
     {
-        // An array of presets.  Add each element.
+        // An array of presets. Add each element.
         int count = hb_value_array_len(preset);
         int ii;
         for (ii = 0; ii < count; ii++)

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -191,7 +191,7 @@ static void blend( hb_buffer_t *dst, hb_buffer_t *src, int left, int top )
 // applies subtitle 'sub' YUVA420P buffer into destination 'buf'
 // 'buf' is currently YUV420P, but in future will be other formats as well
 // Assumes that the input destination buffer has the same dimensions
-// as the original title diminsions
+// as the original title dimensions
 static void ApplySub( hb_filter_private_t * pv, hb_buffer_t * buf, hb_buffer_t * sub )
 {
     blend( buf, sub, sub->f.x, sub->f.y );
@@ -339,7 +339,7 @@ static hb_buffer_t * ScaleSubtitle(hb_filter_private_t *pv,
 }
 
 // Assumes that the input buffer has the same dimensions
-// as the original title diminsions
+// as the original title dimensions
 static void ApplyVOBSubs( hb_filter_private_t * pv, hb_buffer_t * buf )
 {
     int ii;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -735,7 +735,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
                     // There are 2 conditions we decode additional
                     // video frames for during scan.
                     // 1. We did not detect IDR frames, so the initial video
-                    //    frames may be corrupt.  We docode extra frames to
+                    //    frames may be corrupt.  We decode extra frames to
                     //    increase the probability of a complete preview frame
                     // 2. Some frames do not contain CC data, even though
                     //    CCs are present in the stream.  So we need to decode

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -1537,7 +1537,7 @@ struct pts_pos {
 
 #define NDURSAMPLES 128
 
-// get one (position, timestamp) sampple from a transport or program
+// get one (position, timestamp) sample from a transport or program
 // stream.
 static struct pts_pos hb_sample_pts(hb_stream_t *stream, uint64_t fpos)
 {
@@ -1990,7 +1990,7 @@ static void pes_add_subtitle_to_title(
             break;
         default:
             // Unrecognized, don't add to list
-            hb_log("unregonized subtitle!");
+            hb_log("unrecognized subtitle!");
             free( subtitle );
             return;
     }
@@ -3843,7 +3843,7 @@ static void hb_ps_stream_find_streams(hb_stream_t *stream)
             else if ( pes_info.stream_id == 0xbd )
             {
                 int ssid = pes_info.bd_substream_id;
-                // Add a potentail audio stream
+                // Add a potential audio stream
                 // Check dvd substream id
                 if ( ssid >= 0x20 && ssid <= 0x37 )
                 {

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -1887,7 +1887,7 @@ static void ProcessSCRDelayQueue( sync_common_t * common )
             int           hash = buf->s.scr_sequence & SCR_HASH_MASK;
             if (buf->s.scr_sequence < 0)
             {
-                // Unset scr_sequence inidicates an external stream
+                // Unset scr_sequence indicates an external stream
                 // (e.g. SRT subtitle) that is not on the same timebase
                 // as the source tracks. Do not adjust timestamps for
                 // scr_offset in this case.
@@ -3424,7 +3424,7 @@ static int syncSubtitleWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
 hb_work_object_t hb_sync_subtitle =
 {
     WORK_SYNC_SUBTITLE,
-    "Subitle Synchronization",
+    "Subtitle Synchronization",
     syncSubtitleInit,
     syncSubtitleWork,
     syncSubtitleClose

--- a/libhb/taskset.c
+++ b/libhb/taskset.c
@@ -70,7 +70,7 @@ taskset_init( taskset_t *ts, int thread_count, size_t arg_size )
     memset(ts->task_threads_args, 0, ts->arg_size * ts->thread_count );
 
     /*
-     * Inialize bitmaps to all bits set.  This means that any unused bits
+     * Initialize bitmaps to all bits set.  This means that any unused bits
      * in the bitmap are already in the "condition satisfied" state allowing
      * us to test the bitmap 32bits at a time without having to mask off
      * the end.

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1939,7 +1939,7 @@ static inline void copy_chapter( hb_buffer_t * dst, hb_buffer_t * src )
  * Performs the work object's specific work function.
  * Loops calling work function for associated work object. Sleeps when fifo is full.
  * Monitors work done indicator.
- * Exits loop when work indiactor is set.
+ * Exits loop when work indicator is set.
  * @param _w Handle to work object.
  */
 void hb_work_loop( void * _w )

--- a/macosx/Base.lproj/Subtitles.xib
+++ b/macosx/Base.lproj/Subtitles.xib
@@ -301,7 +301,7 @@
                                                             <binding destination="4bh-my-GeM" name="enabled" keyPath="objectValue.isExternal" id="cQ5-cT-bqm"/>
                                                             <binding destination="4bh-my-GeM" name="selectedValue" keyPath="objectValue.isoLanguage" previousBinding="OIo-fF-3vU" id="Ubv-kn-nf5">
                                                                 <dictionary key="options">
-                                                                    <string key="NSValueTransformerName">HBIsoLanguageTrasformer</string>
+                                                                    <string key="NSValueTransformerName">HBIsoLanguageTransformer</string>
                                                                 </dictionary>
                                                             </binding>
                                                             <binding destination="4bh-my-GeM" name="content" keyPath="objectValue.languages" id="OIo-fF-3vU"/>

--- a/macosx/HBAudio.m
+++ b/macosx/HBAudio.m
@@ -100,7 +100,7 @@ NSString *HBAudioEncoderChangedNotification = @"HBAudioEncoderChangedNotificatio
 {
     [self removeTracksAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.tracks.count)]];
 
-    // Add the remainings tracks
+    // Add the remaining tracks
     for (NSUInteger idx = 1; idx < self.sourceTracksArray.count; idx++) {
         [self addTrack:[self trackFromSourceTrackIndex:idx]];
     }

--- a/macosx/HBAudio.m
+++ b/macosx/HBAudio.m
@@ -100,7 +100,7 @@ NSString *HBAudioEncoderChangedNotification = @"HBAudioEncoderChangedNotificatio
 {
     [self removeTracksAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.tracks.count)]];
 
-    // Add the remaining tracks
+    // Add the remainings tracks
     for (NSUInteger idx = 1; idx < self.sourceTracksArray.count; idx++) {
         [self addTrack:[self trackFromSourceTrackIndex:idx]];
     }

--- a/macosx/HBAudioTransformers.h
+++ b/macosx/HBAudioTransformers.h
@@ -7,8 +7,8 @@
 #import <Foundation/Foundation.h>
 
 /**
- *  A series of value transformers to bridge the libhb enums
- *  to the textual representations used in the interface.
+ *  A series of value trasformers to bridge the libhb enums
+ *  to the textual rapresentations used in the interface.
  */
 @interface HBFallbackEncodersTransformer : NSValueTransformer
 @end

--- a/macosx/HBAudioTransformers.h
+++ b/macosx/HBAudioTransformers.h
@@ -7,8 +7,8 @@
 #import <Foundation/Foundation.h>
 
 /**
- *  A series of value trasformers to bridge the libhb enums
- *  to the textual rapresentations used in the interface.
+ *  A series of value transformers to bridge the libhb enums
+ *  to the textual representations used in the interface.
  */
 @interface HBFallbackEncodersTransformer : NSValueTransformer
 @end

--- a/macosx/HBAudioTransformers.m
+++ b/macosx/HBAudioTransformers.m
@@ -8,7 +8,7 @@
 #import "HBLocalizationUtilities.h"
 #include "hb.h"
 
-#pragma mark - Value Trasformers
+#pragma mark - Value Transformers
 
 @implementation HBFallbackEncodersTransformer
 

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -272,7 +272,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     fFiltersViewController = [[HBFiltersViewController alloc] init];
     [fFiltersTab setView:[fFiltersViewController view]];
 
-    // Add the observers
+    // Add the observeers
 
     [self.core addObserver:self forKeyPath:@"state"
                    options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial
@@ -636,7 +636,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     // Check if we can scan the source and if there is any warning.
     BOOL canScan = [self.core canScan:mediaURL error:&outError];
 
-    // Notify the user that we don't support removal of copy protection.
+    // Notify the user that we don't support removal of copy proteciton.
     if (canScan && [outError code] == 101 && !self.suppressCopyProtectionWarning)
     {
         self.suppressCopyProtectionWarning = YES;

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -272,7 +272,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     fFiltersViewController = [[HBFiltersViewController alloc] init];
     [fFiltersTab setView:[fFiltersViewController view]];
 
-    // Add the observeers
+    // Add the observers
 
     [self.core addObserver:self forKeyPath:@"state"
                    options:NSKeyValueObservingOptionNew | NSKeyValueObservingOptionInitial
@@ -636,7 +636,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     // Check if we can scan the source and if there is any warning.
     BOOL canScan = [self.core canScan:mediaURL error:&outError];
 
-    // Notify the user that we don't support removal of copy proteciton.
+    // Notify the user that we don't support removal of copy protection.
     if (canScan && [outError code] == 101 && !self.suppressCopyProtectionWarning)
     {
         self.suppressCopyProtectionWarning = YES;

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -139,7 +139,7 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
 @property (nonatomic, copy) NSString *name;
 
 /**
- *  Determines whether the scan operation can scan a particural URL or whether an additional decryption lib is needed.
+ *  Determines whether the scan operation can scan a particular URL or whether an additional decryption lib is needed.
  *
  *  @param url   the URL of the input file.
  *  @param error an error containing additional info.

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -139,7 +139,7 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
 @property (nonatomic, copy) NSString *name;
 
 /**
- *  Determines whether the scan operation can scan a particular URL or whether an additional decryption lib is needed.
+ *  Determines whether the scan operation can scan a particural URL or whether an additional decryption lib is needed.
  *
  *  @param url   the URL of the input file.
  *  @param error an error containing additional info.

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -453,7 +453,7 @@ typedef void (^HBCoreCleanupHandler)(void);
 {
     [self stopProgressReporting];
 
-    // HB_STATE_WORKDONE happpens as a result of libhb finishing all its jobs
+    // HB_STATE_WORKDONE happens as a result of libhb finishing all its jobs
     // or someone calling hb_stop. In the latter case, hb_stop does not clear
     // out the remaining passes/jobs in the queue. We'll do that here.
     hb_job_t *job;

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -453,7 +453,7 @@ typedef void (^HBCoreCleanupHandler)(void);
 {
     [self stopProgressReporting];
 
-    // HB_STATE_WORKDONE happens as a result of libhb finishing all its jobs
+    // HB_STATE_WORKDONE happpens as a result of libhb finishing all its jobs
     // or someone calling hb_stop. In the latter case, hb_stop does not clear
     // out the remaining passes/jobs in the queue. We'll do that here.
     hb_job_t *job;

--- a/macosx/HBLanguagesSelection.m
+++ b/macosx/HBLanguagesSelection.m
@@ -245,7 +245,7 @@ NSString *kHBLanguagesDragRowsType = @"kHBLanguagesDragRowsType";
 
         NSUInteger i = [indexSet countOfIndexesInRange:NSMakeRange(0, row)];
 
-        // Rearrange the objects.
+        // Rearrage the objects.
         [self moveObjectsInArrangedObjectsFromIndexes:indexSet toIndex:row];
 
         // Update the selection.

--- a/macosx/HBLanguagesSelection.m
+++ b/macosx/HBLanguagesSelection.m
@@ -245,7 +245,7 @@ NSString *kHBLanguagesDragRowsType = @"kHBLanguagesDragRowsType";
 
         NSUInteger i = [indexSet countOfIndexesInRange:NSMakeRange(0, row)];
 
-        // Rearrage the objects.
+        // Rearrange the objects.
         [self moveObjectsInArrangedObjectsFromIndexes:indexSet toIndex:row];
 
         // Update the selection.

--- a/macosx/HBOutputFileWriter.m
+++ b/macosx/HBOutputFileWriter.m
@@ -26,7 +26,7 @@
                                                                  error:&error];
         if (!result)
         {
-            [HBUtilities writeToActivityLog:"Error: coudln't open activity log file, %@", error];
+            [HBUtilities writeToActivityLog:"Error: couldn't open activity log file, %@", error];
             return nil;
         }
 

--- a/macosx/HBOutputFileWriter.m
+++ b/macosx/HBOutputFileWriter.m
@@ -26,7 +26,7 @@
                                                                  error:&error];
         if (!result)
         {
-            [HBUtilities writeToActivityLog:"Error: couldn't open activity log file, %@", error];
+            [HBUtilities writeToActivityLog:"Error: coudln't open activity log file, %@", error];
             return nil;
         }
 

--- a/macosx/HBOutputPanelController.m
+++ b/macosx/HBOutputPanelController.m
@@ -45,7 +45,7 @@
     {
         /* NSWindowController likes to lazily load its window nib. Since this
          * controller tries to touch the outlets before accessing the window, we
-         * need to force it to load immediately by invoking its accessor.
+         * need to force it to load immadiately by invoking its accessor.
          *
          * If/when we switch to using bindings, this can probably go away.
          */

--- a/macosx/HBOutputPanelController.m
+++ b/macosx/HBOutputPanelController.m
@@ -45,7 +45,7 @@
     {
         /* NSWindowController likes to lazily load its window nib. Since this
          * controller tries to touch the outlets before accessing the window, we
-         * need to force it to load immadiately by invoking its accessor.
+         * need to force it to load immediately by invoking its accessor.
          *
          * If/when we switch to using bindings, this can probably go away.
          */

--- a/macosx/HBPreferencesController.m
+++ b/macosx/HBPreferencesController.m
@@ -98,7 +98,7 @@ NSString * const HBQueueMinFreeSpace             = @"HBQueueMinFreeSpace";
         }];
 
     // Overwrite the update check interval because previous versions
-    // could be set to a daily check.
+    // could be set to a dayly check.
     NSUInteger week = 60 * 60 * 24 * 7;
     [[NSUserDefaults standardUserDefaults] setObject:@(week) forKey:@"SUScheduledCheckInterval"];
 }

--- a/macosx/HBPreferencesController.m
+++ b/macosx/HBPreferencesController.m
@@ -98,7 +98,7 @@ NSString * const HBQueueMinFreeSpace             = @"HBQueueMinFreeSpace";
         }];
 
     // Overwrite the update check interval because previous versions
-    // could be set to a dayly check.
+    // could be set to a daily check.
     NSUInteger week = 60 * 60 * 24 * 7;
     [[NSUserDefaults standardUserDefaults] setObject:@(week) forKey:@"SUScheduledCheckInterval"];
 }

--- a/macosx/HBPresetsViewController.m
+++ b/macosx/HBPresetsViewController.m
@@ -484,7 +484,7 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
 	else
 	{
 		// drop at the top root level
-		if (index == -1)	// drop area might be ambiguous (not at a particular location)
+		if (index == -1)	// drop area might be ambibuous (not at a particular location)
 			indexPath = [NSIndexPath indexPathWithIndex:self.presets.root.children.count]; // drop at the end of the top level
 		else
 			indexPath = [NSIndexPath indexPathWithIndex:index]; // drop at a particular place at the top level

--- a/macosx/HBPresetsViewController.m
+++ b/macosx/HBPresetsViewController.m
@@ -484,7 +484,7 @@ static void *HBPresetsViewControllerContext = &HBPresetsViewControllerContext;
 	else
 	{
 		// drop at the top root level
-		if (index == -1)	// drop area might be ambibuous (not at a particular location)
+		if (index == -1)	// drop area might be ambiguous (not at a particular location)
 			indexPath = [NSIndexPath indexPathWithIndex:self.presets.root.children.count]; // drop at the end of the top level
 		else
 			indexPath = [NSIndexPath indexPathWithIndex:index]; // drop at a particular place at the top level

--- a/macosx/HBPreviewGenerator.h
+++ b/macosx/HBPreviewGenerator.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCore:(HBCore *)core job:(HBJob *)job NS_DESIGNATED_INITIALIZER;
 
 /**
- * Wait until all the asyncronous operations are done.
+ * Wait until all the asynchronous operations are done.
  */
 - (void)invalidate;
 

--- a/macosx/HBPreviewGenerator.h
+++ b/macosx/HBPreviewGenerator.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithCore:(HBCore *)core job:(HBJob *)job NS_DESIGNATED_INITIALIZER;
 
 /**
- * Wait until all the asynchronous operations are done.
+ * Wait until all the asyncronous operations are done.
  */
 - (void)invalidate;
 

--- a/macosx/HBPreviewGenerator.m
+++ b/macosx/HBPreviewGenerator.m
@@ -136,7 +136,7 @@
     // they are needed.
     [self purgeImageCache];
 
-    // Enqueue the reload call on the main runloop
+    // Enquee the reload call on the main runloop
     // to avoid reloading the same image multiple times.
     if (self.reloadInQueue == NO)
     {

--- a/macosx/HBPreviewGenerator.m
+++ b/macosx/HBPreviewGenerator.m
@@ -136,7 +136,7 @@
     // they are needed.
     [self purgeImageCache];
 
-    // Enquee the reload call on the main runloop
+    // Enqueue the reload call on the main runloop
     // to avoid reloading the same image multiple times.
     if (self.reloadInQueue == NO)
     {

--- a/macosx/HBPreviewView.m
+++ b/macosx/HBPreviewView.m
@@ -172,7 +172,7 @@
             backingScaleFactor = self.window.backingScaleFactor;
         }
         // HiDPI mode usually display everything
-        // with douple pixel count, but we don't
+        // with double pixel count, but we don't
         // want to double the size of the video
         NSSize imageScaledSize = NSMakeSize(imageSize.width / backingScaleFactor, imageSize.height / backingScaleFactor);
         NSSize frameSize = self.frame.size;
@@ -241,7 +241,7 @@
     if (self.window.backingScaleFactor != 1.0)
     {
         // HiDPI mode usually display everything
-        // with douple pixel count, but we don't
+        // with double pixel count, but we don't
         // want to double the size of the video
         imageSize.height /= self.window.backingScaleFactor;
         imageSize.width /= self.window.backingScaleFactor;

--- a/macosx/HBPreviewView.m
+++ b/macosx/HBPreviewView.m
@@ -172,7 +172,7 @@
             backingScaleFactor = self.window.backingScaleFactor;
         }
         // HiDPI mode usually display everything
-        // with double pixel count, but we don't
+        // with douple pixel count, but we don't
         // want to double the size of the video
         NSSize imageScaledSize = NSMakeSize(imageSize.width / backingScaleFactor, imageSize.height / backingScaleFactor);
         NSSize frameSize = self.frame.size;
@@ -241,7 +241,7 @@
     if (self.window.backingScaleFactor != 1.0)
     {
         // HiDPI mode usually display everything
-        // with double pixel count, but we don't
+        // with douple pixel count, but we don't
         // want to double the size of the video
         imageSize.height /= self.window.backingScaleFactor;
         imageSize.width /= self.window.backingScaleFactor;

--- a/macosx/HBQueue.m
+++ b/macosx/HBQueue.m
@@ -325,7 +325,7 @@ NSString * const HBQueueItemNotificationItemKey = @"HBQueueItemNotificationItemK
 {
     if ([self.items beginTransaction] == HBDistributedArrayContentReload)
     {
-        // Do not execture the action if the array changed.
+        // Do not execute the action if the array changed.
         [self.items commit];
         return;
     }

--- a/macosx/HBQueue.m
+++ b/macosx/HBQueue.m
@@ -325,7 +325,7 @@ NSString * const HBQueueItemNotificationItemKey = @"HBQueueItemNotificationItemK
 {
     if ([self.items beginTransaction] == HBDistributedArrayContentReload)
     {
-        // Do not execute the action if the array changed.
+        // Do not execture the action if the array changed.
         [self.items commit];
         return;
     }

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -59,7 +59,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     {
         _queue = queue;
         
-        // Load the dockTile and instantiate initial text fields
+        // Load the dockTile and initiate initial text fields
         _dockTile = [[HBDockTile alloc] initWithDockTile:NSApplication.sharedApplication.dockTile
                                                   image:NSApplication.sharedApplication.applicationIconImage];
 

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -417,7 +417,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
 {
     if ([self.queue.items beginTransaction] == HBDistributedArrayContentReload)
     {
-        // Do not execture the action if the array changed.
+        // Do not execute the action if the array changed.
         [self.queue.items commit];
         return;
     }

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -58,7 +58,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     if (self = [super initWithWindowNibName:@"Queue"])
     {
         _queue = queue;
-
+        
         // Load the dockTile and instantiate initial text fields
         _dockTile = [[HBDockTile alloc] initWithDockTile:NSApplication.sharedApplication.dockTile
                                                   image:NSApplication.sharedApplication.applicationIconImage];

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -59,7 +59,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
     {
         _queue = queue;
         
-        // Load the dockTile and initiate initial text fields
+        // Load the dockTile and instantiate initial text fields
         _dockTile = [[HBDockTile alloc] initWithDockTile:NSApplication.sharedApplication.dockTile
                                                   image:NSApplication.sharedApplication.applicationIconImage];
 
@@ -417,7 +417,7 @@ static void *HBControllerQueueCoreContext = &HBControllerQueueCoreContext;
 {
     if ([self.queue.items beginTransaction] == HBDistributedArrayContentReload)
     {
-        // Do not execute the action if the array changed.
+        // Do not execture the action if the array changed.
         [self.queue.items commit];
         return;
     }

--- a/macosx/HBRange+UIAdditions.h
+++ b/macosx/HBRange+UIAdditions.h
@@ -18,7 +18,7 @@
 
 @end
 
-#pragma mark - Value Trasformers
+#pragma mark - Value Transformers
 
 @interface HBTimeTransformer : NSValueTransformer
 @end

--- a/macosx/HBSubtitles.m
+++ b/macosx/HBSubtitles.m
@@ -180,7 +180,7 @@ extern NSString *keySubTrackExternalFileURLBookmark;
 {
     [self removeTracksAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.tracks.count)]];
 
-    // Add the remaining tracks
+    // Add the remainings tracks
     for (NSUInteger idx = 1; idx < self.sourceTracksArray.count; idx++) {
         [self addTrack:[self trackFromSourceTrackIndex:idx]];
     }

--- a/macosx/HBSubtitles.m
+++ b/macosx/HBSubtitles.m
@@ -180,7 +180,7 @@ extern NSString *keySubTrackExternalFileURLBookmark;
 {
     [self removeTracksAtIndexes:[NSIndexSet indexSetWithIndexesInRange:NSMakeRange(0, self.tracks.count)]];
 
-    // Add the remainings tracks
+    // Add the remaining tracks
     for (NSUInteger idx = 1; idx < self.sourceTracksArray.count; idx++) {
         [self addTrack:[self trackFromSourceTrackIndex:idx]];
     }

--- a/macosx/HBSubtitlesTrack.h
+++ b/macosx/HBSubtitlesTrack.h
@@ -77,10 +77,10 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * HBIsoLanguageTrasformer is a trasformer to transform
+ * HBIsoLanguageTransformer is a transformer to transform
  * a ISO 639/2 code to a human readable language name.
  */
-@interface HBIsoLanguageTrasformer : NSValueTransformer
+@interface HBIsoLanguageTransformer : NSValueTransformer
 @end
 
 NS_ASSUME_NONNULL_END

--- a/macosx/HBSubtitlesTrack.m
+++ b/macosx/HBSubtitlesTrack.m
@@ -391,9 +391,9 @@ fail:
 
 @end
 
-#pragma mark - Value Trasformers
+#pragma mark - Value Transformers
 
-@implementation HBIsoLanguageTrasformer
+@implementation HBIsoLanguageTransformer
 
 + (Class)transformedValueClass
 {

--- a/macosx/HBSummaryViewController.m
+++ b/macosx/HBSummaryViewController.m
@@ -230,7 +230,7 @@ static void *HBSummaryViewControllerSubsContext = &HBSummaryViewControllerSubsCo
 
 - (void)updatePicture:(NSNotification *)notification
 {
-    // Enquee the reload call on the main runloop
+    // Enqueue the reload call on the main runloop
     // to avoid reloading the same image multiple times.
     if (self.pictureReloadInQueue == NO)
     {

--- a/macosx/HBSummaryViewController.m
+++ b/macosx/HBSummaryViewController.m
@@ -230,7 +230,7 @@ static void *HBSummaryViewControllerSubsContext = &HBSummaryViewControllerSubsCo
 
 - (void)updatePicture:(NSNotification *)notification
 {
-    // Enqueue the reload call on the main runloop
+    // Enquee the reload call on the main runloop
     // to avoid reloading the same image multiple times.
     if (self.pictureReloadInQueue == NO)
     {

--- a/macosx/HBVideo+UIAdditions.h
+++ b/macosx/HBVideo+UIAdditions.h
@@ -35,7 +35,7 @@
 @end
 
 /**
- *  A series of value trasformers to bridge the libhb enums
+ *  A series of value transformers to bridge the libhb enums
  *  to the textual rapresentations used in the interface.
  */
 @interface HBVideoEncoderTransformer : NSValueTransformer

--- a/macosx/HBVideo+UIAdditions.m
+++ b/macosx/HBVideo+UIAdditions.m
@@ -215,7 +215,7 @@
 @end
 
 
-#pragma mark - Value Trasformers
+#pragma mark - Value Transformers
 
 @implementation HBVideoEncoderTransformer
 

--- a/make/configure.py
+++ b/make/configure.py
@@ -608,7 +608,7 @@ class HostTupleAction( Action, list ):
 
 ###############################################################################
 ##
-## value wrapper; value is accepted only if one of host specs matcheds
+## value wrapper; value is accepted only if one of host specs matches
 ## otherwise it is None (or a keyword-supplied val)
 ##
 ## result is attribute 'value'
@@ -1525,7 +1525,7 @@ try:
 
     ## create main objects; actions/probes run() is delayed.
     ## if any actions must be run earlier (eg: for configure --help purposes)
-    ## then run() must be invoked earlier. subequent run() invocations
+    ## then run() must be invoked earlier. subsequent run() invocations
     ## are ignored.
     cfg         = Configure( verbose )
     build_tuple = BuildTupleProbe(); build_tuple.run()

--- a/test/test.c
+++ b/test/test.c
@@ -3718,7 +3718,7 @@ static hb_dict_t * PreparePreset(const char *preset_name)
         // No explicit audio tracks, but track settings modified.
         // Modify the presets audio settings.
         //
-        // Note that --all-audio is explicitely asking for all tracks
+        // Note that --all-audio is explicitly asking for all tracks
         hb_value_array_t *list;
         list = hb_dict_get(preset, "AudioList");
         if (list == NULL)


### PR DESCRIPTION
Fix some typos in libhb


Clion notified me about some typos in some files inside /libhb. I've tried to correct all of them.
For completeness, there are also some code specific warnings Clion is telling me, which I did not correct. Apart from "Code xy can be simplified" there are for instance the following:


https://github.com/HandBrake/HandBrake/blob/master/libhb/reader.c#L403
`Variable 'r' used in loop condition is not updated in the loop`



https://github.com/HandBrake/HandBrake/blob/master/libhb/rendersub.c#L994
Alle "break' from here downwards : `Unreachable code`



https://github.com/HandBrake/HandBrake/blob/master/libhb/decvobsub.c#L171
For the 'buf_out' Clion tells `Condition is always true`



https://github.com/HandBrake/HandBrake/blob/master/libhb/fifo.c#L303
`Condition is always false`



https://github.com/HandBrake/HandBrake/blob/master/libhb/fifo.c#L305
`Unreachable code`


After enabling some linting plugins, it tells much more things. I did not correct any of them.