### PR TITLE
Add a configure option to enable the app sandbox (and move --hardening to the new Security group)

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1669,7 +1669,7 @@ int hb_global_init_no_hardware()
 int hb_global_init()
 {
     /* Print hardening status on global init */
-#if HB_PROJECT_HOST_HARDEN
+#if HB_PROJECT_SECURITY_HARDEN
     hb_log( "Compile-time hardening features are enabled" );
 #endif
 

--- a/libhb/project.h.m4
+++ b/libhb/project.h.m4
@@ -38,7 +38,6 @@ dnl
 <<#>>define HB_PROJECT_HOST_RELEASE              "__HOST_release"
 <<#>>define HB_PROJECT_HOST_TITLE                "__HOST_title"
 <<#>>define HB_PROJECT_HOST_ARCH                 "__HOST_arch"
-<<#>>define HB_PROJECT_HOST_HARDEN               __HOST_harden
 
 <<#>>define HB_PROJECT_FEATURE_ASM               __FEATURE_asm
 <<#>>define HB_PROJECT_FEATURE_FDK_AAC           __FEATURE_fdk_aac
@@ -53,5 +52,7 @@ dnl
 <<#>>define HB_PROJECT_FEATURE_VCE               __FEATURE_vce
 <<#>>define HB_PROJECT_FEATURE_X265              __FEATURE_x265
 <<#>>define HB_PROJECT_FEATURE_NUMA              __FEATURE_numa
+
+<<#>>define HB_PROJECT_SECURITY_HARDEN           __SECURITY_harden
 
 #endif /* HB_PROJECT_PROJECT_H */

--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -21,7 +21,7 @@ BUILD.out += $(MACOSX.osl.filelist)
 MACOSX.project = -project $(MACOSX.src/)HandBrake.xcodeproj
 
 ## configuration: must be one of { release, debug }
-ifeq (1,$(FEATURE.sandbox))
+ifeq (1,$(SECURITY.sandbox))
    MACOSX.configuration = -configuration $(MACOSX.map.g.$(MACOSX.GCC.g))-sandbox
 else
    MACOSX.configuration = -configuration $(MACOSX.map.g.$(MACOSX.GCC.g))

--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -21,7 +21,11 @@ BUILD.out += $(MACOSX.osl.filelist)
 MACOSX.project = -project $(MACOSX.src/)HandBrake.xcodeproj
 
 ## configuration: must be one of { release, debug }
-MACOSX.configuration = -configuration $(MACOSX.map.g.$(MACOSX.GCC.g))
+ifeq (1,$(FEATURE.sandbox))
+   MACOSX.configuration = -configuration $(MACOSX.map.g.$(MACOSX.GCC.g))-sandbox
+else
+   MACOSX.configuration = -configuration $(MACOSX.map.g.$(MACOSX.GCC.g))
+endif
 
 ## mapping from symbolic debug value to xcode configuration
 MACOSX.map.g.none = release

--- a/make/configure.py
+++ b/make/configure.py
@@ -1368,6 +1368,7 @@ def createCLI( cross = None ):
     grp = cli.add_argument_group( 'Security Options' )
     h = IfHost( 'enable the Sandbox capability (currently macOS-only)', '*-*-darwin*', none=argparse.SUPPRESS).value
     grp.add_argument( '--sandbox', dest="enable_sandbox", default=False, action='store_true', help=(( '%s' %h ) if h != argparse.SUPPRESS else h) )
+    grp.add_argument( '--hardening', dest="enable_harden", default=False, action='store_true', help='enable buffer overflow protection' )
     cli.add_argument_group( grp )
 
     ## add launch options
@@ -1389,8 +1390,6 @@ def createCLI( cross = None ):
     arch.mode.cli_add_argument( grp, '--arch' )
     grp.add_argument( '--cross', default=None, action='store', metavar='SPEC',
         help='specify GCC cross-compilation spec' )
-    grp.add_argument( '--enable-hardening', dest="enable_host_harden", default=False, action='store_true',
-        help='enable buffer overflow protection' )
     cli.add_argument_group( grp )
 
     ## add Xcode options
@@ -1945,7 +1944,6 @@ int main()
         doc.add( 'HOST.cross.prefix', '' )
 
     doc.add( 'HOST.arch',   arch.mode.mode )
-    doc.add( 'HOST.harden', int( options.enable_host_harden) )
 
     doc.addBlank()
     doc.add( 'SRC',     cfg.src_final )
@@ -1973,6 +1971,7 @@ int main()
 
     doc.addBlank()
     doc.add( 'SECURITY.sandbox',    int( options.enable_sandbox ))
+    doc.add( 'SECURITY.harden',     int( options.enable_harden ))
 
     if build_tuple.match( '*-*-darwin*' ) and options.cross is None:
         doc.add( 'FEATURE.xcode',      int( not (Tools.xcodebuild.fail or options.disable_xcode) ))

--- a/make/configure.py
+++ b/make/configure.py
@@ -1361,6 +1361,9 @@ def createCLI( cross = None ):
     h = IfHost( 'AMD VCE video encoder', '*-*-mingw*', none=argparse.SUPPRESS).value
     grp.add_argument( '--enable-vce', dest="enable_vce", default=IfHost(True, '*-*-mingw*', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-vce', dest="enable_vce", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
+    h = IfHost( 'enable the App Sandbox capability (currently macOS-only)', '*-*-darwin*', none=argparse.SUPPRESS).value
+    grp.add_argument( '--enable-sandbox', dest="enable_sandbox", default=False, action='store_true', help=(( '%s' %h ) if h != argparse.SUPPRESS else h) )
+
 
 
     cli.add_argument_group( grp )
@@ -1666,6 +1669,10 @@ try:
     # Disable VCE on unsupported platforms
     options.enable_vce        = IfHost(options.enable_vce, '*-*-mingw*',
                                        none=False).value
+    # Sandboxing is currently only implemented on macOS
+    options.enable_sandbox    = IfHost(options.enable_sandbox, '*-*-darwin*',
+                                       none=False).value
+
 
     #########################################
     ## OSX specific library and tool checks
@@ -1961,6 +1968,7 @@ int main()
     doc.add( 'FEATURE.vce',        int( options.enable_vce ))
     doc.add( 'FEATURE.x265',       int( options.enable_x265 ))
     doc.add( 'FEATURE.numa',       int( options.enable_numa ))
+    doc.add( 'FEATURE.sandbox',    int( options.enable_sandbox ))
 
     if build_tuple.match( '*-*-darwin*' ) and options.cross is None:
         doc.add( 'FEATURE.xcode',      int( not (Tools.xcodebuild.fail or options.disable_xcode) ))
@@ -2083,6 +2091,8 @@ int main()
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.system == 'mingw') else stdout.write( '\n' )
     stdout.write( 'Enable VCE:         %s' % options.enable_vce )
     stdout.write( ' (%s)\n' % note_unsupported ) if not host_tuple.system == 'mingw' else stdout.write( '\n' )
+    stdout.write( 'Enable Sandbox:     %s' % options.enable_sandbox )
+    stdout.write( ' (%s)\n' % note_unsupported ) if not host_tuple.system == 'darwin' else stdout.write( '\n' )
 
     if options.launch:
         stdout.write( '%s\n' % ('-' * 79) )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1361,11 +1361,13 @@ def createCLI( cross = None ):
     h = IfHost( 'AMD VCE video encoder', '*-*-mingw*', none=argparse.SUPPRESS).value
     grp.add_argument( '--enable-vce', dest="enable_vce", default=IfHost(True, '*-*-mingw*', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-vce', dest="enable_vce", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
-    h = IfHost( 'enable the App Sandbox capability (currently macOS-only)', '*-*-darwin*', none=argparse.SUPPRESS).value
-    grp.add_argument( '--enable-sandbox', dest="enable_sandbox", default=False, action='store_true', help=(( '%s' %h ) if h != argparse.SUPPRESS else h) )
 
+    cli.add_argument_group( grp )
 
-
+    ## add security options
+    grp = cli.add_argument_group( 'Security Options' )
+    h = IfHost( 'enable the Sandbox capability (currently macOS-only)', '*-*-darwin*', none=argparse.SUPPRESS).value
+    grp.add_argument( '--sandbox', dest="enable_sandbox", default=False, action='store_true', help=(( '%s' %h ) if h != argparse.SUPPRESS else h) )
     cli.add_argument_group( grp )
 
     ## add launch options
@@ -1968,7 +1970,9 @@ int main()
     doc.add( 'FEATURE.vce',        int( options.enable_vce ))
     doc.add( 'FEATURE.x265',       int( options.enable_x265 ))
     doc.add( 'FEATURE.numa',       int( options.enable_numa ))
-    doc.add( 'FEATURE.sandbox',    int( options.enable_sandbox ))
+
+    doc.addBlank()
+    doc.add( 'SECURITY.sandbox',    int( options.enable_sandbox ))
 
     if build_tuple.match( '*-*-darwin*' ) and options.cross is None:
         doc.add( 'FEATURE.xcode',      int( not (Tools.xcodebuild.fail or options.disable_xcode) ))

--- a/make/configure.py
+++ b/make/configure.py
@@ -1366,9 +1366,9 @@ def createCLI( cross = None ):
 
     ## add security options
     grp = cli.add_argument_group( 'Security Options' )
-    h = IfHost( 'enable the Sandbox capability (currently macOS-only)', '*-*-darwin*', none=argparse.SUPPRESS).value
+    grp.add_argument( '--harden', dest="enable_harden", default=False, action='store_true', help='harden app to protect against buffer overflows' )
+    h = IfHost( 'sandbox app to limit host system access (macOS only)', '*-*-darwin*', none=argparse.SUPPRESS).value
     grp.add_argument( '--sandbox', dest="enable_sandbox", default=False, action='store_true', help=(( '%s' %h ) if h != argparse.SUPPRESS else h) )
-    grp.add_argument( '--hardening', dest="enable_harden", default=False, action='store_true', help='enable buffer overflow protection' )
     cli.add_argument_group( grp )
 
     ## add launch options

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -89,7 +89,7 @@ GCC.args.extra.exe++   = $(LDFLAGS)
 # If hardening is enabled -D_FORTIFY_SOURCE=2 adds compile-time protection and run-time
 # checking against static sized buffer overflow flaws. -fstack-protector-strong enables
 # stack canaries to detect stack buffer overflows (stack overwrites).
-ifeq (1,$(HOST.harden))
+ifeq (1,$(SECURITY.harden))
     GCC.args.extra     += $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2
     GCC.args.extra.exe += -fstack-protector-strong
 endif


### PR DESCRIPTION
Currently only implemented for macOS. If it will be implemented on other systems, it can be switched based on the target system, per https://github.com/HandBrake/HandBrake/issues/428#issuecomment-522677832

**Description of Change:**
This should fix the point "Add an option in configure to make it possible to select the release-sandbox scheme" from https://github.com/HandBrake/HandBrake/issues/428#issuecomment-471955053
Works for setting release-sandbox or (if debug is enabled) debug-sandbox.




**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
