### PR TITLE
Add --enable-small to FFmpeg for size optimized builds

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -60,6 +60,11 @@ FFMPEG.CONFIGURE.extra = \
     --cc="$(FFMPEG.GCC.gcc)" \
     --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib)"
 
+ifeq (size-aggressive,$(GCC.O))
+FFMPEG.CONFIGURE.extra += \
+    --enable-small
+endif
+
 ifeq (1-linux,$(FEATURE.qsv)-$(HOST.system))
     FFMPEG.CONFIGURE.extra += --enable-vaapi
     FFMPEG.CONFIGURE.extra += --disable-xlib

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -23,10 +23,18 @@ ifneq (1,$(FEATURE.numa))
     X265_10.CONFIGURE.extra  += -DENABLE_LIBNUMA=OFF
 endif
 
-ifneq (none,$(X265_10.GCC.g))
-    X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+ifeq (size-aggressive,$(GCC.O))
+    X265_10.CONFIGURE.extra += -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG" -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG"
+endif
+
+ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
+    X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
 else
-    X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    ifneq (none,$(X265_10.GCC.g))
+        X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    else
+        X265_10.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    endif
 endif
 
 ifeq (1,$(HOST.cross))

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -23,10 +23,18 @@ ifneq (1,$(FEATURE.numa))
     X265_12.CONFIGURE.extra  += -DENABLE_LIBNUMA=OFF
 endif
 
-ifneq (none,$(X265_12.GCC.g))
-    X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+ifeq (size-aggressive,$(GCC.O))
+    X265_12.CONFIGURE.extra += -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG" -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG"
+endif
+
+ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
+    X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
 else
-    X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    ifneq (none,$(X265_12.GCC.g))
+        X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    else
+        X265_12.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    endif
 endif
 
 ifeq (1,$(HOST.cross))

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -20,10 +20,18 @@ ifneq (1,$(FEATURE.numa))
     X265_8.CONFIGURE.extra  += -DENABLE_LIBNUMA=OFF
 endif
 
-ifneq (none,$(X265_8.GCC.g))
-    X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+ifeq (size-aggressive,$(GCC.O))
+    X265_8.CONFIGURE.extra += -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG" -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG"
+endif
+
+ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
+    X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
 else
-    X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    ifneq (none,$(X265_8.GCC.g))
+        X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    else
+        X265_8.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    endif
 endif
 
 ifeq (1,$(HOST.cross))

--- a/make/configure.py
+++ b/make/configure.py
@@ -1617,9 +1617,6 @@ try:
     for tool in ToolProbe.tools:
         tool.run()
 
-    debugMode = SelectMode( 'debug', ('none','none'), ('min','min'), ('std','std'), ('max','max') )
-    optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), default='speed' )
-
     ## find xcconfig values
     xcconfigMode = SelectMode( 'xcconfig', ('none',None), what='' )
     if build_tuple.match( '*-*-darwin*' ):
@@ -1638,6 +1635,16 @@ try:
         for tool in ( Tools.ar, Tools.gcc, Tools.ranlib, Tools.strip ):
             tool.__init__( tool.var, tool.option, '%s-%s' % (cross,tool.name), **tool.kwargs )
             tool.run()
+
+    debugMode = SelectMode( 'debug', ('none','none'), ('min','min'), ('std','std'), ('max','max') )
+
+    Oz_check_command = '%s -Oz -S -o /dev/null -xc /dev/null > /dev/null 2>&1' % Tools.gcc.pathname
+    Oz_check = ShellProbe('checking for -Oz', '%s' % Oz_check_command)
+    Oz_check.run()
+    if Oz_check.fail is False:
+        optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), ('size-aggressive','size-aggressive'), default='speed' )
+    else:
+        optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), default='speed' )
 
     # run host tuple and arch actions
     host_tuple = HostTupleAction(cross)

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -41,37 +41,38 @@ GCC.extra.cpp_o   = 1
 GCC.extra.dylib++ = 1
 GCC.extra.exe++   = 1
 
-GCC.args.pipe      = -pipe
-GCC.args.strip     = -Wl,-S
-GCC.args.dylib     = -dynamiclib
-GCC.args.ML        = -fmessage-length=0
-GCC.args.H         = -H
-GCC.args.W         = -W$(1)
+GCC.args.pipe              = -pipe
+GCC.args.strip             = -Wl,-S
+GCC.args.dylib             = -dynamiclib
+GCC.args.ML                = -fmessage-length=0
+GCC.args.H                 = -H
+GCC.args.W                 = -W$(1)
 ifeq (darwin,$(HOST.system))
-    GCC.args.archs = -arch $(1)
+    GCC.args.archs         = -arch $(1)
 endif
-GCC.args.sysroot   = --sysroot=$(1)
-GCC.args.minver    = -mmacosx-version-min=$(1)
-GCC.args.vis       = -fvisibility=hidden
-GCC.args.pic       = -fPIC
-GCC.args.c_std     = -std=gnu99
-GCC.args.cxx_std   = -std=c++98
-GCC.args.g.none    = -g0
-GCC.args.g.min     = -gdwarf-2 -g1
-GCC.args.g.std     = -gdwarf-2
-GCC.args.g.max     = -gdwarf-2 -g3
-GCC.args.O.none    = -O0
-GCC.args.O.size    = -Os
-GCC.args.O.speed   = -O3
-GCC.args.D         = -D$(1)
-GCC.args.I         = -I$(1)
-GCC.args.muldefs   = -Wl,--allow-multiple-definition
-GCC.args.start     = -Wl,--start-group
-GCC.args.F         = -F$(1)
-GCC.args.f         = -framework $(1)
-GCC.args.L         = -L$(1)
-GCC.args.l         = -l$(1)
-GCC.args.end       = -Wl,--end-group
+GCC.args.sysroot           = --sysroot=$(1)
+GCC.args.minver            = -mmacosx-version-min=$(1)
+GCC.args.vis               = -fvisibility=hidden
+GCC.args.pic               = -fPIC
+GCC.args.c_std             = -std=gnu99
+GCC.args.cxx_std           = -std=c++98
+GCC.args.g.none            = -g0
+GCC.args.g.min             = -gdwarf-2 -g1
+GCC.args.g.std             = -gdwarf-2
+GCC.args.g.max             = -gdwarf-2 -g3
+GCC.args.O.none            = -O0
+GCC.args.O.size            = -Os
+GCC.args.O.size-aggressive = -Oz
+GCC.args.O.speed           = -O3
+GCC.args.D                 = -D$(1)
+GCC.args.I                 = -I$(1)
+GCC.args.muldefs           = -Wl,--allow-multiple-definition
+GCC.args.start             = -Wl,--start-group
+GCC.args.F                 = -F$(1)
+GCC.args.f                 = -framework $(1)
+GCC.args.L                 = -L$(1)
+GCC.args.l                 = -l$(1)
+GCC.args.end               = -Wl,--end-group
 
 ifeq ($(HOST.machine),$(filter $(HOST.machine),i686 x86_64))
     GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2


### PR DESCRIPTION
See #2571 for details.


**Description of Change:**
`--optimize=size` should trigger FFmpeg to build with `--enable-small`. This reduces the size of the application about 9%, as my tests have shown on macOS 10.15.





**Test on:**
- [x] macOS 10.15
- [x] Linux
- [x] Windows (mingw-w64)