### PR TITLE
qsv: enable qsv decoding by default

### DIFF
--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -276,7 +276,7 @@ namespace HandBrakeWPF.Services
 
             // Video
             defaults.Add(UserSettingConstants.EnableQuickSyncEncoding, true);
-            defaults.Add(UserSettingConstants.EnableQuickSyncDecoding, false);
+            defaults.Add(UserSettingConstants.EnableQuickSyncDecoding, true);
             defaults.Add(UserSettingConstants.UseQSVDecodeForNonQSVEnc, false);
             defaults.Add(UserSettingConstants.EnableVceEncoder, true);
             defaults.Add(UserSettingConstants.EnableNvencEncoder, true);


### PR DESCRIPTION
Enable QSV decoding by default in Nightly Build.

Increase performance with latest QSV decode + QSV encode changes and reduce CPU load.
  
 