### PR TITLE
contrib: Update to HarfBuzz 2.6.1 and convert to CMake.

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,24 +3,49 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/harfbuzz-2.3.1.tar.bz2
-HARFBUZZ.FETCH.url    += https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-2.3.1.tar.bz2
-HARFBUZZ.FETCH.sha256  = f205699d5b91374008d6f8e36c59e419ae2d9a7bb8c5d9f34041b9a5abcae468
+HARFBUZZ.FETCH.url     = https://download.handbrake.fr/handbrake/contrib/harfbuzz-2.6.1.tar.xz
+HARFBUZZ.FETCH.url    += https://www.freedesktop.org/software/harfbuzz/release/harfbuzz-2.6.1.tar.xz
+HARFBUZZ.FETCH.sha256  = c651fb3faaa338aeb280726837c2384064cdc17ef40539228d88a1260960844f
 
-# Tell configure where to find our version of freetype
-HARFBUZZ.CONFIGURE.extra = \
-    --with-freetype=yes \
-    FREETYPE_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfreetype" \
-    FREETYPE_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2" \
+HARFBUZZ.build_dir             = build
+HARFBUZZ.CONFIGURE.exe         = cmake
+HARFBUZZ.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(HARFBUZZ.CONFIGURE.prefix)"
+HARFBUZZ.CONFIGURE.deps        =
+HARFBUZZ.CONFIGURE.static      =
+HARFBUZZ.CONFIGURE.shared      = -DBUILD_SHARED_LIBS=OFF
+HARFBUZZ.CONFIGURE.extra       = -DHB_BUILD_UTILS=OFF -DHB_BUILD_TESTS=OFF
+HARFBUZZ.CONFIGURE.extra      += -DHB_HAVE_FREETYPE=ON \
+                                 -DFREETYPE_LIBRARIES="$(call fn.ABSOLUTE,$(CONTRIB.build/))lib" \
+                                 -DFREETYPE_INCLUDE_DIRS="$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2" \
+                                 -DFREETYPE_INCLUDE_DIR_freetype2="$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2" \
+                                 -DFREETYPE_INCLUDE_DIR_ft2build="$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2"
 
-HARFBUZZ.CONFIGURE.extra += --with-fontconfig=no
+ifeq (1,$(HOST.cross))
+    ifeq (mingw,$(HOST.system))
+        HARFBUZZ.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_SYSTEM_NAME=Windows
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_C_COMPILER=$(HARFBUZZ.GCC.gcc)
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_C_FLAGS="-static-libgcc -static-libstdc++ -static"
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="-static-libgcc -static-libstdc++ -static"
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_CXX_COMPILER=$(HARFBUZZ.GCC.gxx)
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
+        HARFBUZZ.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+        HARFBUZZ.CONFIGURE.extra += -DHB_HAVE_DIRECTWRITE=OFF \
+                                    -DHB_HAVE_GLIB=OFF \
+                                    -DHB_HAVE_GOBJECT=OFF \
+                                    -DHB_HAVE_GRAPHITE2=OFF \
+                                    -DHB_HAVE_ICU=OFF \
+                                    -DHB_HAVE_UNISCRIBE=OFF
+    endif
+    HARFBUZZ.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(HARFBUZZ.CONFIGURE.host)"
+    HARFBUZZ.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(HARFBUZZ.CONFIGURE.build)"
+else
+    HARFBUZZ.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(HARFBUZZ.CONFIGURE.host)"
+endif
 
 ifeq ($(HOST.system),darwin)
-    HARFBUZZ.CONFIGURE.extra += --with-coretext=yes --with-glib=no
+    HARFBUZZ.CONFIGURE.extra += -DHB_HAVE_CORETEXT=OFF -DHB_HAVE_GLIB=OFF
 endif
 
-ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
-    HARFBUZZ.CONFIGURE.extra += --with-directwrite=no --with-glib=no \
-        --with-gobject=no --with-cairo=no --with-icu=no --with-graphite2=no \
-        --with-uniscribe=no
-endif
+## find CMakeLists.txt
+HARFBUZZ.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(HARFBUZZ.EXTRACT.dir/))"


### PR DESCRIPTION
CoreText disabled on macOS; appears to be no longer actively supported upstream.

I was unable to get the latest version of HarfBuzz to build with `make` alone, so I converted the module to use CMake (using the x265 modules as template), which seems to be the actively supported build system at this time. HarfBuzz might be moving to Meson in the future, so we'll probably be here again before too long, but this gets us current.

In https://github.com/HandBrake/HandBrake/commit/05e07e140d718b9b59f8e16e0e40bc692297985d I updated our build system to allow `tar` to extract xz archives. HarfBuzz no longer distributes other archive formats such as bzip2. The current solution works for me on macOS. I haven't tested Linux yet and do not have an MSYS2 installation.

Note also, CoreText seems to have languished upstream and other projects are reporting build issues. I hope everything works on macOS without it but this we need to test.

Smoke tested only on macOS and Windows. Subtitle burn-in with appropriate languages needs full testing. I can probably do this eventually if nobody gets to it first.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+