### PR TITLE
Fix some configure related build warnings

### DIFF
--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -8,8 +8,3 @@ FRIBIDI.FETCH.basename = fribidi-1.0.5.tar.gz
 
 FRIBIDI.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
 
-ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
-    FRIBIDI.CONFIGURE.extra = --with-glib=no
-else ifeq (darwin,$(HOST.system))
-    FRIBIDI.CONFIGURE.extra = --with-glib=no
-endif

--- a/contrib/libogg/module.defs
+++ b/contrib/libogg/module.defs
@@ -5,6 +5,4 @@ LIBOGG.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/libogg-1.
 LIBOGG.FETCH.url    += https://downloads.xiph.org/releases/ogg/libogg-1.3.3.tar.gz
 LIBOGG.FETCH.sha256  = c2e8a485110b97550f453226ec644ebac6cb29d1caef2902c007edab4308d985
 
-LIBOGG.CONFIGURE.extra = --disable-sdl
-
 LIBOGG.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;

--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -8,4 +8,8 @@ LIBOPUS.FETCH.sha256  = 4f3d69aefdf2dbaf9825408e452a8a414ffc60494c70633560700398
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs
 
+# Suppress a warning given by opus_decoder.c that tells us
+# optimizations are turned off.
+LIBOPUS.GCC.args.extra += -DOPUS_WILL_BE_SLOW
+
 LIBOPUS.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;


### PR DESCRIPTION
Closes #2265.

This PR will fix the warning 
`configure: WARNING: unrecognized options: --with-glib`
fribidi droped glib dependency in 2017. https://github.com/fribidi/fribidi/pull/14

The PR will fix the warning
`configure: WARNING: unrecognized options: --disable-sdl`
liboggs configure doesn't know about this option.

The PR suppresses the harmless but annoying warning
```
  : src/opus_decoder.c:37:10: warning: You appear to be compiling without optimization, if so opus will be very slow. [-W#pragma-messages]
  : # pragma message "You appear to be compiling without optimization, if so opus will be very slow."
  : 
  :          ^
  : 1 warning generated.
  :   CC       src/opus_encoder.lo
```

Tested on macOS 10.14.