### PR TITLE
contrib: x265: Don't redundantly set CMAKE_SYSTEM_NAME to the triple when cross compiling for windows

### DIFF
--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -48,8 +48,9 @@ ifeq (1,$(HOST.cross))
         X265_10.CONFIGURE.extra += -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_10.CONFIGURE.extra += -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_10.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+    else
+        X265_10.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_10.CONFIGURE.host)"
     endif
-    X265_10.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_10.CONFIGURE.host)"
     X265_10.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.build)"
 else
     X265_10.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_10.CONFIGURE.host)"

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -48,8 +48,9 @@ ifeq (1,$(HOST.cross))
         X265_12.CONFIGURE.extra += -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_12.CONFIGURE.extra += -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_12.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+    else
+        X265_12.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_12.CONFIGURE.host)"
     endif
-    X265_12.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_12.CONFIGURE.host)"
     X265_12.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.build)"
 else
     X265_12.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_12.CONFIGURE.host)"

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -45,8 +45,9 @@ ifeq (1,$(HOST.cross))
         X265_8.CONFIGURE.extra += -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_8.CONFIGURE.extra += -DCMAKE_SHARED_LIBRARY_LINK_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
         X265_8.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+    else
+        X265_8.CONFIGURE.args.host = -DCMAKE_SYSTEM_NAME="$(X265_8.CONFIGURE.host)"
     endif
-    X265_8.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(X265_8.CONFIGURE.host)"
     X265_8.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.build)"
 else
     X265_8.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.host)"


### PR DESCRIPTION
It's already explicitly set to "Windows" in these cases, and CMake does recognize CMAKE_SYSTEM_NAME being set to "Windows", but might not recognize generic triples.
