### PR TITLE
Added track number to audio and subtitle scan JSON

### DIFF
--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -391,7 +391,8 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
 
         attributes = hb_audio_attributes_to_dict(audio->config.lang.attributes);
         audio_dict = json_pack_ex(&error, 0,
-        "{s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
+        "{s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
+            "TrackNumber",       hb_value_int(ii + 1),
             "Description",       hb_value_string(audio->config.lang.description),
             "Language",          hb_value_string(audio->config.lang.simple),
             "LanguageCode",      hb_value_string(audio->config.lang.iso639_2),
@@ -429,7 +430,8 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
         format = subtitle->format == PICTURESUB ? "bitmap" : "text";
         attributes = hb_subtitle_attributes_to_dict(subtitle->attributes);
         subtitle_dict = json_pack_ex(&error, 0,
-            "{s:o, s:o, s:o, s:o, s:o, s:o}",
+            "{s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
+            "TrackNumber",  hb_value_int(ii + 1),
             "Format",       hb_value_string(format),
             "Source",       hb_value_int(subtitle->source),
             "SourceName",   hb_value_string(hb_subsource_name(subtitle->source)),


### PR DESCRIPTION
Technically not needed, but makes working with the objects easier. As
long as you have the object, you have the track number needed to put
it into the output.