### PR TITLE
WinGui: keep all previous gui advanced options and add qsv lowpower

### DIFF
--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -325,11 +325,11 @@ namespace HandBrakeWPF.Services.Encode.Factories
             {
                 if (configuration.EnableQsvLowPower && !video.Options.Contains("lowpower"))
                 {
-                    video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=1" : ":lowpower=1";
+                    video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=1" : string.Concat(video.Options, ":lowpower=1");
                 }
                 else if(!configuration.EnableQsvLowPower && !video.Options.Contains("lowpower"))
                 {
-                    video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=0" : ":lowpower=0";
+                    video.Options = string.IsNullOrEmpty(video.Options) ? "lowpower=0" : string.Concat(video.Options, ":lowpower=0");
                 }
             }
 


### PR DESCRIPTION
Fix concatenation of gui advanced options and lowpower option. 