### PR TITLE
WinGui: Invoke QueueChanged after Import

### DIFF
--- a/win/CS/HandBrakeWPF/Services/Queue/QueueService.cs
+++ b/win/CS/HandBrakeWPF/Services/Queue/QueueService.cs
@@ -197,6 +197,10 @@ namespace HandBrakeWPF.Services.Queue
                 {
                     this.queue.Add(task);
                 }
+                if (reloadedQueue.Count > 0)
+                {
+                    this.InvokeQueueChanged(EventArgs.Empty);
+                }
             }
         }
 


### PR DESCRIPTION
**Description of Change:**

Fixes #2463 

Queue Service was not invoking QueueChanged after adding items to the queue during a JSON import, causing the UI to be out of date. This adds the missing call so that the change will propagate correctly.

**Test on:**

- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**
N/A

**Log file output (If relevant):**
N/A