### PR TITLE
gtk: configure: Do not attempt to link pthreadGC2 when pthread is not found.

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -230,8 +230,6 @@ case $host in
 	fi
 	if test "x$use_libpthread" = "xyes" ; then
 		HB_LIBS="$HB_LIBS -lpthread"
-	else
-		HB_LIBS="$HB_LIBS -lpthreadGC2"
 	fi
 	HB_LIBS="$HB_LIBS -lbcrypt -lregex -luuid -lole32"
 	;;

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -36,26 +36,26 @@ AC_SUBST(CC_FOR_BUILD)
 # introduce the optional configure parameter for the path of libXXX.a
 AC_ARG_WITH(hb,
 	AC_HELP_STRING(
-	    [--with-hb=prefix],
-	    [try this for the hb-library prefix install directory]
+		[--with-hb=prefix],
+		[try this for the hb-library prefix install directory]
 	  ),
 	  hb_PATHSET=1,
 	  hb_PATHSET=0
 )
 
 if test  $hb_PATHSET = 1 ; then
-    case ${with_hb} in
-    /*)
+	case ${with_hb} in
+	/*)
 		HBINC="-I$with_hb/libhb -I$with_hb/contrib/include"
 		LDFLAGS="$LDFLAGS -L$with_hb/libhb -L$with_hb/contrib/lib"
 		AC_SUBST(HB_DIR, "$with_hb")
-        ;;
-    *)
+		;;
+	*)
 		HBINC='-I$(top_srcdir)/'"$with_hb/libhb "'-I$(top_srcdir)/'"$with_hb/contrib/include"
 		LDFLAGS="$LDFLAGS "'-L$(top_srcdir)/'"$with_hb/libhb "'-L$(top_srcdir)/'"$with_hb/contrib/lib"
 		AC_SUBST(HB_DIR, '$(top_srcdir)/'"$with_hb")
-        ;;
-    esac
+		;;
+	esac
 else
 	HBINC='-I$(top_srcdir)/'"../libhb "'-I$(top_srcdir)/'"../contrib/include"
 	LDFLAGS="$LDFLAGS "'-L$(top_srcdir)/'"../libhb "'-L$(top_srcdir)/'"../contrib/lib"
@@ -121,17 +121,17 @@ AC_SYS_LARGEFILE
 
 case $host in
   *-*-mingw*)
-    GHB_PACKAGES="gthread-2.0 gio-2.0 gmodule-2.0"
+	GHB_PACKAGES="gthread-2.0 gio-2.0 gmodule-2.0"
 	mingw_flag=yes
-    ;;
+	;;
   *)
-    case "$host_os" in
+	case "$host_os" in
 	linux*)
 	  ;;
-    esac
-    GHB_PACKAGES="gthread-2.0 gio-2.0 gmodule-2.0"
+	esac
+	GHB_PACKAGES="gthread-2.0 gio-2.0 gmodule-2.0"
 	mingw_flag=no
-    ;;
+	;;
 esac
 
 PKG_PROG_PKG_CONFIG
@@ -139,13 +139,13 @@ PKG_PROG_PKG_CONFIG
 HAVE_GTK_400=0
 HAVE_GTK_316=0
 if test "x$use_gtk4" = "xyes" ; then
-    PKG_CHECK_MODULES([gtk], [gtk4 >= 3.92], [HAVE_GTK_400=1], [HAVE_GTK_400=0])
+	PKG_CHECK_MODULES([gtk], [gtk4 >= 3.92], [HAVE_GTK_400=1], [HAVE_GTK_400=0])
 else
-    PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.16], [HAVE_GTK_316=1], [HAVE_GTK_316=0])
+	PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.16], [HAVE_GTK_316=1], [HAVE_GTK_316=0])
 fi
 
 if test "$HAVE_GTK_316" -eq 0 -a "$HAVE_GTK_400" -eq 0 ; then
-    AC_MSG_ERROR("GTK 3.16 or above is required)
+	AC_MSG_ERROR("GTK 3.16 or above is required)
 fi
 HB_LIBS="$HB_LIBS $gtk_LIBS"
 HB_CPPFLAGS="$HB_CPPFLAGS $gtk_CFLAGS"
@@ -158,8 +158,8 @@ HB_CPPFLAGS="$HB_CPPFLAGS $GHB_CFLAGS"
 pkg_gudev="gudev-1.0"
 PKG_CHECK_MODULES([gudev], [$pkg_gudev], have_gudev=yes, have_gudev=no)
 if test "x$have_gudev" = "xyes" ; then
-    HB_LIBS="$HB_LIBS $gudev_LIBS"
-    HB_CPPFLAGS="$HB_CPPFLAGS $gudev_CFLAGS"
+	HB_LIBS="$HB_LIBS $gudev_LIBS"
+	HB_CPPFLAGS="$HB_CPPFLAGS $gudev_CFLAGS"
 
 	CXXFLAGS="$CXXFLAGS -D_HAVE_GUDEV"
 	CFLAGS="$CFLAGS -D_HAVE_GUDEV"
@@ -167,13 +167,13 @@ fi
 
 GST1_MODULES="gstreamer-1.0 gstreamer-video-1.0 gstreamer-audio-1.0 gstreamer-pbutils-1.0"
 if test "x$gst_disable" = "xno" ; then
-    PKG_CHECK_MODULES([gstreamer1], [$GST1_MODULES], use_gst1=yes, use_gst1=no)
-    if test "x$use_gst1" = "xyes" ; then
-        HB_LIBS="$HB_LIBS $gstreamer1_LIBS"
-        HB_CPPFLAGS="$HB_CPPFLAGS $gstreamer1_CFLAGS"
-    else
-        gst_disable="yes"
-    fi
+	PKG_CHECK_MODULES([gstreamer1], [$GST1_MODULES], use_gst1=yes, use_gst1=no)
+	if test "x$use_gst1" = "xyes" ; then
+		HB_LIBS="$HB_LIBS $gstreamer1_LIBS"
+		HB_CPPFLAGS="$HB_CPPFLAGS $gstreamer1_CFLAGS"
+	else
+		gst_disable="yes"
+	fi
 fi
 
 if test "x$gst_disable" = "xno" ; then
@@ -182,14 +182,14 @@ if test "x$gst_disable" = "xno" ; then
 fi
 
 if test "x$update_checks" = "xyes" ; then
-    PKG_CHECK_MODULES([webkitgtk], webkitgtk-3.0, use_webkitgtk=yes, use_webkitgtk=no)
-    if test "x$use_webkitgtk" = "xyes" ; then
-        HB_LIBS="$HB_LIBS $webkitgtk_LIBS"
-        HB_CPPFLAGS="$HB_CPPFLAGS $webkitgtk_CFLAGS"
-    else
-        update_checks="no"
-        CFLAGS="$CFLAGS -D_NO_UPDATE_CHECK"
-    fi
+	PKG_CHECK_MODULES([webkitgtk], webkitgtk-3.0, use_webkitgtk=yes, use_webkitgtk=no)
+	if test "x$use_webkitgtk" = "xyes" ; then
+		HB_LIBS="$HB_LIBS $webkitgtk_LIBS"
+		HB_CPPFLAGS="$HB_CPPFLAGS $webkitgtk_CFLAGS"
+	else
+		update_checks="no"
+		CFLAGS="$CFLAGS -D_NO_UPDATE_CHECK"
+	fi
 else
 	CFLAGS="$CFLAGS -D_NO_UPDATE_CHECK"
 fi
@@ -204,68 +204,68 @@ HB_CPPFLAGS="$HB_CPPFLAGS $HBINC"
 
 PKG_CHECK_MODULES([x264], [x264], sys_x264=yes, sys_x264=no)
 if test "x$sys_x264" = "xyes" ; then
-    HB_LIBS="$HB_LIBS $x264_LIBS"
-    HB_CPPFLAGS="$HB_CPPFLAGS $x264_CFLAGS"
+	HB_LIBS="$HB_LIBS $x264_LIBS"
+	HB_CPPFLAGS="$HB_CPPFLAGS $x264_CFLAGS"
 else
-    # Assume it's built as a libhandbrake contrib package
-    HB_LIBS="$HB_LIBS -lx264"
+	# Assume it's built as a libhandbrake contrib package
+	HB_LIBS="$HB_LIBS -lx264"
 fi
 
 if test "x$use_fdk_aac" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lfdk-aac"
+	HB_LIBS="$HB_LIBS -lfdk-aac"
 fi
 
 if test "x$use_x265" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lx265"
+	HB_LIBS="$HB_LIBS -lx265"
 fi
 
 if test "x$use_qsv" = "xyes" ; then
-    HB_LIBS="$HB_LIBS -lmfx"
+	HB_LIBS="$HB_LIBS -lmfx"
 fi
 
 case $host in
   *-*-mingw*)
-    if test "x$use_libdl" = "xyes" ; then
+	if test "x$use_libdl" = "xyes" ; then
 		HB_LIBS="$HB_LIBS -ldl"
 	fi
-    if test "x$use_libpthread" = "xyes" ; then
+	if test "x$use_libpthread" = "xyes" ; then
 		HB_LIBS="$HB_LIBS -lpthread"
-    else
-        HB_LIBS="$HB_LIBS -lpthreadGC2"
+	else
+		HB_LIBS="$HB_LIBS -lpthreadGC2"
 	fi
-    HB_LIBS="$HB_LIBS -lbcrypt -lregex -luuid -lole32"
-    ;;
+	HB_LIBS="$HB_LIBS -lbcrypt -lregex -luuid -lole32"
+	;;
   *-*-freebsd*)
-    HB_LIBS="$HB_LIBS -lpthread"
-    if test "x$use_qsv" = "xyes" ; then
-        HB_LIBS="$HB_LIBS -lva -lva-drm"
-    fi
-    ;;
+	HB_LIBS="$HB_LIBS -lpthread"
+	if test "x$use_qsv" = "xyes" ; then
+		HB_LIBS="$HB_LIBS -lva -lva-drm"
+	fi
+	;;
   *-*-netbsd*)
-    HB_LIBS="$HB_LIBS -pthread"
-    ;;
+	HB_LIBS="$HB_LIBS -pthread"
+	;;
   *-*-linux*)
-    if test "x$use_qsv" = "xyes" ; then
-        HB_LIBS="$HB_LIBS -lva -lva-drm"
-    fi
-    if test "x$use_x265" = "xyes" ; then
-    if test "x$use_numa" = "xyes" ; then
-        HB_LIBS="$HB_LIBS -lnuma"
-    fi
-    fi
-    HB_LIBS="$HB_LIBS -ldl -lpthread"
-    ;;
+	if test "x$use_qsv" = "xyes" ; then
+		HB_LIBS="$HB_LIBS -lva -lva-drm"
+	fi
+	if test "x$use_x265" = "xyes" ; then
+	if test "x$use_numa" = "xyes" ; then
+		HB_LIBS="$HB_LIBS -lnuma"
+	fi
+	fi
+	HB_LIBS="$HB_LIBS -ldl -lpthread"
+	;;
   *)
-    HB_LIBS="$HB_LIBS -ldl -lpthread"
-    ;;
+	HB_LIBS="$HB_LIBS -ldl -lpthread"
+	;;
 esac
 
 AM_CONDITIONAL([GHB_FLATPAK], [test "$use_flatpak" = "yes"])
 
 if test "x$PYTHON" != "x" ; then
-    HB_PYTHON="$PYTHON"
+	HB_PYTHON="$PYTHON"
 else
-    HB_PYTHON="python2"
+	HB_PYTHON="python2"
 fi
 
 AC_SUBST(HB_PYTHON)


### PR DESCRIPTION
Probably safest to target 1.4.0 in case anyone is relying on this behavior.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
