### PR TITLE
libhb: fix image plane copying in nlmeans pre-filter setup

### DIFF
--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -616,10 +616,7 @@ static void nlmeans_prefilter(BorderedPlane *src,
         // Duplicate plane
         uint8_t *mem_pre = malloc(bw * bh * sizeof(uint8_t));
         uint8_t *image_pre = mem_pre + border + bw * border;
-        for (int y = 0; y < h; y++)
-        {
-            memcpy(mem_pre + y * bw, mem + y * bw, bw);
-        }
+        memcpy(mem_pre, mem, bw * bh * sizeof(uint8_t));
 
         // Filter plane; should already have at least 2px extra border on each side
         if (filter_type & NLMEANS_PREFILTER_MODE_CSM5X5)


### PR DESCRIPTION
**Description of Change:**

When `nlmeans_prefilter()` is preparing to apply a pre-filter to an image plane, it first attempts to make a copy of the `mem` image plane into the `mem_pre` plane which will hold the pre-filter's output.

However, the existing logic, which mirrors the loop over all pixel rows in `nlmeans_alloc()`, improperly leaves the bottom `2*border` rows of the `mem_pre` plane uninitialized.

Where `nlmeans_alloc()` correctly copies the source image's rows into its plane, by adding the correct offset to the `memcpy(3)` destination to locate the image pixel data between the horizontal and vertical borders, in `nlmeans_prefilter()` the intention is to copy both the image and the borders.  However, the current loop only iterates `h` times, i.e., the size of the image itself, and skips the last `(bh - h) = 2*border` rows.

As described in #2576, this bug is not apparent when using the older "mean" and "median" pre-filters as they rewrite every pixel's value in the `mem_pre` plane.  However, when using the newer CSM pre-filter, which only rewrites a pixel's value if it should change, any pixels whose value should remain unaltered by the pre-filter (i.e., those which fall through the end of the [`if/else` block](https://github.com/HandBrake/HandBrake/blob/073c2fb84b3ead86d2f2b28cbd737bb936cc0696/libhb/nlmeans.c#L457-L481) in `nlmeans_filter_csm()`), and which happen to be in the bottom `border` rows of the image, will actually be left with uninitialized values.

Instead, we replace the loop with a single `memcpy(3)` call which just duplicates the entire `mem` image plane, including the border data.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

Illustration of bug when using `HandBrakeCLI ... --nlmeans=y-prefilter=3104`:

![nlmeans_csm_edgeboost_bug](https://user-images.githubusercontent.com/28857117/72214627-ff4cb500-34ba-11ea-9e45-98eed4c35aec.png)

After applying this PR and re-running `HandBrakeCLI` with the same options and inputs:

![nlmeans_csm_edgeboost_fix](https://user-images.githubusercontent.com/28857117/72214636-1c818380-34bb-11ea-9c93-5c1d59f866e6.png)

Resolves #2576. 