### PR TITLE
qsv: added HW offload of resize filter

### DIFF
--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -240,9 +240,7 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
 #if HB_PROJECT_FEATURE_QSV
     mfxFrameSurface1 *surface = NULL;
     // We need to keep surface pointer because hb_avfilter_add_buf set it to 0 after in ffmpeg call
-    int use_qsv_filters = (pv->input.job && pv->input.job->qsv.ctx &&
-        pv->input.job->qsv.ctx->qsv_filters_are_enabled && in && in->qsv_details.frame) ? 1 : 0;
-    if (use_qsv_filters)
+    if (hb_qsv_hw_filters_are_enabled(pv->input.job) && in && in->qsv_details.frame)
     {
         surface = (mfxFrameSurface1 *)in->qsv_details.frame->data[3];
     }
@@ -262,7 +260,7 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
         buf = hb_avfilter_get_buf(pv->graph);
     }
 #if HB_PROJECT_FEATURE_QSV
-    if (use_qsv_filters && surface)
+    if (hb_qsv_hw_filters_are_enabled(pv->input.job) && surface)
     {
         hb_qsv_release_surface_from_pool_by_surface_pointer(pv->input.job->qsv.ctx->hb_dec_qsv_frames_ctx, surface);
     }

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -237,7 +237,8 @@ void hb_avfilter_alias_close( hb_filter_object_t * filter )
 static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
 {
     hb_buffer_list_t   list;
-    hb_buffer_t      * buf, * next;
+    hb_buffer_t      * buf = NULL, * next = NULL;
+    int av_frame_is_not_null = 1; // TODO: find the reason for emply input av_frame for ffmpeg filters
 #if HB_PROJECT_FEATURE_QSV
     mfxFrameSurface1 *surface = NULL;
     // We need to keep surface pointer because hb_avfilter_add_buf set it to 0 after in ffmpeg call
@@ -245,9 +246,16 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
     {
         surface = (mfxFrameSurface1 *)in->qsv_details.frame->data[3];
     }
+    else
+    {
+        av_frame_is_not_null= 0;
+    }
 #endif
-    hb_avfilter_add_buf(pv->graph, in);
-    buf = hb_avfilter_get_buf(pv->graph);
+    if (av_frame_is_not_null)
+    {
+        hb_avfilter_add_buf(pv->graph, in);
+        buf = hb_avfilter_get_buf(pv->graph);
+    }
     while (buf != NULL)
     {
         hb_buffer_list_append(&pv->list, buf);

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -92,8 +92,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     hb_dict_t * avsettings = hb_dict_init();
 
 #if HB_PROJECT_FEATURE_QSV
-    int use_qsv_filters = (init->job && init->job->qsv.ctx && init->job->qsv.ctx->qsv_filters_are_enabled) ? 1 : 0;
-    if (use_qsv_filters)
+    if (hb_qsv_hw_filters_are_enabled(init->job))
     {
         hb_dict_set_int(avsettings, "w", width);
         hb_dict_set_int(avsettings, "h", height);
@@ -169,7 +168,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     avsettings = hb_dict_init();
 
 #if HB_PROJECT_FEATURE_QSV
-    if (!use_qsv_filters)
+    if (!hb_qsv_hw_filters_are_enabled(init->job))
 #endif
     {
         // TODO: Support other pix formats

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -97,7 +97,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
         hb_dict_set_int(avsettings, "w", width);
         hb_dict_set_int(avsettings, "h", height);
         hb_dict_set(avfilter, "scale_qsv", avsettings);
-        int result = hb_create_ffmpeg_pool(width, height, AV_PIX_FMT_NV12, HB_POOL_SURFACE_SIZE, 0, &init->job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
+        int result = hb_create_ffmpeg_pool(width, height, AV_PIX_FMT_NV12, HB_QSV_POOL_SURFACE_SIZE, 0, &init->job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
         if (result < 0)
         {
             hb_error("hb_create_ffmpeg_pool vpp allocation failed");

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1176,7 +1176,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     {
         settings = hb_dict_init();
 #if HB_PROJECT_FEATURE_QSV
-        if (pv->job && pv->job->qsv.ctx && pv->job->qsv.ctx->qsv_filters_are_enabled)
+        if (hb_qsv_hw_filters_are_enabled(pv->job))
         {
             hb_dict_set(settings, "w", hb_value_int(orig_width));
             hb_dict_set(settings, "h", hb_value_int(orig_height));

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -52,7 +52,6 @@
 #include "libavutil/hwcontext_qsv.h"
 #include "handbrake/qsv_common.h"
 #include "handbrake/qsv_libav.h"
-extern HBQSVFramesContext hb_dec_qsv_frames_ctx;
 #endif
 
 static void compute_frame_duration( hb_work_private_t *pv );
@@ -1408,23 +1407,21 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
                     // more surfaces may be needed for the lookahead
                     pv->qsv.config.additional_buffers = 160;
                 }
-                if(!pv->job->qsv.ctx)
+                if (!pv->job->qsv.ctx)
                 {
-                    pv->job->qsv.ctx = av_mallocz(sizeof(hb_qsv_context));
-                    if(!pv->job->qsv.ctx)
-                    {
-                        hb_error( "decavcodecvInit: qsv ctx alloc failed" );
-                        return 1;
-                    }
+                    hb_error( "decavcodecvInit: no context" );
+                    return 1;
+                }
+                if (!pv->job->qsv.ctx->hb_dec_qsv_frames_ctx)
+                {
                     pv->job->qsv.ctx->hb_dec_qsv_frames_ctx = av_mallocz(sizeof(HBQSVFramesContext));
                     if(!pv->job->qsv.ctx->hb_dec_qsv_frames_ctx)
                     {
-                        hb_error( "sanitize_qsv: HBQSVFramesContext dec alloc failed" );
+                        hb_error( "decavcodecvInit: HBQSVFramesContext dec alloc failed" );
                         return 1;
                     }
                 }
-                hb_qsv_add_context_usage(pv->job->qsv.ctx, 0);
-
+                hb_qsv_update_frames_context(pv->job);
                 if (!pv->job->qsv.ctx->dec_space)
                 {
                     pv->job->qsv.ctx->dec_space = av_mallocz(sizeof(hb_qsv_space));

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -746,12 +746,8 @@ int qsv_enc_init(hb_work_private_t *pv)
 
     if (qsv == NULL)
     {
-        if (!pv->is_sys_mem)
-        {
-            hb_error("qsv_enc_init: decode enabled but no context!");
-            return 3;
-        }
-        job->qsv.ctx = qsv = av_mallocz(sizeof(hb_qsv_context));
+        hb_error("qsv_enc_init: no context!");
+        return 3;
     }
 
     hb_qsv_space *qsv_encode = qsv->enc_space;
@@ -1815,11 +1811,6 @@ void encqsvClose(hb_work_object_t *w)
                 }
                 qsv_enc_space->is_init_done = 0;
             }
-
-            if (pv->is_sys_mem)
-            {
-                av_freep(&qsv_ctx);
-            }
         }
     }
 
@@ -2261,7 +2252,7 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         else
         {
             // Create black buffer in the begining of the encoding, usually first 2 frames
-            hb_qsv_get_free_surface_from_pool_with_range(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
+            hb_qsv_get_free_surface_from_pool_with_range(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, HB_QSV_POOL_SURFACE_SIZE - HB_QSV_POOL_ENCODER_SIZE, HB_QSV_POOL_SURFACE_SIZE, &mid, &surface);
         }
 
         if (hb_qsv_hw_filters_are_enabled(pv->job))

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -42,8 +42,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "libavutil/hwcontext.h"
 #include <mfx/mfxvideo.h>
 
+extern int qsv_filters_are_enabled;
 extern AVBufferRef *hb_hw_device_ctx;
-EncQSVFramesContext hb_enc_qsv_frames_ctx;
+HBQSVFramesContext hb_dec_qsv_frames_ctx;
+extern HBQSVFramesContext hb_vpp_qsv_frames_ctx;
 
 /*
  * The frame info struct remembers information about each frame across calls to
@@ -554,7 +556,7 @@ static int qsv_setup_mids(mfxFrameAllocResponse *resp, AVBufferRef *hw_frames_re
 static mfxStatus hb_qsv_frame_alloc(mfxHDL pthis, mfxFrameAllocRequest *req,
                                  mfxFrameAllocResponse *resp)
 {
-    EncQSVFramesContext *ctx = pthis;
+    HBQSVFramesContext *ctx = pthis;
     int ret;
 
     /* this should only be called from an encoder or decoder and
@@ -795,13 +797,18 @@ int qsv_enc_init(hb_work_private_t *pv)
             // reuse parent session
             qsv->mfx_session = parent_session;
             mfxFrameAllocator frame_allocator = {
-                .pthis  = &hb_enc_qsv_frames_ctx,
+                .pthis  = &hb_dec_qsv_frames_ctx,
                 .Alloc  = hb_qsv_frame_alloc,
                 .Lock   = hb_qsv_frame_lock,
                 .Unlock = hb_qsv_frame_unlock,
                 .GetHDL = hb_qsv_frame_get_hdl,
                 .Free   = hb_qsv_frame_free,
             };
+
+            if (qsv_filters_are_enabled)
+            {
+                frame_allocator.pthis = &hb_vpp_qsv_frames_ctx;
+            }
 
             err = MFXVideoCORE_SetFrameAllocator(qsv->mfx_session, &frame_allocator);
             if (err != MFX_ERR_NONE)
@@ -2155,7 +2162,14 @@ static int qsv_enc_work(hb_work_private_t *pv,
                 mfxFrameSurface1 *surface = task->stage->in.p_surface;
                 if(!pv->is_sys_mem && surface)
                 {
-                    hb_qsv_release_surface_from_pool(surface->Data.MemId);
+                    if (qsv_filters_are_enabled)
+                    {
+                        hb_qsv_release_surface_from_pool(&hb_vpp_qsv_frames_ctx, surface->Data.MemId);
+                    }
+                    else
+                    {
+                        hb_qsv_release_surface_from_pool(&hb_dec_qsv_frames_ctx, surface->Data.MemId);
+                    }
                 }
 
                 if (task->bs->DataLength > 0)
@@ -2238,21 +2252,28 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         if(in->qsv_details.frame)
         {
             surface = ((mfxFrameSurface1*)in->qsv_details.frame->data[3]);
-            mid = surface->Data.MemId;
+            if (qsv_filters_are_enabled)
+            {
+                hb_qsv_get_mid_by_surface_from_pool(&hb_vpp_qsv_frames_ctx, surface, &mid);
+            }
+            else
+            {
+                hb_qsv_get_mid_by_surface_from_pool(&hb_dec_qsv_frames_ctx, surface, &mid);
+            }
         }
         else
         {
             // Create black buffer in the begining of the encoding, usually first 2 frames
-            hb_qsv_get_free_surface_from_pool(HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
+            hb_qsv_get_free_surface_from_pool_with_range(&hb_dec_qsv_frames_ctx, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
         }
 
-        if(surface)
+        if (qsv_filters_are_enabled) 
         {
-            hb_qsv_replace_surface_mid(mid, surface);
+            hb_qsv_replace_surface_mid(&hb_vpp_qsv_frames_ctx, mid, surface);
         }
         else
         {
-            goto fail;
+            hb_qsv_replace_surface_mid(&hb_dec_qsv_frames_ctx, mid, surface);
         }
 #endif
         // At this point, enc_qsv takes ownership of the QSV resources

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -802,7 +802,7 @@ int qsv_enc_init(hb_work_private_t *pv)
                 .Free   = hb_qsv_frame_free,
             };
 
-            if (pv->job->qsv.ctx->qsv_filters_are_enabled)
+            if (hb_qsv_hw_filters_are_enabled(pv->job))
             {
                 frame_allocator.pthis = pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx;
             }
@@ -2159,7 +2159,7 @@ static int qsv_enc_work(hb_work_private_t *pv,
                 mfxFrameSurface1 *surface = task->stage->in.p_surface;
                 if(!pv->is_sys_mem && surface)
                 {
-                    if (pv->job->qsv.ctx->qsv_filters_are_enabled)
+                    if (hb_qsv_hw_filters_are_enabled(pv->job))
                     {
                         hb_qsv_release_surface_from_pool(pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx, surface->Data.MemId);
                     }
@@ -2264,7 +2264,7 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
             hb_qsv_get_free_surface_from_pool_with_range(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
         }
 
-        if (pv->job->qsv.ctx->qsv_filters_are_enabled)
+        if (hb_qsv_hw_filters_are_enabled(pv->job))
         {
             hb_qsv_replace_surface_mid(pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx, mid, surface);
         }

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -42,10 +42,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "libavutil/hwcontext.h"
 #include <mfx/mfxvideo.h>
 
-extern int qsv_filters_are_enabled;
 extern AVBufferRef *hb_hw_device_ctx;
-HBQSVFramesContext hb_dec_qsv_frames_ctx;
-extern HBQSVFramesContext hb_vpp_qsv_frames_ctx;
 
 /*
  * The frame info struct remembers information about each frame across calls to
@@ -797,7 +794,7 @@ int qsv_enc_init(hb_work_private_t *pv)
             // reuse parent session
             qsv->mfx_session = parent_session;
             mfxFrameAllocator frame_allocator = {
-                .pthis  = &hb_dec_qsv_frames_ctx,
+                .pthis  = pv->job->qsv.ctx->hb_dec_qsv_frames_ctx,
                 .Alloc  = hb_qsv_frame_alloc,
                 .Lock   = hb_qsv_frame_lock,
                 .Unlock = hb_qsv_frame_unlock,
@@ -805,9 +802,9 @@ int qsv_enc_init(hb_work_private_t *pv)
                 .Free   = hb_qsv_frame_free,
             };
 
-            if (qsv_filters_are_enabled)
+            if (pv->job->qsv.ctx->qsv_filters_are_enabled)
             {
-                frame_allocator.pthis = &hb_vpp_qsv_frames_ctx;
+                frame_allocator.pthis = pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx;
             }
 
             err = MFXVideoCORE_SetFrameAllocator(qsv->mfx_session, &frame_allocator);
@@ -1771,6 +1768,8 @@ void encqsvClose(hb_work_object_t *w)
                 hb_qsv_unload_plugins(&pv->loaded_plugins, qsv_ctx->mfx_session, version);
             }
 
+            hb_qsv_uninit_enc(pv->job);
+
             /* QSV context cleanup and MFXClose */
             hb_qsv_context_clean(qsv_ctx,hb_qsv_full_path_is_enabled(pv->job));
 
@@ -1822,8 +1821,6 @@ void encqsvClose(hb_work_object_t *w)
                 av_freep(&qsv_ctx);
             }
         }
-
-        hb_qsv_uninit_enc();
     }
 
     if (pv != NULL)
@@ -2162,13 +2159,13 @@ static int qsv_enc_work(hb_work_private_t *pv,
                 mfxFrameSurface1 *surface = task->stage->in.p_surface;
                 if(!pv->is_sys_mem && surface)
                 {
-                    if (qsv_filters_are_enabled)
+                    if (pv->job->qsv.ctx->qsv_filters_are_enabled)
                     {
-                        hb_qsv_release_surface_from_pool(&hb_vpp_qsv_frames_ctx, surface->Data.MemId);
+                        hb_qsv_release_surface_from_pool(pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx, surface->Data.MemId);
                     }
                     else
                     {
-                        hb_qsv_release_surface_from_pool(&hb_dec_qsv_frames_ctx, surface->Data.MemId);
+                        hb_qsv_release_surface_from_pool(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, surface->Data.MemId);
                     }
                 }
 
@@ -2252,28 +2249,28 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         if(in->qsv_details.frame)
         {
             surface = ((mfxFrameSurface1*)in->qsv_details.frame->data[3]);
-            if (qsv_filters_are_enabled)
+            if (pv->job->qsv.ctx->qsv_filters_are_enabled)
             {
-                hb_qsv_get_mid_by_surface_from_pool(&hb_vpp_qsv_frames_ctx, surface, &mid);
+                hb_qsv_get_mid_by_surface_from_pool(pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx, surface, &mid);
             }
             else
             {
-                hb_qsv_get_mid_by_surface_from_pool(&hb_dec_qsv_frames_ctx, surface, &mid);
+                hb_qsv_get_mid_by_surface_from_pool(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, surface, &mid);
             }
         }
         else
         {
             // Create black buffer in the begining of the encoding, usually first 2 frames
-            hb_qsv_get_free_surface_from_pool_with_range(&hb_dec_qsv_frames_ctx, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
+            hb_qsv_get_free_surface_from_pool_with_range(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, HB_POOL_SURFACE_SIZE, &mid, &surface);
         }
 
-        if (qsv_filters_are_enabled) 
+        if (pv->job->qsv.ctx->qsv_filters_are_enabled)
         {
-            hb_qsv_replace_surface_mid(&hb_vpp_qsv_frames_ctx, mid, surface);
+            hb_qsv_replace_surface_mid(pv->job->qsv.ctx->hb_vpp_qsv_frames_ctx, mid, surface);
         }
         else
         {
-            hb_qsv_replace_surface_mid(&hb_dec_qsv_frames_ctx, mid, surface);
+            hb_qsv_replace_surface_mid(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, mid, surface);
         }
 #endif
         // At this point, enc_qsv takes ownership of the QSV resources

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -728,7 +728,7 @@ void hb_buffer_close( hb_buffer_t ** _b )
         if(b->qsv_details.frame)
         {
             mfxFrameSurface1 *surface = (mfxFrameSurface1*)b->qsv_details.frame->data[3];
-            if(surface)
+            if(surface && b->qsv_details.ctx)
             {
                 if(b->qsv_details.ctx->qsv_filters_are_enabled)
                 {

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -715,12 +715,6 @@ void hb_buffer_swap_copy( hb_buffer_t *src, hb_buffer_t *dst )
     src->alloc = alloc;
 }
 
-#if HB_PROJECT_FEATURE_QSV
-extern HBQSVFramesContext hb_dec_qsv_frames_ctx;
-extern HBQSVFramesContext hb_vpp_qsv_frames_ctx;
-extern int qsv_filters_are_enabled;
-#endif
-
 // Frees the specified buffer list.
 void hb_buffer_close( hb_buffer_t ** _b )
 {
@@ -736,13 +730,13 @@ void hb_buffer_close( hb_buffer_t ** _b )
             mfxFrameSurface1 *surface = (mfxFrameSurface1*)b->qsv_details.frame->data[3];
             if(surface)
             {
-                if(qsv_filters_are_enabled)
+                if(b->qsv_details.ctx->qsv_filters_are_enabled)
                 {
-                    hb_qsv_release_surface_from_pool_by_surface_pointer(&hb_dec_qsv_frames_ctx, surface);
+                    hb_qsv_release_surface_from_pool_by_surface_pointer(b->qsv_details.ctx->hb_dec_qsv_frames_ctx, surface);
                 }
                 else
                 {
-                    hb_qsv_release_surface_from_pool(&hb_dec_qsv_frames_ctx, surface->Data.MemId);
+                    hb_qsv_release_surface_from_pool(b->qsv_details.ctx->hb_dec_qsv_frames_ctx, surface->Data.MemId);
                 }
                 b->qsv_details.frame->data[3] = 0;
             }

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -12,12 +12,7 @@
 
 #include "libavutil/imgutils.h"
 #include "libavutil/pixdesc.h"
-
 #include "handbrake/project.h"
-#if HB_PROJECT_FEATURE_QSV
-#include "handbrake/qsv_libav.h"
-#include "libavcodec/avcodec.h"
-#endif
 
 /***********************************************************************
  * common.c
@@ -63,6 +58,10 @@ void hb_job_setup_passes(hb_handle_t *h, hb_job_t *job, hb_list_t *list_pass);
  * that are conditionally used depending on the type of packet.
  */
 typedef struct hb_buffer_s hb_buffer_t;
+
+#if HB_PROJECT_FEATURE_QSV
+#include "handbrake/qsv_libav.h"
+#endif
 
 struct hb_buffer_settings_s
 {

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -221,7 +221,11 @@ const char* hb_qsv_impl_get_name(int impl);
 const char* hb_qsv_impl_get_via_name(int impl);
 
 /* Full QSV pipeline helpers */
-int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
+int hb_qsv_is_enabled(hb_job_t *job);
+hb_qsv_context* hb_qsv_context_init();
+void hb_qsv_context_uninit();
+int hb_qsv_sanitize_filter_list(hb_job_t *job);
+int hb_qsv_hw_frames_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_create_ffmpeg_pool(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int pool_size, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_qsv_hw_filters_are_enabled(hb_job_t *job);
 void hb_qsv_update_frames_context(hb_job_t *job);

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -267,9 +267,10 @@ typedef struct HBQSVFramesContext {
 /* Full QSV pipeline helpers */
 int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_create_ffmpeg_pool(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int pool_size, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
+void hb_qsv_update_frames_context(hb_job_t *job);
 int hb_qsv_full_path_is_enabled(hb_job_t *job);
 AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref);
-hb_buffer_t* hb_qsv_copy_frame(HBQSVFramesContext* hb_qsv_frames_ctx, AVFrame *frame, hb_qsv_context *qsv_ctx, int is_vpp);
+hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp);
 int hb_qsv_get_free_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, AVFrame* frame, QSVMid** out_mid);
 void hb_qsv_get_free_surface_from_pool_with_range(HBQSVFramesContext* hb_enc_qsv_frames_ctx, const int start_index, const int end_index, QSVMid** out_mid, mfxFrameSurface1** out_surface);
 void hb_qsv_get_mid_by_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, mfxFrameSurface1 *surface, QSVMid **out_mid);
@@ -280,7 +281,7 @@ int hb_qsv_get_buffer(AVCodecContext *s, AVFrame *frame, int flags);
 enum AVPixelFormat hb_qsv_get_format(AVCodecContext *s, const enum AVPixelFormat *pix_fmts);
 int hb_qsv_preset_is_zero_copy_enabled(const hb_dict_t *job_dict);
 void hb_qsv_uninit_dec(AVCodecContext *s);
-void hb_qsv_uninit_enc();
+void hb_qsv_uninit_enc(hb_job_t *job);
 
 #endif // __LIBHB__
 #endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -228,6 +228,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job);
 int hb_qsv_hw_frames_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_create_ffmpeg_pool(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int pool_size, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_qsv_hw_filters_are_enabled(hb_job_t *job);
+// TODO: After moving globals to pv->context->opaque = job remove hb_qsv_update_frames_context()
 void hb_qsv_update_frames_context(hb_job_t *job);
 int hb_qsv_full_path_is_enabled(hb_job_t *job);
 AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref);

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -267,6 +267,7 @@ typedef struct HBQSVFramesContext {
 /* Full QSV pipeline helpers */
 int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
 int hb_create_ffmpeg_pool(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int pool_size, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);
+int hb_qsv_hw_filters_are_enabled(hb_job_t *job);
 void hb_qsv_update_frames_context(hb_job_t *job);
 int hb_qsv_full_path_is_enabled(hb_job_t *job);
 AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref);

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -25,8 +25,8 @@ void hb_qsv_force_workarounds(); // for developers only
 
 #include "mfx/mfxvideo.h"
 #include "mfx/mfxplugin.h"
-#include "libavcodec/avcodec.h"
 #include "handbrake/hb_dict.h"
+#include "handbrake/qsv_libav.h"
 
 /* Minimum Intel Media SDK version (currently 1.3, for Sandy Bridge support) */
 #define HB_QSV_MINVERSION_MAJOR HB_QSV_MSDK_VERSION_MAJOR
@@ -219,50 +219,6 @@ uint8_t     hb_qsv_frametype_xlat(uint16_t qsv_frametype, uint16_t *out_flags);
 
 const char* hb_qsv_impl_get_name(int impl);
 const char* hb_qsv_impl_get_via_name(int impl);
-
-
-typedef struct QSVMid {
-    AVBufferRef *hw_frames_ref;
-    mfxHDL handle;
-
-    void *texture;
-
-    AVFrame *locked_frame;
-    AVFrame *hw_frame;
-    mfxFrameSurface1 surf;
-} QSVMid;
-
-typedef struct QSVFrame {
-    AVFrame *frame;
-    mfxFrameSurface1 surface;
-    mfxEncodeCtrl enc_ctrl;
-    mfxExtDecodedFrameInfo dec_info;
-    mfxExtBuffer *ext_param;
-
-    int queued;
-    int used;
-
-    struct QSVFrame *next;
-} QSVFrame;
-
-#define HB_POOL_FFMPEG_SURFACE_SIZE (64)
-#define HB_POOL_SURFACE_SIZE (64)
-#define HB_POOL_ENCODER_SIZE (8)
-
-typedef struct HBQSVFramesContext {
-    AVBufferRef *hw_frames_ctx;
-    //void *logctx;
-
-    /* The memory ids for the external frames.
-     * Refcounted, since we need one reference owned by the HBQSVFramesContext
-     * (i.e. by the encoder/decoder) and another one given to the MFX session
-     * from the frame allocator. */
-    AVBufferRef *mids_buf;
-    QSVMid *mids;
-    int  nb_mids;
-    int pool[HB_POOL_SURFACE_SIZE];
-    void *input_texture;
-} HBQSVFramesContext;
 
 /* Full QSV pipeline helpers */
 int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt, int extra_hw_frames, AVBufferRef **out_hw_frames_ctx);

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -260,6 +260,8 @@ typedef struct hb_qsv_space {
     mfxMemId *mids;
 } hb_qsv_space;
 
+typedef struct HBQSVFramesContext HBQSVFramesContext;
+
 typedef struct hb_qsv_context {
     volatile int is_context_active;
 
@@ -288,6 +290,10 @@ typedef struct hb_qsv_context {
 
     void *qsv_config;
 
+    int num_cpu_filters;
+    int qsv_filters_are_enabled;
+    HBQSVFramesContext *hb_dec_qsv_frames_ctx;
+    HBQSVFramesContext *hb_vpp_qsv_frames_ctx;
 } hb_qsv_context;
 
 typedef enum {

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -17,8 +17,6 @@
 
 #if HB_PROJECT_FEATURE_QSV
 #include "handbrake/qsv_common.h"
-extern int qsv_filters_are_enabled;
-extern HBQSVFramesContext hb_vpp_qsv_frames_ctx;
 #endif
 
 struct hb_avfilter_graph_s
@@ -30,6 +28,7 @@ struct hb_avfilter_graph_s
     char             * settings;
     AVFrame          * frame;
     AVRational         out_time_base;
+    hb_job_t         * job;
 };
 
 static AVFilterContext * append_filter( hb_avfilter_graph_t * graph,
@@ -91,6 +90,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 
+    graph->job = init->job;
     graph->settings = settings_str;
     graph->avgraph = avfilter_graph_alloc();
     if (graph->avgraph == NULL)
@@ -99,7 +99,8 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 #if HB_PROJECT_FEATURE_QSV
-    if (!qsv_filters_are_enabled)
+    int use_qsv_filters = (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled) ? 1 : 0;
+    if (!use_qsv_filters)
 #endif
     {
         av_opt_set(graph->avgraph, "scale_sws_opts", "lanczos+accurate_rnd", 0);
@@ -115,7 +116,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
     AVBufferSrcParameters *par = 0;
     // Build filter input
 #if HB_PROJECT_FEATURE_QSV
-    if (qsv_filters_are_enabled)
+    if (use_qsv_filters)
     {
         par = av_buffersrc_parameters_alloc();
         init->pix_fmt = AV_PIX_FMT_QSV;
@@ -270,7 +271,7 @@ int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in)
     if (in != NULL)
     {
 #if HB_PROJECT_FEATURE_QSV
-        if (qsv_filters_are_enabled)
+        if (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled)
         {
             hb_video_buffer_to_avframe(in->qsv_details.frame, in);
             return hb_avfilter_add_frame(graph, in->qsv_details.frame);
@@ -297,9 +298,9 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
     {
         hb_buffer_t * buf;
 #if HB_PROJECT_FEATURE_QSV
-        if (qsv_filters_are_enabled)
+        if (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled)
         {
-            buf = hb_qsv_copy_frame(&hb_vpp_qsv_frames_ctx, graph->frame, 0, 1);
+            buf = hb_qsv_copy_frame(graph->job, graph->frame, 1);
             hb_avframe_set_video_buffer_flags(buf, graph->frame, graph->out_time_base);
         }
         else

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -70,12 +70,13 @@ static AVFilterContext * append_filter( hb_avfilter_graph_t * graph,
 hb_avfilter_graph_t *
 hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
 {
-    hb_avfilter_graph_t * graph;
-    AVFilterInOut       * in = NULL, * out = NULL;
-    AVFilterContext     * avfilter;
-    char                * settings_str;
-    int                   result;
-    char                * filter_args;
+    hb_avfilter_graph_t   * graph;
+    AVFilterInOut         * in = NULL, * out = NULL;
+    AVBufferSrcParameters * par = NULL;
+    AVFilterContext       * avfilter;
+    char                  * settings_str;
+    int                     result;
+    char                  * filter_args;
 
     graph = calloc(1, sizeof(hb_avfilter_graph_t));
     if (graph == NULL)
@@ -112,7 +113,6 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 
-    AVBufferSrcParameters *par = 0;
     // Build filter input
 #if HB_PROJECT_FEATURE_QSV
     if (hb_qsv_hw_filters_are_enabled(graph->job))
@@ -148,6 +148,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
                     init->vrate.num, init->vrate.den);
     }
     avfilter = append_filter(graph, "buffer", filter_args, par);
+    av_free(par);
     free(filter_args);
     if (avfilter == NULL)
     {
@@ -206,6 +207,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
     return graph;
 
 fail:
+    av_free(par);
     avfilter_inout_free(&in);
     avfilter_inout_free(&out);
     hb_avfilter_graph_close(&graph);

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -99,8 +99,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 #if HB_PROJECT_FEATURE_QSV
-    int use_qsv_filters = (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled) ? 1 : 0;
-    if (!use_qsv_filters)
+    if (!hb_qsv_hw_filters_are_enabled(graph->job))
 #endif
     {
         av_opt_set(graph->avgraph, "scale_sws_opts", "lanczos+accurate_rnd", 0);
@@ -116,7 +115,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
     AVBufferSrcParameters *par = 0;
     // Build filter input
 #if HB_PROJECT_FEATURE_QSV
-    if (use_qsv_filters)
+    if (hb_qsv_hw_filters_are_enabled(graph->job))
     {
         par = av_buffersrc_parameters_alloc();
         init->pix_fmt = AV_PIX_FMT_QSV;
@@ -271,7 +270,7 @@ int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in)
     if (in != NULL)
     {
 #if HB_PROJECT_FEATURE_QSV
-        if (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled)
+        if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
             hb_video_buffer_to_avframe(in->qsv_details.frame, in);
             return hb_avfilter_add_frame(graph, in->qsv_details.frame);
@@ -298,7 +297,7 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
     {
         hb_buffer_t * buf;
 #if HB_PROJECT_FEATURE_QSV
-        if (graph->job && graph->job->qsv.ctx && graph->job->qsv.ctx->qsv_filters_are_enabled)
+        if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
             buf = hb_qsv_copy_frame(graph->job, graph->frame, 1);
             hb_avframe_set_video_buffer_flags(buf, graph->frame, graph->out_time_base);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -29,6 +29,8 @@
 #include "libavutil/hwcontext_qsv.h"
 #include "libavutil/hwcontext.h"
 
+// TODO: Moving globals to pv->context->opaque = job in decavcodecvInit where get_format is assigned and then retrieve the job where these are used in hb_qsv_get_format
+// (which calls hb_qsv_hw_frames_init which calls hb_create_ffmpeg_pool), then remove function hb_qsv_update_frames_context
 static HBQSVFramesContext *hb_dec_qsv_frames_ctx = NULL;
 static int qsv_filters_are_enabled = 0;
 
@@ -2312,6 +2314,7 @@ void hb_qsv_force_workarounds()
 #undef FORCE_WORKAROUNDS
 }
 
+// TODO: Moving globals to pv->context->opaque = job in decavcodecvInit where get_format is assigned
 AVBufferRef *hb_hw_device_ctx = NULL;
 char *qsv_device = NULL;
 static mfxHDL device_manager_handle = NULL;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -991,6 +991,11 @@ int hb_qsv_decode_is_enabled(hb_job_t *job)
 static int hb_dxva2_device_check();
 static int hb_d3d11va_device_check();
 
+int hb_qsv_hw_filters_are_enabled(hb_job_t *job)
+{
+    return job && job->qsv.ctx && job->qsv.ctx->qsv_filters_are_enabled;
+}
+
 void hb_qsv_update_frames_context(hb_job_t *job)
 {
     qsv_filters_are_enabled = job->qsv.ctx->qsv_filters_are_enabled;
@@ -2851,7 +2856,7 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
         hb_qsv_frames_ctx = job->qsv.ctx->hb_dec_qsv_frames_ctx;
     }
 
-    if (!is_vpp && job->qsv.ctx->qsv_filters_are_enabled)
+    if (!is_vpp && hb_qsv_hw_filters_are_enabled(job))
     {
         ret = hb_qsv_get_free_surface_from_pool(hb_qsv_frames_ctx, out->qsv_details.frame, &mid);
         if (ret < 0)
@@ -2867,7 +2872,7 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
     {
         mfxFrameSurface1* input_surface = (mfxFrameSurface1*)frame->data[3];
         // copy all surface fields
-        if (job->qsv.ctx->qsv_filters_are_enabled)
+        if (hb_qsv_hw_filters_are_enabled(job))
         {
             mfxMemId mem = output_surface->Data.MemId; 
             *output_surface = *input_surface; 

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2865,7 +2865,7 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
     }
     else
     {
-        hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_POOL_SURFACE_SIZE - HB_POOL_ENCODER_SIZE, &mid, &output_surface);
+        hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_QSV_POOL_SURFACE_SIZE - HB_QSV_POOL_ENCODER_SIZE, &mid, &output_surface);
     }
 
     if (device_manager_handle_type == MFX_HANDLE_D3D9_DEVICE_MANAGER)
@@ -3055,7 +3055,7 @@ int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt
 
     int ret;
 
-    ret = hb_create_ffmpeg_pool(coded_width, coded_height, sw_pix_fmt, HB_POOL_FFMPEG_SURFACE_SIZE, extra_hw_frames, out_hw_frames_ctx);
+    ret = hb_create_ffmpeg_pool(coded_width, coded_height, sw_pix_fmt, HB_QSV_POOL_FFMPEG_SURFACE_SIZE, extra_hw_frames, out_hw_frames_ctx);
     if (ret < 0) {
         hb_error("hb_qsv_init: hb_create_ffmpeg_pool decoder failed %d", ret);
         return ret;
@@ -3066,7 +3066,7 @@ int hb_qsv_init(int coded_width, int coded_height, enum AVPixelFormat sw_pix_fmt
     frames_hwctx = frames_ctx->hwctx;
     hb_dec_qsv_frames_ctx->input_texture = frames_hwctx->texture;
 
-    ret = hb_create_ffmpeg_pool(coded_width, coded_height, sw_pix_fmt, HB_POOL_SURFACE_SIZE, extra_hw_frames, &hb_dec_qsv_frames_ctx->hw_frames_ctx);
+    ret = hb_create_ffmpeg_pool(coded_width, coded_height, sw_pix_fmt, HB_QSV_POOL_SURFACE_SIZE, extra_hw_frames, &hb_dec_qsv_frames_ctx->hw_frames_ctx);
     if (ret < 0) {
         hb_error("hb_qsv_init: hb_create_ffmpeg_pool qsv surface allocation failed %d", ret);
         return ret;


### PR DESCRIPTION
Started to close gap of filters to be offloaded for HW acceleration,
when possible.
Resize filter is validated and others are in the pipeline, including
DX11.

It gives ~3.5x overall transcoding boost for QSV pipeline.