### PR TITLE
qsv: allow building on FreeBSD

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -65,7 +65,7 @@ FFMPEG.CONFIGURE.extra += \
     --enable-small
 endif
 
-ifeq (1-linux,$(FEATURE.qsv)-$(HOST.system))
+ifneq (,$(filter $(FEATURE.qsv)-$(HOST.system),1-linux 1-freebsd))
     FFMPEG.CONFIGURE.extra += --enable-vaapi
     FFMPEG.CONFIGURE.extra += --disable-xlib
 else

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -237,6 +237,9 @@ case $host in
     ;;
   *-*-freebsd*)
     HB_LIBS="$HB_LIBS -lpthread"
+    if test "x$use_qsv" = "xyes" ; then
+        HB_LIBS="$HB_LIBS -lva -lva-drm"
+    fi
     ;;
   *-*-netbsd*)
     HB_LIBS="$HB_LIBS -pthread"

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -28,7 +28,7 @@
 
 #if HB_PROJECT_FEATURE_QSV
 #include "mfx/mfxstructures.h"
-#ifdef SYS_LINUX
+#if defined(SYS_LINUX) || defined(SYS_FREEBSD)
 #include <va/va_drm.h>
 #endif
 #endif
@@ -36,9 +36,9 @@
 /************************************************************************
  * HW accel display
  ***********************************************************************/
-#ifdef SYS_LINUX
+#if defined(SYS_LINUX) || defined(SYS_FREEBSD)
 extern const char* DRM_INTEL_DRIVER_NAME;
-#endif // SYS_LINUX
+#endif // SYS_LINUX || SYS_FREEBSD
 
 typedef struct
 {
@@ -46,10 +46,10 @@ typedef struct
 #if HB_PROJECT_FEATURE_QSV
     mfxHandleType   mfxType;
 
-#ifdef SYS_LINUX
+#if defined(SYS_LINUX) || defined(SYS_FREEBSD)
     int             vaFd;
     VADisplay       vaDisplay;
-#endif // SYS_LINUX
+#endif // SYS_LINUX || SYS_FREEBSD
 #endif
 } hb_display_t;
 

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -28,6 +28,10 @@
 #if defined(SYS_DARWIN) || defined(SYS_FREEBSD)
 #include <sys/types.h>
 #include <sys/sysctl.h>
+#if HB_PROJECT_FEATURE_QSV && defined(SYS_FREEBSD)
+#include <libdrm/drm.h>
+#include <fcntl.h>
+#endif
 #endif
 
 #ifdef SYS_OPENBSD
@@ -1518,7 +1522,7 @@ char * hb_strndup(const char * src, size_t len)
 }
 
 #if HB_PROJECT_FEATURE_QSV
-#ifdef SYS_LINUX
+#if defined(SYS_LINUX) || defined(SYS_FREEBSD)
 
 #define MAX_NODES             16
 #define DRI_RENDER_NODE_START 128
@@ -1676,7 +1680,7 @@ void hb_display_close(hb_display_t ** _d)
     *_d = NULL;
 }
 
-#else // !SYS_LINUX
+#else // !SYS_LINUX && !SYS_FREEBSD
 
 hb_display_t * hb_display_init(const char         *  driver_name,
                                const char * const * interface_names)
@@ -1689,7 +1693,7 @@ void hb_display_close(hb_display_t ** _d)
     (void)_d;
 }
 
-#endif // SYS_LINUX
+#endif // SYS_LINUX || SYS_FREEBSD
 #else // !HB_PROJECT_FEATURE_QSV
 
 hb_display_t * hb_display_init(const char         *  driver_name,

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -678,7 +678,7 @@ int hb_qsv_info_init()
      */
     mfxSession session;
     mfxVersion version = { .Major = 1, .Minor = 0, };
-#ifdef SYS_LINUX
+#if defined(SYS_LINUX) || defined(SYS_FREEBSD)
     mfxIMPL hw_preference = MFX_IMPL_VIA_ANY;
 #else
     mfxIMPL hw_preference = MFX_IMPL_VIA_D3D11;
@@ -738,7 +738,7 @@ int hb_qsv_info_init()
         }
         else
         {
-#ifndef SYS_LINUX
+#if !defined(SYS_LINUX) && !defined(SYS_FREEBSD)
             // Windows only: After D3D11 we will try D3D9
             if (hw_preference == MFX_IMPL_VIA_D3D11)
                 hw_preference = MFX_IMPL_VIA_D3D9;

--- a/make/configure.py
+++ b/make/configure.py
@@ -1413,7 +1413,7 @@ def createCLI( cross = None ):
     grp.add_argument( '--enable-nvenc', dest="enable_nvenc", default=IfHost( True, '*-*-linux*', '*-*-mingw*', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-nvenc', dest="enable_nvenc", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
-    h = IfHost( 'Intel QSV video encoder/decoder', '*-*-linux*', '*-*-mingw*', none=argparse.SUPPRESS).value
+    h = IfHost( 'Intel QSV video encoder/decoder', '*-*-linux*', '*-*-freebsd*', '*-*-mingw*', none=argparse.SUPPRESS).value
     grp.add_argument( '--enable-qsv', dest="enable_qsv", default=IfHost(True, "*-*-mingw*", none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-qsv', dest="enable_qsv", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
@@ -1690,7 +1690,7 @@ try:
                                         none=False).value
                                  and options.enable_x265)
     # Disable QSV on unsupported platforms
-    options.enable_qsv        = IfHost(options.enable_qsv, '*-*-linux*',
+    options.enable_qsv        = IfHost(options.enable_qsv, '*-*-linux*', '*-*-freebsd*',
                                        '*-*-mingw*', none=False).value
     # Disable VCE on unsupported platforms
     options.enable_vce        = IfHost(options.enable_vce, '*-*-linux*', '*-*-mingw*',
@@ -2130,7 +2130,7 @@ int main()
     stdout.write( 'Enable NVENC:       %s' % options.enable_nvenc )
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.system == 'mingw') else stdout.write( '\n' )
     stdout.write( 'Enable QSV:         %s' % options.enable_qsv )
-    stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.system == 'mingw') else stdout.write( '\n' )
+    stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.system == 'freebsd' or host_tuple.system == 'mingw') else stdout.write( '\n' )
     stdout.write( 'Enable VCE:         %s' % options.enable_vce )
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.system == 'mingw') else stdout.write( '\n' )
 

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -53,7 +53,9 @@ MODULES += contrib/libdvdnav
 MODULES += contrib/libbluray
 
 ifeq (1,$(FEATURE.qsv))
+ifeq (,$(filter $(HOST.system),freebsd))
     MODULES += contrib/libmfx
+endif
 endif
 
 ifeq (1,$(FEATURE.vce))

--- a/test/module.defs
+++ b/test/module.defs
@@ -25,7 +25,7 @@ endif
 
 ifeq (1,$(FEATURE.qsv))
     TEST.GCC.l += mfx
-ifeq ($(HOST.system),linux)
+ifneq (,$(filter $(HOST.system),linux freebsd))
     TEST.GCC.l += va va-drm
 endif
 endif


### PR DESCRIPTION
FreeBSD recently [packaged](https://www.freshports.org/multimedia/intel-media-sdk) MediaSDK and connected to [6 consumers](https://github.com/freebsd/freebsd-ports/search?q=%22:multimedia/intel-media-sdk%22). HandBrake runtime was tested [downstream](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=242849) by @yuichiro-naito. See also [example build log](https://github.com/HandBrake/HandBrake/files/4020365/handbrake-1.3.0.114.log).
