### PR TITLE
qsv: full mode only when needed

### DIFF
--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1394,16 +1394,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             {
                 hb_filter_object_t *filter;
                 filter = hb_filter_init(filter_id);
-#if HB_PROJECT_FEATURE_QSV
-                if(hb_qsv_full_path_is_enabled(job))
-                {
-                    hb_log("Filter with ID=%d is disabled", filter_id);
-                }
-                else
-#endif
-                {
-                    hb_add_filter_dict(job, filter, filter_settings);
-                }
+                hb_add_filter_dict(job, filter, filter_settings);
             }
         }
     }

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1004,13 +1004,18 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
 {
     static int device_check_completed = 0;
     static int device_check_succeded = 0;
+    int filter_count = hb_list_count(job->list_filter);
+
     if(!device_check_completed)
     {
        device_check_succeded = ((hb_d3d11va_device_check() >= 0)
         || (hb_dxva2_device_check() == 0)) ? 1 : 0;
        device_check_completed = 1;
     }
-    return (hb_qsv_decode_is_enabled(job) && hb_qsv_info_get(job->vcodec) && device_check_succeded);
+    return (hb_qsv_decode_is_enabled(job) &&
+        hb_qsv_info_get(job->vcodec) &&
+        device_check_succeded &&
+        (filter_count == 0));
 }
 
 int hb_qsv_copyframe_is_slow(int encoder)


### PR DESCRIPTION
Disable QSV full path and enable QSV encode-only if any filters remain after sanitizing the filters.