### PR TITLE
contrib: Update libdav1d to 0.6.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Print Warning
       run: |
-        echo "Builds are disabled for forked repositories."      
+        echo "Builds are disabled for forked repositories."
 
   build:
     name: Build on Ubuntu
@@ -18,18 +18,19 @@ jobs:
     if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@master
-    
+
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake build-essential cmake git libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev 
-        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make nasm ninja-build patch pkg-config python tar yasm zlib1g-dev
+        sudo apt-get install autoconf automake build-essential cmake git libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev
+        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make ninja-build patch pkg-config python tar yasm xz-utils zlib1g-dev
         sudo apt-get install python3-pip
         sudo apt-get install python3-setuptools
         sudo pip3 install meson
         sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev
-        
+        wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz && tar -xf nasm-2.14.02.tar.xz && cd nasm-2.14.02 && ./configure --prefix=/usr && make && sudo make install
+
     - name: Build HandBrake Linux
       run: |
         ./configure --launch-jobs=0 --disable-gtk-update-checks  --enable-qsv --launch

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: Print Warning
       run: |
-        echo "Builds are disabled for forked repositories."      
+        echo "Builds are disabled for forked repositories."
 
   build_mingw:
     name: CLI / LibHB
@@ -18,22 +18,24 @@ jobs:
     if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@master
-    
+
     - name: Environment Setup
       run: |
-        sudo apt-get install automake autoconf build-essential cmake curl gcc git intltool libtool libtool-bin m4 make nasm patch pkg-config python tar yasm zlib1g-dev ninja-build zip
+        sudo apt-get update
+        sudo apt-get install automake autoconf build-essential cmake curl gcc git intltool libtool libtool-bin m4 make patch pkg-config python tar yasm zlib1g-dev ninja-build xz-utils zip
         sudo apt-get install bison bzip2 flex g++ gzip pax
         sudo apt-get install python3-pip
         sudo apt-get install python3-setuptools
         sudo pip3 install meson
-        
+        wget https://www.nasm.us/pub/nasm/releasebuilds/2.14.02/nasm-2.14.02.tar.xz && tar -xf nasm-2.14.02.tar.xz && cd nasm-2.14.02 && ./configure --prefix=/usr && make && sudo make install
+
     - name: Toolchain Cache
       id: mingw-toolchain
       uses: actions/cache@v1
       with:
         path: /home/runner/toolchains/
         key: mingw-toolchain
-    
+
     - name: Compile Toolchain
       if: steps.mingw-toolchain.outputs.cache-hit != 'true'
       run: |
@@ -44,7 +46,7 @@ jobs:
         rm -rf build-mingw-w64-x86_64.noindex
         rm -rf source.noindex
         rm -rf pkg
-          
+
     - name: Build CLI and LibHB
       run: |
         export PATH="/home/runner/toolchains/mingw-w64-x86_64/bin:${PATH}"
@@ -59,24 +61,24 @@ jobs:
     needs: build_mingw
     steps:
     - uses: actions/checkout@master
-        
+
     - name: Environment Setup
       run: |
         choco install wget
         wget https://nsis.sourceforge.io/mediawiki/images/c/c9/Inetc.zip
         mkdir plugins
         move Inetc.zip plugins
-        cd plugins        
+        cd plugins
         7z x Inetc.zip
         dir
-  
+
     - name: NuGet Restore
       run: |
          choco install nuget.commandline
          cd win/CS/
          nuget restore HandBrake.sln
-        
+
     - name: Build Windows GUI
-      run: |      
+      run: |
         $env:Path += ";C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin"
         msbuild win\cs\build.xml /t:Nightly

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.5.1.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.5.1/dav1d-0.5.1.tar.bz2
-LIBDAV1D.FETCH.sha256  = 0214d201a338e8418f805b68f9ad277e33d79c18594dee6eaf6dcd74db2674a9
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.6.0.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.6.0/dav1d-0.6.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = 7fcfb4d2e43681f99faaad29d2a81c0ecc42d6e2b94eb4d1fded4e9dcb3661f1
 
 LIBDAV1D.build_dir     = build/
 

--- a/make/configure.py
+++ b/make/configure.py
@@ -1608,7 +1608,7 @@ try:
         lipo       = ToolProbe( 'LIPO.exe',       'lipo',       'lipo', abort=False )
         pkgconfig  = ToolProbe( 'PKGCONFIG.exe',  'pkgconfig',  'pkg-config', abort=True, minversion=[0,29,0] )
         meson      = ToolProbe( 'MESON.exe',      'meson',      'meson', abort=True, minversion=[0,47,0] )
-        nasm       = ToolProbe( 'NASM.exe',       'asm',        'nasm', abort=True, minversion=[2,13,0] )
+        nasm       = ToolProbe( 'NASM.exe',       'asm',        'nasm', abort=True, minversion=[2,14,0] )
         ninja      = ToolProbe( 'NINJA.exe',      'ninja',      'ninja-build', 'ninja', abort=True )
 
         xcodebuild = ToolProbe( 'XCODEBUILD.exe', 'xcodebuild', 'xcodebuild', abort=(True if (build_tuple.match('*-*-darwin*') and cross is None) else False), versionopt='-version', minversion=[10,3,0] )


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Updates libdav1d to their latest stable. Features some performance enhancements. Per their NEWS:

```
Changes for 0.6.0 'Gyrfalcon':
------------------------------

0.6.0 is a major release for dav1d:
 - New ARM64 optimizations for the 10/12bit depth:
    - mc_avg, mc_w_avg, mc_mask
    - mc_put/mc_prep 8tap/bilin
    - mc_warp_8x8
    - mc_w_mask
    - mc_blend
    - wiener
    - SGR
    - loopfilter
    - cdef
 - New AVX-512 optimizations for prep_bilin, prep_8tap, cdef_filter, mc_avg/w_avg/mask
 - New SSSE3 optimizations for film grain
 - New AVX2 optimizations for msac_adapt16
 - Fix rare mismatches against the reference decoder, notably because of clipping
 - Improvements on ARM64 on msac, cdef and looprestoration optimizations
 - Improvements on AVX2 optimizations for cdef_filter
 - Improvements in the C version for itxfm, cdef_filter

Changes for 0.5.2 'Asiatic Cheetah':
------------------------------------

0.5.2 is a small release improving speed for ARM32 and adding minor features:
 - ARM32 optimizations for loopfilter, ipred_dc|h|v
 - Add section-5 raw OBU demuxer
 - Improve the speed by reducing the L2 cache collisions
 - Fix minor issues
```

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
