### PR TITLE
Add libjpeg-turbo for preview image size reduction on disk.

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,0 +1,48 @@
+$(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
+$(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
+
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-2.0.4.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://sourceforge.net/projects/libjpeg-turbo/files/2.0.4/libjpeg-turbo-2.0.4.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 33dd8547efd5543639e890efbf2ef52d5a21df81faf41bb940657af916a23406
+
+LIBJPEGTURBO.build_dir             = build
+LIBJPEGTURBO.CONFIGURE.exe         = cmake
+LIBJPEGTURBO.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(LIBJPEGTURBO.CONFIGURE.prefix)"
+LIBJPEGTURBO.CONFIGURE.deps        =
+LIBJPEGTURBO.CONFIGURE.static      =
+LIBJPEGTURBO.CONFIGURE.shared      = -DENABLE_SHARED=OFF
+
+ifeq (size-aggressive,$(GCC.O))
+    LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG" -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG"
+endif
+
+ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
+    LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
+else
+    ifneq (none,$(LIBJPEGTURBO.GCC.g))
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    else
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    endif
+endif
+
+ifeq (1,$(HOST.cross))
+    ifeq (mingw,$(HOST.system))
+        LIBJPEGTURBO.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_SYSTEM_NAME=Windows
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_C_COMPILER=$(LIBJPEGTURBO.GCC.gcc)
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_C_FLAGS="-static-libgcc -static-libstdc++ -static"
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_SHARED_LIBRARY_LINK_C_FLAGS="-static-libgcc -static-libstdc++ -static"
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_CXX_COMPILER=$(LIBJPEGTURBO.GCC.gxx)
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_CXX_FLAGS="-static-libgcc -static-libstdc++ -static"
+        LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+    endif
+    LIBJPEGTURBO.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(LIBJPEGTURBO.CONFIGURE.host)"
+    LIBJPEGTURBO.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(LIBJPEGTURBO.CONFIGURE.build)"
+else
+    LIBJPEGTURBO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(LIBJPEGTURBO.CONFIGURE.host)"
+endif
+
+## find CMakeLists.txt
+LIBJPEGTURBO.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(LIBJPEGTURBO.EXTRACT.dir/))"

--- a/contrib/libjpeg-turbo/module.rules
+++ b/contrib/libjpeg-turbo/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBJPEGTURBO))
+$(eval $(call import.CONTRIB.rules,LIBJPEGTURBO))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -199,7 +199,7 @@ AM_CONDITIONAL([GHB_GTK_3_16], [test "$HAVE_GTK_316" -eq 1])
 
 AM_CONDITIONAL([MINGW], [test "x$mingw_flag" = "xyes"])
 
-HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -llzma"
+HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -ljpeg -lopus -lspeex -lturbojpeg -llzma"
 HB_CPPFLAGS="$HB_CPPFLAGS $HBINC"
 
 PKG_CHECK_MODULES([x264], [x264], sys_x264=yes, sys_x264=no)

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -199,7 +199,7 @@ AM_CONDITIONAL([GHB_GTK_3_16], [test "$HAVE_GTK_316" -eq 1])
 
 AM_CONDITIONAL([MINGW], [test "x$mingw_flag" = "xyes"])
 
-HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -ljpeg -lopus -lspeex -lturbojpeg -llzma"
+HB_LIBS="$HB_LIBS -lhandbrake -lavformat -lavfilter -lavcodec -lavutil -ldav1d -lswresample -lpostproc -ldvdnav -ldvdread -lmp3lame -lvorbis -lvorbisenc -logg -lswscale -ltheoraenc -ltheoradec -lvpx -lz -lbz2 -lbluray -lass -lfontconfig -lfreetype -lxml2 -ljansson -lopus -lspeex -lturbojpeg -llzma"
 HB_CPPFLAGS="$HB_CPPFLAGS $HBINC"
 
 PKG_CHECK_MODULES([x264], [x264], sys_x264=yes, sys_x264=no)

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -28,6 +28,8 @@ extern "C" {
    etc) */
 #define HB_DEBUG_NONE 0
 #define HB_DEBUG_ALL  1
+#define HB_PREVIEW_FORMAT_YUV 0
+#define HB_PREVIEW_FORMAT_JPG 1
 void          hb_register( hb_work_object_t * );
 void          hb_register_logger( void (*log_cb)(const char* message) );
 hb_handle_t * hb_init( int verbose );
@@ -68,9 +70,9 @@ int hb_detect_comb( hb_buffer_t * buf, int color_equal, int color_diff, int thre
 
 // JJJ: title->job?
 int           hb_save_preview( hb_handle_t * h, int title, int preview,
-                               hb_buffer_t *buf );
+                               hb_buffer_t *buf, int format );
 hb_buffer_t * hb_read_preview( hb_handle_t * h, hb_title_t *title,
-                               int preview );
+                               int preview, int format );
 #endif // __LIBHB__
 
 hb_image_t  * hb_get_preview2(hb_handle_t * h, int title_idx, int picture,

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -114,7 +114,7 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 LIBHB.dll.libs = $(foreach n, \
         ass avformat avfilter avcodec avutil swresample postproc dvdnav dvdread \
         freetype mp3lame swscale vpx theora vorbis vorbisenc ogg x264 xml2 \
-        bluray jansson harfbuzz opus speex dav1d jpeg turbojpeg, \
+        bluray jansson harfbuzz opus speex dav1d turbojpeg, \
         $(CONTRIB.build/)lib/lib$(n).a )
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,7 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX FFMPEG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBSAMPLERATE LIBTHEORA LIBVORBIS LIBOGG \
     LIBXML2 X264 X265 ZLIB LIBBLURAY FDKAAC LIBMFX LIBGNURX JANSSON \
-    HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D
+    HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D LIBJPEGTURBO
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     __deps__ += FONTCONFIG
@@ -113,8 +113,8 @@ LIBHB.lib = $(LIBHB.build/)hb.lib
 
 LIBHB.dll.libs = $(foreach n, \
         ass avformat avfilter avcodec avutil swresample postproc dvdnav dvdread \
-        freetype mp3lame swscale vpx theora vorbis vorbisenc ogg \
-        x264 xml2 bluray jansson harfbuzz opus speex dav1d, \
+        freetype mp3lame swscale vpx theora vorbis vorbisenc ogg x264 xml2 \
+        bluray jansson harfbuzz opus speex dav1d jpeg turbojpeg, \
         $(CONTRIB.build/)lib/lib$(n).a )
 
 ifeq (1,$(FEATURE.fdk_aac))

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -844,7 +844,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
 
         if( data->store_previews )
         {
-            hb_save_preview( data->h, title->index, i, vid_buf );
+            hb_save_preview( data->h, title->index, i, vid_buf, HB_PREVIEW_FORMAT_JPG );
         }
 
         /* Detect black borders */

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -34,6 +34,10 @@
 		1C7776A5202301D5001C31EB /* HBRenamePresetController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1C7776A3202301D5001C31EB /* HBRenamePresetController.xib */; };
 		1CBC683420BE014800A26CC2 /* liblzma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC683320BE014800A26CC2 /* liblzma.a */; };
 		1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC683320BE014800A26CC2 /* liblzma.a */; };
+		1CDCF0C3241F28D400FB62C6 /* libturbojpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */; };
+		1CDCF0C4241F28D400FB62C6 /* libturbojpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */; };
+		1CDCF0C5241F28D400FB62C6 /* libjpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C2241F28D400FB62C6 /* libjpeg.a */; };
+		1CDCF0C6241F28D400FB62C6 /* libjpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C2241F28D400FB62C6 /* libjpeg.a */; };
 		22DD2C4B177B95DA00EF50D3 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
 		273F202614ADB8A40021BE6D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202514ADB8A40021BE6D /* libz.dylib */; };
@@ -447,6 +451,8 @@
 		1C7776A0202300DC001C31EB /* HBRenamePresetController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HBRenamePresetController.m; sourceTree = "<group>"; };
 		1C7776A1202300DC001C31EB /* HBRenamePresetController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBRenamePresetController.h; sourceTree = "<group>"; };
 		1CBC683320BE014800A26CC2 /* liblzma.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblzma.a; path = external/contrib/lib/liblzma.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libturbojpeg.a; path = external/contrib/lib/libturbojpeg.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		1CDCF0C2241F28D400FB62C6 /* libjpeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libjpeg.a; path = external/contrib/lib/libjpeg.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22CC9E74191EBEA500C69D81 /* libx265.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libx265.a; path = external/contrib/lib/libx265.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DD2C49177B94DB00EF50D3 /* libvpx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvpx.a; path = external/contrib/lib/libvpx.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		271BA4C014B119F800BC1D2C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = external/macosx/Info.plist; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -934,6 +940,8 @@
 				27D6C75014B102DA00B785E4 /* libdvdnav.a in Frameworks */,
 				27D6C75214B102DA00B785E4 /* libdvdread.a in Frameworks */,
 				1C53DE8C20BD598D006BBCA8 /* libspeex.a in Frameworks */,
+				1CDCF0C5241F28D400FB62C6 /* libjpeg.a in Frameworks */,
+				1CDCF0C3241F28D400FB62C6 /* libturbojpeg.a in Frameworks */,
 				27D6C75814B102DA00B785E4 /* libfreetype.a in Frameworks */,
 				27D6C75A14B102DA00B785E4 /* libfribidi.a in Frameworks */,
 				27D6C75F14B102DA00B785E4 /* libmp3lame.a in Frameworks */,
@@ -1024,6 +1032,8 @@
 				A91CE2B91C7DABBC0068F46F /* libbluray.a in Frameworks */,
 				D0DC8F69233159C700C12A24 /* libdav1d.a in Frameworks */,
 				A91CE2BA1C7DABBC0068F46F /* libdvdnav.a in Frameworks */,
+				1CDCF0C6241F28D400FB62C6 /* libjpeg.a in Frameworks */,
+				1CDCF0C4241F28D400FB62C6 /* libturbojpeg.a in Frameworks */,
 				A91CE2BB1C7DABBC0068F46F /* libdvdread.a in Frameworks */,
 				1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */,
 				A91CE2BD1C7DABBC0068F46F /* libfreetype.a in Frameworks */,
@@ -1058,6 +1068,8 @@
 		271BA4C714B1236D00BC1D2C /* Static Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				1CDCF0C2241F28D400FB62C6 /* libjpeg.a */,
+				1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */,
 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
 				1CBC683320BE014800A26CC2 /* liblzma.a */,
 				1C0695AA20BD193D001543DA /* libpostproc.a */,

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -36,8 +36,6 @@
 		1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CBC683320BE014800A26CC2 /* liblzma.a */; };
 		1CDCF0C3241F28D400FB62C6 /* libturbojpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */; };
 		1CDCF0C4241F28D400FB62C6 /* libturbojpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */; };
-		1CDCF0C5241F28D400FB62C6 /* libjpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C2241F28D400FB62C6 /* libjpeg.a */; };
-		1CDCF0C6241F28D400FB62C6 /* libjpeg.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 1CDCF0C2241F28D400FB62C6 /* libjpeg.a */; };
 		22DD2C4B177B95DA00EF50D3 /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
 		273F202614ADB8A40021BE6D /* libz.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202514ADB8A40021BE6D /* libz.dylib */; };
@@ -452,7 +450,6 @@
 		1C7776A1202300DC001C31EB /* HBRenamePresetController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBRenamePresetController.h; sourceTree = "<group>"; };
 		1CBC683320BE014800A26CC2 /* liblzma.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = liblzma.a; path = external/contrib/lib/liblzma.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libturbojpeg.a; path = external/contrib/lib/libturbojpeg.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		1CDCF0C2241F28D400FB62C6 /* libjpeg.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libjpeg.a; path = external/contrib/lib/libjpeg.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22CC9E74191EBEA500C69D81 /* libx265.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libx265.a; path = external/contrib/lib/libx265.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		22DD2C49177B94DB00EF50D3 /* libvpx.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libvpx.a; path = external/contrib/lib/libvpx.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		271BA4C014B119F800BC1D2C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = external/macosx/Info.plist; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -940,7 +937,6 @@
 				27D6C75014B102DA00B785E4 /* libdvdnav.a in Frameworks */,
 				27D6C75214B102DA00B785E4 /* libdvdread.a in Frameworks */,
 				1C53DE8C20BD598D006BBCA8 /* libspeex.a in Frameworks */,
-				1CDCF0C5241F28D400FB62C6 /* libjpeg.a in Frameworks */,
 				1CDCF0C3241F28D400FB62C6 /* libturbojpeg.a in Frameworks */,
 				27D6C75814B102DA00B785E4 /* libfreetype.a in Frameworks */,
 				27D6C75A14B102DA00B785E4 /* libfribidi.a in Frameworks */,
@@ -1032,7 +1028,6 @@
 				A91CE2B91C7DABBC0068F46F /* libbluray.a in Frameworks */,
 				D0DC8F69233159C700C12A24 /* libdav1d.a in Frameworks */,
 				A91CE2BA1C7DABBC0068F46F /* libdvdnav.a in Frameworks */,
-				1CDCF0C6241F28D400FB62C6 /* libjpeg.a in Frameworks */,
 				1CDCF0C4241F28D400FB62C6 /* libturbojpeg.a in Frameworks */,
 				A91CE2BB1C7DABBC0068F46F /* libdvdread.a in Frameworks */,
 				1C6D76561CD7733400F5B943 /* libharfbuzz.a in Frameworks */,
@@ -1068,7 +1063,6 @@
 		271BA4C714B1236D00BC1D2C /* Static Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				1CDCF0C2241F28D400FB62C6 /* libjpeg.a */,
 				1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */,
 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
 				1CBC683320BE014800A26CC2 /* liblzma.a */,

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -28,6 +28,7 @@ ifneq (,$(filter $(HOST.system),darwin cygwin mingw))
     MODULES += contrib/x264
     MODULES += contrib/jansson
     MODULES += contrib/libvpx
+    MODULES += contrib/libjpeg-turbo
 endif
 
 ifeq (1,$(FEATURE.flatpak))

--- a/test/module.defs
+++ b/test/module.defs
@@ -15,9 +15,9 @@ TEST.libs = $(LIBHB.a)
 
 TEST.GCC.l = \
         ass avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
-        dvdread fribidi \
-        swscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 \
-        bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma dav1d
+        dvdread fribidi swscale vpx theoraenc theoradec vorbis vorbisenc ogg \
+        x264 bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma dav1d \
+        jpeg turbojpeg
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     TEST.GCC.l += fontconfig

--- a/test/module.defs
+++ b/test/module.defs
@@ -17,7 +17,7 @@ TEST.GCC.l = \
         ass avformat avfilter avcodec avutil swresample postproc mp3lame dvdnav \
         dvdread fribidi swscale vpx theoraenc theoradec vorbis vorbisenc ogg \
         x264 bluray freetype xml2 bz2 z jansson harfbuzz opus speex lzma dav1d \
-        jpeg turbojpeg
+        turbojpeg
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     TEST.GCC.l += fontconfig


### PR DESCRIPTION
**Update:** Wired up and functional (https://github.com/HandBrake/HandBrake/pull/2696#issuecomment-605739894).

As the title states, we may wish to use this ~for experimentation~, specifically with improving on-disk cache sizes for preview images as storage resolutions increase. Speed will likely also improve due to reducing storage/retrieval times, offloading part of the workload to the CPU which is usually not under high load during scan.

[API Documentation](https://libjpeg-turbo.org/Documentation/Documentation). `libjpeg.a|so` exposes the original libjpeg API while `libturbojpeg.a|so` exposes the TurboJPEG API, which is simpler albeit less powerful. ~Both are linked. If all platforms decide on the same API, we can exclude the other lib. There's no major pressure to do so as each should be under 1 MB.~ This would seem to affect libhb only and I implemented compression/decompression using the TurboJPEG API.

**On Fedora, please install the `turbojpeg-devel` package**. Not `libturbojpeg-devel`, which is probably installed already, but does not provide `libturbojpeg.so`.

I have not yet tested on other distros or architectures other than x86_64. I hope I properly ensured `module.defs` is compatible with other architectures, including aarch64.

This builds and statically links on macOS/mingw-w64. My mingw-w64 cross build was from macOS.

Quoting [my previous comments](https://github.com/HandBrake/HandBrake/issues/2574#issuecomment-573934103) on #2574:

> For grins, I ran tests with libjpeg-turbo 2.0.4 against 30 images from Tears Of Steel 4K (3840x2160 letterboxed) on my dual X5680 3.33 GHz (12 total cores, 24 threads). Encoding/decoding is to/from memory and benchmarks are an average of four runs. I used GNU parallel (which adds ~0.2s latency in this case) for parallelism.

> Encoding:

| Encode Threads | Time - To YUV | Time - To RGB |
|----------------|---------------|---------------|
| 1              | 3.01s         | 4.25s         |
| 2              | 1.67s         | 2.29s         |
| 4              | 1.03s         | 1.36s         |
| 8              | 0.69s         | 0.87s         |
| 16             | 0.60s         | 0.71s         |
| 24             | 0.61s         | 0.68s         |

> Decoding (to RGB, no speed impact vs. YUV):

| Decode Threads | Time - From YUV | Time - From RGB |
|----------------|-----------------|-----------------|
| 1              | 1.83s           | 2.80s           |
| 2              | 1.04s           | 1.54s           |
| 4              | 0.68s           | 0.94s           |
| 8              | 0.50s           | 0.64s           |
| 16             | 0.49s           | 0.55s           |
| 24             | 0.49s           | 0.55s           |

> It would seem simultaneously encoding/decoding 30 4K images to/from JPEG can be accomplished in around a second on consumer hardware (say, 4 reasonably fast cores).

> In reality, HandBrake would probably not be trying to compress or decompress 30 images simultaneously. Encoding a single image on a single thread takes ~120-145ms, and decoding a single image on a single thread is as fast as 45ms, including SSD load times. This is probably fast enough to be transparent for images stored/loaded on the fly, should we choose to use such a technique to reduce temporary storage.

> Size comparison, 30 total files:

| Format        | Size     |
|---------------|----------|
| BMP Original  | 748.3 MB |
| JPEG 90% RGB  |  86.7 MB |
| JPEG 90% YUV  |  32.0 MB |

**Test on:**

Smoke tested building and launching the GUI on each platform.

- [x] Windows 10
- [x] macOS 10.14
- [x] Fedora Linux 31

