### PR TITLE
gtk: Skip building the metainfo xml when targeting windows

### DIFF
--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -41,8 +41,10 @@ hb_menu = fr.handbrake.ghb.desktop
 
 metainfodir = $(datarootdir)/metainfo
 metainfo_in_files = fr.handbrake.ghb.metainfo.xml.in
+if ! MINGW
 metainfo_DATA = $(metainfo_in_files:.xml.in=.xml)
 dist_metainfo_DATA = $(metainfo_files)
+endif
 
 EXTRA_DIST = \
 	$(metainfo_in_files)


### PR DESCRIPTION
This file is only supposed to be used by desktop managers to get info
about the app. On windows, the file is unused.

Since 368576dc9aa94c792a309e227c9a893776d8cdd1, the translation step
for this file requires gettext 0.20 or newer.
