### PR TITLE
libhb: Improve buffer pool sizes.

### DIFF
--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -106,7 +106,7 @@ void hb_buffer_pool_init( void )
     for (i = 1; i < HB_BUFFER_POOL_NUM_SIZES; ++i)
     {
         buffers.pool[i] = hb_fifo_init(HB_BUFFER_POOL_BUFFERS_PER_SIZE, 1);
-        buffers.pool[i]->buffer_size = buffers.pool[i-1]->buffer_size * HB_BUFFER_POOL_SIZE_MULTIPLIER;
+        buffers.pool[i]->buffer_size = (uint32_t)(buffers.pool[i-1]->buffer_size * HB_BUFFER_POOL_SIZE_MULTIPLIER);
     }
 #endif
 }


### PR DESCRIPTION
Buffer sizes were 1 KiB to 32 MiB with 16 total variations (up to 23 possible starting at 1 KiB). 32 buffers per size. Max buffer size supports 5K yuv420.

Buffer sizes are now 4 KiB to ~65 MiB with 25 total variations, each size increment 50% larger instead of 100%. 2^N is mostly unnecessary these days. Many more variations are possible due to de-duplicating the first 10 array indices and making the first buffer size and multiplier configurable (up to 35 variations are possible with these settings alone). Better granularity leads to less memory use in some cases, depending on frame resolution. 96 buffers per size means more pool hits for all frame resolutions. Max buffer size supports 8K yuv420.

Edit: I should add, this is up to 20% faster for resolutions above around 5K (source and/or destination), while typically allocating 13% more memory or less. Moderate resolutions perform on-par or slightly better.

Edit 2: Performance improvements here observed using macOS 10.14.6; other systems' memory allocators may perform differently.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.14.6
- [ ] Ubuntu Linux
