### PR TITLE
gtk: Remove unnecessary linker flags when targeting mingw

### DIFF
--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -115,7 +115,7 @@ ghb_SOURCES = \
 
 if MINGW
 ghb_LDFLAGS = \
-	-mwindows -Wl,--export-dynamic -Wl,--exclude-libs,ALL
+	-mwindows
 else
 ghb_LDFLAGS = \
 	-Wl,--export-dynamic -Wl,--exclude-libs,ALL


### PR DESCRIPTION
The `--export-dynamic` flag is a no-op when targeting mingw; when used, binutils ld prints this warning:
```
warning: --export-dynamic is not supported for PE+ targets, did you mean --export-all-symbols?
```

The `--exclude-libs ALL` flag also is unnecessary; as this is an exe, there's no symbols being exported automatically, so there's no need to exclude anything.

LLD's COFF/mingw backend doesn't implement these flags, and this fixes linking ghb.exe with it.
