### PR TITLE
Improve detail in logging of jobs. #2285

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -171,6 +171,7 @@ static void work_func( void * _work )
         hb_force_rescan(h);
     }
     
+    t = time(NULL);
     hb_log("Finished work at: %s", asctime(localtime(&t)));
     free( work );
 }

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1448,7 +1448,18 @@ static void do_job(hb_job_t *job)
     w = hb_get_work(job->h, WORK_READER);
     hb_list_add(job->list_work, w);
 
-    hb_log( "starting job" );
+    if (job->indepth_scan)
+    {
+        hb_log( "Starting Job: Subtitle Scan" );
+    } 
+    else if (job->pass_id == HB_PASS_ENCODE_1ST) 
+    {
+        hb_log( "Starting Job: Encode First Pass" );
+    } 
+    else 
+    {
+        hb_log( "Starting Job: Encode Second Pass" );
+    }
 
     // This must be performed before initializing filters because
     // it can add the subtitle render filter.

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1458,11 +1458,11 @@ static void do_job(hb_job_t *job)
     } 
     else if (job->pass_id == HB_PASS_ENCODE_1ST) 
     {
-        hb_log( "Starting Task: Encode First Pass" );
+        hb_log( "Starting Task: Analysis Pass" );
     } 
     else 
     {
-        hb_log( "Starting Task: Encode Second Pass" );
+        hb_log( "Starting Task: Encoding Pass" );
     }
 
     // This must be performed before initializing filters because

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -102,6 +102,8 @@ static void work_func( void * _work )
     hb_work_t  * work = _work;
     hb_job_t   * job;
 
+    time_t t = time(NULL);
+    hb_log("Starting work at: %s", asctime(localtime(&t)));
     hb_log( "%d job(s) to process", hb_list_count( work->jobs ) );
 
     while( !*work->die && ( job = hb_list_item( work->jobs, 0 ) ) )
@@ -168,7 +170,8 @@ static void work_func( void * _work )
         // TODO: Fix this ugly hack!
         hb_force_rescan(h);
     }
-
+    
+    hb_log("Finished work at: %s", asctime(localtime(&t)));
     free( work );
 }
 
@@ -1450,15 +1453,15 @@ static void do_job(hb_job_t *job)
 
     if (job->indepth_scan)
     {
-        hb_log( "Starting Job: Subtitle Scan" );
+        hb_log( "Starting Task: Subtitle Scan" );
     } 
     else if (job->pass_id == HB_PASS_ENCODE_1ST) 
     {
-        hb_log( "Starting Job: Encode First Pass" );
+        hb_log( "Starting Task: Encode First Pass" );
     } 
     else 
     {
-        hb_log( "Starting Job: Encode Second Pass" );
+        hb_log( "Starting Task: Encode Second Pass" );
     }
 
     // This must be performed before initializing filters because


### PR DESCRIPTION
**Description of Change:**

- "Starting Job" is now descriptive. #2285
- Added Start / End Date/Time for each work unit. #2006 

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Logging (If relevant):**

### **Start / End Time**

[21:27:19] hb_init: starting libhb thread
**[21:27:19] Staring work at: Sun Sep 01 21:27:19 2019**
[21:27:19] 1 job(s) to process
[21:27:19] json job:

x264 [info]: i8c dc,h,v,p: 39% 23% 25% 13%
x264 [info]: kb/s:3523.92
[21:27:32] mux: track 0, 5021 frames, 88467017 bytes, 3523.18 kbps, fifo 1024
**[21:27:32] Finished work at: Sun Sep 01 21:27:32 2019**
[21:27:32] libhb: work result = 0
 
### **Starting Job**

[21:31:48] scan: 10 previews, 1920x1080, 23.976 fps, autocrop = 132/132/0/0, aspect 16:9, PAR 1:1
[21:31:49] libhb: scan thread found 1 valid title(s)
**[21:31:49] Starting Job: Subtitle Scan**
[21:31:49] work: only 1 chapter, disabling chapter markers
[21:31:49] job configuration:

[21:27:19] Skipping subtitle scan.  No suitable subtitle tracks.
**[21:27:19] Starting Job: Encode First Pass**
[21:27:19] job configuration:

x264 [info]: kb/s:3649.75
**[21:27:25] Starting Job: Encode Second Pass**
[21:27:25] job configuration:

