### PR TITLE
encavcodec: Set the framerate field in addition to time_base

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -250,6 +250,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
 
     context->time_base.den = fps.num;
     context->time_base.num = fps.den;
+    context->framerate     = fps;
     context->gop_size  = ((double)job->orig_vrate.num / job->orig_vrate.den +
                                   0.5) * 10;
     if ((job->vcodec == HB_VCODEC_FFMPEG_VCE_H264) || (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265))


### PR DESCRIPTION
The AVCodecContext struct nowadays has got a frame rate field, which
is supposed to be used for indicating the frame rate, allowing the
time_base to be different, for properly describing VFR content.
(There's potentially still some encoders that still interpret
1/time_base as the frame rate though.)
