### PR TITLE
removing thread priority change for better performance

### DIFF
--- a/contrib/x265/A04-threads-priority.patch
+++ b/contrib/x265/A04-threads-priority.patch
@@ -1,0 +1,18 @@
+diff --git a/source/common/threadpool.cpp b/source/common/threadpool.cpp
+index 2db7a146b..4ed534d6b 100644
+--- a/source/common/threadpool.cpp
++++ b/source/common/threadpool.cpp
+@@ -115,12 +115,6 @@ void WorkerThread::threadMain()
+ {
+     THREAD_NAME("Worker", m_id);
+ 
+-#if _WIN32
+-    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+-#else
+-    __attribute__((unused)) int val = nice(10);
+-#endif
+-
+     m_pool.setCurrentThreadAffinity();
+ 
+     sleepbitmap_t idBit = (sleepbitmap_t)1 << m_id;
+

--- a/contrib/x265_10bit/A04-threads-priority.patch
+++ b/contrib/x265_10bit/A04-threads-priority.patch
@@ -1,0 +1,18 @@
+diff --git a/source/common/threadpool.cpp b/source/common/threadpool.cpp
+index 2db7a146b..4ed534d6b 100644
+--- a/source/common/threadpool.cpp
++++ b/source/common/threadpool.cpp
+@@ -115,12 +115,6 @@ void WorkerThread::threadMain()
+ {
+     THREAD_NAME("Worker", m_id);
+ 
+-#if _WIN32
+-    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+-#else
+-    __attribute__((unused)) int val = nice(10);
+-#endif
+-
+     m_pool.setCurrentThreadAffinity();
+ 
+     sleepbitmap_t idBit = (sleepbitmap_t)1 << m_id;
+

--- a/contrib/x265_12bit/A04-threads-priority.patch
+++ b/contrib/x265_12bit/A04-threads-priority.patch
@@ -1,0 +1,18 @@
+diff --git a/source/common/threadpool.cpp b/source/common/threadpool.cpp
+index 2db7a146b..4ed534d6b 100644
+--- a/source/common/threadpool.cpp
++++ b/source/common/threadpool.cpp
+@@ -115,12 +115,6 @@ void WorkerThread::threadMain()
+ {
+     THREAD_NAME("Worker", m_id);
+ 
+-#if _WIN32
+-    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+-#else
+-    __attribute__((unused)) int val = nice(10);
+-#endif
+-
+     m_pool.setCurrentThreadAffinity();
+ 
+     sleepbitmap_t idBit = (sleepbitmap_t)1 << m_id;
+

--- a/contrib/x265_8bit/A04-threads-priority.patch
+++ b/contrib/x265_8bit/A04-threads-priority.patch
@@ -1,0 +1,18 @@
+diff --git a/source/common/threadpool.cpp b/source/common/threadpool.cpp
+index 2db7a146b..4ed534d6b 100644
+--- a/source/common/threadpool.cpp
++++ b/source/common/threadpool.cpp
+@@ -115,12 +115,6 @@ void WorkerThread::threadMain()
+ {
+     THREAD_NAME("Worker", m_id);
+ 
+-#if _WIN32
+-    SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_BELOW_NORMAL);
+-#else
+-    __attribute__((unused)) int val = nice(10);
+-#endif
+-
+     m_pool.setCurrentThreadAffinity();
+ 
+     sleepbitmap_t idBit = (sleepbitmap_t)1 << m_id;
+


### PR DESCRIPTION
x265 should rely on final application settings instead of default switch,
temporary solution until upstreamed to x265

OS scheduler can make wrong decision based on priority lower than normal