### PR TITLE
ffmpeg: support 'H265' FourCC in AVI.

### DIFF
--- a/contrib/ffmpeg/A01-riff-tag-h265-in-avi.patch
+++ b/contrib/ffmpeg/A01-riff-tag-h265-in-avi.patch
@@ -1,0 +1,26 @@
+From 6c79abcfaa30675943081ef62caa984f9185a3b3 Mon Sep 17 00:00:00 2001
+From: Tim Walker <tdskywalker@gmail.com>
+Date: Wed, 5 Feb 2020 22:34:34 +0100
+Subject: [PATCH] avformat/avidec: add support for recognizing H265 fourcc when demuxing
+
+See commit 2e31774b409d77f046f166fb3ff630a9ef91def7
+
+---
+ libavformat/riff.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/libavformat/riff.c b/libavformat/riff.c
+index c73f6e9db0..32914f9ab0 100644
+--- a/libavformat/riff.c
++++ b/libavformat/riff.c
+@@ -496,6 +496,7 @@ const AVCodecTag ff_codec_bmp_tags[] = {
+ 
+ const AVCodecTag ff_codec_bmp_tags_unofficial[] = {
+     { AV_CODEC_ID_HEVC,         MKTAG('H', 'E', 'V', 'C') },
++    { AV_CODEC_ID_HEVC,         MKTAG('H', '2', '6', '5') },
+     { AV_CODEC_ID_NONE,         0 }
+ };
+ 
+-- 
+2.20.1 (Apple Git-117)
+


### PR DESCRIPTION
Produced by security cameras, see:
https://forum.handbrake.fr/viewtopic.php?f=11&t=39824