### PR TITLE
qsv: changed default behaviour of crop and vfr filters

### DIFF
--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1394,16 +1394,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             {
                 hb_filter_object_t *filter;
                 filter = hb_filter_init(filter_id);
-#if HB_PROJECT_FEATURE_QSV
-                if(hb_qsv_full_path_is_enabled(job))
-                {
-                    hb_log("Filter with ID=%d is disabled", filter_id);
-                }
-                else
-#endif
-                {
-                    hb_add_filter_dict(job, filter, filter_settings);
-                }
+                hb_add_filter_dict(job, filter, filter_settings);
             }
         }
     }

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1623,16 +1623,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
     filter_dict = hb_dict_init();
     hb_dict_set(filter_dict, "ID", hb_value_int(HB_FILTER_VFR));
     hb_dict_set(filter_dict, "Settings", filter_settings);
-#if HB_PROJECT_FEATURE_QSV
-    if(hb_qsv_preset_is_zero_copy_enabled(job_dict))
-    {
-        hb_log("HB_FILTER_VFR filter is disabled");
-    }
-    else
-#endif
-    {
-        hb_add_filter2(filter_list, filter_dict);
-    }
+    hb_add_filter2(filter_list, filter_dict);
     return 0;
 }
 
@@ -2007,16 +1998,7 @@ int hb_preset_apply_title(hb_handle_t *h, int title_index,
     filter_dict = hb_dict_init();
     hb_dict_set(filter_dict, "ID", hb_value_int(HB_FILTER_CROP_SCALE));
     hb_dict_set(filter_dict, "Settings", filter_settings);
-#if HB_PROJECT_FEATURE_QSV
-    if(hb_qsv_preset_is_zero_copy_enabled(job_dict))
-    {
-        hb_log("HB_FILTER_CROP_SCALE filter is disabled");
-    }
-    else
-#endif
-    {
-        hb_add_filter2(filter_list, filter_dict);
-    }
+    hb_add_filter2(filter_list, filter_dict);
     // Audio settings
     if (hb_preset_job_add_audio(h, title_index, preset, job_dict) != 0)
     {


### PR DESCRIPTION
Moved filters control into right place - sanitize functions. 
Skipped crop filter and VFR filter if no affect on output for all configuration.  

When QSV full mode is used skipped all filters for now while QSV VPP filter has not been ready yet. 
QSV VPP filters are coming to play soon. 


