### PR TITLE
LinGui: tweak About dialog so Close button works

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -4542,7 +4542,8 @@ about_action_cb(GSimpleAction *action, GVariant *param, signal_user_data_t *ud)
                                 HB_PROJECT_URL_WEBSITE);
     gtk_about_dialog_set_website_label(GTK_ABOUT_DIALOG(widget),
                                         HB_PROJECT_URL_WEBSITE);
-    gtk_widget_show (widget);
+    gtk_dialog_run(GTK_DIALOG(widget));
+    gtk_widget_hide(widget);
 }
 
 #define HB_DOCS "https://handbrake.fr/docs/"


### PR DESCRIPTION
Clicking on "Close" emits a "response" signal which was ignored. Make
the button work by calling gtk_dialog_run(), as it's done for similar
dialogs in callbacks.c.

Fixes https://github.com/HandBrake/HandBrake/issues/2405

_Tested on Xfce 4.14 with GTK+ 3.24.20._