### PR TITLE
qsv: performance optimization of dx11 texture copying

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -2081,11 +2081,6 @@ static int qsv_enc_work(hb_work_private_t *pv,
 
             if (sts == MFX_ERR_MORE_DATA)
             {
-                if(!pv->is_sys_mem && surface)
-                {
-                    hb_qsv_release_surface_from_pool(surface->Data.MemId);
-                }
-
                 if (qsv_atom != NULL)
                 {
                     hb_list_add(pv->delayed_processing, qsv_atom);


### PR DESCRIPTION
Created dedicated pool of single textures instead of using DirectX pool
textures with slices from FFMPEG.
Explicitly call ID3D11DeviceContext_Flush function
Improved overall 4K AVC -> 4k HEVC transcoding performance from 58 fps to 63 fps on IceLake when using zero copy