### PR TITLE
qsv: fix incorrect async depth values in GUI binary

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3814,7 +3814,7 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
 
 #if HB_PROJECT_FEATURE_QSV
     job->qsv.enc_info.is_init_done = 0;
-    job->qsv.async_depth           = qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G7 ? 6 : HB_QSV_ASYNC_DEPTH_DEFAULT;
+    job->qsv.async_depth           = hb_qsv_param_default_async_depth();
     job->qsv.decode                = !!(title->video_decode_support &
                                         HB_DECODE_SUPPORT_QSV);
 #endif

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -193,11 +193,12 @@ int   hb_qsv_atobool (const char *str, int *err);
 int   hb_qsv_atoi    (const char *str, int *err);
 float hb_qsv_atof    (const char *str, int *err);
 
-int hb_qsv_param_default_preset(hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info, const char *preset);
-int hb_qsv_param_default       (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info);
-int hb_qsv_param_parse         (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *key, const char *value);
-int hb_qsv_profile_parse       (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key, const int codec);
-int hb_qsv_level_parse         (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *level_key);
+int hb_qsv_param_default_async_depth();
+int hb_qsv_param_default_preset     (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info, const char *preset);
+int hb_qsv_param_default            (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info);
+int hb_qsv_param_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *key, const char *value);
+int hb_qsv_profile_parse            (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key, const int codec);
+int hb_qsv_level_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *level_key);
 
 typedef struct
 {

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1139,10 +1139,15 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
         hb_error("hb_dict_to_job: failed to parse dict: %s", error.text);
         goto fail;
     }
-
     // Make sure QSV Decode is only True if the hardware is available.
     job->qsv.decode = job->qsv.decode && hb_qsv_available();
-
+#if HB_PROJECT_FEATURE_QSV
+    int async_depth_default = hb_qsv_param_default_async_depth();
+    if(job->qsv.async_depth <= 0 || job->qsv.async_depth > async_depth_default)
+    {
+        job->qsv.async_depth = async_depth_default;
+    }
+#endif
     // Lookup mux id
     if (hb_value_type(mux) == HB_VALUE_TYPE_STRING)
     {

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1945,6 +1945,11 @@ int hb_qsv_param_default_preset(hb_qsv_param_t *param,
     return 0;
 }
 
+int hb_qsv_param_default_async_depth()
+{
+    return qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G7 ? 6 : HB_QSV_ASYNC_DEPTH_DEFAULT;
+}
+
 int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
                          hb_qsv_info_t  *info)
 {
@@ -2047,14 +2052,7 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         param->videoParam->mfx.GopRefDist   = 0; // use Media SDK default
         param->videoParam->mfx.LowPower     = MFX_CODINGOPTION_OFF; // use Media SDK default
         // introduced in API 1.1
-        if (qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G7)
-        {
-            param->videoParam->AsyncDepth = 6;
-        }
-        else
-        {
-            param->videoParam->AsyncDepth = HB_QSV_ASYNC_DEPTH_DEFAULT;
-        }
+        param->videoParam->AsyncDepth       = hb_qsv_param_default_async_depth();
         // introduced in API 1.3
         param->videoParam->mfx.BRCParamMultiplier = 0; // no multiplier
 


### PR DESCRIPTION
Additional verification async depth parameter was added. 

The HB Windows GUI binary exports job as JSON with AsyncDepth = 0, because [it does not respect AsyncDepth value](https://github.com/HandBrake/HandBrake/issues/3037).
When it is used by CLI binary AsyncDepth parameter is initialised incorrectly.   

