### PR TITLE
contrib: Explicitly declare pkgconfig install dir [libdav1d]

### DIFF
--- a/contrib/libdav1d/P01-freebsd-pkgconfig-location.patch
+++ b/contrib/libdav1d/P01-freebsd-pkgconfig-location.patch
@@ -1,0 +1,10 @@
+--- dav1d-0.5.1/src/meson.build.orig    2019-10-26 04:38:21.000000000 +0900
++++ dav1d-0.5.1/src/meson.build 2020-02-27 16:48:19.664008000 +0900
+@@ -288,6 +288,7 @@
+ #
+ pkg_mod = import('pkgconfig')
+ pkg_mod.generate(libraries: libdav1d,
++    install_dir: 'lib/pkgconfig',
+     version: meson.project_version(),
+     name: 'libdav1d',
+     filebase: 'dav1d',


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Adds a patchfile to explicitly declare the install location for dav1d.pc as it differs for FreeBSD under certain conditions.

Fixes #2662

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
