### PR TITLE
contrib: Update to FFmpeg 4.2.3.

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -12,9 +12,9 @@ endif
 $(eval $(call import.MODULE.defs,FFMPEG,ffmpeg,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FFMPEG))
 
-FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-4.2.2.tar.bz2
-FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-4.2.2.tar.bz2
-FFMPEG.FETCH.sha256 = b620d187c26f76ca19e74210a0336c3b8380b97730df5cdf45f3e69e89000e5c
+FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-4.2.3.tar.bz2
+FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-4.2.3.tar.bz2
+FFMPEG.FETCH.sha256 = 217eb211c33303b37c5521a5abe1f0140854d6810c6a6ee399456cc96356795e
 
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =


### PR DESCRIPTION
Numerous bug fixes. Will be good to get this in for HandBrake 1.3.3.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.14
- [x] Ubuntu Linux
