### PR TITLE
qsv: encoder fixes for newer cpus

### DIFF
--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1784,12 +1784,7 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(qsv, "Decode",
                     hb_value_xform(value, HB_VALUE_TYPE_BOOL));
     }
-    if ((value = hb_dict_get(preset, "VideoQSVLowPower")) != NULL)
-    {
-        hb_dict_set(qsv, "LowPower",
-                    hb_value_xform(value, HB_VALUE_TYPE_BOOL));
-    }
-     if ((value = hb_dict_get(preset, "VideoQSVAsyncDepth")) != NULL)
+    if ((value = hb_dict_get(preset, "VideoQSVAsyncDepth")) != NULL)
     {
         hb_dict_set(qsv, "AsyncDepth",
                     hb_value_xform(value, HB_VALUE_TYPE_INT));

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2054,7 +2054,7 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         {
             param->videoParam->ExtParam[param->videoParam->NumExtParam++] = (mfxExtBuffer*)&param->codingOption2;
         }
-        if ((info->capabilities & HB_QSV_CAP_LOWPOWER_ENCODE) && (info->codec_id == MFX_CODEC_HEVC))
+        if (info->capabilities & HB_QSV_CAP_LOWPOWER_ENCODE)
         {
             param->videoParam->mfx.LowPower = MFX_CODINGOPTION_ON;
         }

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2030,6 +2030,7 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         param->videoParam->mfx.NumRefFrame  = 0; // use Media SDK default
         param->videoParam->mfx.GopPicSize   = 0; // use Media SDK default
         param->videoParam->mfx.GopRefDist   = 0; // use Media SDK default
+        param->videoParam->mfx.LowPower     = MFX_CODINGOPTION_OFF; // use Media SDK default
         // introduced in API 1.1
         param->videoParam->AsyncDepth = HB_QSV_ASYNC_DEPTH_DEFAULT;
         // introduced in API 1.3
@@ -2052,6 +2053,10 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         if (info->capabilities & HB_QSV_CAP_OPTION2)
         {
             param->videoParam->ExtParam[param->videoParam->NumExtParam++] = (mfxExtBuffer*)&param->codingOption2;
+        }
+        if ((info->capabilities & HB_QSV_CAP_LOWPOWER_ENCODE) && (info->codec_id == MFX_CODEC_HEVC))
+        {
+            param->videoParam->mfx.LowPower = MFX_CODINGOPTION_ON;
         }
     }
     else

--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -327,6 +327,10 @@ namespace HandBrakeWPF.Services.Encode.Factories
                 {
                     video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=1" : ":lowpower=1";
                 }
+                else if(!configuration.EnableQsvLowPower && !video.Options.Contains("lowpower"))
+                {
+                    video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=0" : ":lowpower=0";
+                }
             }
 
             return video;


### PR DESCRIPTION
* Encoder fixes for newer CPUs (IceLake and higher), no impact on preceding cpus
* Fix checkbox in WinGUI for https://github.com/HandBrake/HandBrake/commit/56aba26a4da0fda058196fcb866e13d35dda538e