### PR TITLE
crop/resize and vfr filters used only when needed

### DIFF
--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1623,16 +1623,7 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
     filter_dict = hb_dict_init();
     hb_dict_set(filter_dict, "ID", hb_value_int(HB_FILTER_VFR));
     hb_dict_set(filter_dict, "Settings", filter_settings);
-#if HB_PROJECT_FEATURE_QSV
-    if(hb_qsv_preset_is_zero_copy_enabled(job_dict))
-    {
-        hb_log("HB_FILTER_VFR filter is disabled");
-    }
-    else
-#endif
-    {
-        hb_add_filter2(filter_list, filter_dict);
-    }
+    hb_add_filter2(filter_list, filter_dict);
     return 0;
 }
 
@@ -2007,16 +1998,7 @@ int hb_preset_apply_title(hb_handle_t *h, int title_index,
     filter_dict = hb_dict_init();
     hb_dict_set(filter_dict, "ID", hb_value_int(HB_FILTER_CROP_SCALE));
     hb_dict_set(filter_dict, "Settings", filter_settings);
-#if HB_PROJECT_FEATURE_QSV
-    if(hb_qsv_preset_is_zero_copy_enabled(job_dict))
-    {
-        hb_log("HB_FILTER_CROP_SCALE filter is disabled");
-    }
-    else
-#endif
-    {
-        hb_add_filter2(filter_list, filter_dict);
-    }
+    hb_add_filter2(filter_list, filter_dict);
     // Audio settings
     if (hb_preset_job_add_audio(h, title_index, preset, job_dict) != 0)
     {

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1432,7 +1432,7 @@ static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
         {
             hb_list_rem(list, filter);
             hb_filter_close(&filter);
-            hb_log("Skipping VRF filter");
+            hb_log("Skipping vfr filter");
         }
     }
     
@@ -1455,7 +1455,7 @@ static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
             {
                 hb_list_rem(list, filter);
                 hb_filter_close(&filter);
-                hb_log("Skipping CROP filter");
+                hb_log("Skipping crop/scale filter");
             }
         }
     }

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1428,7 +1428,7 @@ static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
     {
         int mode = hb_dict_get_int(filter->settings, "mode");
         // "Same as source" FPS and no HB_FILTER_DETELECINE
-        if ( (mode == 0) || (is_detel = 0) )
+        if ( (mode == 0) || (is_detel == 0) )
         {
             hb_list_rem(list, filter);
             hb_filter_close(&filter);

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1395,7 +1395,7 @@ static int sanitize_qsv( hb_job_t * job )
     return 0;
 }
 
-static void sanitize_filter_list(hb_list_t *list)
+static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
 {
     // Add selective deinterlacing mode if comb detection is enabled
     if (hb_filter_find(list, HB_FILTER_COMB_DETECT) != NULL)
@@ -1412,6 +1412,50 @@ static void sanitize_filter_list(hb_list_t *list)
                 mode |= MODE_DECOMB_SELECTIVE;
                 hb_dict_set(filter->settings, "mode", hb_value_int(mode));
                 break;
+            }
+        }
+    }
+
+    int is_detel = 0;
+    hb_filter_object_t * filter = hb_filter_find(list, HB_FILTER_DETELECINE);
+    if (filter != NULL)
+    {
+        is_detel = 1;
+    }
+
+    filter = hb_filter_find(list, HB_FILTER_VFR);
+    if (filter != NULL)
+    {
+        int mode = hb_dict_get_int(filter->settings, "mode");
+        // "Same as source" FPS and no HB_FILTER_DETELECINE
+        if ( (mode == 0) || (is_detel = 0) )
+        {
+            hb_list_rem(list, filter);
+            hb_filter_close(&filter);
+            hb_log("Skipping VRF filter");
+        }
+    }
+    
+    filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
+    if (filter != NULL)
+    {
+        hb_dict_t* settings = filter->settings;
+        if (settings != NULL)
+        {
+            int width, height, top, bottom, left, right;
+            width = hb_dict_get_int(settings, "width");
+            height = hb_dict_get_int(settings, "height");
+            top = hb_dict_get_int(settings, "crop-top");
+            bottom = hb_dict_get_int(settings, "crop-bottom");
+            left = hb_dict_get_int(settings, "crop-left");
+            right = hb_dict_get_int(settings, "crop-right");
+            
+            if ( (src_geo.width == width) && (src_geo.height == height) &&
+                (top == 0) && (bottom == 0 ) && (left == 0) && (right == 0) )
+            {
+                hb_list_rem(list, filter);
+                hb_filter_close(&filter);
+                hb_log("Skipping CROP filter");
             }
         }
     }
@@ -1484,14 +1528,13 @@ static void do_job(hb_job_t *job)
         *job->die = 1;
         goto cleanup;
     }
-
     // Filters have an effect on settings.
     // So initialize the filters and update the job.
     if (job->list_filter && hb_list_count(job->list_filter))
     {
         hb_filter_init_t init;
 
-        sanitize_filter_list(job->list_filter);
+        sanitize_filter_list(job->list_filter, title->geometry);
 
         memset(&init, 0, sizeof(init));
         init.time_base.num = 1;


### PR DESCRIPTION
Moved filters control into right place - sanitize functions.
Skipped CROP filter and VFR filter if no affect on output for all configuration.