### PR TITLE
contrib: Update libdav1d to 0.7.0

### DIFF
--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.5.1.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.5.1/dav1d-0.5.1.tar.bz2
-LIBDAV1D.FETCH.sha256  = 0214d201a338e8418f805b68f9ad277e33d79c18594dee6eaf6dcd74db2674a9
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.7.0.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.7.0/dav1d-0.7.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = 8057149f5f08c5ca47e1344fba9046ff84ac85ca409d7adbec8268c707ec5c19
 
 LIBDAV1D.build_dir     = build/
 

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -14,7 +14,7 @@ LIBDAV1D.CONFIGURE.host   =
 LIBDAV1D.CONFIGURE.build  =
 LIBDAV1D.CONFIGURE.static = -Ddefault_library=static
 LIBDAV1D.CONFIGURE.extra  = --libdir=$(call fn.ABSOLUTE,$(CONTRIB.build/))lib/ \
-                            -Denable_tools=false -Denable_tests=false
+                            -Denable_tools=false -Denable_tests=false -Denable_avx512=false
 LIBDAV1D.CONFIGURE.env    =
 
 ifneq (none,$(LIBDAV1D.GCC.g))


### PR DESCRIPTION
Updates libdav1d to 0.7.0, which includes many performance optimizations. In contrary to dav1d 0.6.0, version 0.7.0 is compatible with Nasm 2.13 again.

Dav1d changelog: https://code.videolan.org/videolan/dav1d/-/blob/master/NEWS

**Tested on** (help wanted for macOS and Ubuntu)
- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

dav1d 0.7.0 was also [tested extensively](https://code.videolan.org/videolan/dav1d/pipelines/17653) on the VideoLAN CI and is integrated in FFmpeg, [VLC](https://git.videolan.org/?p=vlc/vlc-3.0.git;a=commit;h=5476f6252571b11c41fcf93014ed5e916fa08607) and [Chromium](https://chromium.googlesource.com/external/github.com/videolan/dav1d/).

This PR succeeds #2679.