### PR TITLE
[HBJob+UIAdditions.m] Localization support for FPS PFR and FPS CFR

### DIFF
--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -713,11 +713,11 @@ static NSDictionary            *shortHeightAttr;
         }
         if (self.video.frameRateMode == 0)
         {
-            [info appendString:@" FPS PFR"];
+            [info appendString:HBKitLocalizedString(@" FPS PFR", @"HBJob -> video short description framerate")];
         }
         else
         {
-            [info appendString:@" FPS CFR"];
+            [info appendString:HBKitLocalizedString(@" FPS CFR", @"HBJob -> video short description framerate")];
         }
     }
 


### PR DESCRIPTION
**Before Posting:**

Make it possible to localize the strings " FPS PFR" and " FPS CFR".

**Test on:**

- [x] macOS 10.14