### PR TITLE
Increase buffer memory for hevc QSV.

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -315,12 +315,12 @@ static int qsv_hevc_make_header(hb_work_object_t *w, mfxSession session)
     }
 
     /* need more space for 10bits */
-    int bpp12 = 3;
-    if (pv->param.videoParam->mfx.FrameInfo.FourCC == MFX_FOURCC_P010)
+    if (pv->param.videoParam->mfx.FrameInfo.FourCC == MFX_FOURCC_P010 ||
+        pv->param.videoParam->mfx.CodecId == MFX_CODEC_HEVC)
     {
          hb_buffer_realloc(bitstream_buf,bitstream_buf->size*2);
-         bpp12 = 6;
     }
+    int bpp12 = (pv->param.videoParam->mfx.FrameInfo.FourCC == MFX_FOURCC_P010) ? 6 : 3;
     bitstream.Data      = bitstream_buf->data;
     bitstream.MaxLength = bitstream_buf->alloc;
 


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
Increase buffer size for H265. QSV.
It seems that Intel Media SDK requires more buffer memory since 20.1.0,  HEVC code has been refactored. 

This PR solves following issue.
https://github.com/HandBrake/HandBrake/issues/2858

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [ ] FreeBSD

**Screenshots (If relevant):**


**Log file output (If relevant):**
