### PR TITLE
Support building for windows/aarch64 with llvm-mingw

### DIFF
--- a/contrib/amf/P00-mingw-clang-comdat.patch
+++ b/contrib/amf/P00-mingw-clang-comdat.patch
@@ -1,0 +1,14 @@
+Backport of upstream fix from
+https://github.com/GPUOpen-LibrariesAndSDKs/AMF/commit/328e888ddadc7d9e3fcdf621a59463320b88186b.
+
+--- AMF-1.4.9/amf/public/include/core/Platform.h.orig	2020-02-07 23:57:42.037510218 +0200
++++ AMF-1.4.9/amf/public/include/core/Platform.h	2020-02-07 23:57:16.198081758 +0200
+@@ -131,7 +131,7 @@
+ #endif // WIN32
+ 
+ 
+-#if defined(_MSC_VER)
++#if defined(_WIN32)
+ #define AMF_WEAK __declspec( selectany ) 
+ #elif defined (__GNUC__) || defined (__GCC__) || defined(__clang__)//GCC or CLANG
+ #define AMF_WEAK __attribute__((weak))

--- a/contrib/harfbuzz/P00-mingw-emmintrin.patch
+++ b/contrib/harfbuzz/P00-mingw-emmintrin.patch
@@ -1,11 +1,13 @@
 diff -Naur harfbuzz-1.2.6.orig/src/hb.h harfbuzz-1.2.6/src/hb.h
 --- harfbuzz-1.2.6.orig/src/hb.h	2016-01-06 04:00:36.000000000 -0800
 +++ harfbuzz-1.2.6/src/hb.h	2016-06-15 05:30:43.212202580 -0700
-@@ -32,6 +32,7 @@
+@@ -32,6 +32,9 @@
  #define HB_EXTERN extern
  #endif
  
++#ifdef __x86_64__
 +#include <emmintrin.h>
++#endif
  #include "hb-blob.h"
  #include "hb-buffer.h"
  #include "hb-common.h"

--- a/contrib/libdav1d/A00-add-cross-file.patch
+++ b/contrib/libdav1d/A00-add-cross-file.patch
@@ -17,3 +17,22 @@ diff -Naur /dev/null dav1d-f1b756ef5bdc0bb759b2b140f15362fec024c1ff/x86_64-w64-m
 +cpu_family = 'x86_64'
 +cpu = 'x86_64'
 +endian = 'little'
+diff -Naur /dev/null dav1d-f1b756ef5bdc0bb759b2b140f15362fec024c1ff/aarch64-w64-mingw32.meson
+--- /dev/null	2019-02-01 11:36:25.027425148 -0500
++++ dav1d-f1b756ef5bdc0bb759b2b140f15362fec024c1ff/aarch64-w64-mingw32.meson	2019-02-01 12:10:45.582462644 -0500
+@@ -0,0 +1,15 @@
++[binaries]
++c = 'aarch64-w64-mingw32-gcc'
++cpp = 'aarch64-w64-mingw32-g++'
++ar = 'aarch64-w64-mingw32-ar'
++strip = 'aarch64-w64-mingw32-strip'
++windres = 'aarch64-w64-mingw32-windres'
++
++[properties]
++c_link_args = ['-static-libgcc']
++
++[host_machine]
++system = 'windows'
++cpu_family = 'aarch64'
++cpu = 'aarch64'
++endian = 'little'

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -30,7 +30,7 @@ else
 endif
 
 ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
-    LIBDAV1D.CONFIGURE.extra += --cross-file=$(call fn.ABSOLUTE,$(LIBDAV1D.EXTRACT.dir/))x86_64-w64-mingw32.meson
+    LIBDAV1D.CONFIGURE.extra += --cross-file=$(call fn.ABSOLUTE,$(LIBDAV1D.EXTRACT.dir/))$(HOST.machine)-w64-mingw32.meson
 endif
 
 LIBDAV1D.BUILD.make       = $(NINJA.exe)

--- a/contrib/libtheora/module.defs
+++ b/contrib/libtheora/module.defs
@@ -5,6 +5,8 @@ LIBTHEORA.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releas
 LIBTHEORA.FETCH.url    += https://downloads.xiph.org/releases/theora/libtheora-1.1.1.tar.bz2
 LIBTHEORA.FETCH.sha256  = b6ae1ee2fa3d42ac489287d3ec34c5885730b1296f0801ae577a35193d3affbc
 
+LIBTHEORA.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
+
 LIBTHEORA.CONFIGURE.extra = \
     --disable-examples \
     --disable-oggtest \

--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -25,6 +25,8 @@ ifeq (1,$(HOST.cross))
         LIBVPX.CONFIGURE.extra += --target=x86-win32-gcc
     else ifeq (x86_64,$(HOST.machine))
         LIBVPX.CONFIGURE.extra += --target=x86_64-win64-gcc
+    else ifeq (aarch64,$(HOST.machine))
+        LIBVPX.CONFIGURE.extra += --target=arm64-win64-gcc
     endif
 endif
 

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -52,6 +52,7 @@ ifeq (1,$(HOST.cross))
         X265_10.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_10.CONFIGURE.host)"
     endif
     X265_10.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.build)"
+    X265_10.CONFIGURE.extra     += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
 else
     X265_10.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.host)"
 endif

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -52,6 +52,7 @@ ifeq (1,$(HOST.cross))
         X265_12.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_12.CONFIGURE.host)"
     endif
     X265_12.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.build)"
+    X265_12.CONFIGURE.extra     += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
 else
     X265_12.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.host)"
 endif

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -49,6 +49,7 @@ ifeq (1,$(HOST.cross))
         X265_8.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_8.CONFIGURE.host)"
     endif
     X265_8.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.build)"
+    X265_8.CONFIGURE.extra     += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
 else
     X265_8.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.host)"
 endif

--- a/make/configure.py
+++ b/make/configure.py
@@ -1410,7 +1410,7 @@ def createCLI( cross = None ):
     grp.add_argument( '--disable-ffmpeg-aac', dest="enable_ffmpeg_aac", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = IfHost( 'Nvidia NVENC video encoder', '*-*-linux*', '*-*-mingw*', none=argparse.SUPPRESS).value
-    grp.add_argument( '--enable-nvenc', dest="enable_nvenc", default=IfHost( True, '*-*-linux*', '*-*-mingw*', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
+    grp.add_argument( '--enable-nvenc', dest="enable_nvenc", default=IfHost( True, '*-*-linux*', 'x86_64-*-mingw*', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-nvenc', dest="enable_nvenc", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = IfHost( 'Intel QSV video encoder/decoder', '*-*-linux*', '*-*-freebsd*', '*-*-mingw*', none=argparse.SUPPRESS).value


### PR DESCRIPTION
**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this. #2378
- [X] Discuss the issue with the HandBrake team to ensure that the idea has been accepted.


**Description of Change:**

This pull request adds support for building with the https://github.com/mstorsjo/llvm-mingw toolchain. This is a toolchain (available both as cross compiler and native compiler) that uses llvm based tools instead of gcc/binutils based tools. It behaves as a full drop-in replacement for normal gcc based mingw toolchains (it even has tools named e.g. `x86_64-w64-mingw32-gcc` which ends up calling clang instead, to make sure that all build systems transparently can use these tools). In addition to the regular i686 and x86_64, it also contains compilers targeting armv7 and aarch64.

With the few fixes in this pull request, one can build for windows/arm and arm64 just like normal mingw cross compilation, just by using e.g. `./configure --cross=aarch64-w64-mingw32`.




**Test on:**

- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
