### PR TITLE
Windows: Added TrackNumber to SourceAudioTrack and SourceSubtitleTrack.

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
+++ b/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
@@ -15,6 +15,11 @@ namespace HandBrake.Interop.Interop.Json.Scan
     public class SourceAudioTrack
     {
         /// <summary>
+        /// Gets or sets the track number (1-based).
+        /// </summary>
+        public int TrackNumber { get; set; }
+
+        /// <summary>
         /// Gets or sets the bit rate.
         /// </summary>
         public int BitRate { get; set; }

--- a/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceSubtitleTrack.cs
+++ b/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceSubtitleTrack.cs
@@ -3,17 +3,22 @@
 //   This file is part of the HandBrake source code - It may be used under the terms of the GNU General Public License.
 // </copyright>
 // <summary>
-//   The subtitle list.
+//   A subtitle track from the source video.
 // </summary>
 // --------------------------------------------------------------------------------------------------------------------
 
 namespace HandBrake.Interop.Interop.Json.Scan
 {
     /// <summary>
-    /// The subtitle list.
+    /// A subtitle track from the source video.
     /// </summary>
     public class SourceSubtitleTrack
     {
+        /// <summary>
+        /// Gets or sets the track number (1-based).
+        /// </summary>
+        public int TrackNumber { get; set; }
+
         /// <summary>
         /// Gets or sets the format.
         /// </summary>


### PR DESCRIPTION
**Description of Change:**
Added the Audio/Subtitle track number to the JSON types.

Builds on https://github.com/HandBrake/HandBrake/commit/f04e441f7553e980e4f4144e8f94080c370f3164