### PR TITLE
Only dither audio when necessary

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1775,10 +1775,16 @@ int hb_audio_dither_get_default_method()
     return SWR_DITHER_TRIANGULAR;
 }
 
-int hb_audio_dither_is_supported(uint32_t codec)
+int hb_audio_dither_is_supported(uint32_t codec, int depth)
 {
     // Since dithering is performed by swresample, all codecs are supported
-    return 1;
+    switch (codec)
+    {
+        case HB_ACODEC_FFFLAC:
+            if (depth == 0 || depth > 16)
+                return 1;
+    }
+    return 0;
 }
 
 int hb_audio_dither_get_from_name(const char *name)

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -253,7 +253,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                        context->sample_rate, 0);
         av_opt_set_int(pv->swresample, "out_sample_rate",
                        context->sample_rate, 0);
-        if (hb_audio_dither_is_supported(audio->config.out.codec))
+        if (hb_audio_dither_is_supported(audio->config.out.codec,
+                                         audio->config.in.sample_bit_depth))
         {
             // dithering needs the sample rate
             av_opt_set_int(pv->swresample, "dither_method",

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -385,7 +385,7 @@ float hb_audio_compression_get_default(uint32_t codec);
 
 int                hb_audio_dither_get_default(void);
 int                hb_audio_dither_get_default_method(void); // default method, if enabled && supported
-int                hb_audio_dither_is_supported(uint32_t codec);
+int                hb_audio_dither_is_supported(uint32_t codec, int depth);
 int                hb_audio_dither_get_from_name(const char *name);
 const char*        hb_audio_dither_get_description(int method);
 const hb_dither_t* hb_audio_dither_get_next(const hb_dither_t *last);

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -703,7 +703,8 @@ void hb_display_job_info(hb_job_t *job)
                 {
                     hb_log( "   + dynamic range compression: %f", audio->config.out.dynamic_range_compression );
                 }
-                if (hb_audio_dither_is_supported(audio->config.out.codec))
+                if (hb_audio_dither_is_supported(audio->config.out.codec,
+                                            audio->config.in.sample_bit_depth))
                 {
                     hb_log("   + dither: %s",
                            hb_audio_dither_get_description(audio->config.out.dither_method));
@@ -1203,7 +1204,8 @@ static int sanitize_audio(hb_job_t *job)
         }
 
         /* sense-check the requested dither */
-        if (hb_audio_dither_is_supported(audio->config.out.codec))
+        if (hb_audio_dither_is_supported(audio->config.out.codec,
+                                         audio->config.in.sample_bit_depth))
         {
             if (audio->config.out.dither_method ==
                 hb_audio_dither_get_default())

--- a/test/test.c
+++ b/test/test.c
@@ -1613,7 +1613,7 @@ static void ShowHelp()
     encoder = NULL;
     while ((encoder = hb_audio_encoder_get_next(encoder)) != NULL)
     {
-        if (hb_audio_dither_is_supported(encoder->codec))
+        if (hb_audio_dither_is_supported(encoder->codec, 0))
         {
             fprintf(out, "                               %s\n", encoder->short_name);
         }
@@ -5021,7 +5021,7 @@ PrepareJob(hb_handle_t *h, hb_title_t *title, hb_dict_t *preset_dict)
             int codec;
             audio_dict = hb_value_array_get(audio_array, ii);
             codec = hb_value_get_int(hb_dict_get(audio_dict, "Encoder"));
-            if (hb_audio_dither_is_supported(codec))
+            if (hb_audio_dither_is_supported(codec, 0))
             {
                 hb_dict_set(audio_dict, "DitherMethod",
                             hb_value_double(dither));


### PR DESCRIPTION
If dither is "auto", only enable dither if source depth > dest depth


**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

