### PR TITLE
CI: Upload Windows and macOS build artifacts to GitHub Actions

### DIFF
--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -36,3 +36,7 @@ jobs:
         ./configure --launch-jobs=$(sysctl -n hw.ncpu) --launch
         cd build
         make pkg.create
+    - uses: actions/upload-artifact@v1
+      with:
+        name: HandBrake macOS
+        path: ./build/pkg

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,6 +51,10 @@ jobs:
         ./configure --cross=x86_64-w64-mingw32 --enable-qsv --enable-vce --enable-nvenc --launch-jobs=$(nproc) --launch
         cd build
         make pkg.create.zip
+    - uses: actions/upload-artifact@v1
+      with:
+        name: HandBrake Windows CLI
+        path: ./build/HandBrakeCLI.exe
 
   build_gui:
     name: Windows UI
@@ -80,3 +84,11 @@ jobs:
       run: |      
         $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         msbuild win\cs\build.xml /t:Nightly
+    - name: Copy HandBrake libary
+      run: | 
+        cd ../..
+        copy build/libhb/hb.dll win/CS/HandBrakeWPF/bin/x64/Release/hb.dll
+    - uses: actions/upload-artifact@v1
+      with:
+        name: HandBrake Windows GUI
+        path: ./win/CS/HandBrakeWPF/bin/x64/Release

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -55,6 +55,10 @@ jobs:
       with:
         name: HandBrake Windows CLI
         path: ./build/HandBrakeCLI.exe
+    - uses: actions/upload-artifact@v1
+      with:
+        name: HandBrake Windows Library
+        path: ./build/libhb/hb.dll
 
   build_gui:
     name: Windows UI
@@ -84,10 +88,6 @@ jobs:
       run: |      
         $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         msbuild win\cs\build.xml /t:Nightly
-    - name: Copy HandBrake libary
-      run: | 
-        cd ../..
-        copy build/libhb/hb.dll win/CS/HandBrakeWPF/bin/x64/Release/hb.dll
     - uses: actions/upload-artifact@v1
       with:
         name: HandBrake Windows GUI


### PR DESCRIPTION
This PR extends the GitHub Actions configuration to upload build artifacts of the Windows CLI and GUI and macOS CLI and GUI. It can speed up development by enabling quicker and easier accessible Windows and macOS builds, which can also be used for future CI configurations.

- [Example Windows run](https://github.com/HandBrake/HandBrake/actions/runs/45637045)
- [Example macOS run](https://github.com/HandBrake/HandBrake/actions/runs/45637042)

I tested the Window CLI and GUI builds, both work as expected. Can anyone test the macOS .dmg?
- [x] Windows 10+
- [ ] macOS 10.13+

My development branch for this PR can be found here: [EwoutH/HandBrake/tree/artifacts-exp](https://github.com/EwoutH/HandBrake/tree/artifacts-exp)