### PR TITLE
gtk: Link to ole32 on mingw

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -233,7 +233,7 @@ case $host in
     else
         HB_LIBS="$HB_LIBS -lpthreadGC2"
 	fi
-    HB_LIBS="$HB_LIBS -lbcrypt -lregex -luuid"
+    HB_LIBS="$HB_LIBS -lbcrypt -lregex -luuid -lole32"
     ;;
   *-*-freebsd*)
     HB_LIBS="$HB_LIBS -lpthread"


### PR DESCRIPTION
Fixes undefined reference to `__imp_CoTaskMemFree'