### PR TITLE
Enbale potential for conservative cropping per #2219

### DIFF
--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -554,6 +554,8 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
     hb_stream_t      * stream = NULL;
     info_list_t      * info_list;
     int                abort_audio = 0;
+    // TODO: Expose this as an option in GUI
+    bool               conservative_crop = FALSE;
 
     info_list = calloc(data->preview_count+1, sizeof(*info_list));
     crop_record_t *crops = crop_record_init( data->preview_count );
@@ -1072,11 +1074,15 @@ skip_preview:
             sort_crops( crops );
             // The next line selects median cropping - at least
             // 50% of the frames will have their borders removed.
-            // Other possible choices are loose cropping (i = 0) where
+            // Other possible choices are conservative cropping (i = 0) where
             // no non-black pixels will be cropped from any frame and a
-            // tight cropping (i = crops->n - (crops->n >> 2)) where at
+            // aggressive cropping (i = crops->n - (crops->n >> 2)) where at
             // least 75% of the frames will have their borders removed.
             i = crops->n >> 1;
+            if ( conservative_crop )
+            {
+                i = 0;
+            }
             title->crop[0] = EVEN( crops->t[i] );
             title->crop[1] = EVEN( crops->b[i] );
             title->crop[2] = EVEN( crops->l[i] );


### PR DESCRIPTION
Include a flag that if set, overrides the autocrop value to prefer the most conservative cropping possible. Also reduce confusion in the comment by changing "loose" cropping to "conservative" cropping (and "strict" to "aggressive"). (Which seems minor, but that did confuse a lot of us when discussing #2219 ).

This is a minimal change and would still require a GUI update to become a live option. It is recommended primarily to make testing and future implementation easier.


**Before Posting:**

- [] Create an issue describing the change. If an issue already exists, please use this.

#2219 

- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

I do not know if this is sufficient acceptance, but jstebbins [wrote](https://github.com/HandBrake/HandBrake/issues/2219#issuecomment-517965858):

> "It would be a poor default choice but could certainly be exposed as an option."

That's all I'm shooting for here, not a new default, just an option.

**Description of Change:**

This change creates a flag that will change the cropping algorithm to be more conservative, cropping no pixels that appear to have content. This flag is not hooked to the GUI so it does not currently change anything.

Welcome suggestions if the flag should be moved to another module, or if there's another convention on how to set a flag like this.


**Test on:**

(Note: Does not currently change any functionality, only enables future enhancements.)

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
