### PR TITLE
Replace `/` in default path with windows compatible '\'

### DIFF
--- a/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
+++ b/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
@@ -196,7 +196,8 @@ namespace HandBrakeWPF.Helpers
 
         private static string GetAutonamePath(IUserSettingService userSettingService, EncodeTask task, string sourceName)
         {
-            string autoNamePath = userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNamePath).Trim();
+            string autoNamePath = userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNamePath).Trim()
+                .Replace("/", "\\");
 
             // If enabled, use the current Destination path.
             if (!userSettingService.GetUserSetting<bool>(UserSettingConstants.AlwaysUseDefaultPath) && !string.IsNullOrEmpty(task.Destination))
@@ -209,9 +210,9 @@ namespace HandBrakeWPF.Helpers
             }
 
             // Handle {source_path} 
-            if (userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNamePath).Trim().StartsWith("{source_path}") && !string.IsNullOrEmpty(task.Source))
+            if (autoNamePath.StartsWith("{source_path}") && !string.IsNullOrEmpty(task.Source))
             {
-                string savedPath = userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNamePath).Trim().Replace("{source_path}\\", string.Empty).Replace("{source_path}", string.Empty);
+                string savedPath = autoNamePath.Replace("{source_path}\\", string.Empty).Replace("{source_path}", string.Empty);
                 string directory = Directory.Exists(task.Source) ? task.Source : Path.GetDirectoryName(task.Source);
                 autoNamePath = Path.Combine(directory, savedPath);
             }


### PR DESCRIPTION
**Description of Change:**

Windows usually uses a back-slash `\` as path separator. However, many
applications (e.g. the Windows Explorer) also support using
forward-slashes `/` and replace them with `\`.

HandBrake did not do this and as a result, the path was broken when
using e.g. `{source_path}/converted` as "Default Path". (See #2522)

This commit fixes #2522 by replacing `/` with `\` before further
processing the path.

**Test on:**

- [x] Windows 10+  (via MinGW)
- (**N/A**) macOS 10.13+
- (**N/A**) Ubuntu Linux

**Screenshots (If relevant):**

N/A

**Log file output (If relevant):**

N/A
