### PR TITLE
Build improvements.

### DIFF
--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -51,7 +51,16 @@ ifneq (,$(filter $(HOST.system),freebsd netbsd))
 else ifneq (,$(filter $(HOST.system),darwin cygwin mingw))
     LIBHB.GCC.I += $(CONTRIB.build/)include/libxml2
 else
-    LIBHB.GCC.I += /usr/include/libxml2
+    LIBHB.libxml2 := $(shell $(PKGCONFIG.exe) --cflags libxml2)
+    ifeq (,$(LIBHB.libxml2))
+        LIBHB.libxml2 := $(shell $(PKGCONFIG.exe) --cflags libxml-2.0)
+    endif
+    ifneq (,$(LIBHB.libxml2))
+        LIBHB.libxml2 := $(patsubst -I%,%,$(LIBHB.libxml2))
+        LIBHB.GCC.I += $(LIBHB.libxml2)
+    else
+        LIBHB.GCC.I += /usr/include/libxml2
+    endif
 endif
 
 ifeq ($(HOST.system),cygwin)

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -125,7 +125,7 @@ define import.CONTRIB.defs
     endif
     $(1).CONFIGURE.env.CPPFLAGS = CPPFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver *D)"
     $(1).CONFIGURE.env.LDFLAGS  = LDFLAGS="-L$$(call fn.ABSOLUTE,$(CONTRIB.build/))lib $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?extra.exe *D)"
-    $(1).CONFIGURE.env.PKG_CONFIG_PATH  = PKG_CONFIG_PATH="$$(call fn.ABSOLUTE,$$(CONTRIB.build/))lib/pkgconfig"
+    $(1).CONFIGURE.env.PKG_CONFIG_PATH  = PKG_CONFIG_PATH="$$(call fn.ABSOLUTE,$$(CONTRIB.build/))lib/pkgconfig:$$(PKG_CONFIG_PATH)"
 
     $(1).CONFIGURE.env.args = !CC !CFLAGS !CXX !CXXFLAGS !CPPFLAGS !LD !LDFLAGS !PKG_CONFIG_PATH !LOCAL_PATH !CROSS
     $(1).CONFIGURE.env = $$(call fn.ARGS,$(1).CONFIGURE.env,$$($(1).CONFIGURE.env.args))


### PR DESCRIPTION
Improves library detection for system packages and allows custom pkg-config files paths. On Linux, uses pkg-config to locate libxml2 for libhb if possible, falling back to the previous hardcoded path. FFmpeg looks for libxml2 in the same manner.

While I initially worked on these improvements due to #2690 (and this PR does fix building on NixOS), the solutions are more generic in nature and should make the build system a bit more robust in these areas.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
