### PR TITLE
x265: Fix limit-tu bug in loading co-located CU's TU depth

### DIFF
--- a/contrib/x265/A01-limit-tu_fix.patch
+++ b/contrib/x265/A01-limit-tu_fix.patch
@@ -1,0 +1,26 @@
+# HG changeset patch
+# User Aruna Matheswaran <aruna@multicorewareinc.com>
+# Date 1573207250 -19800
+# Branch Release_3.2
+# Node ID 09f3b1d9349ac84d74f14f99297f9418bc8b2b02
+# Parent  b5c86a64bbbede216b25092def72272ecde5523a
+limit-tu: Fix bug in loading co-located CU's TU depth
+
+diff --git a/source/encoder/analysis.cpp b/source/encoder/analysis.cpp
+--- a/source/encoder/analysis.cpp
++++ b/source/encoder/analysis.cpp
+@@ -375,12 +375,12 @@
+     CUData* neighbourCU;
+     uint8_t count = 0;
+     int32_t maxTUDepth = -1;
+-    neighbourCU = m_slice->m_refFrameList[0][0]->m_encData->m_picCTU;
++    neighbourCU = &m_slice->m_refFrameList[0][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+     predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+     count++;
+     if (m_slice->isInterB())
+     {
+-        neighbourCU = m_slice->m_refFrameList[1][0]->m_encData->m_picCTU;
++        neighbourCU = &m_slice->m_refFrameList[1][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+         predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+         count++;
+     }

--- a/contrib/x265/A02-2pass_fix.patch
+++ b/contrib/x265/A02-2pass_fix.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Niranjan <niranjan@multicorewareinc.com>
+# Date 1574665937 -19800
+# Node ID f0fe46ce379dbdf21ee255146796dbf5c4e02ac7
+# Parent  4a29e0c5bfaf30aaed2c5224bcba1f464d68de83
+Fix pass 2 encode failure (Issue #524)
+
+diff --git a/source/encoder/ratecontrol.cpp b/source/encoder/ratecontrol.cpp
+--- a/source/encoder/ratecontrol.cpp
++++ b/source/encoder/ratecontrol.cpp
+@@ -53,7 +53,7 @@
+ {\
+     bErr = 0;\
+     p = strstr(opts, opt "=");\
+-    char* q = strstr(opts, "no-" opt);\
++    char* q = strstr(opts, "no-" opt " ");\
+     if (p && sscanf(p, opt "=%d" , &i) && param_val != i)\
+         bErr = 1;\
+     else if (!param_val && !q && !p)\

--- a/contrib/x265_10bit/A01-limit-tu_fix.patch
+++ b/contrib/x265_10bit/A01-limit-tu_fix.patch
@@ -1,0 +1,26 @@
+# HG changeset patch
+# User Aruna Matheswaran <aruna@multicorewareinc.com>
+# Date 1573207250 -19800
+# Branch Release_3.2
+# Node ID 09f3b1d9349ac84d74f14f99297f9418bc8b2b02
+# Parent  b5c86a64bbbede216b25092def72272ecde5523a
+limit-tu: Fix bug in loading co-located CU's TU depth
+
+diff --git a/source/encoder/analysis.cpp b/source/encoder/analysis.cpp
+--- a/source/encoder/analysis.cpp
++++ b/source/encoder/analysis.cpp
+@@ -375,12 +375,12 @@
+     CUData* neighbourCU;
+     uint8_t count = 0;
+     int32_t maxTUDepth = -1;
+-    neighbourCU = m_slice->m_refFrameList[0][0]->m_encData->m_picCTU;
++    neighbourCU = &m_slice->m_refFrameList[0][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+     predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+     count++;
+     if (m_slice->isInterB())
+     {
+-        neighbourCU = m_slice->m_refFrameList[1][0]->m_encData->m_picCTU;
++        neighbourCU = &m_slice->m_refFrameList[1][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+         predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+         count++;
+     }

--- a/contrib/x265_10bit/A02-2pass_fix.patch
+++ b/contrib/x265_10bit/A02-2pass_fix.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Niranjan <niranjan@multicorewareinc.com>
+# Date 1574665937 -19800
+# Node ID f0fe46ce379dbdf21ee255146796dbf5c4e02ac7
+# Parent  4a29e0c5bfaf30aaed2c5224bcba1f464d68de83
+Fix pass 2 encode failure (Issue #524)
+
+diff --git a/source/encoder/ratecontrol.cpp b/source/encoder/ratecontrol.cpp
+--- a/source/encoder/ratecontrol.cpp
++++ b/source/encoder/ratecontrol.cpp
+@@ -53,7 +53,7 @@
+ {\
+     bErr = 0;\
+     p = strstr(opts, opt "=");\
+-    char* q = strstr(opts, "no-" opt);\
++    char* q = strstr(opts, "no-" opt " ");\
+     if (p && sscanf(p, opt "=%d" , &i) && param_val != i)\
+         bErr = 1;\
+     else if (!param_val && !q && !p)\

--- a/contrib/x265_12bit/A01-limit-tu_fix.patch
+++ b/contrib/x265_12bit/A01-limit-tu_fix.patch
@@ -1,0 +1,26 @@
+# HG changeset patch
+# User Aruna Matheswaran <aruna@multicorewareinc.com>
+# Date 1573207250 -19800
+# Branch Release_3.2
+# Node ID 09f3b1d9349ac84d74f14f99297f9418bc8b2b02
+# Parent  b5c86a64bbbede216b25092def72272ecde5523a
+limit-tu: Fix bug in loading co-located CU's TU depth
+
+diff --git a/source/encoder/analysis.cpp b/source/encoder/analysis.cpp
+--- a/source/encoder/analysis.cpp
++++ b/source/encoder/analysis.cpp
+@@ -375,12 +375,12 @@
+     CUData* neighbourCU;
+     uint8_t count = 0;
+     int32_t maxTUDepth = -1;
+-    neighbourCU = m_slice->m_refFrameList[0][0]->m_encData->m_picCTU;
++    neighbourCU = &m_slice->m_refFrameList[0][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+     predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+     count++;
+     if (m_slice->isInterB())
+     {
+-        neighbourCU = m_slice->m_refFrameList[1][0]->m_encData->m_picCTU;
++        neighbourCU = &m_slice->m_refFrameList[1][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+         predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+         count++;
+     }

--- a/contrib/x265_12bit/A02-2pass_fix.patch
+++ b/contrib/x265_12bit/A02-2pass_fix.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Niranjan <niranjan@multicorewareinc.com>
+# Date 1574665937 -19800
+# Node ID f0fe46ce379dbdf21ee255146796dbf5c4e02ac7
+# Parent  4a29e0c5bfaf30aaed2c5224bcba1f464d68de83
+Fix pass 2 encode failure (Issue #524)
+
+diff --git a/source/encoder/ratecontrol.cpp b/source/encoder/ratecontrol.cpp
+--- a/source/encoder/ratecontrol.cpp
++++ b/source/encoder/ratecontrol.cpp
+@@ -53,7 +53,7 @@
+ {\
+     bErr = 0;\
+     p = strstr(opts, opt "=");\
+-    char* q = strstr(opts, "no-" opt);\
++    char* q = strstr(opts, "no-" opt " ");\
+     if (p && sscanf(p, opt "=%d" , &i) && param_val != i)\
+         bErr = 1;\
+     else if (!param_val && !q && !p)\

--- a/contrib/x265_8bit/A01-limit-tu_fix.patch
+++ b/contrib/x265_8bit/A01-limit-tu_fix.patch
@@ -1,0 +1,26 @@
+# HG changeset patch
+# User Aruna Matheswaran <aruna@multicorewareinc.com>
+# Date 1573207250 -19800
+# Branch Release_3.2
+# Node ID 09f3b1d9349ac84d74f14f99297f9418bc8b2b02
+# Parent  b5c86a64bbbede216b25092def72272ecde5523a
+limit-tu: Fix bug in loading co-located CU's TU depth
+
+diff --git a/source/encoder/analysis.cpp b/source/encoder/analysis.cpp
+--- a/source/encoder/analysis.cpp
++++ b/source/encoder/analysis.cpp
+@@ -375,12 +375,12 @@
+     CUData* neighbourCU;
+     uint8_t count = 0;
+     int32_t maxTUDepth = -1;
+-    neighbourCU = m_slice->m_refFrameList[0][0]->m_encData->m_picCTU;
++    neighbourCU = &m_slice->m_refFrameList[0][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+     predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+     count++;
+     if (m_slice->isInterB())
+     {
+-        neighbourCU = m_slice->m_refFrameList[1][0]->m_encData->m_picCTU;
++        neighbourCU = &m_slice->m_refFrameList[1][0]->m_encData->m_picCTU[parentCTU.m_cuAddr];
+         predDepth += neighbourCU->m_refTuDepth[cuGeom.geomRecurId];
+         count++;
+     }

--- a/contrib/x265_8bit/A02-2pass_fix.patch
+++ b/contrib/x265_8bit/A02-2pass_fix.patch
@@ -1,0 +1,19 @@
+# HG changeset patch
+# User Niranjan <niranjan@multicorewareinc.com>
+# Date 1574665937 -19800
+# Node ID f0fe46ce379dbdf21ee255146796dbf5c4e02ac7
+# Parent  4a29e0c5bfaf30aaed2c5224bcba1f464d68de83
+Fix pass 2 encode failure (Issue #524)
+
+diff --git a/source/encoder/ratecontrol.cpp b/source/encoder/ratecontrol.cpp
+--- a/source/encoder/ratecontrol.cpp
++++ b/source/encoder/ratecontrol.cpp
+@@ -53,7 +53,7 @@
+ {\
+     bErr = 0;\
+     p = strstr(opts, opt "=");\
+-    char* q = strstr(opts, "no-" opt);\
++    char* q = strstr(opts, "no-" opt " ");\
+     if (p && sscanf(p, opt "=%d" , &i) && param_val != i)\
+         bErr = 1;\
+     else if (!param_val && !q && !p)\


### PR DESCRIPTION
There is a bug in x265 3.2.1 implementation of limit-tu. This was fixed today by a commit in x265, which is not included in 3.2.1. So, I added the patch as a file.

See: https://bitbucket.org/multicoreware/x265/commits/branch/Release_3.2
And for the patch: https://bitbucket.org/multicoreware/x265/commits/09f3b1d9349ac84d74f14f99297f9418bc8b2b02

I've tested on Mac.