### PR TITLE
Fix some warnings when compiling with clang.

### DIFF
--- a/contrib/libdvdread/A01-clang-warnings.patch
+++ b/contrib/libdvdread/A01-clang-warnings.patch
@@ -1,0 +1,13 @@
+diff --git a/src/dvdread/ifo_types.h b/src/dvdread/ifo_types.h
+index f679d29..699853f 100644
+--- a/src/dvdread/ifo_types.h
++++ b/src/dvdread/ifo_types.h
+@@ -30,7 +30,7 @@
+ #undef PRAGMA_PACK_BEGIN
+ #undef PRAGMA_PACK_END
+ 
+-#if defined(__GNUC__)
++#if defined(__GNUC__) && !defined(__clang__)
+ #if __GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 95)
+ #if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4)
+ #define ATTRIBUTE_PACKED __attribute__ ((packed,gcc_struct))

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -863,7 +863,7 @@ static void Encode( hb_work_object_t *w, hb_buffer_t *in,
                     hb_buffer_list_t *list )
 {
     hb_work_private_t * pv = w->private_data;
-    AVFrame             frame = {0};
+    AVFrame             frame = {{0}};
     int                 ret;
 
     frame.width       = in->f.width;

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -278,8 +278,6 @@ static int ffmpeg_seek_ts( hb_stream_t *stream, int64_t ts );
 static inline unsigned int bits_get(bitbuf_t *bb, int bits);
 static inline void bits_init(bitbuf_t *bb, uint8_t* buf, int bufsize, int clear);
 static inline unsigned int bits_peek(bitbuf_t *bb, int bits);
-static inline int bits_eob(bitbuf_t *bb);
-static inline int bits_read_ue(bitbuf_t *bb );
 static void pes_add_audio_to_title(hb_stream_t *s, int i, hb_title_t *t, int sort);
 static int hb_parse_ps( hb_stream_t *stream, uint8_t *buf, int len, hb_pes_info_t *pes_info );
 static void hb_ts_resolve_pid_types(hb_stream_t *stream);
@@ -2487,11 +2485,6 @@ static inline int bits_bytes_left(bitbuf_t *bb)
     return bb->size - (bb->pos >> 3);
 }
 
-static inline int bits_eob(bitbuf_t *bb)
-{
-    return bb->pos >> 3 == bb->size;
-}
-
 static inline unsigned int bits_peek(bitbuf_t *bb, int bits)
 {
     unsigned int val;
@@ -2549,17 +2542,6 @@ static inline unsigned int bits_get(bitbuf_t *bb, int bits)
     }
 
     return val;
-}
-
-static inline int bits_read_ue(bitbuf_t *bb )
-{
-    int ii = 0;
-
-    while( bits_get( bb, 1 ) == 0 && !bits_eob( bb ) && ii < 32 )
-    {
-        ii++;
-    }
-    return( ( 1 << ii) - 1 + bits_get( bb, ii ) );
 }
 
 static inline int bits_skip(bitbuf_t *bb, int bits)

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -2490,7 +2490,6 @@
 					HBKitLocalizedString,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				OTHER_CFLAGS = "-Wno-duplicate-decl-specifier ";
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(EXTERNAL_BUILD)/macosx/osl.filelist.txt",
@@ -2570,7 +2569,6 @@
 					HBKitLocalizedString,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				OTHER_CFLAGS = "-Wno-duplicate-decl-specifier ";
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(EXTERNAL_BUILD)/macosx/osl.filelist.txt",
@@ -3292,7 +3290,6 @@
 					HBKitLocalizedString,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				OTHER_CFLAGS = "-Wno-duplicate-decl-specifier ";
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(EXTERNAL_BUILD)/macosx/osl.filelist.txt",
@@ -3557,11 +3554,11 @@
 					HBKitLocalizedString,
 				);
 				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				OTHER_CFLAGS = "-Wno-duplicate-decl-specifier ";
 				OTHER_LDFLAGS = (
 					"-filelist",
 					"$(EXTERNAL_BUILD)/macosx/osl.filelist.txt",
 					"-lc++",
+					"-w",
 				);
 				SDKROOT = macosx;
 				SHARED_PRECOMPS_DIR = "$(CONFIGURATION_TEMP_DIR)/PrecompiledHeaders";


### PR DESCRIPTION
Adds a patch to avoid "gcc_struct" when compiling with clang, and removes two unused functions.

I disable all the linkers warnings too, maybe there is a better way to disable only some ld warnings but I couldn't find it yet.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux