### PR TITLE
build: make: macosx: Make xcodebuild use number of jobs passed to make.

### DIFF
--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -62,7 +62,7 @@ MACOSX.XCODE = $(strip \
         EXTERNAL_CONF_ARGS='$(CONF.args)' \
         EXTERNAL_DRIVER='$(XCODE.driver)' \
         EXTERNAL_GOALS='$(3)' \
-        EXTERNAL_JOBS='$(BUILD.jobs)' \
+        EXTERNAL_JOBS='$(MACOSX.JOBS)' \
         EXTERNAL_VARS='$(-*-command-variables-*-)' \
         \
         $(MACOSX.extra_cflags) \
@@ -87,7 +87,7 @@ MACOSX.XCODE_ARCHIVE = $(strip \
         EXTERNAL_CONF_ARGS='$(CONF.args)' \
         EXTERNAL_DRIVER='$(XCODE.driver)' \
         EXTERNAL_GOALS='$(3)' \
-        EXTERNAL_JOBS='$(BUILD.jobs)' \
+        EXTERNAL_JOBS='$(MACOSX.JOBS)' \
         EXTERNAL_VARS='$(-*-command-variables-*-)' \
         \
         $(MACOSX.extra_cflags) \

--- a/macosx/module.xcodebuild
+++ b/macosx/module.xcodebuild
@@ -52,3 +52,11 @@ $(MACOSX.goals): __goals__
 
 __goals__:
 	$(call MACOSX.XCODE,external,build,$(MACOSX.goals))
+
+###############################################################################
+
+MACOSX.JOBS := $(shell ps T | $(GREP.exe) "^\s*$(shell echo $$PPID).*$(MAKE)" | $(GREP.exe) -o "\(\-j\|\-\-jobs\)[= ]*[^\s]*" | $(GREP.exe) -o "[0-9][0-9]*")
+ifeq "${MACOSX.JOBS}" ""
+	# fall back to number of jobs specified in makefile created by configure
+	MACOSX.JOBS := $(BUILD.jobs)
+endif

--- a/make/include/tool.defs
+++ b/make/include/tool.defs
@@ -14,3 +14,4 @@ LN.exe        = ln
 GIT.exe       = git
 SED.exe       = sed
 PKGCONFIG.exe = pkg-config
+GREP.exe      = grep


### PR DESCRIPTION
Fixes #1648.

Previously, it was always using the number of jobs in the makefile created by configure.py, either specified by --launch-jobs or the number of active CPU cores.

**Test on:**

- [x] macOS 10.13+