### PR TITLE
Fix -Wduplicate-decl-specifier warnings

### DIFF
--- a/libhb/common.h
+++ b/libhb/common.h
@@ -475,7 +475,7 @@ typedef enum
  *****************************************************************************/
 struct hb_job_s
 {
-    PRIVATE const char  * json;   // JSON encoded job string
+    const char  * json;   // JSON encoded job string
 
     /* ID assigned by UI so it can groups job passes together */
     int             sequence_id;
@@ -858,7 +858,7 @@ struct hb_audio_config_s
                                     * These samples should be dropped
                                     * when decoding */
         PRIVATE hb_rational_t timebase;
-        PRIVATE const char * name;
+        const char * name;
     } in;
 
     struct


### PR DESCRIPTION
This will fix 51 -Wduplicate-decl-specifier warnings:

```
  : /HandBrake/build/libhb/common.h:478:13: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
  :     PRIVATE const char  * json;   // JSON encoded job string
  :             ^
  : /HandBrake/build/libhb/common.h:861:17: warning: duplicate 'const' declaration specifier [-Wduplicate-decl-specifier]
  :         PRIVATE const char * name;
  :                 ^
  : 2 warnings generated.
```



**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
