### PR TITLE
contrib: libjpeg-turbo: Add a patch for fixing building for arm64 windows

### DIFF
--- a/contrib/libjpeg-turbo/A00-arm64-neon.patch
+++ b/contrib/libjpeg-turbo/A00-arm64-neon.patch
@@ -1,0 +1,13 @@
+diff --git a/simd/arm64/jsimd_neon.S b/simd/arm64/jsimd_neon.S
+index a3aa406..70cef2c 100644
+--- a/simd/arm64/jsimd_neon.S
++++ b/simd/arm64/jsimd_neon.S
+@@ -33,6 +33,8 @@
+ 
+ #if defined(__APPLE__)
+ .section __DATA, __const
++#elif defined(_WIN32)
++.section .rdata
+ #else
+ .section .rodata, "a", %progbits
+ #endif


### PR DESCRIPTION
This patch has been sent upstream at https://github.com/libjpeg-turbo/libjpeg-turbo/pull/438, but it hasn't been reacted upon yet.
