### PR TITLE
contrib: Update AMF and NVENC.

### DIFF
--- a/contrib/amf/module.defs
+++ b/contrib/amf/module.defs
@@ -1,10 +1,11 @@
 $(eval $(call import.MODULE.defs,AMF,amf))
 $(eval $(call import.CONTRIB.defs,AMF))
 
-AMF.FETCH.url      = https://download.handbrake.fr/contrib/AMF-1.4.9.tar.gz
-AMF.FETCH.url     += https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/v1.4.9.tar.gz
-AMF.FETCH.sha256   = d10f75612da5bcbc26325adecc5d398dcddf216c0dae3406d9a29b9d0b44b112
-AMF.FETCH.basename = AMF-1.4.9.tar.gz
+AMF.FETCH.url       = https://download.handbrake.fr/contrib/AMF-95220c0.tar.gz
+AMF.FETCH.url      += https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/95220c06302b63502021a4d791c339ab755436ed.tar.gz
+AMF.FETCH.sha256    = f5e4361b72317395c8e1c2f1f8d00bfea298450e36073cf9a3b285011515668a
+AMF.FETCH.basename  = AMF-95220c0.tar.gz
+AMF.EXTRACT.tarbase = AMF-95220c06302b63502021a4d791c339ab755436ed
 
 AMF.CONFIGURE = $(TOUCH.exe) $@
 AMF.BUILD     = $(TOUCH.exe) $@

--- a/contrib/nvenc/module.defs
+++ b/contrib/nvenc/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,NVENC,nvenc))
 $(eval $(call import.CONTRIB.defs,NVENC))
 
-NVENC.FETCH.url      = https://download.handbrake.fr/contrib/nv-codec-headers-9.0.18.1.tar.gz
-NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n9.0.18.1/nv-codec-headers-9.0.18.1.tar.gz
-NVENC.FETCH.sha256   = 6181a5dac66a6990aa3baf10a77ae677f372b9068be9ef73abfd37b73fb4c745
-NVENC.EXTRACT.tarbase = nv-codec-headers-n9.0.18.1
+NVENC.FETCH.url       = https://download.handbrake.fr/contrib/nv-codec-headers-9.1.23.0.tar.gz
+NVENC.FETCH.url      += https://github.com/FFmpeg/nv-codec-headers/releases/download/n9.1.23.0/nv-codec-headers-9.1.23.0.tar.gz
+NVENC.FETCH.sha256    = 6b043eb1ca275c087a1028db3241f5a75dfc3d02906b5cf8e47bcf4a37d7e07b
+NVENC.EXTRACT.tarbase = nv-codec-headers-n9.1.23.0
 
 NVENC.CONFIGURE = $(TOUCH.exe) $@
 NVENC.BUILD.extra = PREFIX="$(NVENC.CONFIGURE.prefix)"


### PR DESCRIPTION
AMF 1.4.14 adds support for Navi GPUs and commits following expose encoder low latency property for AVC/HEVC. Exposing low latency control in HandBrake would be good, but not necessary for this to land. Needs testing with compatible GPU(s).

NVENC 9.1.23.0 has a couple interesting changes, notably "filler NALU insertion for achieving true CBR" and "control the number of reference frames used by NVENC (Turing GPUs only)". Unfortunately, updating this contrib makes NVENC support unavailable on my PC running dual 1080 Ti, so it would seem there is a breaking change we need to address.

Targeting for 1.3.0. Would be good to at least get the AMF update in for Navi. Either/both can be pushed back if necessary.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux