### PR TITLE
make: Fix redundant flags added with harden.

### DIFF
--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -90,7 +90,7 @@ GCC.args.extra.exe++   = $(LDFLAGS)
 # checking against static sized buffer overflow flaws. -fstack-protector-strong enables
 # stack canaries to detect stack buffer overflows (stack overwrites).
 ifeq (1,$(SECURITY.harden))
-    GCC.args.extra     += $(CFLAGS) $(CXXFLAGS) $(CPPFLAGS) -fstack-protector-strong -D_FORTIFY_SOURCE=2
+    GCC.args.extra     += -fstack-protector-strong -D_FORTIFY_SOURCE=2
     GCC.args.extra.exe += -fstack-protector-strong
 endif
 


### PR DESCRIPTION
Minor bug duplicating CFLAGS and CPPFLAGS. I believe CXXFLAGS is unnecessary here.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux