### PR TITLE
Gardening: Clean up trailing whitespace

### DIFF
--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -95,7 +95,7 @@ ghb_queue_drag_n_drop_init(signal_user_data_t * ud)
     widget = GHB_WIDGET(ud->builder, "queue_list");
     targets = gdk_content_formats_new(queue_drag_entries,
                                       G_N_ELEMENTS(queue_drag_entries));
-    gtk_drag_dest_set(widget, GTK_DEST_DEFAULT_MOTION|GTK_DEST_DEFAULT_DROP, 
+    gtk_drag_dest_set(widget, GTK_DEST_DEFAULT_MOTION|GTK_DEST_DEFAULT_DROP,
                       targets, GDK_ACTION_MOVE);
     gdk_content_formats_unref(targets);
 }
@@ -110,7 +110,7 @@ ghb_queue_drag_n_drop_init(signal_user_data_t * ud)
     GtkWidget * widget;
 
     widget = GHB_WIDGET(ud->builder, "queue_list");
-    gtk_drag_dest_set(widget, GTK_DEST_DEFAULT_MOTION|GTK_DEST_DEFAULT_DROP, 
+    gtk_drag_dest_set(widget, GTK_DEST_DEFAULT_MOTION|GTK_DEST_DEFAULT_DROP,
                       queue_drag_entries, 1, GDK_ACTION_MOVE);
 }
 #endif
@@ -281,7 +281,7 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
                              "%dx%d storage, %dx%d display\n"
                              "%d:%d Pixel Aspect Ratio\n"
                              "%s Display Aspect Ratio"),
-                           crop[0], crop[1], crop[2], crop[3], 
+                           crop[0], crop[1], crop[2], crop[3],
                            width, height, (int)display_width, display_height,
                            par_width, par_height, display_aspect);
     widget = GHB_WIDGET(ud->builder, "queue_summary_dimensions");
@@ -1723,11 +1723,11 @@ ghb_low_disk_check(signal_user_data_t *ud)
             _("%sThe destination filesystem is almost full: %"PRId64" MB free.\n"
               "Destination: %s\n"
               "Encode may be incomplete if you proceed.\n"),
-            paused_msg, free_size / (1024 * 1024), dest); 
+            paused_msg, free_size / (1024 * 1024), dest);
     gtk_dialog_add_buttons( GTK_DIALOG(dialog),
                            _("Resume, I've fixed the problem"), 1,
                            _("Resume, Don't tell me again"), 2,
-                           _("Cancel Current and Stop"), 3, 
+                           _("Cancel Current and Stop"), 3,
                            NULL);
     response = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_destroy(dialog);

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #include "handbrake/handbrake.h"
 #include "handbrake/lang.h"
 

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -197,10 +197,10 @@ static void add_audio(int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdau
 
     audio->config.lang.attributes = HB_AUDIO_ATTR_NONE;
 
-    snprintf( audio->config.lang.simple, 
+    snprintf( audio->config.lang.simple,
               sizeof( audio->config.lang.simple ), "%s",
               strlen( lang->native_name ) ? lang->native_name : lang->eng_name );
-    snprintf( audio->config.lang.iso639_2, 
+    snprintf( audio->config.lang.iso639_2,
               sizeof( audio->config.lang.iso639_2 ), "%s", lang->iso639_2 );
 
     hb_log("bd: audio id=0x%x, lang=%s (%s), 3cc=%s", audio->id,
@@ -436,7 +436,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
         // All BD clips are not all required to have the same audio.
         // But clips that have seamless transition are required
         // to have the same audio as the previous clip.
-        // So find the clip that has the most other clips with the 
+        // So find the clip that has the most other clips with the
         // matching audio.
         for ( ii = 0; ii < ti->clip_count; ii++ )
         {
@@ -637,7 +637,7 @@ int hb_bd_main_feature( hb_bd_t * d, hb_list_t * list_title )
     {
         hb_title_t * title = hb_list_item( list_title, ii );
         ti = d->title_info[title->index - 1];
-        if ( ti ) 
+        if ( ti )
         {
             BLURAY_STREAM_INFO * bdvideo = &ti->clips[0].video_streams[0];
             if ( title->duration > longest_duration * 0.7 && bdvideo->format < 8 )

--- a/libhb/compat.c
+++ b/libhb/compat.c
@@ -12,7 +12,7 @@
 #ifdef HB_NEED_STRTOK_R
 #include <string.h>
 
-char *strtok_r(char *s, const char *delim, char **save_ptr) 
+char *strtok_r(char *s, const char *delim, char **save_ptr)
 {
     char *token;
 

--- a/libhb/deccc608sub.c
+++ b/libhb/deccc608sub.c
@@ -877,8 +877,8 @@ static int write_cc_buffer_as_ssa(struct eia608_screen *data,
     safe_y = 0.1 * wb->height;
     min_safe_x = 0.025 * cropped_width;
     min_safe_y = 0.025 * cropped_height;
-    cell_height = (wb->height - 2 * safe_y) / 16; 
-    cell_width  = (wb->width  - 2 * safe_x) / screen_columns; 
+    cell_height = (wb->height - 2 * safe_y) / 16;
+    cell_width  = (wb->width  - 2 * safe_x) / screen_columns;
 
     char *pos;
     int y, x, top;
@@ -1365,7 +1365,7 @@ static void handle_command(unsigned char c1, const unsigned char c2,
             }
             erase_memory (wb,1);
 
-            // the last pts is the time to remove the previously 
+            // the last pts is the time to remove the previously
             // displayed CC from the display
             wb->data608->current_visible_start_ms = wb->last_pts;
             wb->data608->current_visible_scr_sequence = wb->last_scr_sequence;
@@ -1513,7 +1513,7 @@ static void handle_pac(unsigned char c1, unsigned char c2, struct s_write *wb)
                 font_text[wb->data608->font]);
 
     // CC spec says to the preferred method to handle a roll-up base row
-    // that causes the display to scroll off the top of the screen is to 
+    // that causes the display to scroll off the top of the screen is to
     // adjust the base row down.
     int keep_lines;
     switch (wb->data608->mode)

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -93,7 +93,7 @@ static void lpcmInfo( hb_work_object_t *w, hb_buffer_t *in )
      * frames plus the start of the 7th, the second packet will contain the
      * end of the 7th, 8-13 & the start of 14, etc. The frame structure is
      * important because the PTS on the packet gives the time of the first
-     * frame that starts in the packet *NOT* the time of the first sample 
+     * frame that starts in the packet *NOT* the time of the first sample
      * in the packet. Also samples get split across packet boundaries
      * so we can't assume that we can consume all the data in one packet
      * on every call to the work routine.
@@ -132,7 +132,7 @@ static void lpcmInfo( hb_work_object_t *w, hb_buffer_t *in )
      * of channels times the bits per sample divided by 8 to get bytes.
      * (we have to compute in bits because 20 bit samples are not an integral
      * number of bytes). We do all the multiplies first then the divides to
-     * avoid truncation errors. 
+     * avoid truncation errors.
      */
     /*
      * Don't trust the number of frames given in the header.  We've seen
@@ -143,11 +143,11 @@ static void lpcmInfo( hb_work_object_t *w, hb_buffer_t *in )
     int samples = chunks * samples_per_chunk;
 
     // Calculate number of frames that start in this packet
-    int frames = ( 90000 * samples / ( pv->samplerate * pv->nchannels ) + 
+    int frames = ( 90000 * samples / ( pv->samplerate * pv->nchannels ) +
                    149 ) / 150;
 
     pv->duration = frames * 150;
-    pv->nchunks =  ( pv->duration * pv->nchannels * pv->samplerate + 
+    pv->nchunks =  ( pv->duration * pv->nchannels * pv->samplerate +
                     samples_per_chunk - 1 ) / ( 90000 * samples_per_chunk );
     pv->nsamples = ( pv->duration * pv->samplerate ) / 90000;
     pv->size = pv->nchunks * chunk_size;
@@ -183,7 +183,7 @@ static int declpcmInit( hb_work_object_t * w, hb_job_t * job )
     return 0;
 }
 
-/* 
+/*
  * Convert DVD encapsulated LPCM to floating point PCM audio buffers.
  * The amount of audio in a PCM frame is always <= the amount that will fit
  * in a DVD block (2048 bytes) but the standard doesn't require that the audio
@@ -238,7 +238,7 @@ static hb_buffer_t *Decode( hb_work_object_t *w )
 {
     hb_work_private_t *pv = w->private_data;
     hb_buffer_t *out;
- 
+
     if (pv->nsamples == 0)
         return NULL;
 
@@ -265,7 +265,7 @@ static hb_buffer_t *Decode( hb_work_object_t *w )
                     // Shifts below result in sign extension which gives
                     // us proper signed values. The final division adjusts
                     // the range to [-1.0 ... 1.0]
-                    *odat++ = (float)( ( (int)( frm[0] << 24 ) >> 16 ) | 
+                    *odat++ = (float)( ( (int)( frm[0] << 24 ) >> 16 ) |
                                        frm[1] ) / 32768.0;
                     frm += 2;
                 }
@@ -324,7 +324,7 @@ static hb_buffer_t *Decode( hb_work_object_t *w )
                         // us proper signed values. The final division adjusts
                         // the range to [-1.0 ... 1.0]
                         *odat++ = (float)( ( (int)( frm[0] << 24 ) >> 8 ) |
-                                           ( frm[1] << 8 ) | lsb[0] ) / 
+                                           ( frm[1] << 8 ) | lsb[0] ) /
                                   (256. * 32768.0);
                         frm += 2;
                         lsb++;

--- a/libhb/decpgssub.c
+++ b/libhb/decpgssub.c
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
 

--- a/libhb/decutf8sub.c
+++ b/libhb/decutf8sub.c
@@ -9,10 +9,10 @@
 
 /*
  * Decoder for UTF-8 subtitles obtained from file input-sources.
- * 
+ *
  * Input and output packet format is UTF-8 encoded text,
  * with limited HTML-style markup (only <b>, <i>, and <u>).
- * 
+ *
  * @author David Foster (davidfstr)
  */
 

--- a/libhb/decvobsub.c
+++ b/libhb/decvobsub.c
@@ -9,7 +9,7 @@
 
 /*
  * Decoder for DVD bitmap subtitles, also known as "VOB subtitles" within the HandBrake source code.
- * 
+ *
  * Input format of the subtitle packets is described here:
  *   http://sam.zoy.org/writings/dvd/subtitles/
  *
@@ -68,7 +68,7 @@ int decsubInit( hb_work_object_t * w, hb_job_t * job )
 
     pv->job = job;
     pv->pts = 0;
-    
+
     // Warn if the input color palette is empty
     pv->palette_set = w->subtitle->palette_set;
     if ( pv->palette_set )
@@ -180,7 +180,7 @@ int decsubWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
         {
             // If we don't get a valid next timestamp, use the stop time
             // of the current sub as the start of the next.
-            // This can happen if reader invalidates timestamps while 
+            // This can happen if reader invalidates timestamps while
             // waiting for an audio to update the SCR.
             pv->pts                  = pv->pts_stop;
             pv->current_scr_sequence = pv->scr_sequence;

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -837,7 +837,7 @@ static int hb_detelecine_init( hb_filter_object_t * filter,
     ctx->strict_breaks = -1;
     ctx->metric_plane  = 0;
     ctx->parity = -1;
-    
+
     // "Skip" array [top, bottom, left, right]
     hb_dict_extract_int(&ctx->junk_top, filter->settings, "skip-top");
     hb_dict_extract_int(&ctx->junk_bottom, filter->settings, "skip-bottom");

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -983,8 +983,8 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
                         continue;
                     }
                     break;
-                } else {  
-                    // First retry the same block, then try the next one, 
+                } else {
+                    // First retry the same block, then try the next one,
                     // adjust the skip increment upwards so that we can skip
                     // large sections of bad blocks more efficiently (at the
                     // cost of some missed good blocks at the end).
@@ -992,7 +992,7 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
                             d->next_vobu, (read_retry * 10));
                     d->next_vobu += (read_retry * 10);
                 }
-                
+
             }
 
             if( read_retry == 1024 )
@@ -1021,7 +1021,7 @@ static hb_buffer_t * hb_dvdread_read( hb_dvd_t * e )
                     hb_log("dvd: Lost sync, searching for NAV pack at blk %d",
                            d->next_vobu);
                     d->in_sync = 0;
-                } 
+                }
                 continue;
             }
 

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -104,7 +104,7 @@ static char * hb_dvdnav_name( char * path )
 static int hb_dvdnav_reset( hb_dvdnav_t * d )
 {
     char * path_ccp = hb_utf8_to_cp( d->path );
-    if ( d->dvdnav ) 
+    if ( d->dvdnav )
         dvdnav_close( d->dvdnav );
 
     /* Open device */
@@ -128,7 +128,7 @@ static int hb_dvdnav_reset( hb_dvdnav_t * d )
     /*
      ** set the PGC positioning flag to have position information
      ** relatively to the whole feature instead of just relatively to the
-     ** current chapter 
+     ** current chapter
      **/
     if (dvdnav_set_PGC_positioning_flag(d->dvdnav, 1) != DVDNAV_STATUS_OK)
     {
@@ -201,7 +201,7 @@ static hb_dvd_t * hb_dvdnav_init( hb_handle_t * h, const char * path )
     /*
      ** set the PGC positioning flag to have position information
      ** relatively to the whole feature instead of just relatively to the
-     ** current chapter 
+     ** current chapter
      **/
     if (dvdnav_set_PGC_positioning_flag(d->dvdnav, 1) != DVDNAV_STATUS_OK)
     {
@@ -1109,8 +1109,8 @@ static int try_button( dvdnav_t * dvdnav, int button, hb_list_t * list_title )
             {
                 if ( hbtitle->duration / 90000 > 10 * 60 )
                 {
-                    hb_deep_log( 3, "dvdnav: Found candidate feature title %d duration %02d:%02d:%02d on button %d", 
-                    cur_title, hbtitle->hours, hbtitle->minutes, 
+                    hb_deep_log( 3, "dvdnav: Found candidate feature title %d duration %02d:%02d:%02d on button %d",
+                    cur_title, hbtitle->hours, hbtitle->minutes,
                     hbtitle->seconds, button+1 );
                     return cur_title;
                 }
@@ -1134,18 +1134,18 @@ done:
         hbtitle = hb_list_item( list_title, index );
         if ( hbtitle != NULL )
         {
-            hb_deep_log( 3, "dvdnav: Found candidate feature title %d duration %02d:%02d:%02d on button %d", 
-            longest, hbtitle->hours, hbtitle->minutes, 
+            hb_deep_log( 3, "dvdnav: Found candidate feature title %d duration %02d:%02d:%02d on button %d",
+            longest, hbtitle->hours, hbtitle->minutes,
             hbtitle->seconds, button+1 );
         }
     }
     return longest;
 }
 
-static int try_menu( 
-    hb_dvdnav_t * d, 
-    hb_list_t * list_title, 
-    DVDMenuID_t menu, 
+static int try_menu(
+    hb_dvdnav_t * d,
+    hb_list_t * list_title,
+    DVDMenuID_t menu,
     uint64_t fallback_duration )
 {
     int result, event, len;
@@ -1359,7 +1359,7 @@ static int hb_dvdnav_main_feature( hb_dvd_t * e, hb_list_t * list_title )
     if ( title )
     {
         hb_deep_log( 2, "dvdnav: Longest title %d duration %02d:%02d:%02d",
-                    longest_fallback, title->hours, title->minutes, 
+                    longest_fallback, title->hours, title->minutes,
                     title->seconds );
     }
 
@@ -1384,7 +1384,7 @@ static int hb_dvdnav_main_feature( hb_dvd_t * e, hb_list_t * list_title )
         }
     }
 
-    if ( longest_root < 0 || 
+    if ( longest_root < 0 ||
          (float)longest_duration_fallback * 0.7 > longest_duration_root)
     {
         longest_root = try_menu( d, list_title, DVD_MENU_Root, longest_duration_fallback );
@@ -1405,7 +1405,7 @@ static int hb_dvdnav_main_feature( hb_dvd_t * e, hb_list_t * list_title )
         }
     }
 
-    if ( longest_root < 0 || 
+    if ( longest_root < 0 ||
          (float)longest_duration_fallback * 0.7 > longest_duration_root)
     {
         longest_title = try_menu( d, list_title, DVD_MENU_Title, longest_duration_fallback );
@@ -1417,7 +1417,7 @@ static int hb_dvdnav_main_feature( hb_dvd_t * e, hb_list_t * list_title )
             {
                 longest_duration_title = title->duration;
                 hb_deep_log( 2, "dvdnav: found title %d duration %02d:%02d:%02d",
-                            longest_title, title->hours, title->minutes, 
+                            longest_title, title->hours, title->minutes,
                             title->seconds );
             }
         }
@@ -1483,7 +1483,7 @@ static int hb_dvdnav_start( hb_dvd_t * e, hb_title_t *title, int c )
         result = dvdnav_part_play(d->dvdnav, t, 1);
     if (result != DVDNAV_STATUS_OK)
     {
-        hb_error( "dvd: dvdnav_*_play failed - %s", 
+        hb_error( "dvd: dvdnav_*_play failed - %s",
                   dvdnav_err_to_string(d->dvdnav) );
         return 0;
     }
@@ -1612,7 +1612,7 @@ static int hb_dvdnav_seek( hb_dvd_t * e, float f )
 
     if (dvdnav_sector_search(d->dvdnav, sector, SEEK_SET) != DVDNAV_STATUS_OK)
     {
-        hb_error( "dvd: dvdnav_sector_search failed - %s", 
+        hb_error( "dvd: dvdnav_sector_search failed - %s",
                   dvdnav_err_to_string(d->dvdnav) );
         return 0;
     }
@@ -1675,7 +1675,7 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
 
         case DVDNAV_NOP:
             /*
-            * Nothing to do here. 
+            * Nothing to do here.
             */
             break;
 
@@ -1685,8 +1685,8 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             * would wait the amount of time specified by the still's
             * length while still handling user input to make menus and
             * other interactive stills work. A length of 0xff means an
-            * indefinite still which has to be skipped indirectly by some 
-            * user interaction. 
+            * indefinite still which has to be skipped indirectly by some
+            * user interaction.
             */
             dvdnav_still_skip( d->dvdnav );
             break;
@@ -1699,36 +1699,36 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             * always the fifo's length ahead in the stream compared to
             * what the application sees. Such applications should wait
             * until their fifos are empty when they receive this type of
-            * event. 
+            * event.
             */
             dvdnav_wait_skip( d->dvdnav );
             break;
 
         case DVDNAV_SPU_CLUT_CHANGE:
             /*
-            * Player applications should pass the new colour lookup table 
-            * to their SPU decoder 
+            * Player applications should pass the new colour lookup table
+            * to their SPU decoder
             */
             break;
 
         case DVDNAV_SPU_STREAM_CHANGE:
             /*
             * Player applications should inform their SPU decoder to
-            * switch channels 
+            * switch channels
             */
             break;
 
         case DVDNAV_AUDIO_STREAM_CHANGE:
             /*
             * Player applications should inform their audio decoder to
-            * switch channels 
+            * switch channels
             */
             break;
 
         case DVDNAV_HIGHLIGHT:
             /*
             * Player applications should inform their overlay engine to
-            * highlight the given button 
+            * highlight the given button
             */
             break;
 
@@ -1737,7 +1737,7 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             * Some status information like video aspect and video scale
             * permissions do not change inside a VTS. Therefore this
             * event can be used to query such information only when
-            * necessary and update the decoding/displaying accordingly. 
+            * necessary and update the decoding/displaying accordingly.
             */
             {
                 int tt = 0, pgcn = 0, pgn = 0;
@@ -1758,7 +1758,7 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             * Some status information like the current Title and Part
             * numbers do not change inside a cell. Therefore this event
             * can be used to query such information only when necessary
-            * and update the decoding/displaying accordingly. 
+            * and update the decoding/displaying accordingly.
             */
             {
                 dvdnav_cell_change_event_t * cell_event;
@@ -1804,7 +1804,7 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             * Angles are handled completely inside libdvdnav. For the
             * menus to work, the NAV packet information has to be passed
             * to the overlay engine of the player so that it knows the
-            * dimensions of the button areas. 
+            * dimensions of the button areas.
             */
 
             // mpegdemux expects to get these.  I don't think it does
@@ -1818,13 +1818,13 @@ static hb_buffer_t * hb_dvdnav_read( hb_dvd_t * e )
             /*
             * This event is issued whenever a non-seamless operation has
             * been executed. Applications with fifos should drop the
-            * fifos content to speed up responsiveness. 
+            * fifos content to speed up responsiveness.
             */
             break;
 
         case DVDNAV_STOP:
             /*
-            * Playback should end here. 
+            * Playback should end here.
             */
             d->stopped = 1;
             hb_buffer_close( &b );

--- a/libhb/eedi2.c
+++ b/libhb/eedi2.c
@@ -5,7 +5,7 @@
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
-   
+
    The EEDI2 interpolator was created by tritical:
    http://web.missouri.edu/~kes25c/
 */
@@ -18,7 +18,7 @@
  *
  * These values are used to limit the range of edge direction searches and filtering.
  */
-const int eedi2_limlut[33] __attribute__ ((aligned (16))) = { 
+const int eedi2_limlut[33] __attribute__ ((aligned (16))) = {
                          6, 6, 7, 7, 8, 8, 9, 9, 9, 10,
                          10, 11, 11, 12, 12, 12, 12, 12, 12, 12,
                          12, 12, 12, 12, 12, 12, 12, 12, 12, 12,
@@ -66,11 +66,11 @@ void eedi2_aligned_free( void *ptr )
 void eedi2_sort_metrics( int *order, const int length )
 {
     int i;
-    for( i = 1; i < length; ++i ) 
+    for( i = 1; i < length; ++i )
     {
         int j = i;
         const int temp = order[j];
-        while( j > 0 && order[j-1] > temp ) 
+        while( j > 0 && order[j-1] > temp )
         {
             order[j] = order[j-1];
             --j;
@@ -80,7 +80,7 @@ void eedi2_sort_metrics( int *order, const int length )
 }
 
 /**
- * Bitblits an image plane (overwrites one bitmap with another) 
+ * Bitblits an image plane (overwrites one bitmap with another)
  * @param dtsp Pointer to destination bitmap
  * @param dst_pitch Stride of destination bitmap
  * @param srcp Pointer to source bitmap
@@ -90,11 +90,11 @@ void eedi2_sort_metrics( int *order, const int length )
  *
  * When row_size, dst_pitch, and src_pitch are equal, eedi2_bit_blit can work more quickly by copying the whole plane at once instead of individual lines.
  */
-void eedi2_bit_blit( uint8_t * dstp, int dst_pitch, 
+void eedi2_bit_blit( uint8_t * dstp, int dst_pitch,
                      const uint8_t * srcp, int src_pitch,
                      int row_size, int height )
 {
-    if( ( !height ) || ( !row_size ) ) 
+    if( ( !height ) || ( !row_size ) )
         return;
 
     if( height == 1 || ( dst_pitch == src_pitch && src_pitch == row_size ) )
@@ -151,7 +151,7 @@ void eedi2_upscale_by_2( uint8_t * srcp, uint8_t * dstp, int height, int pitch )
       memcpy( dstp, srcp, pitch );
       srcp += pitch;
       dstp += pitch;
-    }    
+    }
 }
 
 /**
@@ -170,12 +170,12 @@ void eedi2_build_edge_mask( uint8_t * dstp, int dst_pitch, uint8_t *srcp, int sr
                             int mthresh, int lthresh, int vthresh, int height, int width )
 {
     int x, y;
-    
+
     mthresh = mthresh * 10;
     vthresh = vthresh * 81;
-    
+
     memset( dstp, 0, ( height / 2 ) * dst_pitch );
-    
+
     srcp += src_pitch;
     dstp += dst_pitch;
     unsigned char *srcpp = srcp-src_pitch;
@@ -195,11 +195,11 @@ void eedi2_build_edge_mask( uint8_t * dstp, int dst_pitch, uint8_t *srcp, int sr
                   abs(  srcp[x+1] - srcpn[x+1] ) < 10 &&
                   abs( srcpp[x+1] - srcpn[x+1] ) < 10) )
                 continue;
-            
+
             const int sum = srcpp[x-1] + srcpp[x] + srcpp[x+1] +
                              srcp[x-1] +  srcp[x]+   srcp[x+1] +
                             srcpn[x-1] + srcpn[x] + srcpn[x+1];
-            
+
             const int sumsq = srcpp[x-1] * srcpp[x-1] +
                               srcpp[x]   * srcpp[x]   +
                               srcpp[x+1] * srcpp[x+1] +
@@ -212,7 +212,7 @@ void eedi2_build_edge_mask( uint8_t * dstp, int dst_pitch, uint8_t *srcp, int sr
 
             if( 9 * sumsq-sum * sum < vthresh )
                 continue;
-            
+
             const int Ix = srcp[x+1] - srcp[x-1];
             const int Iy = MAX( MAX( abs( srcpp[x] - srcpn[x] ),
                                      abs( srcpp[x] -  srcp[x] ) ),
@@ -249,9 +249,9 @@ void eedi2_dilate_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int ds
                              int dstr, int height, int width )
 {
     int x, y;
-    
+
     eedi2_bit_blit( dstp, dst_pitch, mskp, msk_pitch, width, height );
-    
+
     mskp += msk_pitch;
     unsigned char *mskpp = mskp - msk_pitch;
     unsigned char *mskpn = mskp + msk_pitch;
@@ -272,7 +272,7 @@ void eedi2_dilate_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int ds
             if( mskpn[x-1] == 0xFF ) ++count;
             if( mskpn[x]   == 0xFF ) ++count;
             if( mskpn[x+1] == 0xFF ) ++count;
-                
+
             if( count >= dstr )
                 dstp[x] = 0xFF;
         }
@@ -297,9 +297,9 @@ void eedi2_erode_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int dst
                             int estr, int height, int width )
 {
     int x, y;
-    
+
     eedi2_bit_blit( dstp, dst_pitch, mskp, msk_pitch, width, height );
-    
+
     mskp += msk_pitch;
     unsigned char *mskpp = mskp - msk_pitch;
     unsigned char *mskpn = mskp + msk_pitch;
@@ -309,7 +309,7 @@ void eedi2_erode_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int dst
         for ( x = 1; x < width - 1; ++x )
         {
             if( mskp[x] != 0xFF ) continue;
-            
+
             int count = 0;
             if  ( mskpp[x-1] == 0xFF ) ++count;
             if  ( mskpp[x]   == 0xFF ) ++count;
@@ -342,13 +342,13 @@ void eedi2_erode_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int dst
  * @param height Height of half-height field-sized frame
  * @param width Width of mskp bitmap rows, as opposed to the pdded stride in msk_pitch
  */
-void eedi2_remove_small_gaps( uint8_t * mskp, int msk_pitch, uint8_t * dstp, int dst_pitch, 
+void eedi2_remove_small_gaps( uint8_t * mskp, int msk_pitch, uint8_t * dstp, int dst_pitch,
                               int height, int width )
 {
     int x, y;
-    
+
     eedi2_bit_blit( dstp, dst_pitch, mskp, msk_pitch, width, height );
-    
+
     mskp += msk_pitch;
     dstp += dst_pitch;
     for( y = 1; y < height - 1; ++y )
@@ -396,7 +396,7 @@ void eedi2_calc_directions( const int plane, uint8_t * mskp, int msk_pitch, uint
                             uint8_t * dstp, int dst_pitch, int maxd, int nt, int height, int width  )
 {
     int x, y, u, i;
-    
+
     memset( dstp, 255, dst_pitch * height );
     mskp += msk_pitch;
     dstp += dst_pitch;
@@ -464,8 +464,8 @@ void eedi2_calc_directions( const int plane, uint8_t * mskp, int msk_pitch, uint
                             const int diff2pp = abs( src2p[x-1] - srcpp[x-1-u] ) +
                                             abs( src2p[x]   - srcpp[x-u] )   +
                                             abs( src2p[x+1] - srcpp[x+1-u] );
-                            const int diffp2p = abs( srcpp[x-1] - src2p[x-1+u] ) + 
-                                            abs( srcpp[x]   - src2p[x+u] )   + 
+                            const int diffp2p = abs( srcpp[x-1] - src2p[x-1+u] ) +
+                                            abs( srcpp[x]   - src2p[x+u] )   +
                                             abs( srcpp[x+1] - src2p[x+1+u] );
                             const int diffa = diff + diff2pp + diffp2p;
                             diffd += diffp2p;
@@ -515,7 +515,7 @@ void eedi2_calc_directions( const int plane, uint8_t * mskp, int msk_pitch, uint
             if( k > 1 )
             {
                 eedi2_sort_metrics( order, k );
-                const int mid = ( k & 1 ) ? 
+                const int mid = ( k & 1 ) ?
                                     order[k>>1] :
                                     ( order[(k-1)>>1] + order[k>>1] + 1 ) >> 1;
                 const int tlim = MAX( eedi2_limlut[abs(mid)] >> 2, 2 );
@@ -528,7 +528,7 @@ void eedi2_calc_directions( const int plane, uint8_t * mskp, int msk_pitch, uint
                         sum += order[i];
                     }
                 }
-                if( count > 1 ) 
+                if( count > 1 )
                     dstp[x] = 128 + ( (int)( (float)sum / (float)count ) * 4 );
                 else
                     dstp[x] = 128;
@@ -564,7 +564,7 @@ void eedi2_filter_map( uint8_t * mskp, int msk_pitch, uint8_t * dmskp, int dmsk_
     int x, y, j;
 
     eedi2_bit_blit( dstp, dst_pitch, dmskp, dmsk_pitch, width, height );
-    
+
     mskp += msk_pitch;
     dmskp += dmsk_pitch;
     dstp += dst_pitch;
@@ -666,9 +666,9 @@ void eedi2_filter_dir_map( uint8_t * mskp, int msk_pitch, uint8_t * dmskp, int d
                            uint8_t * dstp, int dst_pitch, int height, int width )
 {
     int x, y, i;
-    
+
     eedi2_bit_blit( dstp, dst_pitch, dmskp, dmsk_pitch, width, height );
-    
+
     dmskp += dmsk_pitch;
     unsigned char *dmskpp = dmskp - dmsk_pitch;
     unsigned char *dmskpn = dmskp + dmsk_pitch;
@@ -739,7 +739,7 @@ void eedi2_expand_dir_map( uint8_t * mskp, int msk_pitch, uint8_t * dmskp, int d
     int x, y, i;
 
     eedi2_bit_blit( dstp, dst_pitch, dmskp, dmsk_pitch, width, height );
-    
+
     dmskp += dmsk_pitch;
     unsigned char *dmskpp = dmskp - dmsk_pitch;
     unsigned char *dmskpn = dmskp + dmsk_pitch;
@@ -1034,15 +1034,15 @@ void eedi2_fill_gaps_2x( uint8_t *mskp, int msk_pitch, uint8_t * dmskp, int dmsk
     {
         for( x = 1; x < width - 1; ++x )
         {
-            if( dmskp[x] != 0xFF || 
+            if( dmskp[x] != 0xFF ||
                 ( mskp[x] != 0xFF && mskpn[x] != 0xFF ) ) continue;
             int u = x - 1, back = 500, forward = -500;
             while( u )
             {
-                if( dmskp[u] != 0xFF ) 
-                { 
-                    back = dmskp[u]; 
-                    break; 
+                if( dmskp[u] != 0xFF )
+                {
+                    back = dmskp[u];
+                    break;
                 }
                 if( mskp[u] != 0xFF && mskpn[u] != 0xFF ) break;
                 --u;
@@ -1135,7 +1135,7 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                                 int height, int width )
 {
     int x, y, u;
-    
+
     if( field == 1 )
     {
         eedi2_bit_blit( dstp + ( height - 1 ) * dst_pitch,
@@ -1179,7 +1179,7 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
             {
                 const int sum =   dstp[x-1] +   dstp[x] +   dstp[x+1] +
                                 dstpnn[x-1] + dstpnn[x] + dstpnn[x+1];
-                const int sumsq = dstp[x-1] *   dstp[x-1] + 
+                const int sumsq = dstp[x-1] *   dstp[x-1] +
                                   dstp[x]   *   dstp[x]   +
                                   dstp[x+1] *   dstp[x+1] +
                                 dstpnn[x-1] * dstpnn[x-1] +
@@ -1192,7 +1192,7 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                     continue;
                 }
             }
-            if( x > 1 && x < width - 2 && 
+            if( x > 1 && x < width - 2 &&
                 ( (   dstp[x] < MAX(   dstp[x-2],   dstp[x-1] ) - 3 &&
                       dstp[x] < MAX(   dstp[x+2],   dstp[x+1] ) - 3 &&
                     dstpnn[x] < MAX( dstpnn[x-2], dstpnn[x-1] ) - 3 &&
@@ -1223,11 +1223,11 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                 const int diff =
                     abs(   dstp[x-1] - dstpnn[x-u-1] ) +
                     abs(   dstp[x]   - dstpnn[x-u] )   +
-                    abs(   dstp[x+1] - dstpnn[x-u+1] ) + 
-                    abs( dstpnn[x-1] -   dstp[x+u-1] ) + 
+                    abs(   dstp[x+1] - dstpnn[x-u+1] ) +
+                    abs( dstpnn[x-1] -   dstp[x+u-1] ) +
                     abs( dstpnn[x]   -   dstp[x+u] )   +
                     abs( dstpnn[x+1] -   dstp[x+u+1] );
-                if( diff < min && 
+                if( diff < min &&
                     ( ( omskp[x-1+u] != 0xFF && abs( omskp[x-1+u] - dmskp[x] ) <= lim ) ||
                      (  omskp[x+u]   != 0xFF && abs( omskp[x+u]   - dmskp[x]) <= lim )  ||
                      (  omskp[x+1+u] != 0xFF && abs( omskp[x+1+u] - dmskp[x]) <= lim ) ) &&
@@ -1235,18 +1235,18 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                      (  omskn[x-u]   != 0xFF && abs( omskn[x-u]   - dmskp[x]) <= lim ) ||
                      (  omskn[x+1-u] != 0xFF && abs( omskn[x+1-u] - dmskp[x]) <= lim ) ) )
                 {
-                    const int diff2 = 
+                    const int diff2 =
                         abs( dstp[x+(u>>1)-1] - dstpnn[x-(u>>1)-1] ) +
                         abs( dstp[x+(u>>1)]   - dstpnn[x-(u>>1)]   ) +
                         abs( dstp[x+(u>>1)+1] - dstpnn[x-(u>>1)+1] );
                     if( diff2 < 4 * nt &&
                         ( ( ( abs( omskp[x+(u>>1)] - omskn[x-(u>>1)]     ) <= lim ||
-                              abs( omskp[x+(u>>1)] - omskn[x-((u+1)>>1)] ) <= lim ) && 
+                              abs( omskp[x+(u>>1)] - omskn[x-((u+1)>>1)] ) <= lim ) &&
                             omskp[x+(u>>1)] != 0xFF )
-                          || 
+                          ||
                           ( ( abs( omskp[x+((u+1)>>1)] - omskn[x-(u>>1)] )     <= lim ||
-                              abs( omskp[x+((u+1)>>1)] - omskn[x-((u+1)>>1)] ) <= lim ) && 
-                            omskp[x+((u+1)>>1)] != 0xFF ) ) ) 
+                              abs( omskp[x+((u+1)>>1)] - omskn[x-((u+1)>>1)] ) <= lim ) &&
+                            omskp[x+((u+1)>>1)] != 0xFF ) ) )
                     {
                         if( ( abs( dmskp[x] - omskp[x+(u>>1)] )     <= lim ||
                               abs( dmskp[x] - omskp[x+((u+1)>>1)] ) <= lim ) &&
@@ -1266,7 +1266,7 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                 dstpn[x] = val;
                 dmskp[x] = 128 + dir * 4;
             }
-            else 
+            else
             {
                 const int minm = MIN( dstp[x], dstpnn[x] );
                 const int maxm = MAX( dstp[x], dstpnn[x] );
@@ -1279,11 +1279,11 @@ void eedi2_interpolate_lattice( const int plane, uint8_t * dmskp, int dmsk_pitch
                     const int p1 =   dstp[x+(u>>1)] +   dstp[x+((u+1)>>1)];
                     const int p2 = dstpnn[x-(u>>1)] + dstpnn[x-((u+1)>>1)];
                     const int diff =
-                        abs(   dstp[x-1] - dstpnn[x-u-1] ) + 
+                        abs(   dstp[x-1] - dstpnn[x-u-1] ) +
                         abs(   dstp[x]   - dstpnn[x-u] )   +
                         abs(   dstp[x+1] - dstpnn[x-u+1] ) +
-                        abs( dstpnn[x-1] - dstp[x+u-1] )   + 
-                        abs( dstpnn[x]   - dstp[x+u] )     + 
+                        abs( dstpnn[x-1] - dstp[x+u-1] )   +
+                        abs( dstpnn[x]   - dstp[x+u] )     +
                         abs( dstpnn[x+1] - dstp[x+u+1] )   +
                         abs( p1 - p2 );
                     if( diff < min )
@@ -1327,7 +1327,7 @@ void eedi2_post_process( uint8_t * nmskp, int nmsk_pitch, uint8_t * omskp, int o
                          uint8_t * dstp, int src_pitch, int field, int height, int width )
 {
     int x, y;
-    
+
     nmskp += ( 2 - field ) * nmsk_pitch;
     omskp += ( 2 - field ) * omsk_pitch;
     dstp += ( 2 - field ) * src_pitch;
@@ -1368,13 +1368,13 @@ void eedi2_gaussian_blur1( uint8_t * src, int src_pitch, uint8_t * tmp, int tmp_
 
     for( y = 0; y < height; ++y )
     {
-        dstp[0] = ( srcp[3] * 582 + srcp[2] * 7078 + srcp[1] * 31724 + 
+        dstp[0] = ( srcp[3] * 582 + srcp[2] * 7078 + srcp[1] * 31724 +
                     srcp[0] * 26152 + 32768 ) >> 16;
         dstp[1] = ( srcp[4] * 582 + srcp[3] * 7078 +
                     ( srcp[0] + srcp[2] ) * 15862 +
                     srcp[1] * 26152 + 32768 ) >> 16;
         dstp[2] = ( srcp[5] * 582 + ( srcp[0] + srcp[4] ) * 3539 +
-                    ( srcp[1] + srcp[3] ) * 15862 + 
+                    ( srcp[1] + srcp[3] ) * 15862 +
                     srcp[2]*26152 + 32768 ) >> 16;
         for( x = 3; x < width - 3; ++x )
         {
@@ -1406,7 +1406,7 @@ void eedi2_gaussian_blur1( uint8_t * src, int src_pitch, uint8_t * tmp, int tmp_
     unsigned char *src3n = srcp + tmp_pitch * 3;
     for( x = 0; x < width; ++x )
     {
-        dstp[x] = ( src3n[x] * 582 + src2n[x] * 7078 + srcpn[x] * 31724 + 
+        dstp[x] = ( src3n[x] * 582 + src2n[x] * 7078 + srcpn[x] * 31724 +
                      srcp[x] * 26152 + 32768 ) >> 16;
     }
     src3p += tmp_pitch;
@@ -1433,7 +1433,7 @@ void eedi2_gaussian_blur1( uint8_t * src, int src_pitch, uint8_t * tmp, int tmp_
     dstp += dst_pitch;
     for( x = 0; x < width; ++x )
     {
-        dstp[x] = ( src3n[x] * 582 + ( src2p[x] + src2n[x] ) * 3539 + 
+        dstp[x] = ( src3n[x] * 582 + ( src2p[x] + src2n[x] ) * 3539 +
                     ( srcpp[x] + srcpn[x] ) * 15862 +
                     srcp[x] * 26152 + 32768 ) >> 16;
     }
@@ -1513,51 +1513,51 @@ void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch, i
     int * srcp = src;
     int * dstp = tmp;
     int x, y;
-    
+
     for( y = 0; y < height; ++y )
     {
         x = 0;
         dstp[x] = ( srcp[x+4] * 678   + srcp[x+3] * 3902  + srcp[x+2] * 13618 +
                     srcp[x+1] * 28830 + srcp[x]   * 18508 + 32768 ) >> 16;
         ++x;
-        dstp[x] = ( srcp[x+4] * 678   + srcp[x+3] * 3902 + srcp[x+2] * 13618 + 
+        dstp[x] = ( srcp[x+4] * 678   + srcp[x+3] * 3902 + srcp[x+2] * 13618 +
                     ( srcp[x-1] + srcp[x+1] ) *14415 +
                     srcp[x]   * 18508 + 32768 ) >> 16;
         ++x;
-        dstp[x] = ( srcp[x+4] * 678   + srcp[x+3] * 3902 + 
+        dstp[x] = ( srcp[x+4] * 678   + srcp[x+3] * 3902 +
                     ( srcp[x-2] + srcp[x+2] ) * 6809 +
-                    ( srcp[x-1] + srcp[x+1] ) * 14415 + 
+                    ( srcp[x-1] + srcp[x+1] ) * 14415 +
                     srcp[x]   * 18508 + 32768 ) >> 16;
         ++x;
-        dstp[x] = ( srcp[x+4] * 678   + ( srcp[x-3] + srcp[x+3] ) * 1951 + 
+        dstp[x] = ( srcp[x+4] * 678   + ( srcp[x-3] + srcp[x+3] ) * 1951 +
                     ( srcp[x-2] + srcp[x+2] ) * 6809 +
-                    ( srcp[x-1] + srcp[x+1] ) * 14415 + 
+                    ( srcp[x-1] + srcp[x+1] ) * 14415 +
                     srcp[x]   * 18508 + 32768 ) >> 16;
 
         for( x = 4; x < width - 4; ++x )
         {
-            dstp[x] = ( ( srcp[x-4] + srcp[x+4] ) * 339 + 
-                        ( srcp[x-3] + srcp[x+3] ) * 1951 + 
+            dstp[x] = ( ( srcp[x-4] + srcp[x+4] ) * 339 +
+                        ( srcp[x-3] + srcp[x+3] ) * 1951 +
                         ( srcp[x-2] + srcp[x+2] ) * 6809 +
-                        ( srcp[x-1] + srcp[x+1] ) * 14415 + 
+                        ( srcp[x-1] + srcp[x+1] ) * 14415 +
                         srcp[x] * 18508 + 32768 ) >> 16;
         }
 
-        dstp[x] = ( srcp[x-4] * 678 + ( srcp[x-3] + srcp[x+3] ) * 1951 + 
+        dstp[x] = ( srcp[x-4] * 678 + ( srcp[x-3] + srcp[x+3] ) * 1951 +
                     ( srcp[x-2] + srcp[x+2] ) * 6809  +
-                    ( srcp[x-1] + srcp[x+1] ) * 14415 + 
-                    srcp[x] * 18508 + 32768 ) >> 16;
-        ++x;
-        dstp[x] = ( srcp[x-4] * 678 + srcp[x-3] * 3902 + 
-                    ( srcp[x-2] + srcp[x+2] ) * 6809 +
-                    ( srcp[x-1] + srcp[x+1] ) * 14415 + 
-                    srcp[x] * 18508 + 32768 ) >> 16;
-        ++x;
-        dstp[x] = ( srcp[x-4] * 678 + srcp[x+3] * 3902 + srcp[x-2] * 13618 + 
                     ( srcp[x-1] + srcp[x+1] ) * 14415 +
                     srcp[x] * 18508 + 32768 ) >> 16;
         ++x;
-        dstp[x] = ( srcp[x-4] * 678 + srcp[x-3] * 3902 + srcp[x-2] * 13618 + 
+        dstp[x] = ( srcp[x-4] * 678 + srcp[x-3] * 3902 +
+                    ( srcp[x-2] + srcp[x+2] ) * 6809 +
+                    ( srcp[x-1] + srcp[x+1] ) * 14415 +
+                    srcp[x] * 18508 + 32768 ) >> 16;
+        ++x;
+        dstp[x] = ( srcp[x-4] * 678 + srcp[x+3] * 3902 + srcp[x-2] * 13618 +
+                    ( srcp[x-1] + srcp[x+1] ) * 14415 +
+                    srcp[x] * 18508 + 32768 ) >> 16;
+        ++x;
+        dstp[x] = ( srcp[x-4] * 678 + srcp[x-3] * 3902 + srcp[x-2] * 13618 +
                     srcp[x-1] * 28830 +
                     srcp[x] * 18508 + 32768 ) >> 16;
         srcp += pitch;
@@ -1575,7 +1575,7 @@ void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch, i
     int * src4n = srcp + pitch * 4;
     for( x = 0; x < width; ++x )
     {
-        dstp[x] = ( src4n[x] * 678   + src3n[x] * 3902  + 
+        dstp[x] = ( src4n[x] * 678   + src3n[x] * 3902  +
                     src2n[x] * 13618 + srcpn[x] * 28830 +
                      srcp[x] * 18508 + 32768 ) >> 18;
     }
@@ -1591,7 +1591,7 @@ void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch, i
     dstp += pitch;
     for( x = 0; x < width; ++x )
     {
-        dstp[x] = ( src4n[x] * 678 + src3n[x] * 3902 + src2n[x] * 13618 + 
+        dstp[x] = ( src4n[x] * 678 + src3n[x] * 3902 + src2n[x] * 13618 +
                     ( srcpp[x] + srcpn[x] ) * 14415 +
                     srcp[x] * 18508 + 32768 ) >> 18;
     }
@@ -1607,8 +1607,8 @@ void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch, i
     dstp += pitch;
     for( x = 0; x < width; ++x )
     {
-        dstp[x] = ( src4n[x] * 678 + src3n[x] * 3902 + 
-                    ( src2p[x] + src2n[x] ) * 6809 + 
+        dstp[x] = ( src4n[x] * 678 + src3n[x] * 3902 +
+                    ( src2p[x] + src2n[x] ) * 6809 +
                     ( srcpp[x] + srcpn[x] ) * 14415 +
                     srcp[x] * 18508 + 32768 ) >> 18;
     }
@@ -1731,7 +1731,7 @@ void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch, i
  */
 void eedi2_calc_derivatives( uint8_t *srcp, int src_pitch, int height, int width, int *x2, int *y2, int *xy)
 {
-    
+
     unsigned char * srcpp = srcp - src_pitch;
     unsigned char * srcpn = srcp + src_pitch;
     int x, y;
@@ -1845,7 +1845,7 @@ void eedi2_post_process_corner( int *x2, int *y2, int *xy, const int pitch, uint
     int *y2n = y2 + pitch;
     int *xyn = xy + pitch;
     int x, y;
-    
+
     for( y = 8 - field; y < height - 7; y += 2 )
     {
         for( x = 4; x < width - 4; ++x )
@@ -1853,7 +1853,7 @@ void eedi2_post_process_corner( int *x2, int *y2, int *xy, const int pitch, uint
             if( mskp[x] == 255 || mskp[x] == 128 ) continue;
             const int c1 = (int)( x2[x]  *  y2[x] -  xy[x] * xy[x] - 0.09 *
                                   ( x2[x]  + y2[x] )  * ( x2[x]  + y2[x] ) );
-            const int c2 = (int)( x2n[x] * y2n[x] - xyn[x]* xyn[x] - 0.09 * 
+            const int c2 = (int)( x2n[x] * y2n[x] - xyn[x]* xyn[x] - 0.09 *
                                   ( x2n[x] + y2n[x] ) * ( x2n[x] + y2n[x] ) );
             if (c1 > 775 || c2 > 775)
                 dstp[x] = ( dstpp[x] + dstpn[x] + 1 ) >> 1;

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1277,7 +1277,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
         else
         {
             // introduced in API 1.1
-            // HEVC 10b has QP range as [-12;51] 
+            // HEVC 10b has QP range as [-12;51]
             // with shift +12 needed to be in QSV's U16 range
             unsigned int upper_limit = 51;
 

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -75,12 +75,12 @@ static const char * const h26x_nvenc_preset_names[] =
 
 static const char * const h264_nvenc_profile_names[] =
 {
-    "auto", "baseline", "main", "high", NULL  // "high444p" not supported. 
+    "auto", "baseline", "main", "high", NULL  // "high444p" not supported.
 };
 
 static const char * const h265_nvenc_profile_names[] =
 {
-    "auto", "main", NULL // "main10", "rext"  We do not currently support 10bit encodes with this encoder. 
+    "auto", "main", NULL // "main10", "rext"  We do not currently support 10bit encodes with this encoder.
 };
 
 static const char * const h26x_vt_preset_name[] =
@@ -95,7 +95,7 @@ static const char * const h264_vt_profile_name[] =
 
 static const char * const h265_vt_profile_name[] =
 {
-    "auto", "main",  NULL // "main10" not currently supported. 
+    "auto", "main",  NULL // "main10" not currently supported.
 };
 
 int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
@@ -180,7 +180,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         // Catch all when the switch above fails
         hb_log( "encavcodecInit: Unable to determine codec_name "
                 "from hb_work_object_t.codec_param=%d and "
-                "hb_job_t.vcodec=%x", w->codec_param, 
+                "hb_job_t.vcodec=%x", w->codec_param,
                 job->vcodec );
         ret = 1;
         goto done;
@@ -308,7 +308,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         // ffmpeg's mpeg2 encoder requires that the bit_rate_tolerance be >=
         // bitrate * fps
         context->bit_rate_tolerance = context->bit_rate * av_q2d(fps) + 1;
-        
+
         if ( job->vcodec == HB_VCODEC_FFMPEG_NVENC_H264 ||
                   job->vcodec == HB_VCODEC_FFMPEG_NVENC_H265 ) {
             av_dict_set( &av_opts, "rc", "cbr_hq", 0 );
@@ -327,7 +327,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             // what was previously used
             context->flags |= AV_CODEC_FLAG_QSCALE;
             context->global_quality = FF_QP2LAMBDA * job->vquality + 0.5;
-        
+
             char quality[7];
             snprintf(quality, 7, "%.2f", job->vquality);
             av_dict_set( &av_opts, "crf", quality, 0 );
@@ -381,16 +381,16 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
 
             snprintf(quality, 7, "%.2f", job->vquality);
             snprintf(qualityB, 7, "%.2f", adjustedQualityB);
-            
+
             if (adjustedQualityB > 51) {
                 adjustedQualityB = 51;
             }
 
             av_dict_set( &av_opts, "rc", "cqp", 0 );
-           
+
             av_dict_set( &av_opts, "qp_i", quality, 0 );
             av_dict_set( &av_opts, "qp_p", quality, 0 );
-            
+
             if ( job->vcodec != HB_VCODEC_FFMPEG_VCE_H265 )
             {
                 av_dict_set( &av_opts, "qp_b", qualityB, 0 );
@@ -403,7 +403,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             // what was previously used
             context->flags |= AV_CODEC_FLAG_QSCALE;
             context->global_quality = FF_QP2LAMBDA * job->vquality + 0.5;
-            
+
             hb_log( "encavcodec: encoding at constant quantizer %d",
                     context->global_quality );
         }
@@ -532,7 +532,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         // FIXME
         //context->tier = FF_TIER_UNKNOWN;
     }
-    
+
     if (job->vcodec == HB_VCODEC_FFMPEG_NVENC_H264 ||
         job->vcodec == HB_VCODEC_FFMPEG_NVENC_H265)
     {
@@ -1059,7 +1059,7 @@ static int apply_encoder_preset(int vcodec, AVDictionary ** av_opts,
         default:
             break;
     }
-    
+
     return 0;
 }
 

--- a/libhb/enctheora.c
+++ b/libhb/enctheora.c
@@ -236,7 +236,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             unsigned char *buffer;
             int bytes;
 
-            bytes = th_encode_ctl(pv->ctx, TH_ENCCTL_2PASS_OUT, 
+            bytes = th_encode_ctl(pv->ctx, TH_ENCCTL_2PASS_OUT,
                                   &buffer, sizeof(buffer));
             if( bytes < 0 )
             {
@@ -292,7 +292,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             /*And pass them off.*/
             if( bytes > pv->stat_fill - pv->stat_read )
                 bytes = pv->stat_fill - pv->stat_read;
-            ret = th_encode_ctl( pv->ctx, TH_ENCCTL_2PASS_IN, 
+            ret = th_encode_ctl( pv->ctx, TH_ENCCTL_2PASS_IN,
                                  pv->stat_buf+pv->stat_read, bytes);
             if( ret < 0 )
             {
@@ -305,7 +305,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
             if( ret >= pv->stat_fill - pv->stat_read )
                 pv->stat_read = pv->stat_fill = 0;
             /*Otherwise remember how much it used.*/
-            else 
+            else
                 pv->stat_read += ret;
         }
     }
@@ -338,7 +338,7 @@ int enctheoraWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
         unsigned char *buffer;
         int bytes;
 
-        bytes = th_encode_ctl(pv->ctx, TH_ENCCTL_2PASS_OUT, 
+        bytes = th_encode_ctl(pv->ctx, TH_ENCCTL_2PASS_OUT,
                               &buffer, sizeof(buffer));
         if( bytes < 0 )
         {

--- a/libhb/encvobsub.c
+++ b/libhb/encvobsub.c
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
 
@@ -57,7 +57,7 @@ int encsubWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
         *buf_in = NULL;
     }
 
-    return HB_WORK_OK; 
+    return HB_WORK_OK;
 }
 
 void encsubClose( hb_work_object_t * w )

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -441,12 +441,12 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
             min_auto = param.i_keyint_max / 10;
 
         char min[40], max[40];
-        param.i_keyint_min == X264_KEYINT_MIN_AUTO ? 
-            snprintf( min, 40, "auto (%d)", min_auto ) : 
+        param.i_keyint_min == X264_KEYINT_MIN_AUTO ?
+            snprintf( min, 40, "auto (%d)", min_auto ) :
             snprintf( min, 40, "%d", param.i_keyint_min );
 
-        param.i_keyint_max == X264_KEYINT_MAX_INFINITE ? 
-            snprintf( max, 40, "infinite" ) : 
+        param.i_keyint_max == X264_KEYINT_MAX_INFINITE ?
+            snprintf( max, 40, "infinite" ) :
             snprintf( max, 40, "%d", param.i_keyint_max );
 
         hb_log( "encx264: min-keyint: %s, keyint: %s", min, max );
@@ -526,7 +526,7 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
 
     /* B-pyramid is enabled by default. */
     job->areBframes = 2;
-    
+
     if( !param.i_bframe )
     {
         job->areBframes = 0;
@@ -535,7 +535,7 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
     {
         job->areBframes = 1;
     }
-    
+
     /* Log the unparsed x264 options string. */
     char *x264_opts_unparsed = hb_x264_param_unparse(pv->api->bit_depth,
                                                      job->encoder_preset,

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -57,7 +57,7 @@ struct hb_fifo_s
 };
 
 #if defined(HB_FIFO_DEBUG)
-static hb_fifo_t fifo_list = 
+static hb_fifo_t fifo_list =
 {
     .next = NULL
 };
@@ -768,7 +768,7 @@ void hb_buffer_close( hb_buffer_t ** _b )
             continue;
         }
         // either the pool is full or this size doesn't use a pool
-        // free the buf 
+        // free the buf
         if( b->data )
         {
             av_free(b->data);
@@ -1199,7 +1199,7 @@ void hb_fifo_push_head( hb_fifo_t * f, hb_buffer_t * b )
     if( f->size > 0 )
     {
         tmp->next = f->first;
-    } 
+    }
     else
     {
         f->last = tmp;

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #ifndef HANDBRAKE_COMMON_H
 #define HANDBRAKE_COMMON_H
 
@@ -170,7 +170,7 @@ int hb_subtitle_add(const hb_job_t * job, const hb_subtitle_config_t * subtitlec
 int hb_import_subtitle_add( const hb_job_t * job,
                 const hb_subtitle_config_t * subtitlecfg,
                 const char *lang_code, int source );
-int hb_srt_add(const hb_job_t * job, const hb_subtitle_config_t * subtitlecfg, 
+int hb_srt_add(const hb_job_t * job, const hb_subtitle_config_t * subtitlecfg,
                const char *lang);
 int hb_subtitle_can_force( int source );
 int hb_subtitle_can_burn( int source );
@@ -684,7 +684,7 @@ struct hb_job_s
 
     int             angle;              // dvd angle to encode
     int             frame_to_start;     // declare eof when we hit this frame
-    int64_t         pts_to_start;       // drop frames until  we pass this pts 
+    int64_t         pts_to_start;       // drop frames until  we pass this pts
                                         //  in the time-linearized input stream
     int             frame_to_stop;      // declare eof when we hit this frame
     int64_t         pts_to_stop;        // declare eof when we pass this pts in
@@ -912,7 +912,7 @@ struct hb_chapter_s
 
 /*
  * A subtitle track.
- * 
+ *
  * Required fields when a demuxer creates a subtitle track are:
  * > id
  *     - ID of this track
@@ -927,7 +927,7 @@ struct hb_chapter_s
  * > source
  *     - used to create the appropriate subtitle decoder work-object in do_job()
  * > config.dest
- *     - whether to render the subtitle on the video track (RENDERSUB) or 
+ *     - whether to render the subtitle on the video track (RENDERSUB) or
  *       to pass it through its own subtitle track in the output container (PASSTHRUSUB)
  *     - all newly created non-VOBSUB tracks should default to PASSTHRUSUB
  *     - all newly created VOBSUB tracks should default to RENDERSUB, for legacy compatibility
@@ -973,14 +973,14 @@ struct hb_subtitle_s
     char         lang[1024];
     char         iso639_2[4];
     uint32_t     attributes; /* Closed Caption, Childrens, Directors etc */
-    
+
     // Color lookup table for VOB subtitle tracks. Each entry is in YCbCr format.
     // Must be filled out by the demuxer for VOB subtitle tracks.
     uint32_t    palette[16];
     uint8_t     palette_set;
     int         width;
     int         height;
-    
+
     // Codec private data for subtitles originating from FFMPEG sources
     uint8_t *   extradata;
     int         extradata_size;
@@ -1005,7 +1005,7 @@ struct hb_subtitle_s
 
 /*
  * An attachment.
- * 
+ *
  * These are usually used for attaching embedded fonts to movies containing SSA subtitles.
  */
 struct hb_attachment_s
@@ -1029,7 +1029,7 @@ struct hb_coverart_s
     } type;
 };
 
-struct hb_metadata_s 
+struct hb_metadata_s
 {
     char  *name;
     char  *artist;          // Actors
@@ -1217,7 +1217,7 @@ struct hb_work_object_s
      * decode (it can be called even if init & work haven't been).
      * currently it's only called for audio streams & can be null for
      * other work objects. */
-    int              (* bsinfo)  ( hb_work_object_t *, const hb_buffer_t *, 
+    int              (* bsinfo)  ( hb_work_object_t *, const hb_buffer_t *,
                                    hb_work_info_t * );
     void             (* flush)   ( hb_work_object_t * );
 

--- a/libhb/handbrake/decomb.h
+++ b/libhb/handbrake/decomb.h
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #ifndef HANDBRAKE_DECOMB_H
 #define HANDBRAKE_DECOMB_H
 

--- a/libhb/handbrake/eedi2.h
+++ b/libhb/handbrake/eedi2.h
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #ifndef HANDBRAKE_EEDI2_H
 #define HANDBRAKE_EEDI2_H
 
@@ -46,7 +46,7 @@ void eedi2_erode_edge_mask( uint8_t *mskp, int msk_pitch, uint8_t *dstp, int dst
 // If none of the 6 horizontally adjacent pixels are masked,
 // don't consider the current pixel masked. If there are any
 // masked on both sides, consider the current pixel masked.
-void eedi2_remove_small_gaps( uint8_t * mskp, int msk_pitch, uint8_t * dstp, int dst_pitch, 
+void eedi2_remove_small_gaps( uint8_t * mskp, int msk_pitch, uint8_t * dstp, int dst_pitch,
                               int height, int width );
 
 // Spatial vectors. Looks at maximum_search_distance surrounding pixels
@@ -85,10 +85,10 @@ void eedi2_post_process( uint8_t * nmskp, int nmsk_pitch, uint8_t * omskp, int o
 
 void eedi2_gaussian_blur1( uint8_t * src, int src_pitch, uint8_t * tmp, int tmp_pitch, uint8_t * dst,
                            int dst_pitch, int height, int width );
-                           
+
 void eedi2_gaussian_blur_sqrt2( int *src, int *tmp, int *dst, const int pitch,
                                 const int height, const int width );
-                                
+
 void eedi2_calc_derivatives( uint8_t *srcp, int src_pitch, int height, int width,
                              int *x2, int *y2, int *xy);
 

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -6,7 +6,7 @@
    It may be used under the terms of the GNU General Public License v2.
    For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
  */
- 
+
 #ifndef HANDBRAKE_HANDBRAKE_H
 #define HANDBRAKE_HANDBRAKE_H
 
@@ -67,7 +67,7 @@ hb_title_set_t   * hb_get_title_set( hb_handle_t * );
 int hb_detect_comb( hb_buffer_t * buf, int color_equal, int color_diff, int threshold, int prog_equal, int prog_diff, int prog_threshold );
 
 // JJJ: title->job?
-int           hb_save_preview( hb_handle_t * h, int title, int preview, 
+int           hb_save_preview( hb_handle_t * h, int title, int preview,
                                hb_buffer_t *buf );
 hb_buffer_t * hb_read_preview( hb_handle_t * h, hb_title_t *title,
                                int preview );
@@ -80,7 +80,7 @@ void          hb_set_anamorphic_size2(hb_geometry_t *src_geo,
                                       hb_geometry_t *result);
 void          hb_add_filter_dict( hb_job_t * job, hb_filter_object_t * filter,
                                   const hb_dict_t * settings_in );
-void          hb_add_filter( hb_job_t * job, hb_filter_object_t * filter, 
+void          hb_add_filter( hb_job_t * job, hb_filter_object_t * filter,
                              const char * settings );
 void          hb_add_filter2( hb_value_array_t * list, hb_dict_t * filter );
 
@@ -115,7 +115,7 @@ typedef struct hb_interjob_s
     hb_subtitle_t *select_subtitle; /* foreign language scan subtitle */
 } hb_interjob_t;
 
-hb_interjob_t * hb_interjob_get( hb_handle_t * ); 
+hb_interjob_t * hb_interjob_get( hb_handle_t * );
 
 /* hb_get_state()
    Should be regularly called by the UI (like 5 or 10 times a second).

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -27,7 +27,7 @@ extern int global_verbosity_level; // Global variable for hb_deep_log
 typedef enum hb_debug_level_s
 {
     HB_SUPPORT_LOG      = 1, // helpful in tech support
-    HB_HOUSEKEEPING_LOG = 2, // stuff we hate scrolling through  
+    HB_HOUSEKEEPING_LOG = 2, // stuff we hate scrolling through
     HB_GRANULAR_LOG     = 3  // sample-by-sample
 } hb_debug_level_t;
 void hb_valog( hb_debug_level_t level, const char * prefix, const char * log, va_list args) HB_WPRINTF(3,0);
@@ -58,7 +58,7 @@ void hb_job_setup_passes(hb_handle_t *h, hb_job_t *job, hb_list_t *list_pass);
 
 /*
  * Holds a packet of data that is moving through the transcoding process.
- * 
+ *
  * May have metadata associated with it via extra fields
  * that are conditionally used depending on the type of packet.
  */
@@ -74,7 +74,7 @@ struct hb_buffer_settings_s
     int64_t       stop;         // stop time of frame
     int64_t       renderOffset; // DTS used by b-frame offsets in muxmp4
     int64_t       pcr;
-    int           scr_sequence; // The SCR sequence that this buffer's 
+    int           scr_sequence; // The SCR sequence that this buffer's
                                 // timestamps are referenced to
     int           split;
     uint8_t       discontinuity;
@@ -271,9 +271,9 @@ static inline hb_buffer_t * hb_video_buffer_init( int width, int height )
 /***********************************************************************
  * Threads: scan.c, work.c, reader.c, muxcommon.c
  **********************************************************************/
-hb_thread_t * hb_scan_init( hb_handle_t *, volatile int * die, 
-                            const char * path, int title_index, 
-                            hb_title_set_t * title_set, int preview_count, 
+hb_thread_t * hb_scan_init( hb_handle_t *, volatile int * die,
+                            const char * path, int title_index,
+                            hb_title_set_t * title_set, int preview_count,
                             int store_previews, uint64_t min_duration );
 hb_thread_t * hb_work_init( hb_list_t * jobs,
                             volatile int * die, hb_error_code * error, hb_job_t ** job );

--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -16,7 +16,7 @@ int            hb_vce_h265_available();
 static const char * const hb_vce_h264_profile_names[] = { "baseline", "main", "high",  NULL, };
 static const char * const hb_vce_h265_profile_names[] = { "main", NULL, };
 
-static const char * const hb_vce_h264_level_names[] = 
+static const char * const hb_vce_h264_level_names[] =
 {
     "auto", "1.0", "1.1", "1.2", "1.3", "2.0", "2.1", "2.2", "3.0",
     "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2",  NULL,

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1685,7 +1685,7 @@ int hb_global_init()
     }
 
 #if HB_PROJECT_FEATURE_QSV
-    if (!disable_hardware) 
+    if (!disable_hardware)
     {
         result = hb_qsv_info_init();
         if (result < 0)
@@ -1730,7 +1730,7 @@ int hb_global_init()
     hb_register(&hb_encx265);
 #endif
 #if HB_PROJECT_FEATURE_QSV
-    if (!disable_hardware) 
+    if (!disable_hardware)
     {
         hb_register(&hb_encqsv);
     }

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1146,9 +1146,9 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
         hb_error("hb_dict_to_job: failed to parse dict: %s", error.text);
         goto fail;
     }
-    
+
     // Make sure QSV Decode is only True if the hardware is available.
-    job->qsv.decode = job->qsv.decode && hb_qsv_available(); 
+    job->qsv.decode = job->qsv.decode && hb_qsv_available();
 
     // Lookup mux id
     if (hb_value_type(mux) == HB_VALUE_TYPE_STRING)

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -1158,7 +1158,7 @@ static int add_chapter(hb_mux_object_t *m, int64_t start, int64_t end, char * ti
     chap->id = nchap;
     chap->time_base = m->time_base;
     // libav does not currently have a good way to deal with chapters and
-    // delayed stream timestamps.  It makes no corrections to the chapter 
+    // delayed stream timestamps.  It makes no corrections to the chapter
     // track.  A patch to libav would touch a lot of things, so for now,
     // work around the issue here.
     chap->start = start;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -13,7 +13,7 @@
 #if HB_PROJECT_FEATURE_NVENC
 #include <ffnvcodec/nvEncodeAPI.h>
 #include <ffnvcodec/dynlink_loader.h>
-#endif 
+#endif
 
 int hb_check_nvenc_available();
 
@@ -23,7 +23,7 @@ int hb_nvenc_h264_available()
         return hb_check_nvenc_available();
     #else
         return 0;
-    #endif 
+    #endif
 }
 
 int hb_nvenc_h265_available()
@@ -32,21 +32,21 @@ int hb_nvenc_h265_available()
         return hb_check_nvenc_available();
     #else
         return 0;
-    #endif 
+    #endif
 }
 
 static int isAvailable = -1;
-int hb_check_nvenc_available() 
+int hb_check_nvenc_available()
 {
     if (is_hardware_disabled())
     {
         return 0;
-    } 
-    
+    }
+
     if (isAvailable != -1){
         return isAvailable;
     }
-    
+
     #if HB_PROJECT_FEATURE_NVENC
         uint32_t nvenc_ver;
         void *context = NULL;
@@ -57,14 +57,14 @@ int hb_check_nvenc_available()
             isAvailable = 0;
             return 0;
         }
-  
+
         NVENCSTATUS apiErr = nvenc_dl->NvEncodeAPIGetMaxSupportedVersion(&nvenc_ver);
         if (apiErr != NV_ENC_SUCCESS)
         {
             isAvailable = 0;
             return 0;
         }
-        
+
         hb_log("Nvenc version %d.%d\n", nvenc_ver >> 4, nvenc_ver & 0xf);
         if ((NVENCAPI_MAJOR_VERSION << 4 | NVENCAPI_MINOR_VERSION) > nvenc_ver) {
             hb_log("NVENC version not supported. Disabling feature.");
@@ -76,5 +76,5 @@ int hb_check_nvenc_available()
         return 1;
     #else
         return 0;
-    #endif 
+    #endif
 }

--- a/libhb/platform/macosx/config.m
+++ b/libhb/platform/macosx/config.m
@@ -6,7 +6,7 @@ static NSURL * macOS_last_modified_url(NSURL *url1, NSURL* url2)
 
     NSURL *presetsUrl1 = [url1 URLByAppendingPathComponent:presetFile isDirectory:NO];
     NSURL *presetsUrl2 = [url2 URLByAppendingPathComponent:presetFile isDirectory:NO];
-    
+
     NSDate *date1 = nil;
     [presetsUrl1 getResourceValue:&date1 forKey:NSURLAttributeModificationDateKey error:nil];
 

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1357,7 +1357,7 @@ void hb_system_sleep_private_disable(void *opaque)
         hb_error("hb_system_sleep: opaque is NULL");
         return;
     }
-    
+
     IOPMAssertionID *assertionID = (IOPMAssertionID*)opaque;
     if (*assertionID != -1)
     {

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1853,7 +1853,7 @@ int hb_preset_apply_title(hb_handle_t *h, int title_index,
     hb_title_t *title = hb_find_title_by_index(h, title_index);
     if (title == NULL)
         return -1;
-   
+
     int chapters = hb_value_get_bool(hb_dict_get(preset, "ChapterMarkers"));
     if (hb_list_count(title->list_chapter) <= 1)
         chapters = 0;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -161,8 +161,8 @@ int hb_qsv_available()
     if (is_hardware_disabled())
     {
         return 0;
-    } 
-    
+    }
+
     return ((hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0) |
             (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0) |
             (hb_qsv_video_encoder_is_enabled(HB_VCODEC_QSV_H265_10BIT) ? HB_VCODEC_QSV_H265_10BIT : 0));
@@ -1669,7 +1669,7 @@ int hb_qsv_profile_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, const char 
         param->videoParam->mfx.CodecProfile = profile->value;
     }
     /* HEVC 10 bits defautls to Main 10 */
-    else if (((profile_key != NULL && !strcasecmp(profile_key, "auto")) || profile_key == NULL) && 
+    else if (((profile_key != NULL && !strcasecmp(profile_key, "auto")) || profile_key == NULL) &&
               codec == HB_VCODEC_QSV_H265_10BIT &&
               param->videoParam->mfx.CodecId == MFX_CODEC_HEVC &&
               qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G6)

--- a/libhb/qsv_filter.c
+++ b/libhb/qsv_filter.c
@@ -183,7 +183,7 @@ static int filter_init( hb_qsv_context* qsv, hb_filter_private_t * pv ){
         pv->CropY += pv->crop[0];
         pv->CropW -= pv->crop[2] + pv->crop[3];
         pv->CropH -= pv->crop[0] + pv->crop[1];
-        
+
 
         qsv_vpp->m_mfxVideoParam.vpp.In.FourCC          = qsv->dec_space->m_mfxVideoParam.mfx.FrameInfo.FourCC;
         qsv_vpp->m_mfxVideoParam.vpp.In.ChromaFormat    = qsv->dec_space->m_mfxVideoParam.mfx.FrameInfo.ChromaFormat;
@@ -608,7 +608,7 @@ static int hb_qsv_filter_work( hb_filter_object_t * filter,
         *buf_in = NULL;
         return HB_FILTER_OK;
     }
-    
+
     hb_qsv_context* qsv = pv->job->qsv.ctx;
 
     while(1)

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -452,7 +452,7 @@ static uint8_t ssaAlpha( ASS_Image *frame, int x, int y )
     return (uint8_t)alpha;
 }
 
-// Returns a subtitle rendered to a YUVA420P frame 
+// Returns a subtitle rendered to a YUVA420P frame
 static hb_buffer_t * RenderSSAFrame( hb_filter_private_t * pv, ASS_Image * frame )
 {
     hb_buffer_t *sub;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1319,19 +1319,19 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_buffer_t * b)
     if (audio->config.lang.attributes & HB_AUDIO_ATTR_VISUALLY_IMPAIRED)
     {
         strncat(audio->config.lang.description, " (Visually Impaired)",
-                sizeof(audio->config.lang.description) - 
+                sizeof(audio->config.lang.description) -
                 strlen(audio->config.lang.description) - 1);
     }
     if (audio->config.lang.attributes & HB_AUDIO_ATTR_COMMENTARY)
     {
         strncat(audio->config.lang.description, " (Director's Commentary 1)",
-                sizeof(audio->config.lang.description) - 
+                sizeof(audio->config.lang.description) -
                 strlen(audio->config.lang.description) - 1);
     }
     if (audio->config.lang.attributes & HB_AUDIO_ATTR_ALT_COMMENTARY)
     {
         strncat(audio->config.lang.description, " (Director's Commentary 2)",
-                sizeof(audio->config.lang.description) - 
+                sizeof(audio->config.lang.description) -
                 strlen(audio->config.lang.description) - 1);
     }
 
@@ -1380,11 +1380,11 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_buffer_t * b)
 
     // Append input bitrate in kbps to the end of the description if greater than 1
     // ffmpeg may report some audio bitrates as 1, not an issue
-    if (audio->config.in.bitrate > 1) 
+    if (audio->config.in.bitrate > 1)
     {
         char in_bitrate_str[19];
         snprintf(in_bitrate_str, 18, " (%d kbps)", audio->config.in.bitrate / 1000);
-        strncat(audio->config.lang.description, in_bitrate_str, 
+        strncat(audio->config.lang.description, in_bitrate_str,
                 sizeof(audio->config.lang.description) - strlen(audio->config.lang.description) - 1);
     }
 

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -1757,7 +1757,7 @@ int hb_stream_seek_chapter( hb_stream_t * stream, int chapter_num )
     {
         return 0;
     }
-    
+
     if ( stream->hb_stream_type != ffmpeg )
     {
         // currently meaningless for transport and program streams

--- a/libhb/taskset.c
+++ b/libhb/taskset.c
@@ -78,7 +78,7 @@ taskset_init( taskset_t *ts, int thread_count, size_t arg_size )
     memset(ts->task_begin_bitmap, 0xFF, sizeof( uint32_t ) * ts->bitmap_elements );
     memset(ts->task_complete_bitmap, 0xFF, sizeof( uint32_t ) * ts->bitmap_elements );
     memset(ts->task_stop_bitmap, 0, sizeof( uint32_t ) * ts->bitmap_elements );
-    
+
     /*
      * Important to start off with the threads locked waiting
      * on input, no work completed, and not asked to stop.

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -144,7 +144,7 @@ static void unsharp(const uint8_t *src,
             {
                 const uint8_t * srx = src - steps * stride + x - steps;
                 uint8_t       * dsx = dst - steps * stride + x - steps;
-        
+
                 res = (int32_t)*srx + ((((int32_t)*srx -
                      (int32_t)((Tmp1 + halfscale) >> scalebits)) * amount) >> 16);
                 *dsx = res > 255 ? 255 : res < 0 ? 0 : (uint8_t)res;

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -125,8 +125,8 @@ int hb_vce_h264_available()
     if (is_hardware_disabled())
     {
         return 0;
-    } 
-    
+    }
+
     return (check_component_available(AMFVideoEncoderVCE_AVC) == AMF_OK) ? 1 : 0;
 }
 
@@ -135,8 +135,8 @@ int hb_vce_h265_available()
     if (is_hardware_disabled())
     {
         return 0;
-    } 
-    
+    }
+
     return (check_component_available(AMFVideoEncoder_HEVC) == AMF_OK) ? 1 : 0;
 }
 

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -170,7 +170,7 @@ static void work_func( void * _work )
         // TODO: Fix this ugly hack!
         hb_force_rescan(h);
     }
-    
+
     t = time(NULL);
     hb_log("Finished work at: %s", asctime(localtime(&t)));
     free( work );
@@ -1435,7 +1435,7 @@ static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
             hb_log("Skipping vfr filter");
         }
     }
-    
+
     filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
     if (filter != NULL)
     {
@@ -1449,7 +1449,7 @@ static void sanitize_filter_list(hb_list_t *list, hb_geometry_t src_geo)
             bottom = hb_dict_get_int(settings, "crop-bottom");
             left = hb_dict_get_int(settings, "crop-left");
             right = hb_dict_get_int(settings, "crop-right");
-            
+
             if ( (src_geo.width == width) && (src_geo.height == height) &&
                 (top == 0) && (bottom == 0 ) && (left == 0) && (right == 0) )
             {
@@ -1499,12 +1499,12 @@ static void do_job(hb_job_t *job)
     if (job->indepth_scan)
     {
         hb_log( "Starting Task: Subtitle Scan" );
-    } 
-    else if (job->pass_id == HB_PASS_ENCODE_1ST) 
+    }
+    else if (job->pass_id == HB_PASS_ENCODE_1ST)
     {
         hb_log( "Starting Task: Analysis Pass" );
-    } 
-    else 
+    }
+    else
     {
         hb_log( "Starting Task: Encoding Pass" );
     }

--- a/macosx/HBAVPlayer.m
+++ b/macosx/HBAVPlayer.m
@@ -74,7 +74,7 @@ typedef void (^HBPlayableObverser)(void);
 
         }];
     }
-    
+
     return self;
 }
 

--- a/macosx/HBApplication.m
+++ b/macosx/HBApplication.m
@@ -26,7 +26,7 @@ static void CrashMyApplication()
         [result appendAttributedString:attrS];
     }
     [result addAttribute:NSFontAttributeName value:[NSFont fontWithName:@"Monaco" size:10] range:NSMakeRange(0, result.length)];
-    return result;    
+    return result;
 }
 
 - (void)reportException:(NSException *)exception
@@ -58,7 +58,7 @@ static void CrashMyApplication()
     @catch (NSException *e)
     {
         // Suppress any exceptions raised in the handling
-    }    
+    }
 }
 
 @end

--- a/macosx/HBAudioDefaults.m
+++ b/macosx/HBAudioDefaults.m
@@ -430,7 +430,7 @@
         copy->_container = _container;
         copy->_secondaryEncoderMode = _secondaryEncoderMode;
     }
-    
+
     return copy;
 }
 

--- a/macosx/HBChapterTitlesController.m
+++ b/macosx/HBChapterTitlesController.m
@@ -3,7 +3,7 @@
    This file is part of the HandBrake source code.
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License. */
-   
+
 #import "HBChapterTitlesController.h"
 #import "HBPreferencesKeys.h"
 @import HandBrakeKit;

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -332,7 +332,7 @@ typedef void (^HBCoreCleanupHandler)(void);
 }
 
 #pragma mark - Preview images
-        
+
 - (CGImageRef)copyImageAtIndex:(NSUInteger)index
                       forTitle:(HBTitle *)title
                   pictureFrame:(HBPicture *)frame

--- a/macosx/HBDVDDetector.h
+++ b/macosx/HBDVDDetector.h
@@ -1,7 +1,7 @@
  /**
  * HBDVDDetector.h
  * 8/17/2007
- * 
+ *
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License.

--- a/macosx/HBDVDDetector.m
+++ b/macosx/HBDVDDetector.m
@@ -1,7 +1,7 @@
 /**
  * HBDriveDetector.m
  * 8/17/2007
- * 
+ *
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License.
@@ -36,7 +36,7 @@
 - (HBDVDDetector *)initWithPath: (NSString *)aPath
 {
     NSAssert(aPath, @"nil string passed to drive detector.");
-	if( self = [super init] )	
+	if( self = [super init] )
 	{
         path = aPath;
         bsdName = nil;
@@ -159,12 +159,12 @@
 - (BOOL)isService: (io_service_t)service class:(const io_name_t)class
 {
     // Find the IOMedia object that represents the entire (whole) media that the
-    // volume is on. 
+    // volume is on.
     //
     // If the volume is on partitioned media, the whole media object will be a
     // parent of the volume's media object. If the media is not partitioned, the
     // volume's media object will be the whole media object.
-    // 
+    //
     // The whole media object is indicated in the IORegistry by the presence of
     // a property with the key "Whole" and value "Yes".
 
@@ -208,15 +208,15 @@
     // Determine if the object passed in represents an IOMedia (or subclass) object.
     // If it does, test the "Whole" property.
     //
-    
+
     Boolean isWholeMedia = NO;
-    
+
     if( IOObjectConformsTo(service, kIOMediaClass) )
     {
         CFTypeRef wholeMedia;
-        wholeMedia = IORegistryEntryCreateCFProperty( service, 
-                                                      CFSTR(kIOMediaWholeKey), 
-                                                      kCFAllocatorDefault, 
+        wholeMedia = IORegistryEntryCreateCFProperty( service,
+                                                      CFSTR(kIOMediaWholeKey),
+                                                      kCFAllocatorDefault,
                                                       0);
         if( !wholeMedia )
         {

--- a/macosx/HBDockTextField.h
+++ b/macosx/HBDockTextField.h
@@ -1,5 +1,5 @@
 /*  HBDockTextField.h $
- 
+
  This file is part of the HandBrake source code.
  Homepage: <http://handbrake.fr/>.
  It may be used under the terms of the GNU General Public License. */

--- a/macosx/HBDockTextField.m
+++ b/macosx/HBDockTextField.m
@@ -1,5 +1,5 @@
 /*  HBDockTextField.m $
- 
+
  This file is part of the HandBrake source code.
  Homepage: <http://handbrake.fr/>.
  It may be used under the terms of the GNU General Public License. */
@@ -30,7 +30,7 @@
         _smallTextAttributes = [self textAttributesWithFontSize:DOCK_TEXTFIELD_FONTSIZE - 2];
         [self changeGradientColors:[NSColor grayColor] endColor:[NSColor blackColor]];
     }
-    
+
     return self;
 }
 

--- a/macosx/HBExceptionAlertController.m
+++ b/macosx/HBExceptionAlertController.m
@@ -3,7 +3,7 @@
  This file is part of the HandBrake source code.
  Homepage: <http://handbrake.fr/>.
  It may be used under the terms of the GNU General Public License. */
- 
+
 #import "HBExceptionAlertController.h"
 
 @implementation HBExceptionAlertController

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -535,7 +535,7 @@
     filter = hb_filter_init(HB_FILTER_VFR);
     hb_add_filter(job, filter, [[NSString stringWithFormat:@"mode=%d:rate=%d/%d",
                                  fps_mode, fps_num, fps_den] UTF8String]);
-    
+
     return job;
 }
 

--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -528,7 +528,7 @@ static HBMixdownTransformer    *mixdownTransformer;
         [attrString appendString:lavcInfo   withAttributes:detailAttr];
         [attrString appendString:@"\n"      withAttributes:detailAttr];
     }
-    
+
     return attrString;
 }
 

--- a/macosx/HBLanguagesSelection.m
+++ b/macosx/HBLanguagesSelection.m
@@ -84,7 +84,7 @@
             {
                 [internal addObject:item];
             }
-            
+
         }
 
         // Insert the selected items
@@ -198,7 +198,7 @@ NSString *kHBLanguagesDragRowsType = @"kHBLanguagesDragRowsType";
         [pboard declareTypes:@[kHBLanguagesDragRowsType] owner:self];
         [pboard setData:data forType:kHBLanguagesDragRowsType];
     }
-    
+
     return self.isDragginEnabled;
 }
 

--- a/macosx/HBOutputPanelController.m
+++ b/macosx/HBOutputPanelController.m
@@ -105,7 +105,7 @@
     NSAttributedString *attributedString = [[NSAttributedString alloc] initWithString:text attributes:_textAttributes];
 	// Actually write the libhb output to the text view (outputTextStorage)
     [_outputTextStorage appendAttributedString:attributedString];
-    
+
 	// remove text from outputTextStorage as defined by TextStorageUpperSizeLimit and TextStorageLowerSizeLimit */
     if (_outputTextStorage.length > TextStorageUpperSizeLimit)
     {

--- a/macosx/HBOutputRedirect.m
+++ b/macosx/HBOutputRedirect.m
@@ -103,7 +103,7 @@ int	stderrwrite(void *inFD, const char *buffer, int size)
 /**
  * Starts redirecting the stream by redirecting its output to function
  * @c stdoutwrite() or @c stderrwrite(). Old _write function is stored to
- * @c oldWriteFunc so it can be restored. 
+ * @c oldWriteFunc so it can be restored.
  */
 - (void)startRedirect
 {

--- a/macosx/HBPreset.m
+++ b/macosx/HBPreset.m
@@ -215,7 +215,7 @@
 
     return [NSError errorWithDomain:@"HBPresetDomain" code:2 userInfo:@{NSLocalizedDescriptionKey: description,
                                                                         NSLocalizedRecoverySuggestionErrorKey: reason}];
-    
+
 }
 
 /**

--- a/macosx/HBPresetsManager.h
+++ b/macosx/HBPresetsManager.h
@@ -1,5 +1,5 @@
 /*  HBPresetsManager.h $
- 
+
  This file is part of the HandBrake source code.
  Homepage: <http://handbrake.fr/>.
  It may be used under the terms of the GNU General Public License. */

--- a/macosx/HBPresetsManager.m
+++ b/macosx/HBPresetsManager.m
@@ -1,5 +1,5 @@
 /*  HBPresets.m $
- 
+
  This file is part of the HandBrake source code.
  Homepage: <http://handbrake.fr/>.
  It may be used under the terms of the GNU General Public License. */

--- a/macosx/HBPreviewController.m
+++ b/macosx/HBPreviewController.m
@@ -169,7 +169,7 @@
     }
 
     [self switchStateToHUD:self.pictureHUD];
-    
+
     if (generator)
     {
         [self resizeToOptimalSize];
@@ -346,7 +346,7 @@
     {
         controller.view.hidden = YES;
     }
-    
+
     if (self.generator)
     {
         hud.view.hidden = NO;

--- a/macosx/HBPreviewView.m
+++ b/macosx/HBPreviewView.m
@@ -130,7 +130,7 @@
         NSSize imageSize = NSMakeSize(CGImageGetWidth(self.image), CGImageGetHeight(self.image));
         CGFloat backingScaleFactor = self.window.backingScaleFactor;
         CGFloat borderSize = self.showBorder ? BORDER_SIZE : 0;
-        
+
         NSSize imageScaledSize = [self imageScaledSize:imageSize toFit:self.frame.size borderSize:borderSize scaleFactor:self.window.backingScaleFactor];
 
         return (imageScaledSize.width - borderSize * 2) / imageSize.width * backingScaleFactor;
@@ -175,16 +175,16 @@
     // with double pixel count, but we don't
     // want to double the size of the video
     NSSize scaledSource = NSMakeSize(source.width / scaleFactor, source.height / scaleFactor);
-    
+
     scaledSource.width += borderSize * 2;
     scaledSource.height += borderSize * 2;
-        
+
     if (self.fitToView == YES || scaledSource.width > destination.width || scaledSource.height > destination.height)
     {
         // If the image is larger then the view or if we are in Fit to View mode, scale the image
         scaledSource = [self scaledSize:source toFit:destination];
     }
-    
+
     return scaledSource;
 }
 
@@ -197,12 +197,12 @@
     {
         CGFloat borderSize = self.showBorder ? BORDER_SIZE : 0;
         NSSize frameSize = self.frame.size;
-        
+
         NSSize imageScaledSize = [self imageScaledSize:imageSize
                                                  toFit:frameSize
                                             borderSize:borderSize
                                            scaleFactor:self.window.backingScaleFactor];
-        
+
         [CATransaction begin];
         CATransaction.disableActions = YES;
 
@@ -216,7 +216,7 @@
 
         self.backLayer.frame = alignedRect;
         self.pictureLayer.frame = NSInsetRect(alignedRect, borderSize, borderSize);
-        
+
         [CATransaction commit];
     }
 }

--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -768,7 +768,7 @@ NSString * const HBQueueItemNotificationPathKey = @"HBQueueItemNotificationPathK
             [firstChild.view removeFromSuperviewWithoutNeedingDisplay];
             [firstChild removeFromParentViewController];
         }
-        
+
         [self.containerViewController addChildViewController:viewController];
         viewController.view.frame = self.containerViewController.view.bounds;
         viewController.view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;

--- a/macosx/HBRange.m
+++ b/macosx/HBRange.m
@@ -216,7 +216,7 @@ NSString *HBRangeChangedNotification = @"HBRangeChangedNotification";
 
     decodeInt(_frameStart);
     decodeInt(_frameStop);
-    
+
     return self;
 
 fail:

--- a/macosx/HBThumbnailItemView.h
+++ b/macosx/HBThumbnailItemView.h
@@ -1,7 +1,7 @@
 /*
  Copyright (C) 2017 Apple Inc. All Rights Reserved.
  See LICENSE.txt for this sample’s licensing information
- 
+
  Abstract:
  Custom NSScrubberItemView used to display an image.
  */

--- a/macosx/HBThumbnailItemView.m
+++ b/macosx/HBThumbnailItemView.m
@@ -1,7 +1,7 @@
 /*
  Copyright (C) 2017 Apple Inc. All Rights Reserved.
  See LICENSE.txt for this sample’s licensing information
- 
+
  Abstract:
  Custom NSScrubberItemView used to display an image.
  */
@@ -31,7 +31,7 @@
 
         [self addSubview:_imageView];
     }
-    
+
     return self;
 }
 

--- a/macosx/HBTitle.m
+++ b/macosx/HBTitle.m
@@ -437,7 +437,7 @@ fail:
 
         _subtitlesTracks = [tracks copy];
     }
-    
+
     return _subtitlesTracks;
 }
 

--- a/macosx/HBVideo+UIAdditions.m
+++ b/macosx/HBVideo+UIAdditions.m
@@ -208,7 +208,7 @@
     {
         tmpString = @"";
     }
-    
+
     return tmpString;
 }
 

--- a/macosx/HandBrakeKitTests/HBDictTests.m
+++ b/macosx/HandBrakeKitTests/HBDictTests.m
@@ -1,5 +1,5 @@
 /*  HBDictTests.m
- 
+
 This file is part of the HandBrake source code.
 Homepage: <http://handbrake.fr/>.
 It may be used under the terms of the GNU General Public License. */

--- a/macosx/HandBrakeXPCService/main.m
+++ b/macosx/HandBrakeXPCService/main.m
@@ -21,7 +21,7 @@
     newConnection.exportedObject = exportedObject;
 
     [newConnection resume];
-    
+
     return YES;
 }
 
@@ -32,10 +32,10 @@ int main(int argc, const char *argv[])
     HBUtilities.resolveBookmarks = NO;
 
     HBXPCServiceDelegate *delegate = [HBXPCServiceDelegate new];
-    
+
     NSXPCListener *listener = [NSXPCListener serviceListener];
     listener.delegate = delegate;
-    
+
     [listener resume];
 
     return 0;

--- a/macosx/NSWindow+HBAdditions.m
+++ b/macosx/NSWindow+HBAdditions.m
@@ -45,7 +45,7 @@
     // sure that upon resize we do not have the window off the screen
     // So check the origin against the screen origin and adjust if
     // necessary.
-    
+
     if (center.x == 0 && center.y == 0)
     {
         center = [self HB_centerPoint];
@@ -69,7 +69,7 @@
             // the right side of the preview is off the screen, so shift to the left
             frame.origin.x = (screenOrigin.x + screenSize.width) - frame.size.width;
         }
-        
+
         // our origin is off the screen to the bottom
         if (frame.origin.y < screenOrigin.y)
         {

--- a/test/test.c
+++ b/test/test.c
@@ -509,7 +509,7 @@ int main( int argc, char ** argv )
     hb_register_error_handler(&hb_cli_error_handler);
 
     hb_dvd_set_dvdnav( dvdnav );
-    
+
     /* Show version */
     fprintf( stderr, "%s - %s - %s\n",
              HB_PROJECT_TITLE, HB_PROJECT_HOST_TITLE, HB_PROJECT_URL_WEBSITE );
@@ -1994,7 +1994,7 @@ static char** str_width_split( const char *str, int width )
     count++;
     ret = calloc( ( count + 1 ), sizeof(char*) );
     if ( ret == NULL ) return ret;
-    
+
     pos = str;
     end = pos + width;
     for (ii = 0; ii < count - 1 && end < str + len; ii++)


### PR DESCRIPTION
Remove trailing whitespace in foo.c, foo.m, foo.h and foo.cpp files.

I couldn't stop myself to clean up trailing whitespace in all C/C++ files. ☺️ The following command helped me for doing so:
`$ find . -type f \( -name "*.c" -o -name "*.m" -o -name "*.h" -o -name "*.cpp" \) -exec perl -p -i -e "s/[ \t]*$//g" "{}" \; `
