### PR TITLE
Update ShowHelp() with option to name subtitles

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -1824,6 +1824,8 @@ static void ShowHelp()
 "                           or less is selected. This should locate subtitles\n"
 "                           for short foreign language segments. Best used in\n"
 "                           conjunction with --subtitle-forced.\n"
+"  -S, --subname <string>   Set subtitle track name(s).\n"
+"                           Separate tracks by commas.\n"
 "  -F, --subtitle-forced[=string]\n"
 "                           Only display subtitles from the selected stream\n"
 "                           if the subtitle has the forced flag set. The\n"


### PR DESCRIPTION
The option to name subtitle tracks was added in https://github.com/HandBrake/HandBrake/commit/a1b407bc341c493aa027d526faeb3404e085e8a0 but isn't mentioned in the help.  A similar PR has been proposed to docs.

This change simply prints out the -S/--subname option in the subtitle section, using functionally identical wording to the similar -A/--aname option used to name audio tracks.

I opened https://github.com/HandBrake/HandBrake/issues/2473 per the suggestion to open an issue before submitting a PR.  
