### PR TITLE
libhb: make source audio track name available to frontends

### DIFF
--- a/contrib/ffmpeg/A05-mov-read-name-track-tag-written-by-movenc.patch
+++ b/contrib/ffmpeg/A05-mov-read-name-track-tag-written-by-movenc.patch
@@ -1,0 +1,65 @@
+From b6ce7b6a4ec0429069f05e63edce907c0f80aaea Mon Sep 17 00:00:00 2001
+From: John Stebbins <jstebbins@jetheaddev.com>
+Date: Wed, 31 Jul 2019 15:27:40 -0700
+Subject: [PATCH] mov: read 'name' track tag written by movenc
+
+---
+ libavformat/mov.c | 26 +++++++++++++++++---------
+ 1 file changed, 17 insertions(+), 9 deletions(-)
+
+diff --git a/libavformat/mov.c b/libavformat/mov.c
+index 24de5429d1..fce69129d9 100644
+--- a/libavformat/mov.c
++++ b/libavformat/mov.c
+@@ -306,6 +306,7 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+     int (*parse)(MOVContext*, AVIOContext*, unsigned, const char*) = NULL;
+     int raw = 0;
+     int num = 0;
++    AVDictionary *metadata;
+ 
+     switch (atom.type) {
+     case MKTAG( '@','P','R','M'): key = "premiere_version"; raw = 1; break;
+@@ -384,6 +385,7 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+     case MKTAG(0xa9,'m','a','k'): key = "make";      break;
+     case MKTAG(0xa9,'m','o','d'): key = "model";     break;
+     case MKTAG(0xa9,'n','a','m'): key = "title";     break;
++    case MKTAG( 'n','a','m','e'): key = "title";     break;
+     case MKTAG(0xa9,'o','p','e'): key = "original_artist"; break;
+     case MKTAG(0xa9,'p','r','d'): key = "producer";  break;
+     case MKTAG(0xa9,'p','r','f'): key = "performers"; break;
+@@ -514,17 +516,23 @@ retry:
+             }
+             str[str_size] = 0;
+         }
+-        c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
+-        av_dict_set(&c->fc->metadata, key, str, 0);
++        if (c->trak_index < 0) {
++            metadata = c->fc->metadata;
++            c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
++            if (!strcmp(key, "encoder")) {
++                int major, minor, micro;
++                if (sscanf(str, "HandBrake %d.%d.%d", &major, &minor, &micro) == 3) {
++                    c->handbrake_version = 1000000*major + 1000*minor + micro;
++                }
++            }
++        }
++        else {
++            metadata = c->fc->streams[c->trak_index]->metadata;
++        }
++        av_dict_set(&metadata, key, str, 0);
+         if (*language && strcmp(language, "und")) {
+             snprintf(key2, sizeof(key2), "%s-%s", key, language);
+-            av_dict_set(&c->fc->metadata, key2, str, 0);
+-        }
+-        if (!strcmp(key, "encoder")) {
+-            int major, minor, micro;
+-            if (sscanf(str, "HandBrake %d.%d.%d", &major, &minor, &micro) == 3) {
+-                c->handbrake_version = 1000000*major + 1000*minor + micro;
+-            }
++            av_dict_set(&metadata, key2, str, 0);
+         }
+     }
+ 
+-- 
+2.21.0
+

--- a/contrib/ffmpeg/A05-mov-read-name-track-tag-written-by-movenc.patch
+++ b/contrib/ffmpeg/A05-mov-read-name-track-tag-written-by-movenc.patch
@@ -1,14 +1,14 @@
-From b6ce7b6a4ec0429069f05e63edce907c0f80aaea Mon Sep 17 00:00:00 2001
+From 375d09561cb88a7002a833614dbd399446479cd1 Mon Sep 17 00:00:00 2001
 From: John Stebbins <jstebbins@jetheaddev.com>
 Date: Wed, 31 Jul 2019 15:27:40 -0700
-Subject: [PATCH] mov: read 'name' track tag written by movenc
+Subject: [PATCH 1/3] mov: read 'name' track tag written by movenc
 
 ---
  libavformat/mov.c | 26 +++++++++++++++++---------
  1 file changed, 17 insertions(+), 9 deletions(-)
 
 diff --git a/libavformat/mov.c b/libavformat/mov.c
-index 24de5429d1..fce69129d9 100644
+index 24de5429d1..1f933cccfd 100644
 --- a/libavformat/mov.c
 +++ b/libavformat/mov.c
 @@ -306,6 +306,7 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
@@ -19,14 +19,14 @@ index 24de5429d1..fce69129d9 100644
  
      switch (atom.type) {
      case MKTAG( '@','P','R','M'): key = "premiere_version"; raw = 1; break;
-@@ -384,6 +385,7 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
-     case MKTAG(0xa9,'m','a','k'): key = "make";      break;
-     case MKTAG(0xa9,'m','o','d'): key = "model";     break;
-     case MKTAG(0xa9,'n','a','m'): key = "title";     break;
-+    case MKTAG( 'n','a','m','e'): key = "title";     break;
-     case MKTAG(0xa9,'o','p','e'): key = "original_artist"; break;
-     case MKTAG(0xa9,'p','r','d'): key = "producer";  break;
-     case MKTAG(0xa9,'p','r','f'): key = "performers"; break;
+@@ -338,6 +339,7 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+         return mov_metadata_loci(c, pb, atom.size);
+     case MKTAG( 'm','a','n','u'): key = "make"; break;
+     case MKTAG( 'm','o','d','l'): key = "model"; break;
++    case MKTAG( 'n','a','m','e'): key = "title"; raw = 1; break;
+     case MKTAG( 'p','c','s','t'): key = "podcast";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'p','g','a','p'): key = "gapless_playback";
 @@ -514,17 +516,23 @@ retry:
              }
              str[str_size] = 0;

--- a/contrib/ffmpeg/A06-movenc-write-3gpp-track-titl-tag.patch
+++ b/contrib/ffmpeg/A06-movenc-write-3gpp-track-titl-tag.patch
@@ -1,0 +1,126 @@
+From e9dde141a5fc27df87eb4b3454e34d725b211708 Mon Sep 17 00:00:00 2001
+From: John Stebbins <jstebbins@jetheaddev.com>
+Date: Sun, 4 Aug 2019 10:52:30 -0700
+Subject: [PATCH 2/3] movenc: write 3gpp track 'titl' tag
+
+Apple software used to use 'name' raw tag for track titles.  When they
+rewrote everything with AVFoundation, they switched to using 3gpp 'titl'
+tag for track titles and 'name' no longer works.
+---
+ libavformat/movenc.c | 78 +++++++++++++++++++++++---------------------
+ 1 file changed, 40 insertions(+), 38 deletions(-)
+
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index a96139077b..b1b6ef0e4e 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -3077,6 +3077,35 @@ static int mov_write_udta_sdp(AVIOContext *pb, MOVTrack *track)
+     return len + 24;
+ }
+ 
++static uint16_t language_code(const char *str)
++{
++    return (((str[0] - 0x60) & 0x1F) << 10) +
++           (((str[1] - 0x60) & 0x1F) <<  5) +
++           (( str[2] - 0x60) & 0x1F);
++}
++
++static int mov_write_3gp_udta_tag(AVIOContext *pb, AVDictionary *metadata,
++                                  const char *tag, const char *str)
++{
++    int64_t pos = avio_tell(pb);
++    AVDictionaryEntry *t = av_dict_get(metadata, str, NULL, 0);
++    if (!t || !utf8len(t->value))
++        return 0;
++    avio_wb32(pb, 0);   /* size */
++    ffio_wfourcc(pb, tag); /* type */
++    avio_wb32(pb, 0);   /* version + flags */
++    if (!strcmp(tag, "yrrc"))
++        avio_wb16(pb, atoi(t->value));
++    else {
++        avio_wb16(pb, language_code("eng")); /* language */
++        avio_write(pb, t->value, strlen(t->value) + 1); /* UTF8 string value */
++        if (!strcmp(tag, "albm") &&
++            (t = av_dict_get(metadata, "track", NULL, 0)))
++            avio_w8(pb, atoi(t->value));
++    }
++    return update_size(pb, pos);
++}
++
+ static int mov_write_track_metadata(AVIOContext *pb, AVStream *st,
+                                     const char *tag, const char *str)
+ {
+@@ -3105,8 +3134,10 @@ static int mov_write_track_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
+     if (ret < 0)
+         return ret;
+ 
+-    if (mov->mode & (MODE_MP4|MODE_MOV))
++    if (mov->mode & (MODE_MP4|MODE_MOV)) {
+         mov_write_track_metadata(pb_buf, st, "name", "title");
++        mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", "title");
++    }
+ 
+     if ((size = avio_close_dyn_buf(pb_buf, &buf)) > 0) {
+         avio_wb32(pb, size + 8);
+@@ -3680,35 +3711,6 @@ static int ascii_to_wc(AVIOContext *pb, const uint8_t *b)
+     return 0;
+ }
+ 
+-static uint16_t language_code(const char *str)
+-{
+-    return (((str[0] - 0x60) & 0x1F) << 10) +
+-           (((str[1] - 0x60) & 0x1F) <<  5) +
+-           (( str[2] - 0x60) & 0x1F);
+-}
+-
+-static int mov_write_3gp_udta_tag(AVIOContext *pb, AVFormatContext *s,
+-                                  const char *tag, const char *str)
+-{
+-    int64_t pos = avio_tell(pb);
+-    AVDictionaryEntry *t = av_dict_get(s->metadata, str, NULL, 0);
+-    if (!t || !utf8len(t->value))
+-        return 0;
+-    avio_wb32(pb, 0);   /* size */
+-    ffio_wfourcc(pb, tag); /* type */
+-    avio_wb32(pb, 0);   /* version + flags */
+-    if (!strcmp(tag, "yrrc"))
+-        avio_wb16(pb, atoi(t->value));
+-    else {
+-        avio_wb16(pb, language_code("eng")); /* language */
+-        avio_write(pb, t->value, strlen(t->value) + 1); /* UTF8 string value */
+-        if (!strcmp(tag, "albm") &&
+-            (t = av_dict_get(s->metadata, "track", NULL, 0)))
+-            avio_w8(pb, atoi(t->value));
+-    }
+-    return update_size(pb, pos);
+-}
+-
+ static int mov_write_chpl_tag(AVIOContext *pb, AVFormatContext *s)
+ {
+     int64_t pos = avio_tell(pb);
+@@ -3747,14 +3749,14 @@ static int mov_write_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
+         return ret;
+ 
+     if (mov->mode & MODE_3GP) {
+-        mov_write_3gp_udta_tag(pb_buf, s, "perf", "artist");
+-        mov_write_3gp_udta_tag(pb_buf, s, "titl", "title");
+-        mov_write_3gp_udta_tag(pb_buf, s, "auth", "author");
+-        mov_write_3gp_udta_tag(pb_buf, s, "gnre", "genre");
+-        mov_write_3gp_udta_tag(pb_buf, s, "dscp", "comment");
+-        mov_write_3gp_udta_tag(pb_buf, s, "albm", "album");
+-        mov_write_3gp_udta_tag(pb_buf, s, "cprt", "copyright");
+-        mov_write_3gp_udta_tag(pb_buf, s, "yrrc", "date");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "perf", "artist");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "titl", "title");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "auth", "author");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "gnre", "genre");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "dscp", "comment");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "albm", "album");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "cprt", "copyright");
++        mov_write_3gp_udta_tag(pb_buf, s->metadata, "yrrc", "date");
+         mov_write_loci_tag(s, pb_buf);
+     } else if (mov->mode == MODE_MOV && !(mov->flags & FF_MOV_FLAG_USE_MDTA)) { // the title field breaks gtkpod with mp4 and my suspicion is that stuff is not valid in mp4
+         mov_write_string_metadata(s, pb_buf, "\251ART", "artist",      0);
+-- 
+2.21.0
+

--- a/contrib/ffmpeg/A07-mov-read-3gpp-udta-tags.patch
+++ b/contrib/ffmpeg/A07-mov-read-3gpp-udta-tags.patch
@@ -1,0 +1,160 @@
+From 1b02b0afe201cd14a97d83dc08716bf9cc188cb0 Mon Sep 17 00:00:00 2001
+From: John Stebbins <jstebbins@jetheaddev.com>
+Date: Sun, 4 Aug 2019 10:59:38 -0700
+Subject: [PATCH 3/3] mov: read 3gpp udta tags
+
+---
+ libavformat/mov.c | 110 ++++++++++++++++++++++++++++++++++++++++++++--
+ 1 file changed, 107 insertions(+), 3 deletions(-)
+
+diff --git a/libavformat/mov.c b/libavformat/mov.c
+index 1f933cccfd..0c365cde3e 100644
+--- a/libavformat/mov.c
++++ b/libavformat/mov.c
+@@ -50,6 +50,7 @@
+ #include "libavcodec/flac.h"
+ #include "libavcodec/mpegaudiodecheader.h"
+ #include "avformat.h"
++#include "avlanguage.h"
+ #include "internal.h"
+ #include "avio_internal.h"
+ #include "riff.h"
+@@ -295,6 +296,82 @@ static int mov_metadata_hmmt(MOVContext *c, AVIOContext *pb, unsigned len)
+     return 0;
+ }
+ 
++static int mov_read_3gp_udta_tag(MOVContext *c, AVIOContext *pb, MOVAtom atom)
++{
++    const char *key;
++    AVDictionary *metadata;
++    uint16_t langcode = 0;
++    char key2[32], language[4] = {0};
++    uint32_t str_size, version;
++    char *str;
++
++    if (atom.size < 6)
++        return AVERROR_INVALIDDATA;
++
++    switch (atom.type) {
++    case MKTAG( 'a','l','b','m'): key = "album"; break;
++    case MKTAG( 'a','u','t','h'): key = "author"; break;
++    case MKTAG( 'c','p','r','t'): key = "copyright"; break;
++    case MKTAG( 'd','s','c','p'): key = "comment"; break;
++    case MKTAG( 'g','n','r','e'): key = "genre"; break;
++    case MKTAG( 'p','e','r','f'): key = "artist"; break;
++    case MKTAG( 't','i','t','l'): key = "title"; break;
++    case MKTAG( 'y','r','r','c'): key = "date"; break;
++    default: return 0;
++    }
++
++    version = avio_rb32(pb); // version + flags
++    if (version != 0)
++        return AVERROR_INVALIDDATA;
++
++    if (MKTAG( 'y','r','r','c') == atom.type) {
++        int year;
++        year = avio_rb16(pb);
++        str = av_asprintf("%d", year);
++        if (!str)
++            return AVERROR(ENOMEM);
++    } else {
++        int ret;
++        const char *tmp;
++        langcode = avio_rb16(pb);
++        ff_mov_lang_to_iso639(langcode, language);
++        tmp = ff_convert_lang_to(language, AV_LANG_ISO639_2_BIBL);
++        if (!tmp)
++            return AVERROR_INVALIDDATA;
++
++        str_size = atom.size - 6;
++        if (str_size <= 0 || str_size >= INT_MAX/2)
++            return AVERROR_INVALIDDATA;
++
++        str = av_mallocz(str_size + 1);
++        if (!str)
++            return AVERROR(ENOMEM);
++
++        ret = ffio_read_size(pb, str, str_size);
++        if (ret < 0) {
++            av_free(str);
++            return ret;
++        }
++        str[str_size] = 0;
++    }
++
++    if (c->trak_index < 0) {
++        metadata = c->fc->metadata;
++        c->fc->event_flags |= AVFMT_EVENT_FLAG_METADATA_UPDATED;
++    }
++    else {
++        metadata = c->fc->streams[c->trak_index]->metadata;
++    }
++    av_dict_set(&metadata, key, str, 0);
++    if (*language && strcmp(language, "und")) {
++        snprintf(key2, sizeof(key2), "%s-%s", key, language);
++        av_dict_set(&metadata, key2, str, 0);
++    }
++
++    av_freep(&str);
++    return 0;
++}
++
+ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+ {
+     char tmp_key[5];
+@@ -320,15 +397,33 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+     case MKTAG( 'c','a','t','g'): key = "category"; break;
+     case MKTAG( 'c','p','i','l'): key = "compilation";
+         parse = mov_metadata_int8_no_padding; break;
+-    case MKTAG( 'c','p','r','t'): key = "copyright"; break;
++    case MKTAG( 'c','p','r','t'):
++        key = "copyright";
++        if (!c->itunes_metadata) {
++            int64_t pos = avio_tell(pb);
++            int ret = mov_read_3gp_udta_tag(c, pb, atom);
++            if (ret != AVERROR_INVALIDDATA)
++                return ret;
++            avio_seek(pb, pos, SEEK_SET);
++        }
++        break;
+     case MKTAG( 'd','e','s','c'): key = "description"; break;
+     case MKTAG( 'd','i','s','k'): key = "disc";
+         parse = mov_metadata_track_or_disc_number; break;
+     case MKTAG( 'e','g','i','d'): key = "episode_uid";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'F','I','R','M'): key = "firmware"; raw = 1; break;
+-    case MKTAG( 'g','n','r','e'): key = "genre";
+-        parse = mov_metadata_gnre; break;
++    case MKTAG( 'g','n','r','e'):
++        key = "genre";
++        parse = mov_metadata_gnre;
++        if (!c->itunes_metadata) {
++            int64_t pos = avio_tell(pb);
++            int ret = mov_read_3gp_udta_tag(c, pb, atom);
++            if (ret != AVERROR_INVALIDDATA)
++                return ret;
++            avio_seek(pb, pos, SEEK_SET);
++        }
++        break;
+     case MKTAG( 'h','d','v','d'): key = "hd_video";
+         parse = mov_metadata_int8_no_padding; break;
+     case MKTAG( 'H','M','M','T'):
+@@ -399,6 +494,15 @@ static int mov_read_udta_string(MOVContext *c, AVIOContext *pb, MOVAtom atom)
+     case MKTAG(0xa9,'w','r','n'): key = "warning";   break;
+     case MKTAG(0xa9,'w','r','t'): key = "composer";  break;
+     case MKTAG(0xa9,'x','y','z'): key = "location";  break;
++    case MKTAG( 'a','l','b','m'):
++    case MKTAG( 'a','u','t','h'):
++    case MKTAG( 'd','s','c','p'):
++    case MKTAG( 'p','e','r','f'):
++    case MKTAG( 't','i','t','l'):
++    case MKTAG( 'y','r','r','c'):
++        if (!c->itunes_metadata) {
++            return mov_read_3gp_udta_tag(c, pb, atom);
++        }
+     }
+ retry:
+     if (c->itunes_metadata && atom.size > 8) {
+-- 
+2.21.0
+

--- a/contrib/ffmpeg/A08-movenc-write-3gpp-track-names-tags-for-all-available.patch
+++ b/contrib/ffmpeg/A08-movenc-write-3gpp-track-names-tags-for-all-available.patch
@@ -1,0 +1,77 @@
+From defbe24539ad6e2564db84641a84543256f8609f Mon Sep 17 00:00:00 2001
+From: John Stebbins <jstebbins@jetheaddev.com>
+Date: Tue, 6 Aug 2019 11:45:11 -0600
+Subject: [PATCH] movenc: write 3gpp track names tags for all available
+ languages
+
+Metadata keys can have a language suffix.  Iterate through all language
+variations of the metadata key.
+---
+ libavformat/movenc.c | 28 ++++++++++++++++++++++++++--
+ 1 file changed, 26 insertions(+), 2 deletions(-)
+
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index b1b6ef0e4e..3d9800d386 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -26,6 +26,7 @@
+ 
+ #include "movenc.h"
+ #include "avformat.h"
++#include "avlanguage.h"
+ #include "avio_internal.h"
+ #include "riff.h"
+ #include "avio.h"
+@@ -3089,15 +3090,25 @@ static int mov_write_3gp_udta_tag(AVIOContext *pb, AVDictionary *metadata,
+ {
+     int64_t pos = avio_tell(pb);
+     AVDictionaryEntry *t = av_dict_get(metadata, str, NULL, 0);
++
+     if (!t || !utf8len(t->value))
+         return 0;
++
+     avio_wb32(pb, 0);   /* size */
+     ffio_wfourcc(pb, tag); /* type */
+     avio_wb32(pb, 0);   /* version + flags */
+     if (!strcmp(tag, "yrrc"))
+         avio_wb16(pb, atoi(t->value));
+     else {
+-        avio_wb16(pb, language_code("eng")); /* language */
++        int lang = 0, len;
++        len = strlen(t->key);
++        if (t->key[len - 4] == '-') {
++            lang = ff_mov_iso639_to_lang(&t->key[len - 3], 1);
++        }
++        if (!lang)
++            lang = ff_mov_iso639_to_lang("und", 1);
++
++        avio_wb16(pb, lang); /* language */
+         avio_write(pb, t->value, strlen(t->value) + 1); /* UTF8 string value */
+         if (!strcmp(tag, "albm") &&
+             (t = av_dict_get(metadata, "track", NULL, 0)))
+@@ -3135,8 +3146,21 @@ static int mov_write_track_udta_tag(AVIOContext *pb, MOVMuxContext *mov,
+         return ret;
+ 
+     if (mov->mode & (MODE_MP4|MODE_MOV)) {
++        AVDictionaryEntry *t = NULL;
++        int und = 0;
++
+         mov_write_track_metadata(pb_buf, st, "name", "title");
+-        mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", "title");
++        while ((t = av_dict_get(st->metadata, "title-", t, AV_DICT_IGNORE_SUFFIX))) {
++            int len = strlen(t->key);
++            if (len == 10 &&
++                ff_convert_lang_to(&t->key[len - 3], AV_LANG_ISO639_2_BIBL)) {
++                mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", t->key);
++                if (!strcmp("und", &t->key[len - 3]))
++                    und = 1;
++            }
++        }
++        if (!und)
++            mov_write_3gp_udta_tag(pb_buf, st->metadata, "titl", "title");
+     }
+ 
+     if ((size = avio_close_dyn_buf(pb_buf, &buf)) > 0) {
+-- 
+2.21.0
+

--- a/gtk/src/audiohandler.h
+++ b/gtk/src/audiohandler.h
@@ -33,7 +33,7 @@ GhbValue *ghb_get_audio_list(GhbValue *settings);
 void ghb_sanitize_audio_track_settings(GhbValue *settings);
 const gchar* ghb_get_user_audio_lang(GhbValue *settings, const hb_title_t *title, gint track);
 void ghb_audio_list_refresh_selected(signal_user_data_t *ud);
-gint ghb_select_audio_codec(gint mux, hb_audio_config_t *aconfig, gint acodec, gint fallback_acodec, gint copy_mask);
+gint ghb_select_audio_codec(gint mux, guint32 in_codec, gint acodec, gint fallback_acodec, gint copy_mask);
 int ghb_select_fallback( GhbValue *settings, int acodec );
 int ghb_get_copy_mask(GhbValue *settings);
 void ghb_audio_list_refresh_all(signal_user_data_t *ud);

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -2628,11 +2628,13 @@ ghb_set_title_settings(signal_user_data_t *ud, GhbValue *settings)
     ghb_subtitle_set_pref_lang(settings);
     if (title != NULL)
     {
-        GhbValue *job_dict;
+        GhbValue * job_dict, * title_dict;
         char     * label;
 
         job_dict = hb_preset_job_init(ghb_scan_handle(), title_id, settings);
         ghb_dict_set(settings, "Job", job_dict);
+        title_dict = hb_title_to_dict(ghb_scan_handle(), title_id);
+        ghb_dict_set(settings, "Title", title_dict);
 
         gint num_chapters = hb_list_count(title->list_chapter);
 
@@ -2762,6 +2764,9 @@ load_all_titles(signal_user_data_t *ud, int titleindex)
         count = 1;
 
     settings_array = ghb_array_new();
+
+    // Start with a clean job
+    ghb_dict_remove(ud->settings, "Job");
 
     preset = ghb_get_current_preset(ud);
     if (preset != NULL)

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -8732,6 +8732,7 @@ Setting this to 0 means there is no maximum height.</property>
     </action-widgets>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-subtitle-vbox">
+        <property name="orientation">vertical</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="spacing">6</property>
@@ -8797,263 +8798,297 @@ Setting this to 0 means there is no maximum height.</property>
             </child>
           </object>
           <packing>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid" id="subtitle_track_grid">
+            <property name="row-spacing">2</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="column_spacing">5</property>
+            <property name="halign">center</property>
+            <child>
+              <object class="GtkLabel" id="subtitle_track_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">Source Track</property>
+              </object>
+              <packing>
+                <property name="top_attach">0</property>
+                <property name="left_attach">0</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="SubtitleTrack">
+                <property name="valign">GTK_ALIGN_CENTER</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">List of subtitle tracks available from your source.</property>
+                <signal name="changed" handler="subtitle_track_changed_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">0</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="subtitle_name_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Track Name:</property>
+                <property name="use_markup">True</property>
+                <property name="halign">center</property>
+              </object>
+              <packing>
+                <property name="top_attach">0</property>
+                <property name="left_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="SubtitleTrackName">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Set the subtitle track name.
+
+Players may use this in the subtitle selection list.</property>
+                <property name="max_length">80</property>
+                <property name="width-chars">40</property>
+                <property name="activates_default">True</property>
+                <property name="truncate_multiline">True</property>
+                <signal name="changed" handler="subtitle_name_changed_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
             <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="subtitle_settings_box">
-            <property name="orientation">horizontal</property>
+          <object class="GtkGrid" id="subtitle_import_grid">
             <property name="visible">True</property>
+            <property name="row-spacing">2</property>
             <property name="can_focus">False</property>
-            <property name="spacing">6</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="column_spacing">4</property>
             <child>
-              <object class="GtkGrid" id="subtitle_import_grid">
+              <object class="GtkLabel" id="import_lang_label">
                 <property name="visible">True</property>
-                <property name="row-spacing">2</property>
                 <property name="can_focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="column_spacing">4</property>
-                <child>
-                  <object class="GtkLabel" id="import_lang_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="label" translatable="yes">Language</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">1</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="srt_code_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="label" translatable="yes">Character Code</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">2</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="import_file_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="label" translatable="yes">File:</property>
-                    <property name="halign">end</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">0</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="import_offset_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="label" translatable="yes">Offset (ms)</property>
-                  </object>
-                  <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">4</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="ImportLanguage">
-                    <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Set the language of this subtitle.
+                <property name="label" translatable="yes">Language</property>
+              </object>
+              <packing>
+                <property name="top_attach">0</property>
+                <property name="left_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="srt_code_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">Character Code</property>
+              </object>
+              <packing>
+                <property name="top_attach">0</property>
+                <property name="left_attach">2</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="import_file_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">File:</property>
+                <property name="halign">end</property>
+              </object>
+              <packing>
+                <property name="top_attach">2</property>
+                <property name="left_attach">0</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="import_offset_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="label" translatable="yes">Offset (ms)</property>
+              </object>
+              <packing>
+                <property name="top_attach">0</property>
+                <property name="left_attach">4</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="ImportLanguage">
+                <property name="valign">GTK_ALIGN_CENTER</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Set the language of this subtitle.
 This value will be used by players in subtitle menus.</property>
-                    <signal name="changed" handler="import_lang_changed_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">1</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="SrtCodeset">
-                    <property name="valign">GTK_ALIGN_FILL</property>
-                    <property name="width_request">150</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Set the character code used by the SRT file you are importing.
+                <signal name="changed" handler="import_lang_changed_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">1</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="SrtCodeset">
+                <property name="valign">GTK_ALIGN_FILL</property>
+                <property name="width_request">150</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Set the character code used by the SRT file you are importing.
 
 SRTs come in all flavours of character sets.
 We translate the character set to UTF-8.
 The source's character code is needed in order to perform this translation.</property>
-                    <signal name="changed" handler="srt_codeset_changed_cb" swapped="no"/>
-                    <property name="has_entry">True</property>
-                    <child internal-child="entry">
-                      <object class="GtkEntry" id="combobox-entry1">
-                        <property name="can_focus">True</property>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">2</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkFileChooserButton" id="ImportFile">
-                    <property name="visible">True</property>
+                <signal name="changed" handler="srt_codeset_changed_cb" swapped="no"/>
+                <property name="has_entry">True</property>
+                <child internal-child="entry">
+                  <object class="GtkEntry" id="combobox-entry1">
                     <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Select the SRT file to import.</property>
-                    <property name="local_only">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="title" translatable="yes">Import File</property>
-                    <signal name="selection-changed" handler="import_file_changed_cb" swapped="no"/>
                   </object>
-                  <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">1</property>
-                    <property name="width">2</property>
-                    <property name="height">1</property>
-                  </packing>
                 </child>
-                <child>
-                  <object class="GtkSpinButton" id="ImportOffset">
-                    <property name="valign">GTK_ALIGN_FILL</property>
-                    <property name="vexpand">False</property>
-                    <property name="width-chars">8</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
-                    <property name="adjustment">adjustment31</property>
-                    <signal name="value-changed" handler="import_offset_changed_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">4</property>
-                    <property name="width">1</property>
-                    <property name="height">1</property>
-                  </packing>
-                </child>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">2</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="ImportFile">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Select the SRT file to import.</property>
+                <property name="local_only">False</property>
+                <property name="hexpand">True</property>
+                <property name="title" translatable="yes">Import File</property>
+                <signal name="selection-changed" handler="import_file_changed_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="top_attach">2</property>
+                <property name="left_attach">1</property>
+                <property name="width">2</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSpinButton" id="ImportOffset">
+                <property name="valign">GTK_ALIGN_FILL</property>
+                <property name="vexpand">False</property>
+                <property name="width-chars">8</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
+                <property name="adjustment">adjustment31</property>
+                <signal name="value-changed" handler="import_offset_changed_cb" swapped="no"/>
+              </object>
+              <packing>
+                <property name="top_attach">1</property>
+                <property name="left_attach">4</property>
+                <property name="width">1</property>
+                <property name="height">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="subtitle_options_box">
+            <property name="orientation">vertical</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">12</property>
+            <child>
+              <object class="GtkCheckButton" id="SubtitleForced">
+                <property name="label" translatable="yes">Forced Subtitles Only</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
+as forced in the source subtitle track
+
+"Forced" subtitles are usually used to show
+subtitles during scenes where someone is speaking
+a foreign language.</property>
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_forced_toggled_cb" swapped="no"/>
               </object>
               <packing>
                 <property name="position">0</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="subtitle_track_box">
-                <property name="orientation">vertical</property>
+              <object class="GtkCheckButton" id="SubtitleBurned">
+                <property name="label" translatable="yes">Burn into video</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="subtitle_track_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="label" translatable="yes">Track</property>
-                  </object>
-                  <packing>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="SubtitleTrack">
-                    <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">List of subtitle tracks available from your source.</property>
-                    <signal name="changed" handler="subtitle_track_changed_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
+The subtitle will be part of the video and can not be disabled.</property>
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_burned_toggled_cb" swapped="no"/>
               </object>
               <packing>
                 <property name="position">1</property>
               </packing>
             </child>
             <child>
-              <object class="GtkBox" id="subtitle_options_box">
-                <property name="orientation">vertical</property>
+              <object class="GtkCheckButton" id="SubtitleDefaultTrack">
+                <property name="label" translatable="yes">Set Default Track</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleForced">
-                    <property name="label" translatable="yes">Forced Subtitles Only</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
-as forced in the source subtitle track
-
-"Forced" subtitles are usually used to show
-subtitles during scenes where someone is speaking
-a foreign language.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_forced_toggled_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleBurned">
-                    <property name="label" translatable="yes">Burn into video</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
-The subtitle will be part of the video and can not be disabled.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_burned_toggled_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleDefaultTrack">
-                    <property name="label" translatable="yes">Set Default Track</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
 
 Most players will automatically display this
 subtitle track whenever the video is played.
 
 This is useful for creating a "forced" track
 in your output.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_default_toggled_cb" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_default_toggled_cb" swapped="no"/>
               </object>
               <packing>
                 <property name="position">2</property>
@@ -9061,7 +9096,7 @@ in your output.</property>
             </child>
           </object>
           <packing>
-            <property name="position">2</property>
+            <property name="position">3</property>
           </packing>
         </child>
       </object>
@@ -9170,7 +9205,8 @@ in your output.</property>
                 <property name="tooltip_text" translatable="yes">Set the audio track name.
 
 Players may use this in the audio selection list.</property>
-                <property name="max_length">40</property>
+                <property name="max_length">80</property>
+                <property name="width-chars">40</property>
                 <property name="hexpand">True</property>
                 <property name="activates_default">True</property>
                 <property name="truncate_multiline">True</property>

--- a/gtk/src/ghb4.ui
+++ b/gtk/src/ghb4.ui
@@ -7335,210 +7335,244 @@ Setting this to 0 means there is no maximum height.</property>
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="subtitle_settings_box">
-            <property name="orientation">horizontal</property>
+          <object class="GtkGrid" id="subtitle_track_grid">
+            <property name="row-spacing">2</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">6</property>
+            <property name="column-spacing">5</property>
+            <property name="halign">center</property>
             <child>
-              <object class="GtkGrid" id="subtitle_import_grid">
+              <object class="GtkLabel" id="subtitle_track_label">
                 <property name="visible">True</property>
-                <property name="row-spacing">2</property>
                 <property name="can_focus">False</property>
-                <property name="column-spacing">4</property>
-                <child>
-                  <object class="GtkLabel" id="import_lang_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Language</property>
-                    <layout>
-                      <property name="top-attach">0</property>
-                      <property name="left-attach">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="srt_code_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Character Code</property>
-                    <layout>
-                      <property name="top-attach">0</property>
-                      <property name="left-attach">2</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="import_file_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">File:</property>
-                    <property name="halign">end</property>
-                    <layout>
-                      <property name="top-attach">2</property>
-                      <property name="left-attach">0</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="import_offset_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Offset (ms)</property>
-                    <layout>
-                      <property name="top-attach">0</property>
-                      <property name="left-attach">4</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="ImportLanguage">
-                    <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="tooltip_text" translatable="yes">Set the language of this subtitle.
+                <property name="label" translatable="yes">Source Track</property>
+                <layout>
+                  <property name="top_attach">0</property>
+                  <property name="left_attach">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="SubtitleTrack">
+                <property name="valign">GTK_ALIGN_CENTER</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">List of subtitle tracks available from your source.</property>
+                <signal name="changed" handler="subtitle_track_changed_cb" swapped="no"/>
+                <layout>
+                  <property name="top_attach">1</property>
+                  <property name="left_attach">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="subtitle_name_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Track Name:</property>
+                <property name="use_markup">True</property>
+                <property name="halign">center</property>
+                <layout>
+                  <property name="top_attach">0</property>
+                  <property name="left_attach">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkEntry" id="SubtitleTrackName">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Set the subtitle track name.
+
+Players may use this in the subtitle selection list.</property>
+                <property name="max_length">80</property>
+                <property name="width-chars">40</property>
+                <property name="activates_default">True</property>
+                <property name="truncate_multiline">True</property>
+                <signal name="changed" handler="subtitle_name_changed_cb" swapped="no"/>
+                <layout>
+                  <property name="top_attach">1</property>
+                  <property name="left_attach">1</property>
+                </layout>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkGrid" id="subtitle_import_grid">
+            <property name="visible">True</property>
+            <property name="row-spacing">2</property>
+            <property name="can_focus">False</property>
+            <property name="column-spacing">4</property>
+            <child>
+              <object class="GtkLabel" id="import_lang_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Language</property>
+                <layout>
+                  <property name="top-attach">0</property>
+                  <property name="left-attach">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="srt_code_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Character Code</property>
+                <layout>
+                  <property name="top-attach">0</property>
+                  <property name="left-attach">2</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="import_file_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">File:</property>
+                <property name="halign">end</property>
+                <layout>
+                  <property name="top-attach">2</property>
+                  <property name="left-attach">0</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkLabel" id="import_offset_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Offset (ms)</property>
+                <layout>
+                  <property name="top-attach">0</property>
+                  <property name="left-attach">4</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="ImportLanguage">
+                <property name="valign">GTK_ALIGN_CENTER</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Set the language of this subtitle.
 This value will be used by players in subtitle menus.</property>
-                    <signal name="changed" handler="import_lang_changed_cb" swapped="no"/>
-                    <layout>
-                      <property name="top-attach">1</property>
-                      <property name="left-attach">1</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="SrtCodeset">
-                    <property name="valign">GTK_ALIGN_FILL</property>
-                    <property name="width_request">150</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="tooltip_text" translatable="yes">Set the character code used by the SRT file you are importing.
+                <signal name="changed" handler="import_lang_changed_cb" swapped="no"/>
+                <layout>
+                  <property name="top-attach">1</property>
+                  <property name="left-attach">1</property>
+                </layout>
+              </object>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="SrtCodeset">
+                <property name="valign">GTK_ALIGN_FILL</property>
+                <property name="width_request">150</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Set the character code used by the SRT file you are importing.
 
 SRTs come in all flavours of character sets.
 We translate the character set to UTF-8.
 The source's character code is needed in order to perform this translation.</property>
-                    <signal name="changed" handler="srt_codeset_changed_cb" swapped="no"/>
-                    <property name="has_entry">True</property>
-                    <layout>
-                      <property name="top-attach">1</property>
-                      <property name="left-attach">2</property>
-                    </layout>
-                    <child internal-child="entry">
-                      <object class="GtkEntry" id="combobox-entry1">
-                        <property name="can_focus">True</property>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkFileChooserButton" id="ImportFile">
-                    <property name="visible">True</property>
+                <signal name="changed" handler="srt_codeset_changed_cb" swapped="no"/>
+                <property name="has_entry">True</property>
+                <layout>
+                  <property name="top-attach">1</property>
+                  <property name="left-attach">2</property>
+                </layout>
+                <child internal-child="entry">
+                  <object class="GtkEntry" id="combobox-entry1">
                     <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Select the SRT file to import.</property>
-                    <property name="local_only">False</property>
-                    <property name="hexpand">True</property>
-                    <property name="title" translatable="yes">Import File</property>
-                    <signal name="selection-changed" handler="import_file_changed_cb" swapped="no"/>
-                    <layout>
-                      <property name="top-attach">2</property>
-                      <property name="left-attach">1</property>
-                      <property name="column-span">2</property>
-                    </layout>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSpinButton" id="ImportOffset">
-                    <property name="valign">GTK_ALIGN_FILL</property>
-                    <property name="vexpand">False</property>
-                    <property name="width-chars">8</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
-                    <property name="adjustment">adjustment31</property>
-                    <signal name="value-changed" handler="import_offset_changed_cb" swapped="no"/>
-                    <layout>
-                      <property name="top-attach">1</property>
-                      <property name="left-attach">4</property>
-                    </layout>
                   </object>
                 </child>
               </object>
             </child>
             <child>
-              <object class="GtkBox" id="subtitle_track_box">
-                <property name="orientation">vertical</property>
+              <object class="GtkFileChooserButton" id="ImportFile">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkLabel" id="subtitle_track_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">Track</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkComboBox" id="SubtitleTrack">
-                    <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="tooltip_text" translatable="yes">List of subtitle tracks available from your source.</property>
-                    <signal name="changed" handler="subtitle_track_changed_cb" swapped="no"/>
-                  </object>
-                </child>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Select the SRT file to import.</property>
+                <property name="local_only">False</property>
+                <property name="hexpand">True</property>
+                <property name="title" translatable="yes">Import File</property>
+                <signal name="selection-changed" handler="import_file_changed_cb" swapped="no"/>
+                <layout>
+                  <property name="top-attach">2</property>
+                  <property name="left-attach">1</property>
+                  <property name="column-span">2</property>
+                </layout>
               </object>
             </child>
             <child>
-              <object class="GtkBox" id="subtitle_options_box">
-                <property name="orientation">vertical</property>
+              <object class="GtkSpinButton" id="ImportOffset">
+                <property name="valign">GTK_ALIGN_FILL</property>
+                <property name="vexpand">False</property>
+                <property name="width-chars">8</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleForced">
-                    <property name="label" translatable="yes">Forced Subtitles Only</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
+                <property name="adjustment">adjustment31</property>
+                <signal name="value-changed" handler="import_offset_changed_cb" swapped="no"/>
+                <layout>
+                  <property name="top-attach">1</property>
+                  <property name="left-attach">4</property>
+                </layout>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="subtitle_options_box">
+            <property name="orientation">vertical</property>
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_top">12</property>
+            <child>
+              <object class="GtkCheckButton" id="SubtitleForced">
+                <property name="label" translatable="yes">Forced Subtitles Only</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
 as forced in the source subtitle track
 
 "Forced" subtitles are usually used to show
 subtitles during scenes where someone is speaking
 a foreign language.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_forced_toggled_cb" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleBurned">
-                    <property name="label" translatable="yes">Burn into video</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_forced_toggled_cb" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="SubtitleBurned">
+                <property name="label" translatable="yes">Burn into video</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
 The subtitle will be part of the video and can not be disabled.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_burned_toggled_cb" swapped="no"/>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkCheckButton" id="SubtitleDefaultTrack">
-                    <property name="label" translatable="yes">Set Default Track</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="receives_default">False</property>
-                    <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_burned_toggled_cb" swapped="no"/>
+              </object>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="SubtitleDefaultTrack">
+                <property name="label" translatable="yes">Set Default Track</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
 
 Most players will automatically display this
 subtitle track whenever the video is played.
 
 This is useful for creating a "forced" track
 in your output.</property>
-                    <property name="halign">start</property>
-                    <property name="draw_indicator">True</property>
-                    <signal name="toggled" handler="subtitle_default_toggled_cb" swapped="no"/>
-                  </object>
-                </child>
+                <property name="halign">start</property>
+                <property name="draw_indicator">True</property>
+                <signal name="toggled" handler="subtitle_default_toggled_cb" swapped="no"/>
               </object>
             </child>
           </object>

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1268,19 +1268,17 @@ ghb_grey_combo_options(signal_user_data_t *ud)
     acodec = ghb_settings_audio_encoder_codec(ud->settings, "AudioEncoder");
 
     gint64 layout = aconfig != NULL ? aconfig->in.channel_layout : ~0;
+    guint32 in_codec = aconfig != NULL ? aconfig->in.codec : 0;
     fallback = ghb_select_fallback(ud->settings, acodec);
     gint copy_mask = ghb_get_copy_mask(ud->settings);
-    acodec = ghb_select_audio_codec(mux->format, aconfig, acodec,
+    acodec = ghb_select_audio_codec(mux->format, in_codec, acodec,
                                     fallback, copy_mask);
     grey_mix_opts(ud, acodec, layout);
 }
 
 gint
-ghb_get_best_mix(hb_audio_config_t *aconfig, gint acodec, gint mix)
+ghb_get_best_mix(uint64_t layout, gint acodec, gint mix)
 {
-    gint layout;
-    layout = aconfig ? aconfig->in.channel_layout : AV_CH_LAYOUT_5POINT1;
-
     if (mix == HB_AMIXDOWN_NONE)
         mix = HB_INVALID_AMIXDOWN;
 

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -133,7 +133,7 @@ gint64 ghb_get_chapter_duration(const hb_title_t *title, gint chap);
 gint64 ghb_get_chapter_start(const hb_title_t *title, gint chap);
 gint64 ghb_chapter_range_get_duration(const hb_title_t *title,
                                       gint sc, gint ec);
-gint ghb_get_best_mix(hb_audio_config_t *aconfig, gint acodec, gint mix);
+gint ghb_get_best_mix(uint64_t layout, gint acodec, gint mix);
 gboolean ghb_audio_is_passthru(gint acodec);
 gboolean ghb_audio_can_passthru(gint acodec);
 gint ghb_get_default_acodec(void);

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -29,6 +29,7 @@
 #include "hb.h"
 #include "settings.h"
 #include "jobdict.h"
+#include "titledict.h"
 #include "hb-backend.h"
 #include "values.h"
 #include "callbacks.h"
@@ -1915,16 +1916,17 @@ queue_add(signal_user_data_t *ud, GhbValue *settings, gint batch)
 
     ghb_finalize_job(settings);
 
+    GhbValue *titleDict  = ghb_get_title_settings(settings);
     GhbValue *jobDict    = ghb_get_job_settings(settings);
-    GhbValue *sourceDict = ghb_get_job_source_settings(settings);
-    GhbValue *queueDict  = ghb_dict_new();
     GhbValue *uiDict     = ghb_value_dup(settings);
+
     ghb_dict_remove(uiDict, "Job");
-    int       title_id   = ghb_dict_get_int(sourceDict, "Title");
-    GhbValue *titleDict  = ghb_get_title_dict(title_id);
+    ghb_dict_remove(uiDict, "Title");
+
+    GhbValue *queueDict  = ghb_dict_new();
     ghb_dict_set(queueDict, "uiSettings", uiDict);
     ghb_dict_set(queueDict, "Job", ghb_value_dup(jobDict));
-    ghb_dict_set(queueDict, "Title", titleDict);
+    ghb_dict_set(queueDict, "Title", ghb_value_dup(titleDict));
 
     // Copy current prefs into settings
     // The job should run with the preferences that existed
@@ -2560,6 +2562,8 @@ queue_edit_action_cb(GSimpleAction *action, GVariant *param,
         ghb_queue_edit_settings = ghb_value_dup(uiDict);
         ghb_dict_set(ghb_queue_edit_settings,
                      "Job", ghb_value_dup(ghb_dict_get(queueDict, "Job")));
+        ghb_dict_set(ghb_queue_edit_settings,
+                     "Title", ghb_value_dup(ghb_dict_get(queueDict, "Title")));
         status = ghb_dict_get_int(uiDict, "job_status");
         if (status == GHB_QUEUE_PENDING)
         {

--- a/gtk/src/titledict.c
+++ b/gtk/src/titledict.c
@@ -39,9 +39,24 @@ GhbValue *ghb_get_title_audio_list(GhbValue *settings)
     return audio_list;
 }
 
+GhbValue *ghb_get_title_audio_track(GhbValue *settings, int track)
+{
+    GhbValue *audio_list  = ghb_get_title_audio_list(settings);
+    GhbValue *audio_track = ghb_array_get(audio_list, track);
+    return audio_track;
+}
+
 GhbValue *ghb_get_title_subtitle_list(GhbValue *settings)
 {
     GhbValue *title_dict = ghb_get_title_settings(settings);
     GhbValue *subtitle_list = ghb_dict_get(title_dict, "SubtitleList");
     return subtitle_list;
 }
+
+GhbValue *ghb_get_title_subtitle_track(GhbValue *settings, int track)
+{
+    GhbValue *subtitle_list  = ghb_get_title_subtitle_list(settings);
+    GhbValue *subtitle_track = ghb_array_get(subtitle_list, track);
+    return subtitle_track;
+}
+

--- a/gtk/src/titledict.h
+++ b/gtk/src/titledict.h
@@ -28,6 +28,8 @@
 
 GhbValue* ghb_get_title_settings(GhbValue *settings);
 GhbValue* ghb_get_title_audio_list(GhbValue *settings);
+GhbValue *ghb_get_title_audio_track(GhbValue *settings, int track);
 GhbValue* ghb_get_title_subtitle_list(GhbValue *settings);
+GhbValue *ghb_get_title_subtitle_track(GhbValue *settings, int track);
 
 #endif // _TITLEDICT_H_

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4809,6 +4809,14 @@ hb_subtitle_t *hb_subtitle_copy(const hb_subtitle_t *src)
             subtitle->extradata = malloc( src->extradata_size );
             memcpy( subtitle->extradata, src->extradata, src->extradata_size );
         }
+        if (src->name != NULL)
+        {
+            subtitle->name = strdup(src->name);
+        }
+        if (src->config.name != NULL)
+        {
+            subtitle->config.name = strdup(src->config.name);
+        }
     }
     return subtitle;
 }
@@ -4846,6 +4854,8 @@ void hb_subtitle_close( hb_subtitle_t **sub )
 {
     if ( sub && *sub )
     {
+        free ((char*)(*sub)->name);
+        free ((char*)(*sub)->config.name);
         free ((*sub)->extradata);
         free(*sub);
         *sub = NULL;
@@ -4905,6 +4915,10 @@ int hb_subtitle_add(const hb_job_t * job, const hb_subtitle_config_t * subtitlec
     // "track" in job->list_audio is an index into title->list_audio
     subtitle->track = track;
     subtitle->config = *subtitlecfg;
+    if (subtitlecfg->name != NULL && subtitlecfg->name[0] != 0)
+    {
+        subtitle->config.name = strdup(subtitlecfg->name);
+    }
     subtitle->out_track = hb_list_count(job->list_subtitle) + 1;
     hb_list_add(job->list_subtitle, subtitle);
     return 1;
@@ -4944,6 +4958,10 @@ int hb_import_subtitle_add( const hb_job_t * job,
     strcpy(subtitle->iso639_2, lang->iso639_2);
 
     subtitle->config = *subtitlecfg;
+    if (subtitlecfg->name != NULL && subtitlecfg->name[0] != 0)
+    {
+        subtitle->config.name = strdup(subtitlecfg->name);
+    }
     hb_list_add(job->list_subtitle, subtitle);
 
     return 1;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4685,8 +4685,8 @@ void hb_audio_close( hb_audio_t **audio )
 {
     if ( audio && *audio )
     {
-        free((*audio)->config.in.name);
-        free((*audio)->config.out.name);
+        free((char*)(*audio)->config.in.name);
+        free((char*)(*audio)->config.out.name);
         free(*audio);
         *audio = NULL;
     }

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4644,6 +4644,10 @@ hb_audio_t *hb_audio_copy(const hb_audio_t *src)
         {
             audio->config.out.name = strdup(src->config.out.name);
         }
+        if ( src->config.in.name )
+        {
+            audio->config.in.name = strdup(src->config.in.name);
+        }
     }
     return audio;
 }
@@ -4681,6 +4685,7 @@ void hb_audio_close( hb_audio_t **audio )
 {
     if ( audio && *audio )
     {
+        free((*audio)->config.in.name);
         free((*audio)->config.out.name);
         free(*audio);
         *audio = NULL;

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -831,7 +831,7 @@ struct hb_audio_config_s
         double   gain; /* Gain (in dB), negative is quieter */
         int      normalize_mix_level; /* mix level normalization (boolean) */
         int      dither_method; /* dither algorithm */
-        char *   name; /* Output track name */
+        const char * name; /* Output track name */
     } out;
 
     /* Input */
@@ -857,7 +857,7 @@ struct hb_audio_config_s
                                     * These samples should be dropped
                                     * when decoding */
         PRIVATE hb_rational_t timebase;
-        PRIVATE char * name;
+        PRIVATE const char * name;
     } in;
 
     struct

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -857,6 +857,7 @@ struct hb_audio_config_s
                                     * These samples should be dropped
                                     * when decoding */
         PRIVATE hb_rational_t timebase;
+        PRIVATE char * name;
     } in;
 
     struct

--- a/libhb/common.h
+++ b/libhb/common.h
@@ -297,13 +297,14 @@ void hb_image_close(hb_image_t **_image);
 struct hb_subtitle_config_s
 {
     enum subdest { RENDERSUB, PASSTHRUSUB } dest;
-    int  force;
-    int  default_track; 
-    
+    int          force;
+    int          default_track;
+    const char * name;
+
     /* SRT subtitle tracks only */
-    char src_filename[256];
-    char src_codeset[40];
-    int64_t offset;
+    char      src_filename[256];
+    char      src_codeset[40];
+    int64_t   offset;
 };
 
 /*******************************************************************************
@@ -966,9 +967,10 @@ struct hb_subtitle_s
     enum subsource { VOBSUB, CC608SUB, /*unused*/CC708SUB,
                      UTF8SUB, TX3GSUB, SSASUB, PGSSUB,
                      IMPORTSRT, IMPORTSSA, SRTSUB = IMPORTSRT } source;
-    char lang[1024];
-    char iso639_2[4];
-    uint32_t attributes; /* Closed Caption, Childrens, Directors etc */
+    const char * name;
+    char         lang[1024];
+    char         iso639_2[4];
+    uint32_t     attributes; /* Closed Caption, Childrens, Directors etc */
     
     // Color lookup table for VOB subtitle tracks. Each entry is in YCbCr format.
     // Must be filled out by the demuxer for VOB subtitle tracks.

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -210,6 +210,7 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     memcpy(subtitle->palette, palette, 16 * sizeof(uint32_t));
     subtitle->palette_set = 1;
 
+    const char * name = NULL;
     switch (lang_extension)
     {
         case 1:
@@ -218,23 +219,28 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
         case 2:
             subtitle->attributes = HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Large Type");
+            name = "Large Type";
             break;
         case 3:
             subtitle->attributes = HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Children");
+            name = "Children";
             break;
         case 5:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC;
             strcat(subtitle->lang, " Closed Caption");
+            name = "Closed Caption";
             break;
         case 6:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC | HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Closed Caption, Large Type");
+            name = "Closed Caption, Large Type";
             break;
         case 7:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC |
                                    HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Closed Caption, Children");
+            name = "Closed Caption, Children";
             break;
         case 9:
             subtitle->attributes = HB_SUBTITLE_ATTR_FORCED;
@@ -243,19 +249,26 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
         case 13:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY;
             strcat(subtitle->lang, " Director's Commentary");
+            name = "Commentary";
             break;
         case 14:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY |
                                    HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Director's Commentary, Large Type");
+            name = "Commentary, Large Type";
             break;
         case 15:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY |
                                    HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Director's Commentary, Children");
+            name = "Commentary, Children";
         default:
             subtitle->attributes = HB_SUBTITLE_ATTR_UNKNOWN;
             break;
+    }
+    if (name != NULL)
+    {
+        subtitle->name = strdup(name);
     }
     switch (style)
     {
@@ -520,6 +533,7 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
 
         lang = lang_for_code( lang_code );
 
+        const char * name = NULL;
         switch ( lang_extension )
         {
             case 1:
@@ -527,16 +541,23 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
                 break;
             case 2:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_VISUALLY_IMPAIRED;
+                name = "Visually Impaired";
                 break;
             case 3:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_COMMENTARY;
+                name = "Commentary";
                 break;
             case 4:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_ALT_COMMENTARY;
+                name = "Commentary";
                 break;
             default:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_NONE;
                 break;
+        }
+        if (name != NULL)
+        {
+            audio->config.in.name = strdup(name);
         }
 
         snprintf( audio->config.lang.simple,

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -356,6 +356,7 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
     memcpy(subtitle->palette, palette, 16 * sizeof(uint32_t));
     subtitle->palette_set = 1;
 
+    const char * name = NULL;
     switch (lang_extension)
     {
         case 1:
@@ -364,23 +365,28 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
         case 2:
             subtitle->attributes = HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Large Type");
+            name = "Large Type";
             break;
         case 3:
             subtitle->attributes = HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Children");
+            name = "Children";
             break;
         case 5:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC;
             strcat(subtitle->lang, " Closed Caption");
+            name = "Closed Caption";
             break;
         case 6:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC | HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Closed Caption, Large Type");
+            name = "Closed Caption, Large Type";
             break;
         case 7:
             subtitle->attributes = HB_SUBTITLE_ATTR_CC |
                                    HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Closed Caption, Children");
+            name = "Closed Caption, Children";
             break;
         case 9:
             subtitle->attributes = HB_SUBTITLE_ATTR_FORCED;
@@ -389,19 +395,26 @@ static void add_subtitle( hb_list_t * list_subtitle, int position,
         case 13:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY;
             strcat(subtitle->lang, " Director's Commentary");
+            name = "Commentary";
             break;
         case 14:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY |
                                    HB_SUBTITLE_ATTR_LARGE;
             strcat(subtitle->lang, " Director's Commentary, Large Type");
+            name = "Commentary, Large Type";
             break;
         case 15:
             subtitle->attributes = HB_SUBTITLE_ATTR_COMMENTARY |
                                    HB_SUBTITLE_ATTR_CHILDREN;
             strcat(subtitle->lang, " Director's Commentary, Children");
+            name = "Commentary, Children";
         default:
             subtitle->attributes = HB_SUBTITLE_ATTR_UNKNOWN;
             break;
+    }
+    if (name != NULL)
+    {
+        subtitle->name = strdup(name);
     }
     switch (style)
     {
@@ -638,6 +651,7 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
         {
             continue;
         }
+        const char * name = NULL;
         switch ( lang_extension )
         {
             case 1:
@@ -645,16 +659,23 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
                 break;
             case 2:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_VISUALLY_IMPAIRED;
+                name = "Visually Impaired";
                 break;
             case 3:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_COMMENTARY;
+                name = "Commentary";
                 break;
             case 4:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_ALT_COMMENTARY;
+                name = "Commentary";
                 break;
             default:
                 audio->config.lang.attributes = HB_AUDIO_ATTR_NONE;
                 break;
+        }
+        if (name != NULL)
+        {
+            audio->config.in.name = strdup(name);
         }
 
         /* Check for duplicate tracks */

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1538,10 +1538,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                     audio.out.dither_method = hb_value_get_int(dither);
                 }
             }
-            if (name != NULL && name[0] != 0)
-            {
-                audio.out.name = strdup(name);
-            }
+            audio.out.name = name;
             if (audio.in.track >= 0)
             {
                 audio.out.track = ii;

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -397,6 +397,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
             "LanguageCode",      hb_value_string(audio->config.lang.iso639_2),
             "Attributes",        attributes,
             "Codec",             hb_value_int(audio->config.in.codec),
+            "CodecParam",        hb_value_int(audio->config.in.codec_param),
             "CodecName",         hb_value_string(codec_name),
             "SampleRate",        hb_value_int(audio->config.in.samplerate),
             "BitRate",           hb_value_int(audio->config.in.bitrate),
@@ -408,6 +409,10 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
         {
             hb_error("json pack failure: %s", error.text);
             return NULL;
+        }
+        if (audio->config.in.name != NULL)
+        {
+            hb_dict_set_string(audio_dict, "Name", audio->config.in.name);
         }
         hb_value_array_append(audio_list, audio_dict);
     }
@@ -840,8 +845,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
             "CompressionLevel",     hb_value_double(audio->config.out.compression_level));
         if (audio->config.out.name != NULL)
         {
-            hb_dict_set(audio_dict, "Name",
-                        hb_value_string(audio->config.out.name));
+            hb_dict_set_string(audio_dict, "Name", audio->config.out.name);
         }
 
         hb_value_array_append(audio_list, audio_dict);
@@ -1690,6 +1694,19 @@ char* hb_job_init_json(hb_handle_t *h, int title_index)
     hb_job_t *job = hb_job_init_by_index(h, title_index);
     char *json_job = hb_job_to_json(job);
     hb_job_close(&job);
+    return json_job;
+}
+
+char* hb_preset_job_init_json(hb_handle_t *h, int title_index,
+                              const char *json_preset)
+{
+    hb_dict_t * preset   = hb_value_json(json_preset);
+    hb_dict_t * job      = hb_preset_job_init(h, title_index, preset);
+    char      * json_job = hb_value_get_json(job);
+
+    hb_value_free(&preset);
+    hb_value_free(&job);
+
     return json_job;
 }
 

--- a/libhb/hb_json.h
+++ b/libhb/hb_json.h
@@ -24,6 +24,8 @@ hb_dict_t  * hb_title_set_to_dict( const hb_title_set_t * title_set );
 char       * hb_get_title_set_json(hb_handle_t * h);
 char       * hb_title_to_json( hb_handle_t *h, int title_index );
 char       * hb_job_init_json(hb_handle_t *h, int title_index);
+char       * hb_preset_job_init_json(hb_handle_t *h, int title_index,
+                                     const char *json_preset);
 hb_job_t   * hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict );
 char       * hb_job_to_json(const hb_job_t * job);
 hb_job_t   * hb_json_to_job(hb_handle_t * h, const char * json_job);

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -960,6 +960,12 @@ static int avformatInit( hb_mux_object_t * m )
         {
             av_dict_set(&track->st->metadata, "language", lang, 0);
         }
+        if (subtitle->config.name != NULL && subtitle->config.name[0] != 0)
+        {
+            // Set subtitle track title
+            av_dict_set(&track->st->metadata, "title",
+                        subtitle->config.name, 0);
+        }
     }
 
     if (need_fonts)

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -965,6 +965,12 @@ static int avformatInit( hb_mux_object_t * m )
             // Set subtitle track title
             av_dict_set(&track->st->metadata, "title",
                         subtitle->config.name, 0);
+            if (job->mux == HB_MUX_AV_MP4)
+            {
+                // Some software (MPC, mediainfo) use hdlr description
+                // for track title
+                av_dict_set(&track->st->metadata, "handler_name", name, 0);
+            }
         }
     }
 

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -969,7 +969,8 @@ static int avformatInit( hb_mux_object_t * m )
             {
                 // Some software (MPC, mediainfo) use hdlr description
                 // for track title
-                av_dict_set(&track->st->metadata, "handler_name", name, 0);
+                av_dict_set(&track->st->metadata, "handler_name",
+                            subtitle->config.name, 0);
             }
         }
     }

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -673,7 +673,7 @@ static int avformatInit( hb_mux_object_t * m )
             track->st->codecpar->channel_layout = hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL);
         }
 
-        char *name;
+        const char *name;
         if (audio->config.out.name == NULL)
         {
             switch (track->st->codecpar->channels)

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -701,7 +701,7 @@ static int avformatInit( hb_mux_object_t * m )
         {
             // Some software (MPC, mediainfo) use hdlr description
             // for track title
-            av_dict_set(&track->st->metadata, "handler", name, 0);
+            av_dict_set(&track->st->metadata, "handler_name", name, 0);
         }
     }
 

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -687,6 +687,10 @@ static void add_audio_for_lang(hb_value_array_t *list, const hb_dict_t *preset,
                 hb_dict_set(audio_dict, "Name", hb_value_dup(
                     hb_dict_get(encoder_dict, "AudioTrackName")));
             }
+            else if (aconfig->in.name != NULL)
+            {
+                hb_dict_set_string(audio_dict, "Name", aconfig->in.name);
+            }
             if (!(out_codec & HB_ACODEC_PASS_FLAG))
             {
                 if (hb_dict_get(encoder_dict, "AudioTrackGainSlider") != NULL)

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -891,13 +891,15 @@ static int find_subtitle_track(const hb_title_t *title,
 }
 
 static void add_subtitle(hb_value_array_t *list, int track,
-                         int make_default, int force, int burn)
+                         int make_default, int force, int burn,
+                         const char * name)
 {
     hb_dict_t *subtitle_dict = hb_dict_init();
-    hb_dict_set(subtitle_dict, "Track", hb_value_int(track));
-    hb_dict_set(subtitle_dict, "Default", hb_value_bool(make_default));
-    hb_dict_set(subtitle_dict, "Forced", hb_value_bool(force));
-    hb_dict_set(subtitle_dict, "Burn", hb_value_bool(burn));
+    hb_dict_set_int(subtitle_dict, "Track", track);
+    hb_dict_set_bool(subtitle_dict, "Default", make_default);
+    hb_dict_set_bool(subtitle_dict, "Forced", force);
+    hb_dict_set_bool(subtitle_dict, "Burn", burn);
+    hb_dict_set_string(subtitle_dict, "Name", name);
     hb_value_array_append(list, subtitle_dict);
 }
 
@@ -962,7 +964,7 @@ static void add_subtitle_for_lang(hb_value_array_t *list, hb_title_t *title,
         behavior->burn_first &= !burn;
         behavior->one_burned |= burn;
         behavior->used[t] = 1;
-        add_subtitle(list, t, make_default, 0 /*!force*/, burn);
+        add_subtitle(list, t, make_default, 0 /*!force*/, burn, subtitle->name);
     }
 }
 
@@ -1180,7 +1182,8 @@ int hb_preset_job_add_subtitles(hb_handle_t *h, int title_index,
                         behavior.burn_first);
                 behavior.used[track] = 1;
                 behavior.one_burned |= burn;
-                add_subtitle(list, track, 0 /*default*/, 0 /*!force*/, burn);
+                add_subtitle(list, track, 0 /*default*/, 0 /*!force*/, burn,
+                             subtitle->name);
                 break;
             }
         }

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5192,7 +5192,8 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
 {
     AVStream *st                = stream->ffmpeg_ic->streams[id];
     AVCodecParameters *codecpar = st->codecpar;
-    AVDictionaryEntry *tag      = av_dict_get(st->metadata, "language", NULL, 0);
+    AVDictionaryEntry *tag_lang = av_dict_get(st->metadata, "language", NULL, 0);
+    AVDictionaryEntry *tag_name = av_dict_get(st->metadata, "title", NULL, 0);
 
     hb_audio_t *audio              = calloc(1, sizeof(*audio));
     audio->id                      = id;
@@ -5274,7 +5275,11 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
     }
 
     set_audio_description(audio,
-                          lang_for_code2(tag != NULL ? tag->value : "und"));
+                          lang_for_code2(tag_lang != NULL ? tag_lang->value : "und"));
+    if (tag_name != NULL)
+    {
+        audio->config.in.name = strdup(tag_name->value);
+    }
     hb_list_add(title->list_audio, audio);
 }
 

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5414,6 +5414,8 @@ static void add_ffmpeg_subtitle( hb_title_t *title, hb_stream_t *stream, int id 
 {
     AVStream          * st       = stream->ffmpeg_ic->streams[id];
     AVCodecParameters * codecpar = st->codecpar;
+    AVDictionaryEntry * tag_lang = av_dict_get(st->metadata, "language", NULL, 0 );
+    AVDictionaryEntry * tag_name = av_dict_get(st->metadata, "title", NULL, 0);
 
     hb_subtitle_t *subtitle = calloc( 1, sizeof(*subtitle) );
 
@@ -5474,16 +5476,18 @@ static void add_ffmpeg_subtitle( hb_title_t *title, hb_stream_t *stream, int id 
             return;
     }
 
-    AVDictionaryEntry *tag;
     iso639_lang_t *lang;
 
-    tag = av_dict_get( st->metadata, "language", NULL, 0 );
-    lang = lang_for_code2( tag ? tag->value : "und" );
+    lang = lang_for_code2(tag_lang ? tag_lang->value : "und");
     snprintf(subtitle->lang, sizeof( subtitle->lang ), "%s [%s]",
              strlen(lang->native_name) ? lang->native_name : lang->eng_name,
              hb_subsource_name(subtitle->source));
     strncpy(subtitle->iso639_2, lang->iso639_2, 3);
     subtitle->iso639_2[3] = 0;
+    if (tag_name != NULL)
+    {
+        subtitle->name = strdup(tag_name->value);
+    }
 
     // Copy the extradata for the subtitle track
     if (codecpar->extradata != NULL)

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -647,6 +647,10 @@ void hb_display_job_info(hb_job_t *job)
                        subtitle->config.force ? ", Forced Only" : "",
                        subtitle->config.default_track ? ", Default" : "" );
             }
+            if (subtitle->config.name )
+            {
+                hb_log("   + name: %s", subtitle->config.name);
+            }
         }
     }
 

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -260,6 +260,7 @@
                     hb_subtitle_config_t sub_config;
                     int type = subTrack.type;
 
+                    sub_config.name = NULL;
                     sub_config.offset = subTrack.offset;
 
                     // we need to strncpy file name and codeset


### PR DESCRIPTION
It gets stored in new hb_audio_config_t.in.name field.

It is available in the title dict read through hb_title_to_dict() or
hb_title_to_json() in AudioList[].Name.

When a job is initialized with hb_preset_job_init or
hb_preset_job_init_json(), output audio tracks are initialized with the
source track name.

Also adds output track name initialization to LinGui.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
