### PR TITLE
x265: Fix encoder crash with zones and add test for zones

### DIFF
--- a/contrib/x265/A01-fix-zones-crash.patch
+++ b/contrib/x265/A01-fix-zones-crash.patch
@@ -1,0 +1,30 @@
+# HG changeset patch
+# User Pooja Venkatesan <pooja@multicorewareinc.com>
+# Date 1571043796 -19800
+# Branch Release_3.2
+# Node ID a3a088a7262fcc02560bc8b71d0a3cf5b9c69fe3
+# Parent  0f89afaddc5cd36cc1d1677060ef81dedd0f50e0
+Fix encoder crash with zones and add test for zones
+
+diff --git a/source/encoder/api.cpp b/source/encoder/api.cpp
+--- a/source/encoder/api.cpp
++++ b/source/encoder/api.cpp
+@@ -108,6 +108,7 @@
+         int zoneCount = p->rc.zonefileCount ? p->rc.zonefileCount : p->rc.zoneCount;
+         param->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+         latestParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
++        zoneParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+     }
+ 
+     x265_copy_params(param, p);
+diff --git a/source/test/regression-tests.txt b/source/test/regression-tests.txt
+--- a/source/test/regression-tests.txt
++++ b/source/test/regression-tests.txt
+@@ -156,6 +156,7 @@
+ 720p50_parkrun_ter.y4m,--preset medium --bitrate 400 --hme
+ ducks_take_off_420_720p50.y4m,--preset medium --aq-mode 4 --crf 22 --no-cutree
+ ducks_take_off_420_1_720p50.y4m,--preset medium --selective-sao 4 --sao --crf 20
++Kimono1_1920x1080_24_400.yuv,--preset superfast --qp 28 --zones 0,139,q=32
+ 
+ # Main12 intraCost overflow bug test
+ 720p50_parkrun_ter.y4m,--preset medium

--- a/contrib/x265_10bit/A01-fix-zones-crash.patch
+++ b/contrib/x265_10bit/A01-fix-zones-crash.patch
@@ -1,0 +1,30 @@
+# HG changeset patch
+# User Pooja Venkatesan <pooja@multicorewareinc.com>
+# Date 1571043796 -19800
+# Branch Release_3.2
+# Node ID a3a088a7262fcc02560bc8b71d0a3cf5b9c69fe3
+# Parent  0f89afaddc5cd36cc1d1677060ef81dedd0f50e0
+Fix encoder crash with zones and add test for zones
+
+diff --git a/source/encoder/api.cpp b/source/encoder/api.cpp
+--- a/source/encoder/api.cpp
++++ b/source/encoder/api.cpp
+@@ -108,6 +108,7 @@
+         int zoneCount = p->rc.zonefileCount ? p->rc.zonefileCount : p->rc.zoneCount;
+         param->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+         latestParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
++        zoneParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+     }
+ 
+     x265_copy_params(param, p);
+diff --git a/source/test/regression-tests.txt b/source/test/regression-tests.txt
+--- a/source/test/regression-tests.txt
++++ b/source/test/regression-tests.txt
+@@ -156,6 +156,7 @@
+ 720p50_parkrun_ter.y4m,--preset medium --bitrate 400 --hme
+ ducks_take_off_420_720p50.y4m,--preset medium --aq-mode 4 --crf 22 --no-cutree
+ ducks_take_off_420_1_720p50.y4m,--preset medium --selective-sao 4 --sao --crf 20
++Kimono1_1920x1080_24_400.yuv,--preset superfast --qp 28 --zones 0,139,q=32
+ 
+ # Main12 intraCost overflow bug test
+ 720p50_parkrun_ter.y4m,--preset medium

--- a/contrib/x265_12bit/A01-fix-zones-crash.patch
+++ b/contrib/x265_12bit/A01-fix-zones-crash.patch
@@ -1,0 +1,30 @@
+# HG changeset patch
+# User Pooja Venkatesan <pooja@multicorewareinc.com>
+# Date 1571043796 -19800
+# Branch Release_3.2
+# Node ID a3a088a7262fcc02560bc8b71d0a3cf5b9c69fe3
+# Parent  0f89afaddc5cd36cc1d1677060ef81dedd0f50e0
+Fix encoder crash with zones and add test for zones
+
+diff --git a/source/encoder/api.cpp b/source/encoder/api.cpp
+--- a/source/encoder/api.cpp
++++ b/source/encoder/api.cpp
+@@ -108,6 +108,7 @@
+         int zoneCount = p->rc.zonefileCount ? p->rc.zonefileCount : p->rc.zoneCount;
+         param->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+         latestParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
++        zoneParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+     }
+ 
+     x265_copy_params(param, p);
+diff --git a/source/test/regression-tests.txt b/source/test/regression-tests.txt
+--- a/source/test/regression-tests.txt
++++ b/source/test/regression-tests.txt
+@@ -156,6 +156,7 @@
+ 720p50_parkrun_ter.y4m,--preset medium --bitrate 400 --hme
+ ducks_take_off_420_720p50.y4m,--preset medium --aq-mode 4 --crf 22 --no-cutree
+ ducks_take_off_420_1_720p50.y4m,--preset medium --selective-sao 4 --sao --crf 20
++Kimono1_1920x1080_24_400.yuv,--preset superfast --qp 28 --zones 0,139,q=32
+ 
+ # Main12 intraCost overflow bug test
+ 720p50_parkrun_ter.y4m,--preset medium

--- a/contrib/x265_8bit/A01-fix-zones-crash.patch
+++ b/contrib/x265_8bit/A01-fix-zones-crash.patch
@@ -1,0 +1,30 @@
+# HG changeset patch
+# User Pooja Venkatesan <pooja@multicorewareinc.com>
+# Date 1571043796 -19800
+# Branch Release_3.2
+# Node ID a3a088a7262fcc02560bc8b71d0a3cf5b9c69fe3
+# Parent  0f89afaddc5cd36cc1d1677060ef81dedd0f50e0
+Fix encoder crash with zones and add test for zones
+
+diff --git a/source/encoder/api.cpp b/source/encoder/api.cpp
+--- a/source/encoder/api.cpp
++++ b/source/encoder/api.cpp
+@@ -108,6 +108,7 @@
+         int zoneCount = p->rc.zonefileCount ? p->rc.zonefileCount : p->rc.zoneCount;
+         param->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+         latestParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
++        zoneParam->rc.zones = x265_zone_alloc(zoneCount, !!p->rc.zonefileCount);
+     }
+ 
+     x265_copy_params(param, p);
+diff --git a/source/test/regression-tests.txt b/source/test/regression-tests.txt
+--- a/source/test/regression-tests.txt
++++ b/source/test/regression-tests.txt
+@@ -156,6 +156,7 @@
+ 720p50_parkrun_ter.y4m,--preset medium --bitrate 400 --hme
+ ducks_take_off_420_720p50.y4m,--preset medium --aq-mode 4 --crf 22 --no-cutree
+ ducks_take_off_420_1_720p50.y4m,--preset medium --selective-sao 4 --sao --crf 20
++Kimono1_1920x1080_24_400.yuv,--preset superfast --qp 28 --zones 0,139,q=32
+ 
+ # Main12 intraCost overflow bug test
+ 720p50_parkrun_ter.y4m,--preset medium


### PR DESCRIPTION
Patch from https://bitbucket.org/multicoreware/x265/commits/a3a088a7262fcc02560bc8b71d0a3cf5b9c69fe3

Fixes the crash mentioned here: https://github.com/HandBrake/HandBrake/pull/2357#issuecomment-541701244
