### PR TITLE
WinGUI: Update all locale files, add initial support for Ukrainian and Corsican locale

### DIFF
--- a/win/CS/HandBrake.Installer/Product.wxs
+++ b/win/CS/HandBrake.Installer/Product.wxs
@@ -91,44 +91,62 @@
               </Component>
             </Directory>
 
+            <Directory Id="co_lang" Name="co">
+              <Component Win64="yes" Id="co_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42183">
+                <File Id="co_lang" Source="$(var.packagePath)\co\HandBrake.resources.dll" />
+              </Component>
+            </Directory>
+
             <Directory Id="es_lang" Name="es">
-              <Component Win64="yes" Id="es_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42183">
+              <Component Win64="yes" Id="es_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42184">
                 <File Id="es_lang" Source="$(var.packagePath)\es\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
             <Directory Id="fr_lang" Name="fr">
-              <Component Win64="yes" Id="fr_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42184">
+              <Component Win64="yes" Id="fr_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42185">
                 <File Id="fr_lang" Source="$(var.packagePath)\fr\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
             <Directory Id="ja_lang" Name="ja">
-              <Component Win64="yes" Id="ja_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42185">
+              <Component Win64="yes" Id="ja_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42186">
                 <File Id="ja_lang" Source="$(var.packagePath)\ja\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
             <Directory Id="ko_lang" Name="ko">
-              <Component Win64="yes" Id="ko_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42186">
+              <Component Win64="yes" Id="ko_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42187">
                 <File Id="ko_lang" Source="$(var.packagePath)\ko\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
+            <Directory Id="pt-BR_lang" Name="pt-BR">
+              <Component Win64="yes" Id="pt-BR_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42188">
+                <File Id="pt-BR_lang" Source="$(var.packagePath)\pt-BR\HandBrake.resources.dll" />
+              </Component>
+            </Directory>
+
             <Directory Id="ru_lang" Name="ru">
-              <Component Win64="yes" Id="ru_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42187">
+              <Component Win64="yes" Id="ru_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42189">
                 <File Id="ru_lang" Source="$(var.packagePath)\ru\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
             <Directory Id="tr_lang" Name="tr">
-              <Component Win64="yes" Id="tr_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42188">
+              <Component Win64="yes" Id="tr_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42190">
                 <File Id="tr_lang" Source="$(var.packagePath)\tr\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
+            <Directory Id="uk_lang" Name="uk">
+              <Component Win64="yes" Id="uk_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42191">
+                <File Id="uk_lang" Source="$(var.packagePath)\uk\HandBrake.resources.dll" />
+              </Component>
+            </Directory>
+
             <Directory Id="zh_lang" Name="zh">
-              <Component Win64="yes" Id="zh_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42189">
+              <Component Win64="yes" Id="zh_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42192">
                 <File Id="zh_lang" Source="$(var.packagePath)\zh\HandBrake.resources.dll" />
               </Component>
             </Directory>
@@ -168,12 +186,15 @@
       <ComponentRef Id="AppShortcuts"/>
 
       <ComponentRef Id="de_lang"/>
+      <ComponentRef Id="co_lang"/>
       <ComponentRef Id="es_lang"/>
       <ComponentRef Id="fr_lang"/>
       <ComponentRef Id="ja_lang"/>
       <ComponentRef Id="ko_lang"/>
+      <ComponentRef Id="pt-BR_lang"/>
       <ComponentRef Id="ru_lang"/>
       <ComponentRef Id="tr_lang"/>
+      <ComponentRef Id="uk_lang"/>
       <ComponentRef Id="zh_lang"/>
     </Feature>
 

--- a/win/CS/HandBrake.Installer/Product.wxs
+++ b/win/CS/HandBrake.Installer/Product.wxs
@@ -121,9 +121,9 @@
               </Component>
             </Directory>
 
-            <Directory Id="pt-BR_lang" Name="pt-BR">
-              <Component Win64="yes" Id="pt-BR_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42188">
-                <File Id="pt-BR_lang" Source="$(var.packagePath)\pt-BR\HandBrake.resources.dll" />
+            <Directory Id="pt_BR_lang" Name="pt-BR">
+              <Component Win64="yes" Id="pt_BR_lang" Guid="cbae29e7-6d39-49bb-8c76-0305c3d42188">
+                <File Id="pt_BR_lang" Source="$(var.packagePath)\pt-BR\HandBrake.resources.dll" />
               </Component>
             </Directory>
 
@@ -191,7 +191,7 @@
       <ComponentRef Id="fr_lang"/>
       <ComponentRef Id="ja_lang"/>
       <ComponentRef Id="ko_lang"/>
-      <ComponentRef Id="pt-BR_lang"/>
+      <ComponentRef Id="pt_BR_lang"/>
       <ComponentRef Id="ru_lang"/>
       <ComponentRef Id="tr_lang"/>
       <ComponentRef Id="uk_lang"/>

--- a/win/CS/HandBrakeWPF/Installer/Installer64.nsi
+++ b/win/CS/HandBrakeWPF/Installer/Installer64.nsi
@@ -198,6 +198,10 @@ Section "HandBrake" SectionApp
   SetOverwrite ifnewer
   File "co\*.*"
 
+  SetOutPath "$INSTDIR\uk"
+  SetOverwrite ifnewer
+  File "uk\*.*"
+
   ; Copy the standard doc set into the doc folder
   SetOutPath "$INSTDIR\doc"
   SetOverwrite ifnewer
@@ -263,6 +267,8 @@ Section Uninstall
   RMDir  "$INSTDIR\pt-BR"
   Delete "$INSTDIR\co\*.*"
   RMDir  "$INSTDIR\co"
+  Delete "$INSTDIR\uk\*.*"
+  RMDir  "$INSTDIR\uk"
 
   RMDir  "$INSTDIR"
 

--- a/win/CS/HandBrakeWPF/Installer/Installer64.nsi
+++ b/win/CS/HandBrakeWPF/Installer/Installer64.nsi
@@ -194,6 +194,10 @@ Section "HandBrake" SectionApp
   SetOverwrite ifnewer
   File "pt-BR\*.*"
 
+  SetOutPath "$INSTDIR\co"
+  SetOverwrite ifnewer
+  File "co\*.*"
+
   ; Copy the standard doc set into the doc folder
   SetOutPath "$INSTDIR\doc"
   SetOverwrite ifnewer
@@ -257,6 +261,8 @@ Section Uninstall
   RMDir  "$INSTDIR\ja"
   Delete "$INSTDIR\pt-BR\*.*"
   RMDir  "$INSTDIR\pt-BR"
+  Delete "$INSTDIR\co\*.*"
+  RMDir  "$INSTDIR\co"
 
   RMDir  "$INSTDIR"
 

--- a/win/CS/HandBrakeWPF/Installer/MakeNightly64.nsi
+++ b/win/CS/HandBrakeWPF/Installer/MakeNightly64.nsi
@@ -196,6 +196,10 @@ Section "HandBrake" SectionApp
   SetOverwrite ifnewer
   File "co\*.*"
 
+  SetOutPath "$INSTDIR\uk"
+  SetOverwrite ifnewer
+  File "uk\*.*"
+
   ; Copy the standard doc set into the doc folder
   SetOutPath "$INSTDIR\doc"
   SetOverwrite ifnewer
@@ -259,6 +263,8 @@ Section Uninstall
   RMDir  "$INSTDIR\pt-BR"
   Delete "$INSTDIR\co\*.*"
   RMDir  "$INSTDIR\co"
+  Delete "$INSTDIR\uk\*.*"
+  RMDir  "$INSTDIR\uk"
 
   RMDir  "$INSTDIR"
    

--- a/win/CS/HandBrakeWPF/Installer/MakeNightly64.nsi
+++ b/win/CS/HandBrakeWPF/Installer/MakeNightly64.nsi
@@ -192,6 +192,10 @@ Section "HandBrake" SectionApp
   SetOverwrite ifnewer
   File "pt-BR\*.*"
 
+  SetOutPath "$INSTDIR\co"
+  SetOverwrite ifnewer
+  File "co\*.*"
+
   ; Copy the standard doc set into the doc folder
   SetOutPath "$INSTDIR\doc"
   SetOverwrite ifnewer
@@ -253,6 +257,8 @@ Section Uninstall
   RMDir  "$INSTDIR\ja"
   Delete "$INSTDIR\pt-BR\*.*"
   RMDir  "$INSTDIR\pt-BR"
+  Delete "$INSTDIR\co\*.*"
+  RMDir  "$INSTDIR\co"
 
   RMDir  "$INSTDIR"
    

--- a/win/CS/HandBrakeWPF/Properties/Resources.co.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.co.resx
@@ -118,2157 +118,2159 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Video_EncoderExtraArgs" xml:space="preserve">
-    <value>完整的编码器参数列表：
+    <value>A lista sana di i parametri di cudificatore : 
 {0}</value>
   </data>
   <data name="Video_x264FastDecode" xml:space="preserve">
-    <value>减少解码器对CPU的占用。
+    <value>Riduce l’impiegu CPU di u discudificatore.
 
-当你的设备无法流畅播放输出时选择此选项。（例如： 丢帧）</value>
+Attivate st’ozzione s’è u vostru apparechju ùn leghje micca bè u schedariu d’esciuta. (i.e. perdita di fiure)</value>
   </data>
   <data name="Video_LosslessWarning" xml:space="preserve">
-    <value>警告： RF 0 表示无损！</value>
+    <value>Fate casu : RF 0 vole dì senza perdita !</value>
   </data>
   <data name="Video_LosslessWarningTooltip" xml:space="preserve">
-    <value>值为“0”表示无损，将导致文件大小大于原始源，除非源文件也是无损的。
+    <value>Un valore à 0 vole dì senza perdita è per què, u schedariu d’esciuta serà più maiò chì quellu di a fonte, for di s’è a fonte era dinù senza perdita. 
 
-使用x264和x265时比例是对数的，较低的值对应于较高的质量。
+E scale di x264 è x265 sò logaritmiche, è valori più chjuchi currispondenu à una qualità più maiò. 
 
-因此，即使值的小幅减少也会导致文件大小逐渐增大。</value>
+Dunque, chjuchi aumenti di valore aumentanu prugressivamente a dimensione di u schedariu d’esciuta.</value>
   </data>
   <data name="AddPreset_PictureSizeMode" xml:space="preserve">
-    <value>您可以选择使用此预设存储图像设置。有3种模式：
-None: 图像设置不存储在预设中。加载源时，它们将保持在源分辨率的范围内。这也会影响变形、模量、裁剪等。
+    <value>Pudete eventualmente allucà preferenze di fiura cù sta prerigatura. Ci hè 3 modi :
 
-Custom: 您可以选择设置最大宽度和高度。这样做时，输出视频的宽度和高度不会超过设定值。保持宽高比将自动打开。
-Source Maximum: 始终在源分辨率下进行编码。</value>
+Alcunu : E preferenze di fiurà ùn sò micca allucate cù sta prerigatura. À u caricamentu d’una fonte, e preferenze steranu tale quale in i cunfini di a risuluzione di a fonte. Quessa affetta dinù Anamorficu, mudullu, runzicatura, ecc.
+
+Persunalizatu : Pudete eventualmente definisce una larghezza è un’altezza massima. S’è vo fate què, a cudificazione serà inferiore o uguale à sti valori. L’ozzione « Cunservà e prupurzioni » serà autumaticamente attivata.
+
+Fonte massima : Cudificà sempre à a risuluzione di a fonte quand’ella hè pussibule.</value>
   </data>
   <data name="About_GPL" xml:space="preserve">
-    <value>This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
+    <value>Stu prugramma hè liberu ; pudete ridistribuiscellu è/o mudificallu
+dapervoi secondu i termini di a Licenza Publica Generale GNU tale
+chì publicata da a Free Software Foundation ; sia a versione 2 di
+a licenza, o s’è voi preferite, una versione più recente.
 
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
+Stu prugramma hè distribuitu cù a sperenza d’esse ghjuvevule, ma SENZA NISUNA ASSICURANZA ; senza manc’una assicuranza di CUMMERCIALISAZIONE o di CURRISPUNDENZA À UN IMPIEGU PARTICULARE.  Fighjate a licenza GNU General Public License per sapene di più.
 
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.</value>
+Duveriate avè ricevutu una copia di a licenza GNU General Public License
+cù stu prugramma ; osinnò, ci vole à scrive à : Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</value>
   </data>
   <data name="QueueSelection_AutoNameWarning" xml:space="preserve">
-    <value>警告：自动文件命名选项未打开。请在设置中开启。</value>
+    <value>Avertimentu : U numinà autumaticu di i schedarii ùn hè micca attivu. Ci vole à attivallu in l’ozzioni.</value>
   </data>
   <data name="QueueSelection_AutoTrackSelectionWarning" xml:space="preserve">
-    <value>警告：您当前没有自动选择音频和字幕轨道的设置。您可以在选项中设置默认轨道选择行为。</value>
+    <value>Avertimentu : Ùn avete micca attivatu a cunfigurazione autumatica di a selezzione di e traccie audio è di i sottutituli. Pudete cunfigurà in l’ozzioni u cumpurtamentu predefinitu di a selezzione di e traccie.</value>
   </data>
   <data name="Presets_ResetComplete" xml:space="preserve">
-    <value>内置的预设已被重置。</value>
+    <value>E prerigature integrate sò state rimesse d’origine.</value>
   </data>
   <data name="Presets_ResetHeader" xml:space="preserve">
-    <value>重置完成</value>
+    <value>Reinizializazione compia</value>
   </data>
   <data name="Video_HigherQuality" xml:space="preserve">
-    <value>高质量 |</value>
+    <value>Qualità alta |</value>
   </data>
   <data name="Video_LowQuality" xml:space="preserve">
-    <value>| 低质量</value>
+    <value>| Qualità debule</value>
   </data>
   <data name="Video_PlaceboQuality" xml:space="preserve">
-    <value>最高质量 |</value>
+    <value>Qualità placebo |</value>
   </data>
   <data name="Error" xml:space="preserve">
-    <value>错误</value>
+    <value>Sbagliu</value>
   </data>
   <data name="Main_AutoAdd_AudioAndSubWarning" xml:space="preserve">
-    <value>警告：如果您希望为要列队的每个项目添加字幕，请确认您在字幕选项卡上正确设置了字幕默认设置。
+    <value>Avertimentu : s’è vo vulete chì sottutituli sianu aghjunti à ogni elementu chì vo site prontu à mette in fila d’attesa, verificate chì i parametri predefiniti di i sottutituli sianu currettamente cunfigurati in l’unghjetta Sottutituli.
     
-你想继续吗？</value>
+Vulete cuntinuà ?</value>
   </data>
   <data name="Main_TurnOnAutoFileNaming" xml:space="preserve">
-    <value>在添加到队列之前，必须启用自动文件命名并在首选项中设置默认路径。</value>
+    <value>Ci vole à attivà u numinà autumaticu di i schedarii È sceglie un chjassu predefinitu in e preferenze nanzu di pudè aghjunghje à a fila d’attesa.</value>
   </data>
   <data name="Warning" xml:space="preserve">
-    <value>警告</value>
+    <value>Avertimentu</value>
   </data>
   <data name="AreYouSure" xml:space="preserve">
-    <value>你确定吗？</value>
+    <value>Site sicuru ?</value>
   </data>
   <data name="HandBrake_Title" xml:space="preserve">
     <value>HandBrake</value>
   </data>
   <data name="Main_AlreadyEncoding" xml:space="preserve">
-    <value>HandBrake 已在进行编码。</value>
+    <value>HandBrake hè in corsu di cudificazione.</value>
   </data>
   <data name="Main_DuplicateDestinationOnQueue" xml:space="preserve">
-    <value>队列中的作业具有相同的目标路径。请为此作业选择不同的路径。</value>
+    <value>Ci sò travaglii in a fila d’attesa cù u listessu chjassu di destinazione. Ci vole à sceglie un chjassu sfarente per stu travagliu.</value>
   </data>
   <data name="Main_JobsPending_addon" xml:space="preserve">
-    <value>   等待工作 {0}</value>
+    <value>   {0} Travaglii in attesa</value>
   </data>
   <data name="Main_NewDefaultPreset" xml:space="preserve">
-    <value>新的默认预设集：{0}</value>
+    <value>Nova prerigatura predefinita : {0}</value>
   </data>
   <data name="Main_NewUpdate" xml:space="preserve">
-    <value>有新的更新可用。转到“工具”菜单 &gt; “选项”安装</value>
+    <value>Un rinnovu recente hè dispunibule. Andate à u listinu Attrezzi &gt; Ozzioni per installalu</value>
   </data>
   <data name="Main_NoPresetSelected" xml:space="preserve">
-    <value>未选择预设。</value>
+    <value>Alcuna prerigatura selezziunata.</value>
   </data>
   <data name="Main_NoUpdateOfBuiltInPresets" xml:space="preserve">
-    <value>您无法修改内置预设。请选择一个您自己的预设。</value>
+    <value>Ùn pudete micca mudificà e prerigature integrate. Ci vole à selezziunà una di e vostre proprie prerigature.</value>
   </data>
   <data name="Main_PleaseSelectFolder" xml:space="preserve">
-    <value>请选择一个文件夹。</value>
+    <value>Ci vole à selezziunà un cartulare.</value>
   </data>
   <data name="Main_PreparingToEncode" xml:space="preserve">
-    <value>正在准备编码…</value>
+    <value>Preparazione à cudificà…</value>
   </data>
   <data name="Main_PresetErrorBuiltInName" xml:space="preserve">
-    <value>您无法导入与内置预设同名的预设。</value>
+    <value>Ùn pudete micca impurtà una prerigatura cù u listessu nome ch’una prerigatura integrata.</value>
   </data>
   <data name="Main_PresetOverwriteWarning" xml:space="preserve">
-    <value>预设 "{0}" 已经存在。你想覆盖它吗？</value>
+    <value>A prerigatura « {0} » esiste dighjà. Vulete rimpiazzalla ?</value>
   </data>
   <data name="Main_Presets" xml:space="preserve">
-    <value>预设</value>
+    <value>Prerigature</value>
   </data>
   <data name="Main_PresetUpdateConfrimation" xml:space="preserve">
-    <value>您确定要更新所选预设吗？</value>
+    <value>Site sicuru di vulè mudificà a prerigatura selezziunata ?</value>
   </data>
   <data name="Main_PresetUpdated" xml:space="preserve">
-    <value>预设现在已使用您当前的设置进行更新。</value>
+    <value>A prerigatura hè stata mudificata cù e vostre preferenze attuale.</value>
   </data>
   <data name="Main_PresetUpdateNotification" xml:space="preserve">
-    <value>HandBrake 已确认你的内置预设已过期... 现在将更新这些预设。
-您的自定义预设尚未更新，因此您可能需要通过删除和重新添加来重新创建这些预设。
-以前的 user_presets.xml 文件已备份。</value>
+    <value>HandBrake hà determinatu chì e vostre prerigature integrate sò anticogne… Ste prerigature anu da esse rinnovate avà.
+E vostre prerigature persunalizate ùn sò micca state mudificate ; forse ci vulerà à ricrealle, sqassendule è re-aghjunghjendule. 
+U schedariu precedente user_presets.xml hè statu accantatu.</value>
   </data>
   <data name="Main_QueueFinished" xml:space="preserve">
-    <value>队列完成</value>
+    <value>Fila d’attesa compia</value>
   </data>
   <data name="Main_ScanCancelled" xml:space="preserve">
-    <value>扫描取消。</value>
+    <value>Analisa abbandunata.</value>
   </data>
   <data name="Main_ScanCompleted" xml:space="preserve">
-    <value>扫描完成</value>
+    <value>Analisa compia</value>
   </data>
   <data name="Main_ScanFailed_NoReason" xml:space="preserve">
-    <value>扫描失败：</value>
+    <value>Fiascu di l’analisa : </value>
   </data>
   <data name="Main_ScanFailled_CheckLog" xml:space="preserve">
-    <value>扫描失败...有关详细信息，请参阅活动日志。</value>
+    <value>Fiascu di l’analisa… Ci vole à fighjà u ghjurnale d’attività per sapene di più.</value>
   </data>
   <data name="Main_ScanningPleaseWait" xml:space="preserve">
-    <value>正在扫描源，请稍候…</value>
+    <value>Analisa di a fonte, aspittate per piacè…</value>
   </data>
   <data name="Main_ScanningTitleXOfY" xml:space="preserve">
-    <value>正在扫描标题 {0}/{1} ({2}%)</value>
+    <value>Analisa di u titulu {0} nant’à {1} ({2}%)</value>
   </data>
   <data name="Main_ScanSource" xml:space="preserve">
-    <value>在开始编码之前，必须首先扫描源并设置作业。单击工具栏上的“添加源”按钮继续。</value>
+    <value>Prima, ci vole à analizà una fonte è definisce u vostru travagliu nanzu di principià una cudificazione. Appughjate nant’à u buttone « Fonte » in a barre d’attrezzi per cuntinuà.</value>
   </data>
   <data name="Main_SelectPreset" xml:space="preserve">
-    <value>请确保您已选择自己的预设。请注意，您无法导出内置预设。</value>
+    <value>Assicuratevvi chì voi abbiate selezziunatu una di e vostre proprie prerigature. Ci vole à sapè chì ùn pudete micca espurtà e prerigature integrate.</value>
   </data>
   <data name="Main_SelectPresetForUpdate" xml:space="preserve">
-    <value>请选择要更新的预设。</value>
+    <value>Ci vole à selezziunà una prerigatura à mudificà.</value>
   </data>
   <data name="Main_SelectSource" xml:space="preserve">
-    <value>选择“源”以继续</value>
+    <value>Selezziunate « Apre a fonte » per cuntinuà</value>
   </data>
   <data name="Main_XEncodesPending" xml:space="preserve">
-    <value>{0} Jobs Pending</value>
+    <value>{0} Travaglii in attesa</value>
   </data>
   <data name="Notice" xml:space="preserve">
-    <value>注意</value>
+    <value>Avertimentu</value>
   </data>
   <data name="Overwrite" xml:space="preserve">
-    <value>是否覆盖？</value>
+    <value>Rimpiazzallu ?</value>
   </data>
   <data name="Question" xml:space="preserve">
-    <value>问题</value>
+    <value>Dumanda</value>
   </data>
   <data name="State_Ready" xml:space="preserve">
-    <value>准备就绪</value>
+    <value>Prontu</value>
   </data>
   <data name="Updated" xml:space="preserve">
-    <value>更新</value>
+    <value>Mudificatu</value>
   </data>
   <data name="Preset_OldVersion_Header" xml:space="preserve">
-    <value>预设版本</value>
+    <value>Versione di a prerigatura</value>
   </data>
   <data name="Preset_OldVersion_Message" xml:space="preserve">
-    <value>您尝试导入的预设来自不同版本的 HandBrake。
-可能无法从此预设中导入所有值。
+    <value>A prerigatura chì vo circate à impurtà vene d’una versione sfarente d’HandBrake. 
+ Forse ùn serà micca pussibule d’impurtà tutti i valori di sta prerigatura. 
 
-你要继续吗？</value>
+Vulete cuntinuà ?</value>
   </data>
   <data name="Preset_UnableToImport_Header" xml:space="preserve">
-    <value>无法导入预设！</value>
+    <value>Impussibule d’impurtà a prerigatura !</value>
   </data>
   <data name="Preset_UnableToImport_Message" xml:space="preserve">
-    <value>无法导入预设，因为它似乎已损坏或来自旧版本的 HandBrake。</value>
+    <value>Impussibule d’impurtà a prerigatura chì pare esse alterata o vene d’una vechja versione d’HandBrake.</value>
   </data>
   <data name="Main_SetDestination" xml:space="preserve">
-    <value>在添加到队列之前，必须先为输出文件设置目标路径。</value>
+    <value>Prima, ci vole à definisce u chjassu di destinazione di u schedariu d’esciuta nanzu d’aghjunghjelu à a fila d’attesa.</value>
   </data>
   <data name="Main_InvalidDestination" xml:space="preserve">
-    <value>输入的目标路径包含非法字符，将不会更新。</value>
+    <value>U chjassu di destinazione pruvistu cuntene caratteri inaccettevule è ùn serà micca  mudificatu.</value>
   </data>
   <data name="Preview" xml:space="preserve">
-    <value>预览{0}</value>
+    <value>Previsualizazione {0}</value>
   </data>
   <data name="Preview_Scaled" xml:space="preserve">
-    <value>预览（缩放）</value>
+    <value>Previsualizazione (à a scala)</value>
   </data>
   <data name="PictureSettings_OutputResolution" xml:space="preserve">
-    <value>输出：{0}</value>
+    <value>Esciuta : {0}</value>
   </data>
   <data name="Options_AdditionalFormatOptions" xml:space="preserve">
-    <value>输出文件的格式。除了任何受支持的文件系统字符之外，您还可以使用以下占位符，这些占位符将在更改标题或扫描源时被替换。
+    <value>U furmatu di u schedariu d’esciuta. In più di i caratteri pigliati in carica da u sistema di schedariu, pudete impiegà i campi di sustituzione seguente chì seranu rimpiazzati quandu vo cambiate di titulu o analizate una fonte.
 
-实时更新选项：{source} {title} {chapters} 
-非实时选项：{date} {time} {creation-date} {creation-time} {quality} {bitrate} （只有扫描新源、更改标题或章节时才会更改）</value>
+Ozzioni mudificate direttamente : {source} {title} {chapters} 
+Ozzioni tramandate : {date} {time} {creation-date} {creation-time} {quality} {bitrate} (Quesse cambianu solu quandu voi analizate una nova fonte, cambiate di titulu o di capitulu)</value>
   </data>
   <data name="Options_DefaultPathAdditionalParams" xml:space="preserve">
-    <value>可用的附加选项: {source_path} 或 {source_folder_name} 或 {source}</value>
+    <value>Ozzioni cumplementarie dispunibule : {source_path} o {source_folder_name} o {source}</value>
   </data>
   <data name="Main_MatchingFileOverwriteWarning" xml:space="preserve">
-    <value>您不能编码到与源文件具有相同路径和文件名的文件。请更新目标文件名，使其与源文件不匹配。</value>
+    <value>Ùn pudete micca cudificà ver di un schedariu cù u listessu chjassu è u listessu nome chì u schedariu di a fonte. Ci vole à mudificà u nome di schedariu di destinazione per ch’ellu ùn currispondi più à u schedariu di a fonte. </value>
   </data>
   <data name="Main_UnableToLoadHelpMessage" xml:space="preserve">
-    <value>您的系统阻止了 HandBrake 启动Web浏览器。</value>
+    <value>U vostru sistema hà impeditu à HandBrake di lancià un navigatore web.</value>
   </data>
   <data name="Main_UnableToLoadHelpSolution" xml:space="preserve">
-    <value>您仍然可以直接访问网站的帮助页面：https://handbrake.fr</value>
+    <value>Pudete sempre accede à e pagine d’aiutu direttamente da u situ web : https://handbrake.fr</value>
   </data>
   <data name="Main_PresetImportFailed" xml:space="preserve">
-    <value>无法导入所选预设。</value>
+    <value>Impussibule d’impurtà a prerigatura selezziunata.</value>
   </data>
   <data name="Main_PresetImportFailedSolution" xml:space="preserve">
-    <value>预设可能已损坏，或者来自不受支持的旧版 HandBrake。
-必须在当前版本中重新创建旧版本的预设。</value>
+    <value>Forse a prerigatura hè alterata o vene d’una vechja versione d’HandBrake, ciò ch’ùn hè micca accettatu. 
+E prerigature chì venenu da vechje versioni devenu esse create torna in a versione attuale.</value>
   </data>
   <data name="Video_EncoderExtraArgsTooltip" xml:space="preserve">
-    <value>可以传递给视频编码器的其他高级参数。</value>
+    <value>Parametri addiziunale d’espertu chì ponu esse trasmessi à u cudificatore video.</value>
   </data>
   <data name="Subtitles_BurnInBehaviourModes" xml:space="preserve">
-    <value>None - 只有容器不支持的轨道才会被烧入。
-Foreign Audio Track - 如果可用，外语轨道将被烧入。
-First Track - 第一条轨道会被烧入。
-Foreign Audio Preferred, else First - 如果存在外语轨道，则会将其烧入，否则将选择第一条轨道。</value>
+    <value>Alcunu - Solu e traccie per quelle u cuntenentu ùn accetta micca u furmatu seranu intarsiate.
+Traccia audio straniera - A traccia audio straniera serà intarsiata s’ella hè dispunibule. 
+Prima traccia - A prima traccia serà intarsiata.
+Audio straniera preferita, osinnò Prima traccia - A traccia audio straniera serà intarsiata s’ella esiste, osinnò a prima traccia serà scelta.</value>
   </data>
   <data name="Subtitles_WebmSubtitleIncompatibilityHeader" xml:space="preserve">
-    <value>WebM 字幕兼容性</value>
+    <value>Cumpatibilità di sottutituli WebM</value>
   </data>
   <data name="Subtitles_WebmSubtitleIncompatibilityError" xml:space="preserve">
-    <value>HandBrake中的WebM格式仅支持内镶字幕。
+    <value>WebM in HandBrake accetta solu i sottutituli intarsiati.
 
-您应该更改字幕选择。
+Ci vuleria à cambià e vostre selezzione di sottutituli.
 
-如果继续，您未烧录的字幕将丢失。</value>
+S’è vo cuntinuate, i vostri sottutituli micca intarsiati seranu persi.</value>
   </data>
   <data name="Main_ScanNoTitlesFound" xml:space="preserve">
-    <value>找不到有效的源或标题。</value>
+    <value>Alcuna fonte o titulu ùn hè statu trovu.</value>
   </data>
   <data name="Main_ScanNoTitlesFoundMessage" xml:space="preserve">
-    <value>HandBrake 不能对选定的来源进行编码，因为它没有找到一个可以编码的有效来源。
-这可能是由于以下原因之一：
-- 每个源标题的持续时间低于“首选项&gt;高级”中的“最小标题持续时间”阈值选项。
-- 源文件不是有效的视频文件，或者是HandBrake不支持的格式。
-- 源可以是受复制保护的或包括DRM。请注意，HandBrake不支持删除复制保护。
+    <value>HandBrake ùn puderà micca cudificà a fonte selezziunata perchè ùn hà micca trovu di fonte accettevule cù tituli à cudificà. 
+E cagioni pussibule sò :
+- A durata d’ogni titulu di a fonte hè più corta chì l’ozzione di sogliu « Durata minima » in « Ozzioni &gt; Espertu ». 
+- U schedariu di fonte ùn hè micca un schedariu video accettevule o si trova in un furmatu scunnisciutu da HandBrake.
+- U schedariu di fonte pò esse prutettu contr’à a copia o cuntene un dirittu DRM. Ci vole à sapè ch’HandBrake ùn permette micca di squassà e prutezzioni contr’à a copia.
 
-活动日志可能包含更多信息。</value>
+U ghjurnale d’attività puderia cuntene infurmazioni addiziunale.</value>
   </data>
   <data name="Main_QueueLabel" xml:space="preserve">
-    <value>队列{0}</value>
+    <value>Fila d’attesa{0}</value>
   </data>
   <data name="Main_Start" xml:space="preserve">
-    <value>开始编码</value>
+    <value>Principià a cudificazione</value>
   </data>
   <data name="Main_StartQueue" xml:space="preserve">
-    <value>启动队列</value>
+    <value>Principià a fila d’attesa</value>
   </data>
   <data name="MainViewModel_CanNotDeleteDefaultPreset" xml:space="preserve">
-    <value>不能删除默认预设。请先将另一个预设设置为默认值。</value>
+    <value>Ùn pudete micca squassà a prerigatura predefinita. Prima, ci vole à sceglie un’altra prerigatura predefinita.</value>
   </data>
   <data name="MainViewModel_PresetRemove_AreYouSure" xml:space="preserve">
-    <value>您确定要删除预设：</value>
+    <value>Site sicuru di vulè squassà a prerigatura : </value>
   </data>
   <data name="MainViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
-    <value>Encoding: Pass {0} of {1},  {2:00.00}%, FPS: {3:000.0},  Avg FPS: {4:000.0},  Time Remaining: {5},  Elapsed: {6} {7}</value>
+    <value>Cudificazione : Passu {0} nant’à {1},  {2:00.00}%, FPS : {3:000.0},  FPS mediana : {4:000.0},  Tempu rimanente : {5}, Trascorsu : {6} {7}</value>
   </data>
   <data name="AddPresetViewModel_PresetMustProvideName" xml:space="preserve">
-    <value>预设必须有名称。请填写预设名称字段。</value>
+    <value>Una prerigatura deve avè un nome. Ci vole à riempie u campu di u nome di prerigatura.</value>
   </data>
   <data name="AddPresetViewModel_PresetWithSameNameOverwriteWarning" xml:space="preserve">
-    <value>已存在具有此名称的预设。 你想覆盖它吗？</value>
+    <value>Una prerigatura cù stu nome esiste dighjà. Vulete rimpiazzalla ?</value>
   </data>
   <data name="AddPresetViewModel_YouMustFirstScanSource" xml:space="preserve">
-    <value>必须先扫描源才能使用“源最大值”选项。</value>
+    <value>Prima, ci vole à analizà una fonte per impiegà l’ozzione « Fonte massima ».</value>
   </data>
   <data name="AddPresetViewModel_CustomWidthHeightFieldsRequired" xml:space="preserve">
-    <value>必须为“自定义”选项填写自定义宽度或高度字段。</value>
+    <value>I campi persunalizati Larghezza o Altezza devenu esse riimpiuti per impiegà l’ozzione « Persunalizatu ».</value>
   </data>
   <data name="AddPresetViewModel_UnableToAddPreset" xml:space="preserve">
-    <value>无法添加预设</value>
+    <value>Impussibule d’aghjunghje una prerigatura</value>
   </data>
   <data name="UnknownError" xml:space="preserve">
-    <value>未知错误</value>
+    <value>Sbagliu scunnisciutu</value>
   </data>
   <data name="AudioViewModel_AudioDefaults" xml:space="preserve">
-    <value>音频默认值</value>
+    <value>Audio predefinitu</value>
   </data>
   <data name="AudioViewModel_AudioTracks" xml:space="preserve">
-    <value>音轨</value>
+    <value>Traccie audio</value>
   </data>
   <data name="AudioViewModel_ConfigureDefaults" xml:space="preserve">
-    <value>选择行为</value>
+    <value>Selezzione di cumpurtamentu</value>
   </data>
   <data name="AudioViewModel_SwitchBackToTracks" xml:space="preserve">
-    <value>切换回轨道</value>
+    <value>Rivene à e traccie</value>
   </data>
   <data name="ChaptersViewModel_UnableToExportChaptersWarning" xml:space="preserve">
-    <value>无法保存章节标记文件！</value>
+    <value>Impussibule d’arregistrà u schedariu di marcatori di capitulu ! </value>
   </data>
   <data name="ChaptersViewModel_UnableToExportChaptersMsg" xml:space="preserve">
-    <value>章节标记名称不会保存在您的编码中。</value>
+    <value>I nomi di marcatore di capitulu ùn seranu micca arregistrati in a vostra cudificazione.</value>
   </data>
   <data name="CountdownAlertViewModel_NoticeMessage" xml:space="preserve">
-    <value>以下操作 “{0}”将在{1}内发生。</value>
+    <value>L’azzione seguente « {0} » si farà in {1} seconde.</value>
   </data>
   <data name="ErrorViewModel_IfTheProblemPersists" xml:space="preserve">
-    <value>如果问题仍然存在，请尝试重新启动 HandBrake。</value>
+    <value>S'è stu penseru ùn smarisce micca, ci vole à pruvà di rilancià HandBrake.</value>
   </data>
   <data name="ErrorViewModel_NoFurtherInformation" xml:space="preserve">
-    <value>没有关于此错误的更多信息。</value>
+    <value>Ùn ci hè mancu un’altra infurmazione di dispunibule per stu sbagliu.</value>
   </data>
   <data name="ErrorViewModel_UnknownError" xml:space="preserve">
-    <value>出现未知错误。</value>
+    <value>Un sbagliu scunnisciutu hè accadutu.</value>
   </data>
   <data name="OptionsViewModel_NewUpdate" xml:space="preserve">
-    <value>有一个新的更新！请查看网站上的发行说明。</value>
+    <value>Un rinnovu recente hè dispunibule ! Ci vole à cunsultà u situ web per fighjà e note di versione.</value>
   </data>
   <data name="OptionsViewModel_64bitAvailable" xml:space="preserve">
-    <value>您的系统支持64位版本的 HandBrake！ 与32位版本相比，提供了性能和稳定性改进。
-    请查看网站上的发行说明。</value>
+    <value>U vostru sistema accetta a versione 64bit d’HandBrake ! Sta versione permette capacità è stabilità più belle chì a versione 32bit.
+    Ci vole à cunsultà u situ web per fighjà e note di versione.</value>
   </data>
   <data name="OptionsViewModel_NoNewUpdates" xml:space="preserve">
-    <value>目前没有新的更新。</value>
+    <value>À st’ora, ùn ci hè alcunu rinnovu recente.</value>
   </data>
   <data name="OptionsViewModel_UpdateDownloaded" xml:space="preserve">
-    <value>更新已下载</value>
+    <value>Rinnovu scaricatu</value>
   </data>
   <data name="OptionsViewModel_UpdateServiceUnavailable" xml:space="preserve">
-    <value>更新服务不可用。您可以尝试从 https://handbrake.fr 下载更新</value>
+    <value>Serviziu di rinnovu micca dispunibule. Pudete pruvà di scaricà u rinnovu da u situ https://handbrake.fr</value>
   </data>
   <data name="OptionsViewModel_UpdateFailed" xml:space="preserve">
-    <value>更新失败。您可以尝试从 https://handbrake.fr 下载更新</value>
+    <value>Rinnovu fiascu. Pudete pruvà di scaricà u rinnovu da u situ https://handbrake.fr</value>
   </data>
   <data name="PictureSettingsViewModel_StorageDisplayLabel" xml:space="preserve">
-    <value>显示尺寸： {0}x{1},  PAR {2}x{3}</value>
+    <value>Dimensione di u screnu : {0}x{1},  PAR {2}x{3}</value>
   </data>
   <data name="QueueSelectionViewModel_AddToQueue" xml:space="preserve">
-    <value>添加到队列中</value>
+    <value>Aghjunghje à a fila d’attesa</value>
   </data>
   <data name="QueueViewModel_NoEncodesPending" xml:space="preserve">
-    <value>没有在等待的编码</value>
+    <value>Alcuna cudificazione in attesa</value>
   </data>
   <data name="QueueViewModel_NoJobsPending" xml:space="preserve">
-    <value>当前没有编码作业</value>
+    <value>Ùn ci hè alcunu travagliu di cudificazione in corsu</value>
   </data>
   <data name="QueueViewModel_Queue" xml:space="preserve">
-    <value>队列</value>
+    <value>Fila d’attesa</value>
   </data>
   <data name="QueueViewModel_ClearQueueConfrimation" xml:space="preserve">
-    <value>你确定要清除队列吗？</value>
+    <value>Site sicuru di vulè viutà a fila d’attesa ?</value>
   </data>
   <data name="Confirm" xml:space="preserve">
-    <value>确认</value>
+    <value>Cunfirmà</value>
   </data>
   <data name="QueueViewModel_JobsPending" xml:space="preserve">
-    <value>{0} 等待作业</value>
+    <value>{0} travaglii in attesa</value>
   </data>
   <data name="QueueViewModel_QueuePending" xml:space="preserve">
-    <value>列队已暂停</value>
+    <value>Fila d’attesa interrotta</value>
   </data>
   <data name="QueueViewModel_DelSelectedJobConfirmation" xml:space="preserve">
-    <value>您确定要删除所选作业吗？</value>
+    <value>Site sicuru di vulè squassà i travaglii selezziunati ?</value>
   </data>
   <data name="QueueViewModel_JobCurrentlyRunningWarning" xml:space="preserve">
-    <value>此编码目前正在进行中。如果删除它，编码将停止。你确定要继续吗？</value>
+    <value>Sta cudificazione hè in corsu. S’è vo a squassate, a cudificazione serà piantata. Site sicuru di vulè fà què ?</value>
   </data>
   <data name="QueueViewModel_NoPendingJobs" xml:space="preserve">
-    <value>没有待处理的作业。</value>
+    <value>Ùn ci hè alcunu travagliu in attesa.</value>
   </data>
   <data name="QueueViewModel_EditConfrimation" xml:space="preserve">
-    <value>是否确实要编辑此作业？它将从队列中删除并发送到主窗口。</value>
+    <value>Site sicuru di vulè mudificà stu travagliu ? Serà cacciatu da a fila d’attesa è mandatu ver di a finestra principale.</value>
   </data>
   <data name="QueueViewModel_QueueReady" xml:space="preserve">
-    <value>队列已就绪</value>
+    <value>Fila d’attesa pronta</value>
   </data>
   <data name="QueueViewModel_QueueNotRunning" xml:space="preserve">
-    <value>队列未运行</value>
+    <value>A fila d’attesa ùn hè micca in corsu d’esecuzione</value>
   </data>
   <data name="QueueViewModel_QueueCompleted" xml:space="preserve">
-    <value>队列已完成</value>
+    <value>Fila d’attesa compia</value>
   </data>
   <data name="QueueViewModel_LastJobFinished" xml:space="preserve">
-    <value>上次列队的作业已完成</value>
+    <value>Ultimu travagliu in attesa compiu</value>
   </data>
   <data name="QueueViewModel_QueueStarted" xml:space="preserve">
-    <value>列队已开始</value>
+    <value>Fila d’attesa principiata</value>
   </data>
   <data name="QueueViewModel_QueueStatusDisplay" xml:space="preserve">
-    <value>编码中：Pass {0}/{1},  {2:00.00}%, FPS: {3:000.0}, 平均FPS: {4:000.0}, 剩余时间：{5},  已用时间：{6:d\:hh\:mm\:ss}</value>
+    <value>Cudificazione : Passu {0} nant’à {1},  {2:00.00}%, FPS : {3:000.0},  FPS mediana : {4:000.0},  Tempu rimanente : {5}, Trascorsu : {6:g\:oo\:mm\:ss}</value>
   </data>
   <data name="ShellViewModel_CanClose" xml:space="preserve">
-    <value>当前正在运行编码。退出 HandBrake 将停止此编码。
-你确定要退出 HandBrake 吗？</value>
+    <value>Una cudificazione hè in corsu d’esecuzione. L’esce d’HandBrake pianterà sta cudificazione.
+Site sicuru di vulè esce d’HandBrake ?</value>
   </data>
   <data name="StaticPreviewViewModel_Title" xml:space="preserve">
-    <value>图片预览</value>
+    <value>Previsualizazione di a fiura</value>
   </data>
   <data name="StaticPreview_UnableToDeletePreview" xml:space="preserve">
-    <value>无法删除以前的预览文件。您可能需要重新启动应用程序。</value>
+    <value>Impussibule di squassà u schedariu di previsualizazione precedente. Forse, ci vulerà à rilancià l’appiecazione.</value>
   </data>
   <data name="StaticPreviewViewModel_ScanFirst" xml:space="preserve">
-    <value>在创建预览之前，必须先扫描源并设置编码。</value>
+    <value>Prima, ci vole à analizà una fonte è definisce a vostra cudificazione nanzu di creà una previsualizazione.</value>
   </data>
   <data name="StaticPreviewViewModel_UnableToPlayFile" xml:space="preserve">
-    <value>无法找到预览文件。文件已删除或编码失败。检查活动日志以获取详细信息。</value>
+    <value>Impussibule di truvà u schedariu di previsualizazione. U schedariu hè statu squassatu o a cudificazione hè fiasca. Fighjate u ghjurnale d’attività per sapene di più.</value>
   </data>
   <data name="StaticPreviewViewModel_AlreadyEncoding" xml:space="preserve">
-    <value>Handbrake 已经在编码视频了！ 一次只能编码一个文件。</value>
+    <value>Ci hè dighjà una cudificazione video in corsu ! HandBrake pò cudificà una sola video in una volta.</value>
   </data>
   <data name="SubtitlesViewModel_SubDefaults" xml:space="preserve">
-    <value>字幕默认值</value>
+    <value>Sottutituli predefiniti</value>
   </data>
   <data name="SubtitlesViewModel_SubTracks" xml:space="preserve">
-    <value>字幕轨道</value>
+    <value>Traccie di sottutitulu</value>
   </data>
   <data name="SubtitlesViewModel_SwitchToTracks" xml:space="preserve">
-    <value>切换回轨道</value>
+    <value>Rivene à e traccie</value>
   </data>
   <data name="SubtitlesViewModel_ConfigureDefaults" xml:space="preserve">
-    <value>选择行为</value>
+    <value>Selezzione di cumpurtamentu</value>
   </data>
   <data name="PresetService_ArchiveFile" xml:space="preserve">
-    <value>存档的文件：</value>
+    <value>Schedariu archiviatu :</value>
   </data>
   <data name="PresetService_UnableToLoad" xml:space="preserve">
-    <value>无法加载预设。</value>
+    <value>Impussibule di caricà e prerigature.</value>
   </data>
   <data name="PresetService_UnableToLoadPresets" xml:space="preserve">
-    <value>HandBrake 无法加载您的预设文件。它可能来自较旧的不受支持的 HandBrake 版本或已损坏。
+    <value>HandBrake ùn hà micca pussutu caricà u schedariu di prerigature. Forse, hè statu creatu da una vechja versione oramai più accettata d’HandBrake o ancu alteratu. 
 
-您的旧预设文件已归档为：</value>
+U vostru vechju schedariu di prerigature hè statu archiviatu :</value>
   </data>
   <data name="Main_QueueFinishedErrors" xml:space="preserve">
-    <value> 有{0} 个错误或取消检测。</value>
+    <value> cù {0} sbaglii o abbandoni abbentati.</value>
   </data>
   <data name="MainViewModel_LowDiskSpace" xml:space="preserve">
-    <value>磁盘空间不足</value>
+    <value>Spaziu discu chjucu</value>
   </data>
   <data name="MainViewModel_LowDiskSpaceWarning" xml:space="preserve">
-    <value>警告，您的磁盘空间不足。如果空间不足，HandBrake 将无法完成此编码。</value>
+    <value>Avertimentu : ùn ci hè abbastanza spaziu di discu. HandBrake ùn puderà compie sta cudificazione s’ellu ùn ci hè abbastanza spaziu di discu. </value>
   </data>
   <data name="ChaptersViewModel_UnableToImportChaptersMalformedLineMsg" xml:space="preserve">
-    <value>第{0}行无效。不会导入任何内容。</value>
+    <value>A linea {0} hè inaccetevule. Ùn ci serà nunda d’impurtatu.</value>
   </data>
   <data name="ChaptersViewModel_UnableToImportChaptersWarning" xml:space="preserve">
-    <value>无法导入章节文件</value>
+    <value>Impussibule d’impurtà u schedariu di capitulu</value>
   </data>
   <data name="ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns" xml:space="preserve">
-    <value>章节文件中的所有行必须至少有2列数据</value>
+    <value>Tutte e linee d’un schedariu di capitulu devenu cuntene omancu 2 culonne di dati</value>
   </data>
   <data name="ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber" xml:space="preserve">
-    <value>章节文件中的第一列只能包含大于零（0）的整数值</value>
+    <value>A prima culonna d’un schedariu di capitulu deve cuntene solu un numeru interu superiore à zeru (0)</value>
   </data>
   <data name="ChaptersViewModel_UnsupportedFileFormatMsg" xml:space="preserve">
-    <value>目前不支持类型为 '{0}' 的章节文件。</value>
+    <value>I schedarii di capitulu di tipu « {0} » ùn sò micca accettati à st’ora.</value>
   </data>
   <data name="ChaptersViewModel_UnsupportedFileFormatWarning" xml:space="preserve">
-    <value>不支持的章节文件类型</value>
+    <value>Tipu di schedariu di capitulu micca accettatu</value>
   </data>
   <data name="ChaptersViewModel_ValidationFailedWarning" xml:space="preserve">
-    <value>源媒体的章节信息无效</value>
+    <value>Infurmazioni di capitulu inaccettevule in u media di fonte</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatch" xml:space="preserve">
-    <value>媒体源的章节数和输入文件的章节数不匹配( {0} vs {1}).
+    <value>U numeru di capituli nant’à u media di fonte
+è quellu in u schedariu d’entrata ùn currispundenu micca ({0} vs {1}).
 
-你依然要导入章节名吗？</value>
+Vulete impurtà i nomi di capitulu quantunque ?</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg" xml:space="preserve">
-    <value>媒体源的章节数和输入文件的章节数不匹配( {0} vs {1}).
+    <value>U numeru di capituli nant’à u media di fonte
+è quellu in u schedariu d’entrata ùn currispundenu micca ({0} vs {1}).
 
-你依然要导入章节名吗？</value>
+Vulete impurtà i nomi di capitulu quantunque ?</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning" xml:space="preserve">
-    <value>源文件和输入文件的章节数不匹配</value>
+    <value>U numeru di capituli ùn currispunde micca trà u schedariu di fonte è quellu d’entrata</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg" xml:space="preserve">
-    <value>源媒体上各章的持续时长和输入文件中各章的持续时长相差很大。
+    <value>A durata di i capituli nant’à u media di fonte
+è quella in u schedariu d’entrata sò assai sfarente.
 
-本章节文件很可能是从其他源媒体生成的。
+Ghjè sicuramente chì stu schedariu di capitulu fussi creatu da un media di fonte sfarente.
 
-确实要导入章节名称吗？</value>
+Site sicuru di vulè impurtà i nomi di capitulu ?</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning" xml:space="preserve">
-    <value>源文件和输入文件的章节时长不匹配</value>
+    <value>U numeru di capituli ùn currispunde micca trà u schedariu di fonte è quellu d’entrata</value>
   </data>
   <data name="ScanService_ScanStopFailed" xml:space="preserve">
-    <value>尝试停止扫描时发生了错误。请重启HandBrake。</value>
+    <value>Un sbagliu hè accadutu pruvendu di piantà l’analisa. Ci vole à rilancià HandBrake.</value>
   </data>
   <data name="Presets_PresetForceReset" xml:space="preserve">
-    <value>HandBrake 无法将预设文件升级为新版本格式。
-您的预设文件将被存档。您需要重新创建自己的预设。</value>
+    <value>HandBrake ùn pò micca mudernizà u vostru schedariu di prerigature ver di u furmatu di a nova versione.
+U vostru schedariu di prerigatura hà da esse archiviatu è un novu hà da esse creatu. Duverete creà torna e vostre proprie prerigature.</value>
   </data>
   <data name="SettingService_SaveErrorReset" xml:space="preserve">
-    <value>你所更改的任何设置可能会在下次HandBrake 启动时被重置。</value>
+    <value>Forse, tutte e preferenze chì vo avete cambiate duveranu esse rimesse d’origine à u prossimu lanciu d’HandBrake.</value>
   </data>
   <data name="UserSettings_AnErrorOccured" xml:space="preserve">
-    <value>尝试保存你的偏好设置时出现了问题。</value>
+    <value>Un sbagliu hè accadutu pruvendu d’arregistrà e vostre preferenze.</value>
   </data>
   <data name="UserSettings_YourSettingsHaveBeenReset" xml:space="preserve">
-    <value>警告，你的设置已被重置！</value>
+    <value>Avertimentu : e vostre preferenze sò state rimesse d’origine !</value>
   </data>
   <data name="UserSettings_YourSettingsAreCorrupt" xml:space="preserve">
-    <value>你的用户设置文件已损坏或不可访问。设置已经被恢复为默认。</value>
+    <value>U vostru schedariu di preferenze persunalizate era inaccessibile o alteratu. E preferenze sò state rimesse à i so valori d’origine.</value>
   </data>
   <data name="UserSettings_UnableToLoad" xml:space="preserve">
-    <value>无法加载用户设置文件: {0}</value>
+    <value>Impussibule di caricà u schedariu di e preferenze persunalizate : {0}</value>
   </data>
   <data name="UserSettings_UnableToLoadSolution" xml:space="preserve">
-    <value>你的用户设置文件似乎无法访问或已损坏。你可能需要删除它并让HandBrake 生成一份新的。</value>
+    <value>U vostru schedariu di preferenze persunalizate pare esse inaccessibile o alteratu. Forse, duverete squassà u schedariu è lascià HandBrake creane un novu.</value>
   </data>
   <data name="Main_NoPermissionsOrMissingDirectory" xml:space="preserve">
-    <value>你选择的输出目录不存在或者没有写入文件的权限。</value>
+    <value>U cartulare d’esciuta chì vo avete sceltu ùn esiste micca, o ùn avete micca u permessu di scriveci schedarii.</value>
   </data>
   <data name="DirectoryUtils_CreateFolder" xml:space="preserve">
-    <value>创建文件夹？</value>
+    <value>Creà u cartulare ?</value>
   </data>
   <data name="DirectoryUtils_CreateFolderMsg" xml:space="preserve">
-    <value>要写入的文件夹并不存在。你希望HandBrake创建该文件夹吗？
+    <value>U cartulare, in quellu circate à scrive, ùn esiste micca. Vulete chì HandBrake crei quellu cartulare ?
 {0}</value>
   </data>
   <data name="MainViewModel_UnableToLaunchDestDir" xml:space="preserve">
-    <value>无法启动目标目录。</value>
+    <value>Impussibule di lancià u cartulare di destinazione.</value>
   </data>
   <data name="MainViewModel_UnableToLaunchDestDirSolution" xml:space="preserve">
-    <value>请检查目标目录是否有效。</value>
+    <value>Ci vole à verificà chì vo avete un cartulare di destinazione accettevule.</value>
   </data>
   <data name="MainViewModel_EncodeStatusChanged_SubScan_StatusLabel" xml:space="preserve">
-    <value>Processing Pass {0} of {1}, (Subtitle Scan)  {2:00.00}%, Scan Time Remaining: {3},  Elapsed: {4}</value>
+    <value>Passu di trattamentu {0} nant’à {1}, (Analisa di i sottutituli)  {2:00.00}%, Tempu d’analisa rimanente : {3}, Trascorsu : {4}</value>
   </data>
   <data name="NoAdditionalInformation" xml:space="preserve">
-    <value>没有附加信息</value>
+    <value>Alcuna infurmazione cumplementaria</value>
   </data>
   <data name="WindowTitleStatus" xml:space="preserve">
-    <value>{0} - ({1}%, 已完成 {2} /{3} )</value>
+    <value>{0} - ({1}%, Passu {2} nant’à {3})</value>
   </data>
   <data name="TaskTrayStatusTitle" xml:space="preserve">
-    <value>{1}%, 已完成 {2} / {3}
-剩余时间: {4}</value>
+    <value>{1}%, Passu {2} nant’à {3}
+Tempu rimanente : {4}</value>
   </data>
   <data name="PauseOnLowDiskspace" xml:space="preserve">
-    <value>队列已暂停。警告，您编码的驱动器磁盘空间不足。请释放一些空间，然后按开始继续。您还可以调整首选项中的最小空间级别。</value>
+    <value>Fila d’attesa interrotta.  Avertimentu : ùn ci hè abbastanza spaziu di discu nant’à u lettore per fà a cudificazione. Ci vole à liberà qualchì spaziu è appughjate nant’à Principià per cuntinuà. Pudete ancu adattà u livellu minimu di spaziu in e preferenze.</value>
   </data>
   <data name="Main_QueuePaused" xml:space="preserve">
-    <value>列队已暂停</value>
+    <value>Fila d’attesa interrotta</value>
   </data>
   <data name="QueueViewModel_QueuePaused" xml:space="preserve">
-    <value>列队已暂停</value>
+    <value>Fila d’attesa interrotta</value>
   </data>
   <data name="Main_LowDiskspace" xml:space="preserve">
-    <value>Your destination directory is low on diskspace. 
+    <value>Ùn ci hè abbastanza spaziu di discu per u vostru cartulare di destinazione. 
 
-You can configure the level at which this alert appears in preferences. 
+Pudete cunfigurà in e preferenze à chì livellu st’alerta deve accade. 
 
-Do you wish to continue? </value>
+Vulete cuntinuà ? </value>
   </data>
   <data name="Queue_UnableToResetJob" xml:space="preserve">
-    <value>无法重置作业状态，因为它未处于错误或已完成状态</value>
+    <value>Impussibule di reinizià u statu di u travagliu perchè ùn hè micca in un statu « Sbagliu » o « Compiu ».</value>
   </data>
   <data name="Queue_UnableToRestoreFile" xml:space="preserve">
-    <value>无法恢复队列文件。</value>
+    <value>Impussibule di risturà u schedariu di fila d’attesa.</value>
   </data>
   <data name="Queue_UnableToRestoreFileExtended" xml:space="preserve">
-    <value>文件可能损坏或是来自旧的不兼容版本的HandBrake</value>
+    <value>Forse u schedariu hè alteratu o vene d’una vechja versione incumpatibule d’HandBrake.</value>
   </data>
   <data name="Queue_AlreadyEncoding" xml:space="preserve">
-    <value>HandBrake已经在编码文件中。</value>
+    <value>Ci hè dighjà una cudificazione di schedariu in corsu.</value>
   </data>
   <data name="Queue_AlreadyEncodingSolution" xml:space="preserve">
-    <value>请停止当前编码。如果问题依然存在，请重启HandBrake。</value>
+    <value>Ci vole à piantà a cudificazione attuale. S'è stu penseru ùn smarisce micca, ci vole à rilancià HandBrake.</value>
   </data>
   <data name="StaticPreviewView_Title" xml:space="preserve">
-    <value>预览 ({0}% 实际大小)</value>
+    <value>Previsualizazione ({0}% di a dimensione attuale)</value>
   </data>
   <data name="OsBitnessWarning" xml:space="preserve">
-    <value>HandBrake需要在64bit Windows 7或更高版本中运行。</value>
+    <value>HandBrake richiede una versione 64bit di Windows 7 o più recente per funziunà.</value>
   </data>
   <data name="OsVersionWarning" xml:space="preserve">
-    <value>HandBrake 需要Windows 7或更高版本才能运行。版本0.9.9 (XP)和版本0.10.5 (Vista)是支持这些版本的最后一个版本。</value>
+    <value>HandBrake richiede Windows 7 o più recente per funziunà. E versioni 0.9.9 (XP) è 0.10.5 (Vista) sò l’ultime à piglià in carica sti sistemi.</value>
   </data>
   <data name="Main_ContinueAddingToQueue" xml:space="preserve">
-    <value>你希望继续尝试添加剩下的吗？</value>
+    <value>Vulete cuntinuà pruvendu d’aghjunghje u restu ?</value>
   </data>
   <data name="Main_QueueOverwritePrompt" xml:space="preserve">
-    <value>文件 '{0}' 已存在!
-你想要覆盖它吗?</value>
+    <value>U schedariu « {0} » esiste dighjà !
+Vulete rimpiazzallu ?</value>
   </data>
   <data name="Clipboard_Unavailable" xml:space="preserve">
-    <value>系统剪贴板目前无法使用。</value>
+    <value>U preme’papei di u sistema  ùn hè micca dispunibule attualmente.</value>
   </data>
   <data name="Clipboard_Unavailable_Solution" xml:space="preserve">
-    <value>这可能是由于另外的应用程序正监视或锁定了剪贴板。当剪贴板解锁后你才能继续使用它。</value>
+    <value>Forse ci hè un’altra appiecazione chì cuttighjeghja o ammarchjuneghja u preme’papei per u so propriu adopru. Ùn puderete micca impiegalu finch’ellu sia spalancatu?</value>
   </data>
   <data name="AboutView_License" xml:space="preserve">
-    <value>许可：</value>
+    <value>Licenza : </value>
   </data>
   <data name="AboutView_Version" xml:space="preserve">
-    <value>版本：</value>
+    <value>Versione : </value>
   </data>
   <data name="AddPresetView_AddNewCategory" xml:space="preserve">
-    <value>-- 添加新类别 --</value>
+    <value>-- Aghjunghje una nova categuria --</value>
   </data>
   <data name="AddPresetView_AddPreset" xml:space="preserve">
-    <value>添加预设</value>
+    <value>Aghjunghje una prerigatura</value>
   </data>
   <data name="AddPresetView_Category" xml:space="preserve">
-    <value>类别：</value>
+    <value>Categuria :</value>
   </data>
   <data name="AddPresetView_Description" xml:space="preserve">
-    <value>描述：</value>
+    <value>Discrizzione :</value>
   </data>
   <data name="AddPresetView_Name" xml:space="preserve">
-    <value>名字：</value>
+    <value>Nome :</value>
   </data>
   <data name="AddPresetView_SavePictureSize" xml:space="preserve">
-    <value>尺寸：</value>
+    <value>Dimensioni :</value>
   </data>
   <data name="AudioDefaultView_Behaviours" xml:space="preserve">
-    <value>轨道源选择</value>
+    <value>Selezzione di a traccia di fonte</value>
   </data>
   <data name="AudioView_AllowPassThruOf" xml:space="preserve">
-    <value>允许通过：</value>
+    <value>Permette u passthru di :</value>
   </data>
   <data name="AudioView_AudioDefaultsDescription" xml:space="preserve">
-    <value>配置在选择新标题或源视频时如何自动选择和配置音频轨道。</value>
+    <value>Cunfigurate cumu e traccie audio sò autumaticamente selezziunate è cunfigurate quandu vo selezziunate un novu titulu o una nova fonte video.</value>
   </data>
   <data name="AudioView_AutoPassthruBehaviour" xml:space="preserve">
-    <value>“自动通过” 行为：</value>
+    <value>Cumpurtamentu di l’« Auto Passthru » :</value>
   </data>
   <data name="AudioView_Bitrate" xml:space="preserve">
-    <value>比特率</value>
+    <value>Ghjettu</value>
   </data>
   <data name="AudioView_Codec" xml:space="preserve">
-    <value>编码</value>
+    <value>Cudecu</value>
   </data>
   <data name="AudioView_DRC" xml:space="preserve">
     <value>DRC</value>
   </data>
   <data name="AudioView_Gain" xml:space="preserve">
-    <value>增益</value>
+    <value>Guadagnu</value>
   </data>
   <data name="AudioView_Hide" xml:space="preserve">
-    <value>隐藏</value>
+    <value>Piattà</value>
   </data>
   <data name="AudioView_Mixdown" xml:space="preserve">
-    <value>混音</value>
+    <value>Mischiera</value>
   </data>
   <data name="AudioView_OtherwiseFallbackEncoder" xml:space="preserve">
-    <value>后备编码器：</value>
+    <value>Cudificatore di sustituzione :</value>
   </data>
   <data name="AudioView_ReloadDefaults" xml:space="preserve">
-    <value>重新加载</value>
+    <value>Ricaricà</value>
   </data>
   <data name="AudioView_Samplerate" xml:space="preserve">
-    <value>采样率</value>
+    <value>Frequenza di campiunariu</value>
   </data>
   <data name="AudioView_Show" xml:space="preserve">
-    <value>显示</value>
+    <value>Affissà</value>
   </data>
   <data name="AudioView_TrackName" xml:space="preserve">
-    <value>轨道名称</value>
+    <value>Nome di a traccia</value>
   </data>
   <data name="AudioView_TrackSelectionBehaviour" xml:space="preserve">
-    <value>轨道选择行为：</value>
+    <value>Cumpurtamentu di a selezzione di traccia :</value>
   </data>
   <data name="AudioView_TrackSettingDefaultBehaviour" xml:space="preserve">
-    <value>额外的轨道：</value>
+    <value>Per e traccie addiziunale :</value>
   </data>
   <data name="AudioView_WhenAutoPassthru" xml:space="preserve">
-    <value>选择“Auto Passthru”作为音频编解码器时。</value>
+    <value>Quandu l’« Auto Passthru » hè selezziunatu cum’è cudecu audio.</value>
   </data>
   <data name="ChaptersView_ChapterMarkers" xml:space="preserve">
-    <value>章节标记</value>
+    <value>Marcatori di capitulu</value>
   </data>
   <data name="ChaptersView_ChapterName" xml:space="preserve">
-    <value>章节名称</value>
+    <value>Nome di capitulu</value>
   </data>
   <data name="ChaptersView_ChapterNumber" xml:space="preserve">
-    <value>章节编号</value>
+    <value>Numeru di capitulu</value>
   </data>
   <data name="ChaptersView_CreateChapterMarkers" xml:space="preserve">
-    <value>创建章节标记</value>
+    <value>Creà marcatori di capitulu</value>
   </data>
   <data name="ChaptersView_Duration" xml:space="preserve">
-    <value>时长</value>
+    <value>Durata</value>
   </data>
   <data name="ChaptersView_Export" xml:space="preserve">
-    <value>导出</value>
+    <value>Espurtà</value>
   </data>
   <data name="ChaptersView_Import" xml:space="preserve">
-    <value>导入</value>
+    <value>Impurtà</value>
   </data>
   <data name="ChapterView_ExportNames" xml:space="preserve">
-    <value>导出名称</value>
+    <value>Espurtà i nomi</value>
   </data>
   <data name="ChapterView_ImportNames" xml:space="preserve">
-    <value>导入名称</value>
+    <value>Impurtà i nomi</value>
   </data>
   <data name="ChapterView_ResetChapterNames" xml:space="preserve">
-    <value>重置章节名称</value>
+    <value>Reinizià i nomi di capitulu</value>
   </data>
   <data name="CountdownAlterView_CancelAction" xml:space="preserve">
-    <value>取消操作</value>
+    <value>Abbandunà l’azzione</value>
   </data>
   <data name="CountdownAlterView_Proceed" xml:space="preserve">
-    <value>继续</value>
+    <value>Cuntinuà</value>
   </data>
   <data name="CountdownAlterView_WhenDoneAction" xml:space="preserve">
-    <value>完成操作时</value>
+    <value>Qaundu l’azzione hè compia</value>
   </data>
   <data name="ErrorView_ErrorDetails" xml:space="preserve">
-    <value>错误详情：</value>
+    <value>Detaglii di sbagliu :</value>
   </data>
   <data name="FiltersView_Custom" xml:space="preserve">
-    <value>自定义：</value>
+    <value>Persunalizatu :</value>
   </data>
   <data name="FiltersView_Deblock" xml:space="preserve">
-    <value>去块滤波</value>
+    <value>Sblucchime</value>
   </data>
   <data name="FiltersView_Decomb" xml:space="preserve">
     <value>Decomb</value>
   </data>
   <data name="FiltersView_Deinterlace" xml:space="preserve">
-    <value>反交错：</value>
+    <value>Disintricciamentu :</value>
   </data>
   <data name="FiltersView_DeinterlacePreset" xml:space="preserve">
-    <value>预设：</value>
+    <value>Prerigatura :</value>
   </data>
   <data name="FiltersView_DeinterlacePresetAuto" xml:space="preserve">
-    <value>反交错预设</value>
+    <value>Prerigatura di disintricciamentu</value>
   </data>
   <data name="FiltersView_Denoise" xml:space="preserve">
-    <value>降噪：</value>
+    <value>Denoise :</value>
   </data>
   <data name="FiltersView_DenoisePresetAuto" xml:space="preserve">
-    <value>降噪预设</value>
+    <value>Prerigatura « Denoise »</value>
   </data>
   <data name="FiltersView_DenoiseTuneAuto" xml:space="preserve">
-    <value>降噪调节</value>
+    <value>Rigatura « Denoise »</value>
   </data>
   <data name="FiltersView_Detelecine" xml:space="preserve">
-    <value>反胶卷过带：</value>
+    <value>Detelesinema :</value>
   </data>
   <data name="FiltersView_Filters" xml:space="preserve">
-    <value>滤镜</value>
+    <value>Filtri</value>
   </data>
   <data name="FiltersView_FlipVideo" xml:space="preserve">
-    <value>翻转</value>
+    <value>Rivultà</value>
   </data>
   <data name="FiltersView_Grayscale" xml:space="preserve">
-    <value>灰度</value>
+    <value>Scala di grisgiu</value>
   </data>
   <data name="FiltersView_InterlaceDetection" xml:space="preserve">
-    <value>隔行扫描：</value>
+    <value>Abbentata d’intricciamentu :</value>
   </data>
   <data name="FiltersView_Preset" xml:space="preserve">
-    <value>预设：</value>
+    <value>Prerigatura :</value>
   </data>
   <data name="FiltersView_Rotate" xml:space="preserve">
-    <value>旋转：</value>
+    <value>Girà :</value>
   </data>
   <data name="FiltersView_Sharpen" xml:space="preserve">
-    <value>锐化</value>
+    <value>Arrutà</value>
   </data>
   <data name="FiltersView_SharpenPresetAuto" xml:space="preserve">
-    <value>锐化预设</value>
+    <value>Prerigatura d’arrutata</value>
   </data>
   <data name="FiltersView_SharpenTuneAuto" xml:space="preserve">
-    <value>锐化调节</value>
+    <value>Rigatura d’arrutata</value>
   </data>
   <data name="FiltersView_Tune" xml:space="preserve">
-    <value>调节：</value>
+    <value>Rigatura :</value>
   </data>
   <data name="Generic_Add" xml:space="preserve">
-    <value>添加</value>
+    <value>Aghjunghje</value>
   </data>
   <data name="Generic_Cancel" xml:space="preserve">
-    <value>取消</value>
+    <value>Abbandunà</value>
   </data>
   <data name="Generic_Clear" xml:space="preserve">
-    <value>清除</value>
+    <value>Squassà</value>
   </data>
   <data name="Generic_Close" xml:space="preserve">
-    <value>关闭</value>
+    <value>Chjode</value>
   </data>
   <data name="Generic_CopyToClipboard" xml:space="preserve">
-    <value>复制到剪贴板</value>
+    <value>Cupià ver di u preme’papei</value>
   </data>
   <data name="Generic_MoveLeft" xml:space="preserve">
-    <value>左移</value>
+    <value>Dispiazzà à manca</value>
   </data>
   <data name="Generic_MoveRight" xml:space="preserve">
-    <value>右移</value>
+    <value>Dispiazzà à diritta</value>
   </data>
   <data name="Generic_Save" xml:space="preserve">
-    <value>保存</value>
+    <value>Arregistrà</value>
   </data>
   <data name="LogView_CopyClipboard" xml:space="preserve">
-    <value>复制到剪贴板</value>
+    <value>Cupià ver di u preme’papei</value>
   </data>
   <data name="LogView_EncodeLog" xml:space="preserve">
-    <value>编码日志</value>
+    <value>Ghjurnale di cudificazione</value>
   </data>
   <data name="LogView_OpenLogDir" xml:space="preserve">
-    <value>打开日志目录</value>
+    <value>Apre u cartulare di i ghjurnali</value>
   </data>
   <data name="LogView_ScanLog" xml:space="preserve">
-    <value>扫描日志</value>
+    <value>Analisa di u ghjurnale</value>
   </data>
   <data name="MainView_ActivityLog" xml:space="preserve">
-    <value>活动日志</value>
+    <value>Ghjurnale d’attività</value>
   </data>
   <data name="MainView_AddAll" xml:space="preserve">
-    <value>全部添加</value>
+    <value>Tuttu aghjunghje</value>
   </data>
   <data name="MainView_AddCurrent" xml:space="preserve">
-    <value>添加当前</value>
+    <value>Aghjunghje l’elementu attuale</value>
   </data>
   <data name="MainView_AddSelection" xml:space="preserve">
-    <value>添加选中</value>
+    <value>Aghjunghje a selezzione</value>
   </data>
   <data name="MainView_AddToQueue" xml:space="preserve">
-    <value>添加到队列中</value>
+    <value>Aghjunghje à a fila d’attesa</value>
   </data>
   <data name="MainView_AdvancedTab" xml:space="preserve">
-    <value>高级</value>
+    <value>Espertu</value>
   </data>
   <data name="MainView_AlignAVStart" xml:space="preserve">
-    <value>音视频起始对齐</value>
+    <value>Alineà u principiu di l’audio/video</value>
   </data>
   <data name="MainView_Angle" xml:space="preserve">
-    <value>角度</value>
+    <value>Angulu : </value>
   </data>
   <data name="MainView_AudioTab" xml:space="preserve">
-    <value>音频</value>
+    <value>Audio</value>
   </data>
   <data name="MainView_AudioTrackCount" xml:space="preserve">
-    <value>音轨</value>
+    <value>Traccie audio</value>
   </data>
   <data name="MainView_Browser" xml:space="preserve">
-    <value>浏览</value>
+    <value>Navigà</value>
   </data>
   <data name="MainView_ChaptersTab" xml:space="preserve">
-    <value>章节</value>
+    <value>Capituli</value>
   </data>
   <data name="MainView_Container" xml:space="preserve">
-    <value>容器</value>
+    <value>Cuntenentu</value>
   </data>
   <data name="MainView_Destination" xml:space="preserve">
-    <value>目标路径</value>
+    <value>Destinazione</value>
   </data>
   <data name="MainView_Duration" xml:space="preserve">
-    <value>持续时间：</value>
+    <value>Durata : </value>
   </data>
   <data name="MainView_File" xml:space="preserve">
-    <value>保存为：</value>
+    <value>Arregistrà cù u nome :</value>
   </data>
   <data name="MainView_FiltersTab" xml:space="preserve">
-    <value>滤镜</value>
+    <value>Filtri</value>
   </data>
   <data name="MainView_Format" xml:space="preserve">
-    <value>格式：</value>
+    <value>Furmatu :</value>
   </data>
   <data name="MainView_Help" xml:space="preserve">
-    <value>帮助</value>
+    <value>Aiutu</value>
   </data>
   <data name="MainView_iPod5G" xml:space="preserve">
-    <value>iPod 5代 支持</value>
+    <value>Ghjestione di l’iPod 5G</value>
   </data>
   <data name="MainView_MetaDataTab" xml:space="preserve">
-    <value>元数据</value>
+    <value>Metadati</value>
   </data>
   <data name="MainView_ModifiedPreset" xml:space="preserve">
-    <value>(修改的)</value>
+    <value>(mudificatu)</value>
   </data>
   <data name="MainView_Muxing" xml:space="preserve">
-    <value>开始合并：这可能需要一段时间…</value>
+    <value>Muxing : Què pò piglià qualchì tempu…</value>
   </data>
   <data name="MainView_Options" xml:space="preserve">
-    <value>选项</value>
+    <value>Ozzioni</value>
   </data>
   <data name="MainView_OutputSettings" xml:space="preserve">
-    <value>输出设置</value>
+    <value>Preferenze d’esciuta</value>
   </data>
   <data name="MainView_Pause" xml:space="preserve">
-    <value>暂停</value>
+    <value>Pausa</value>
   </data>
   <data name="MainView_PictureTab" xml:space="preserve">
-    <value>尺寸</value>
+    <value>Dimensioni</value>
   </data>
   <data name="MainView_PresetManage" xml:space="preserve">
-    <value>重命名预设</value>
+    <value>Rinumà a prerigatura</value>
   </data>
   <data name="MainView_PresetOptionsContextMenu" xml:space="preserve">
-    <value>预设选项上下文菜单</value>
+    <value>Listinu cuntestuale di l’ozzioni di prerigatura</value>
   </data>
   <data name="MainView_PresetRemove" xml:space="preserve">
-    <value>删除预设</value>
+    <value>Squassà a prerigatura</value>
   </data>
   <data name="MainView_Presets" xml:space="preserve">
-    <value>预设</value>
+    <value>Prerigature</value>
   </data>
   <data name="MainView_Preview" xml:space="preserve">
-    <value>预览</value>
+    <value>Previsualizazione</value>
   </data>
   <data name="MainView_ProgressStatusWithTask" xml:space="preserve">
-    <value>编码中: {0}, {1:00.00}%, 剩余时间: {2}, {3}</value>
+    <value>Cudificazione : {0}, {1:00.00}%, Tempu rimanente : {2}, {3}</value>
   </data>
   <data name="MainView_Range" xml:space="preserve">
-    <value>范围：</value>
+    <value>Stesa :</value>
   </data>
   <data name="MainView_Reload" xml:space="preserve">
-    <value>重新加载</value>
+    <value>Ricaricà</value>
   </data>
   <data name="MainView_Remove" xml:space="preserve">
-    <value>移除</value>
+    <value>Caccià</value>
   </data>
   <data name="MainView_ResetBuiltInPresets" xml:space="preserve">
-    <value>重置内置预设</value>
+    <value>Reinizià e prerigature integrate</value>
   </data>
   <data name="MainView_SaveNewPreset" xml:space="preserve">
-    <value>保存新预设</value>
+    <value>Arregistrà a nova prerigatura</value>
   </data>
   <data name="MainView_Searching" xml:space="preserve">
-    <value>正在寻找开始时间</value>
+    <value>Ricerca di l’ora di principiu</value>
   </data>
   <data name="MainView_SetDefault" xml:space="preserve">
-    <value>设置为默认</value>
+    <value>Sceglie u valore predefinitu</value>
   </data>
   <data name="MainView_ShowPreview" xml:space="preserve">
-    <value>预览</value>
+    <value>Previsualizazione</value>
   </data>
   <data name="MainView_ShowQueue" xml:space="preserve">
-    <value>队列</value>
+    <value>Fila d’attesa</value>
   </data>
   <data name="MainView_Source" xml:space="preserve">
-    <value>源：</value>
+    <value>Fonte :</value>
   </data>
   <data name="MainView_SourceOpen" xml:space="preserve">
-    <value>打开源</value>
+    <value>Apre a fonte</value>
   </data>
   <data name="MainView_StartEncode" xml:space="preserve">
-    <value>开始编码</value>
+    <value>Principià a cudificazione</value>
   </data>
   <data name="MainView_StartQueue" xml:space="preserve">
-    <value>启动队列</value>
+    <value>Principià a fila d’attesa</value>
   </data>
   <data name="MainView_Stop" xml:space="preserve">
-    <value>停止</value>
+    <value>Piantà</value>
   </data>
   <data name="MainView_StopEncode" xml:space="preserve">
-    <value>停止编码</value>
+    <value>Piantà a cudificazione</value>
   </data>
   <data name="MainView_StopEncodeConfirm" xml:space="preserve">
-    <value>你确定要停止此编码吗？</value>
+    <value>Site sicuru di vulè piantà sta cudificazione ?</value>
   </data>
   <data name="MainView_SubtitleBeforeScanError" xml:space="preserve">
-    <value>请在导入字幕文件前选择一个要编码的源</value>
+    <value>Ci vole à sceglie una fonte à cudificà nanzu di pruvà d’impurtà un schedariu di sottutitulu.</value>
   </data>
   <data name="MainView_SubtitlesTab" xml:space="preserve">
-    <value>字幕</value>
+    <value>Sottutituli</value>
   </data>
   <data name="MainView_SubtitleTracksCount" xml:space="preserve">
-    <value>字幕轨道</value>
+    <value>Traccie di sottutitulu</value>
   </data>
   <data name="MainView_SummaryTab" xml:space="preserve">
-    <value>摘要</value>
+    <value>Riassuntu</value>
   </data>
   <data name="MainView_through" xml:space="preserve">
     <value> - </value>
   </data>
   <data name="MainView_Title" xml:space="preserve">
-    <value>标题：</value>
+    <value>Titulu : </value>
   </data>
   <data name="MainView_UpdateSelectedPreset" xml:space="preserve">
-    <value>更新选中的预设</value>
+    <value>Mudificà a prerigatura selezziunata</value>
   </data>
   <data name="MainView_VideoTab" xml:space="preserve">
-    <value>视频</value>
+    <value>Video</value>
   </data>
   <data name="MainView_WebOptimized" xml:space="preserve">
-    <value>网页优化</value>
+    <value>Megliuratu per u Web</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>Manage Presets</value>
+    <value>Ghjestione di e prerigature</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
-    <value>元数据</value>
+    <value>Metadati</value>
   </data>
   <data name="OptionsView_EnableNvencEncoding" xml:space="preserve">
-    <value>允许使用 Nvidia NVENC 编码器</value>
+    <value>Permette l’adopru di i cudificatori Nvidia NVENC</value>
   </data>
   <data name="OptionsView_EnableQuicksyncEncoding" xml:space="preserve">
-    <value>允许使用 Intel QuickSync 编码器</value>
+    <value>Permette l’adopru di i cudificatori Intel QuickSync</value>
   </data>
   <data name="OptionsView_EnableVceEncoding" xml:space="preserve">
-    <value>允许使用 AMD VCE 编码器</value>
+    <value>Permette l’adopru di i cudificatori AMD VCE</value>
   </data>
   <data name="OptionsView_InvalidFileFormatChars" xml:space="preserve">
-    <value>输入的文件格式包含无效的字符。这些字符已被移除。</value>
+    <value>U furmatu di schedariu pruvistu cuntene caratteri inaccettevule. Quelli sò stati cacciati. </value>
   </data>
   <data name="OptionsView_PlaySoundWhenDone" xml:space="preserve">
-    <value>每个编码完成时都发出提示音</value>
+    <value>Sente un sonu quandu ogni cudificazione si compia</value>
   </data>
   <data name="OptionsView_PlaySoundWhenQueueDone" xml:space="preserve">
-    <value>队列完成时发出提示音</value>
+    <value>Sente un sonu quandu a fila d’attesa si compia</value>
   </data>
   <data name="OptionsView_ShowPreviewOnSummaryTab" xml:space="preserve">
-    <value>在摘要栏中显示预览。</value>
+    <value>Affissà e previsualizazioni nant’à l’unghjetta Riassuntu.</value>
   </data>
   <data name="OptionsView_ShowStatusInTitleBar" xml:space="preserve">
-    <value>在应用程序标题栏中显示编码进度。</value>
+    <value>Affissà u statu di a cudificazione in a barra di titulu di l’appiecazione.</value>
   </data>
   <data name="Options_7DayLogClear" xml:space="preserve">
-    <value>Clear Log files older than 7 days</value>
+    <value>Viutà i schedarii di ghjurnale di più di 7 ghjorni</value>
   </data>
   <data name="Options_About" xml:space="preserve">
-    <value>关于 HandBrake</value>
+    <value>Apprupositu d’HandBrake</value>
   </data>
   <data name="Options_Advanced" xml:space="preserve">
-    <value>高级</value>
+    <value>Espertu</value>
   </data>
   <data name="Options_AdvancedOptions" xml:space="preserve">
-    <value>高级选项</value>
+    <value>Ozzioni d’espertu</value>
   </data>
   <data name="Options_Arguments" xml:space="preserve">
-    <value>参数：</value>
+    <value>Argumenti :</value>
   </data>
   <data name="Options_AutomaticFileNaming" xml:space="preserve">
-    <value>自动文件命名</value>
+    <value>Numinà autumaticu di i schedarii</value>
   </data>
   <data name="Options_AutoNameOutput" xml:space="preserve">
-    <value>自动命名输出文件</value>
+    <value>Numinà autumaticamente i schedarii d’esciuta</value>
   </data>
   <data name="Options_CheckForUpdates" xml:space="preserve">
-    <value>检查更新</value>
+    <value>Cuntrollà e nove versioni</value>
   </data>
   <data name="Options_ClearCompleted" xml:space="preserve">
-    <value>每当编码完成时总是清除已完成的队列任务</value>
+    <value>Sempre squassà l’elementi compii di a fila d’attesa dopu a cudificazione</value>
   </data>
   <data name="Options_ClearLogs" xml:space="preserve">
-    <value>清理日志历史</value>
+    <value>Viutà a crunulogia di u ghjurnale</value>
   </data>
   <data name="Options_CopyLogToDir" xml:space="preserve">
-    <value>复制编码日志文件到指定位置：</value>
+    <value>Piazzà una copia individuale di i ghjurnali di cudificazione in un locu specificu :</value>
   </data>
   <data name="Options_CopyLogToEncDir" xml:space="preserve">
-    <value>复制编码日志文件到编码视频所在位置</value>
+    <value>Piazzà una copia individuale di i ghjurnali di cudificazione in u listessu locu chì a video cudificata</value>
   </data>
   <data name="Options_CurVersion" xml:space="preserve">
-    <value>当前版本</value>
+    <value>Versione attuale</value>
   </data>
   <data name="Options_Decoding" xml:space="preserve">
-    <value>解码中</value>
+    <value>Discudificazione</value>
   </data>
   <data name="Options_DefaultPath" xml:space="preserve">
-    <value>默认路径：</value>
+    <value>Chjassu predefinitu :</value>
   </data>
   <data name="Options_DownloadUpdates" xml:space="preserve">
-    <value>下载更新</value>
+    <value>Scaricà u rinnovu</value>
   </data>
   <data name="Options_DVD" xml:space="preserve">
-    <value>DVD 读取中</value>
+    <value>Lettura di DVD</value>
   </data>
   <data name="Options_DvdRead" xml:space="preserve">
-    <value>禁止LibDVDNav。(将会使用livdvdread)</value>
+    <value>Disattivà LibDVDNav. (libdvdread serà impiegatu à a so piazza)</value>
   </data>
   <data name="Options_Encoding" xml:space="preserve">
-    <value>编码中</value>
+    <value>Cudificazione</value>
   </data>
   <data name="Options_Format" xml:space="preserve">
-    <value>文件格式：</value>
+    <value>Furmatu di Schedariu :</value>
   </data>
   <data name="Options_General" xml:space="preserve">
-    <value>常规</value>
+    <value>Generale</value>
   </data>
   <data name="Options_Logging" xml:space="preserve">
-    <value>日志记录</value>
+    <value>Cunnettassi</value>
   </data>
   <data name="Options_LogLevel" xml:space="preserve">
-    <value>日志详细级别：</value>
+    <value>Livellu di verbusità di u ghjurnale :</value>
   </data>
   <data name="Options_LogPath" xml:space="preserve">
-    <value>日志文件路径：</value>
+    <value>Chjassu d’accessu à i ghjurnali :</value>
   </data>
   <data name="Options_LowDiskspaceSize" xml:space="preserve">
-    <value>Pause queue if disk space is low</value>
+    <value>Interrompe a fila d’attesa s’ella ùn basta u spaziu discu</value>
   </data>
   <data name="Options_MinimiseTray" xml:space="preserve">
-    <value>最小化到系统托盘(需要重启)</value>
+    <value>Impuculì in lu spaziu di nutificazione di u sistema (Richiede un rilanciu)</value>
   </data>
   <data name="Options_MinTitleScanLength" xml:space="preserve">
-    <value>DVD和蓝光标题的最短持续时间"秒"。将跳过较短的标题：</value>
+    <value>Durata minima in seconde di i tituli DVD è Blu-ray. I tituli più corti seranu tralasciati :</value>
   </data>
   <data name="Options_MP4FileExtension" xml:space="preserve">
-    <value>MP4 文件扩展名：</value>
+    <value>Estensione di schedariu MP4 :</value>
   </data>
   <data name="Options_OnStartup" xml:space="preserve">
-    <value>启动时</value>
+    <value>À u lanciu</value>
   </data>
   <data name="Options_Output" xml:space="preserve">
-    <value>输出文件</value>
+    <value>Schedarii d’esciuta</value>
   </data>
   <data name="Options_Path" xml:space="preserve">
-    <value>路径：</value>
+    <value>Chjassu d’accessu : </value>
   </data>
   <data name="Options_PathToMediaPlayer" xml:space="preserve">
-    <value>Path to Media Player</value>
+    <value>Chjassu ver di u lettore media</value>
   </data>
   <data name="Options_PreventSleep" xml:space="preserve">
-    <value>在编码时防止系统进入睡眠状态</value>
+    <value>Impedisce u sistema di mettesi in veghja durante a cudificazione</value>
   </data>
   <data name="Options_PreviewScanCount" xml:space="preserve">
-    <value>要扫描的预览图片数：</value>
+    <value>Numeru di previsualizazione di fiure à analizà :</value>
   </data>
   <data name="Options_PriorityLevel" xml:space="preserve">
-    <value>优先级：</value>
+    <value>Livellu di priurità :</value>
   </data>
   <data name="Options_QsvDecode" xml:space="preserve">
-    <value>如果可用，优先使用 Intel QuickSync 解码视频。</value>
+    <value>Preferisce l’adopru d’Intel QuickSync, quand’ellu hè dispunibule, per a discudificazione video. </value>
   </data>
   <data name="Options_QsvDecodeForNonFullPath" xml:space="preserve">
-    <value>在没有使用QuickSync 编码器时使用QSV 解码器。(如 x265)</value>
+    <value>Impiegà dinù a discudificazione QSV quandu u cudificatore QuickSync ùn hè micca impiegatu. (i.e. x265) </value>
   </data>
   <data name="Options_RemovePunctuation" xml:space="preserve">
-    <value>移除常见的标点符号</value>
+    <value>Caccià a puntuazione cumuna</value>
   </data>
   <data name="Options_ReplaceUnderscores" xml:space="preserve">
-    <value>用空格替换下划线</value>
+    <value>Rimpiazzà i spazii sottulineati cù un spaziu</value>
   </data>
   <data name="Options_ResetDoNothing" xml:space="preserve">
-    <value>当应用重启时重置为“无操作”。</value>
+    <value>Reinizià cù « Ùn fà nunda » quandu l’appiecazione hè rilanciata.</value>
   </data>
   <data name="Options_Scaler" xml:space="preserve">
-    <value>选择缩放器：</value>
+    <value>Sceglie a scala :</value>
   </data>
   <data name="Options_Scaling" xml:space="preserve">
-    <value>缩放</value>
+    <value>Messa à a scala</value>
   </data>
   <data name="Options_SendFileTo" xml:space="preserve">
-    <value>发送文件至：</value>
+    <value>Mandà u schedariu à :</value>
   </data>
   <data name="Options_TitleCase" xml:space="preserve">
-    <value>更改大写格式为词首字母大写</value>
+    <value>Maiuscula per ogni Parolla Impurtante</value>
   </data>
   <data name="Options_Updates" xml:space="preserve">
-    <value>更新</value>
+    <value>Rinnovi</value>
   </data>
   <data name="Options_UserInterface" xml:space="preserve">
-    <value>用户界面</value>
+    <value>Interfaccia d’utilizatore</value>
   </data>
   <data name="Options_Version" xml:space="preserve">
-    <value>版本：</value>
+    <value>Versione :</value>
   </data>
   <data name="Options_Video" xml:space="preserve">
-    <value>视频</value>
+    <value>Video</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>This path is used for the video preview feature only.
-VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
+    <value>Stu chjassu hè impiegatu solu per a funzione di previsualizazione di video.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
-    <value>查看日志目录</value>
+    <value>Fighjà u cartulare di u ghjurnale</value>
   </data>
   <data name="Options_WhenDone" xml:space="preserve">
-    <value>当完成时</value>
+    <value>Quandu hè compiu</value>
   </data>
   <data name="Options_x264" xml:space="preserve">
-    <value>x264/5 设置</value>
+    <value>Preferenze x264/5</value>
   </data>
   <data name="Options_x264Granularity" xml:space="preserve">
-    <value>固定质量模式的最小刻度：</value>
+    <value>Granularità frazziunale di qualità custente :</value>
   </data>
   <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
-    <value>变形：</value>
+    <value>Anamorficu :</value>
   </data>
   <data name="PictureSettingsView_Automatic" xml:space="preserve">
-    <value>自动</value>
+    <value>Autumaticu</value>
   </data>
   <data name="PictureSettingsView_Bottom" xml:space="preserve">
-    <value>下</value>
+    <value>Inghjò</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>Cropping:</value>
+    <value>Riquadramentu :</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
-    <value>自定义</value>
+    <value>Persunalizatu</value>
   </data>
   <data name="PictureSettingsView_DisplayWitdh" xml:space="preserve">
-    <value>显示宽度：</value>
+    <value>Larghezza d’affissera :</value>
   </data>
   <data name="PictureSettingsView_Height" xml:space="preserve">
-    <value>高度：</value>
+    <value>Altezza :</value>
   </data>
   <data name="PictureSettingsView_KeepAR" xml:space="preserve">
-    <value>保持宽高比</value>
+    <value>Cunservà e prupurzioni</value>
   </data>
   <data name="PictureSettingsView_Left" xml:space="preserve">
-    <value>左</value>
+    <value>Manca</value>
   </data>
   <data name="PictureSettingsView_Modulus" xml:space="preserve">
-    <value>系数：</value>
+    <value>Mudullu :</value>
   </data>
   <data name="PictureSettingsView_Output" xml:space="preserve">
-    <value>输出</value>
+    <value>Esciuta</value>
   </data>
   <data name="PictureSettingsView_PAR" xml:space="preserve">
-    <value>标准：</value>
+    <value>PAR :</value>
   </data>
   <data name="PictureSettingsView_Right" xml:space="preserve">
-    <value>右</value>
+    <value>Diritta</value>
   </data>
   <data name="PictureSettingsView_Size" xml:space="preserve">
-    <value>大小：</value>
+    <value>Dimensione</value>
   </data>
   <data name="PictureSettingsView_Source" xml:space="preserve">
-    <value>源：</value>
+    <value>Fonte :</value>
   </data>
   <data name="PictureSettingsView_Top" xml:space="preserve">
-    <value>上</value>
+    <value>Insù</value>
   </data>
   <data name="PictureSettingsView_Width" xml:space="preserve">
-    <value>宽度：</value>
+    <value>Larghezza :</value>
   </data>
   <data name="Preset_Custom" xml:space="preserve">
-    <value>自定义</value>
+    <value>Persunalizatu</value>
   </data>
   <data name="Preset_Export" xml:space="preserve">
-    <value>导出文件</value>
+    <value>Espurtà ver di un schedariu</value>
   </data>
   <data name="Preset_Import" xml:space="preserve">
-    <value>导入文件</value>
+    <value>Impurtà da un schedariu</value>
   </data>
   <data name="Preset_Official" xml:space="preserve">
-    <value>官方的</value>
+    <value>Officiale</value>
   </data>
   <data name="QueueSelectionView_ChooseTitles" xml:space="preserve">
-    <value>选择标题：</value>
+    <value>Sciglite tituli :</value>
   </data>
   <data name="QueueSelectionView_Title" xml:space="preserve">
-    <value>添加到队列中</value>
+    <value>Aghjunghje à a fila d’attesa</value>
   </data>
   <data name="QueueSelection_UsingPreset" xml:space="preserve">
-    <value>选中的标题将会使用 "{0}" 预设添加</value>
+    <value>I tituli selezziunati seranu aghjunti impieghendu a prerigatura « {0} ».</value>
   </data>
   <data name="QueueView_Advanced" xml:space="preserve">
-    <value>高级：</value>
+    <value>Espertu :</value>
   </data>
   <data name="QueueView_Audio" xml:space="preserve">
-    <value>音频：</value>
+    <value>Audio :</value>
   </data>
   <data name="QueueView_ClearAll" xml:space="preserve">
-    <value>清除全部</value>
+    <value>Tuttu viutà</value>
   </data>
   <data name="QueueView_ClearCompleted" xml:space="preserve">
-    <value>清除已完成的</value>
+    <value>Viutatura compia</value>
   </data>
   <data name="QueueView_ClearQueue" xml:space="preserve">
-    <value>清除队列</value>
+    <value>Viutà a fila d’attesa</value>
   </data>
   <data name="QueueView_ClearSelected" xml:space="preserve">
-    <value>清除选中的</value>
+    <value>Viutà a selezzione</value>
   </data>
   <data name="QueueView_Delete" xml:space="preserve">
-    <value>删除</value>
+    <value>Squassà</value>
   </data>
   <data name="QueueView_Destination" xml:space="preserve">
-    <value>目标路径：</value>
+    <value>Destinazione :</value>
   </data>
   <data name="WhenDone_DoNothing" xml:space="preserve">
-    <value>无操作</value>
+    <value>Ùn fà nunda</value>
   </data>
   <data name="QueueView_Duration" xml:space="preserve">
-    <value>编码时间：</value>
+    <value>Durata di cudificazione :</value>
   </data>
   <data name="QueueView_Edit" xml:space="preserve">
-    <value>编辑</value>
+    <value>Mudificà</value>
   </data>
   <data name="QueueView_EndTime" xml:space="preserve">
-    <value>结束时间：</value>
+    <value>Ora di fine :</value>
   </data>
   <data name="QueueView_Export" xml:space="preserve">
-    <value>导出队列</value>
+    <value>Espurtà a fila d’attesa</value>
   </data>
   <data name="QueueView_FileSize" xml:space="preserve">
-    <value>文件大小：</value>
+    <value>Dimensione di u schedariu : </value>
   </data>
   <data name="WhenDone_Hibernate" xml:space="preserve">
-    <value>休眠</value>
+    <value>Veghja prulungata</value>
   </data>
   <data name="WhenDone_LockSystem" xml:space="preserve">
-    <value>锁定系统</value>
+    <value>Ammarchjunà u sistema</value>
   </data>
   <data name="QueueView_LogNotAvailableYet" xml:space="preserve">
-    <value>日志将在编码完成后可用。</value>
+    <value>U ghjurnale serà dispunibule quandu a cudificazione serà compia.</value>
   </data>
   <data name="WhenDone_Logoff" xml:space="preserve">
-    <value>登出</value>
+    <value>Scunnettassi</value>
   </data>
   <data name="QueueView_OpenDestDir" xml:space="preserve">
-    <value>打开目标目录</value>
+    <value>Apre u cartulare di destinazione</value>
   </data>
   <data name="QueueView_OpenSourceDir" xml:space="preserve">
-    <value>打开源目录</value>
+    <value>Apre u cartulare di fonte</value>
   </data>
   <data name="QueueView_Options" xml:space="preserve">
-    <value>选项</value>
+    <value>Ozzioni</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>暂停</value>
+    <value>Interrompe a fila d’attesa</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
-    <value>暂停时常：</value>
+    <value>Durata di l’interruzzione :</value>
   </data>
   <data name="QueueView_PictureSettings" xml:space="preserve">
-    <value>图像设置：</value>
+    <value>Preferenze di fiura :</value>
   </data>
   <data name="WhenDone_QuitHandBrake" xml:space="preserve">
-    <value>退出HandBrake</value>
+    <value>Piantà Handbrake</value>
   </data>
   <data name="QueueView_ResetAllJobs" xml:space="preserve">
-    <value>重试所有任务</value>
+    <value>Rilancià tutti i travaglii</value>
   </data>
   <data name="QueueView_ResetFailed" xml:space="preserve">
-    <value>重试失败的</value>
+    <value>Fiascu di u novu tentativu</value>
   </data>
   <data name="QueueView_ResetSelectedJobs" xml:space="preserve">
-    <value>重置选中的任务</value>
+    <value>Reinizià i travaglii selezziunati</value>
   </data>
   <data name="QueueView_Reset" xml:space="preserve">
-    <value>重置</value>
+    <value>Reinizià</value>
   </data>
   <data name="WhenDone_Shutdown" xml:space="preserve">
-    <value>关机</value>
+    <value>Spenghje l’urdinatore</value>
   </data>
   <data name="QueueView_Source" xml:space="preserve">
-    <value>源：</value>
+    <value>Fonte :</value>
   </data>
   <data name="QueueView_Start" xml:space="preserve">
-    <value>启动队列</value>
+    <value>Principià a fila d’attesa</value>
   </data>
   <data name="QueueView_StartTime" xml:space="preserve">
-    <value>开始时间：</value>
+    <value>Ora di principiu :</value>
   </data>
   <data name="QueueView_Statistics" xml:space="preserve">
-    <value>统计数据</value>
+    <value>Statistiche</value>
   </data>
   <data name="QueueView_StatsNotAvailableYet" xml:space="preserve">
-    <value>统计数据将在编码完成后可用。</value>
+    <value>E statistiche seranu dispunibule quandu una cudificazione si compia.</value>
   </data>
   <data name="QueueView_Subtitles" xml:space="preserve">
-    <value>字幕：</value>
+    <value>Sottutituli :</value>
   </data>
   <data name="QueueView_Summary" xml:space="preserve">
-    <value>概要</value>
+    <value>Riassuntu</value>
   </data>
   <data name="WhenDone_Suspend" xml:space="preserve">
-    <value>睡眠</value>
+    <value>Veghja</value>
   </data>
   <data name="QueueView_Video" xml:space="preserve">
-    <value>视频：</value>
+    <value>Video :</value>
   </data>
   <data name="QueueView_WhenDone" xml:space="preserve">
-    <value>当完成时：</value>
+    <value>Quandu hè compiu :</value>
   </data>
   <data name="Shared_AddAllForSelected" xml:space="preserve">
-    <value>添加所有剩余选中的语言</value>
+    <value>Aghjunghje tutte e lingue selezziunate chì fermanu</value>
   </data>
   <data name="Shared_AddAllRemaining" xml:space="preserve">
-    <value>添加所有剩余的轨道</value>
+    <value>Aghjunghje tutte e traccie chì fermanu</value>
   </data>
   <data name="Shared_AddNewTrack" xml:space="preserve">
-    <value>添加新轨道</value>
+    <value>Aghjunghje una nova traccia</value>
   </data>
   <data name="Shared_AddTrack" xml:space="preserve">
-    <value>添加轨道</value>
+    <value>Aghjunghje una traccia</value>
   </data>
   <data name="Shared_AvailableLanguages" xml:space="preserve">
-    <value>可用的语言：</value>
+    <value>Lingue dispunibule :</value>
   </data>
   <data name="Shared_ChooseLanguages" xml:space="preserve">
-    <value>选择语言：</value>
+    <value>Sceglie e lingue :</value>
   </data>
   <data name="Shared_ChosenLangages" xml:space="preserve">
-    <value>选择语言：</value>
+    <value>Lingue selezziunate :</value>
   </data>
   <data name="Shared_ConfigureDefaultBehaviours" xml:space="preserve">
-    <value>配置默认行为</value>
+    <value>Sceglie i cumpurtamenti predefiniti</value>
   </data>
   <data name="Shared_ReloadDefaults" xml:space="preserve">
-    <value>重新加载</value>
+    <value>Ricaricà</value>
   </data>
   <data name="SourceSelection_ChooseDisc" xml:space="preserve">
-    <value>选择要扫描的光盘</value>
+    <value>Sceglie un discu à analizà</value>
   </data>
   <data name="SourceSelection_ChooseFile" xml:space="preserve">
-    <value>选择要扫描的文件</value>
+    <value>Sceglie un schedariu à analizà</value>
   </data>
   <data name="SourceSelection_ChooseFolder" xml:space="preserve">
-    <value>选择要扫描的文件夹</value>
+    <value>Sceglie un cartulare à analizà</value>
   </data>
   <data name="SourceSelection_ChooseSpecificTitle" xml:space="preserve">
-    <value>视需要选择一个具体的标题：</value>
+    <value>Sceglie eventualmente un titulu specificu : </value>
   </data>
   <data name="SourceSelection_ChooseVideo" xml:space="preserve">
-    <value>然后选择你想编码的视频：</value>
+    <value>Tandu, sciglite a - o e - video qu’ellu ci vole à cudificà : </value>
   </data>
   <data name="SourceSelection_File" xml:space="preserve">
-    <value>文件</value>
+    <value>Schedariu</value>
   </data>
   <data name="SourceSelection_FolderBatchScan" xml:space="preserve">
-    <value>文件夹(批量扫描)</value>
+    <value>Cartulare (Analisa da gruppu)</value>
   </data>
   <data name="SourceSelection_OpenDVDBluray" xml:space="preserve">
-    <value>打开DVD或蓝光驱动器</value>
+    <value>Apre stu lettore DVD o Blu-ray</value>
   </data>
   <data name="SourceSelection_OpenFolderWIth" xml:space="preserve">
-    <value>打开有一个或多个文件的文件夹。</value>
+    <value>Apre un cartulare cù un o parechji schedarii.</value>
   </data>
   <data name="SourceSelection_QueueArchiveRecovery" xml:space="preserve">
-    <value>恢复队列文件</value>
+    <value>Ricuperà i schedarii in fila d’attesa</value>
   </data>
   <data name="SourceSelection_QueueArchiveRecoveryDesc" xml:space="preserve">
-    <value>以前的队列存档可用。</value>
+    <value>Un archiviu precedente di fila d’attesa hè dispunibule. </value>
   </data>
   <data name="SourceSelection_SingleVideoFile" xml:space="preserve">
-    <value>打开单个视频文件。</value>
+    <value>Apre un solu schedariu video.</value>
   </data>
   <data name="SourceSelection_SourceSelection" xml:space="preserve">
-    <value>选择源</value>
+    <value>Selezzione di a fonte</value>
   </data>
   <data name="StaticPreviewView_Duration" xml:space="preserve">
-    <value>时长：</value>
+    <value>Durata :</value>
   </data>
   <data name="StaticPreviewView_LivePreview" xml:space="preserve">
-    <value>实时预览</value>
+    <value>Previsualizazione diretta</value>
   </data>
   <data name="StaticPreviewView_SelectPreviewImage" xml:space="preserve">
-    <value>选择预览图片</value>
+    <value>Selezziunà una previsualizazione di fiura</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Prefer system default video player</value>
+    <value>Impiegà u lettore video predefinitu di u sistema</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
-    <value>添加隐藏式字幕（可用时）</value>
+    <value>Aghjunghje i sottutituli ditagliati s’elli sò dispunibule</value>
   </data>
   <data name="SubtitlesView_AddForeignAudioSearch" xml:space="preserve">
-    <value>添加“外部音频扫描”</value>
+    <value>Aghjunghje un « Analisa audio straniera »</value>
   </data>
   <data name="SubtitlesView_BurnInBehaviour" xml:space="preserve">
-    <value>烧录行为：</value>
+    <value>Cumpurtamentu d’intarsiatura :</value>
   </data>
   <data name="SubtitlesView_ImportSubtitle" xml:space="preserve">
-    <value>导入字幕</value>
+    <value>Impurtà un sottutitulu</value>
   </data>
   <data name="SubtitlesView_TrackSelectionBehaviour" xml:space="preserve">
-    <value>轨道选择行为：</value>
+    <value>Cumpurtamentu di a selezzione di traccia :</value>
   </data>
   <data name="SubtitleView_AddAllCC" xml:space="preserve">
-    <value>添加所有剩余的隐藏式字幕</value>
+    <value>Aghjunghje tutti i sottutituli ditagliati chì fermanu</value>
   </data>
   <data name="SubtitleView_SubtitleDefaultsDescription" xml:space="preserve">
-    <value>选择新标题或源视频时自动选择和配置字幕轨道的方式。</value>
+    <value>Cunfigurate cumu e traccie di sottutitulu sò autumaticamente selezziunate è cunfigurate quandu vo selezziunate un novu titulu o una nova fonte video.</value>
   </data>
   <data name="SummaryView_AdditionalAudioTracks" xml:space="preserve">
-    <value>额外的音频轨道</value>
+    <value>Traccie audio addiziunale</value>
   </data>
   <data name="SummaryView_AdditionalSubtitleTracks" xml:space="preserve">
-    <value>额外的字幕轨道</value>
+    <value>Traccie di sottutitulu addiziunale</value>
   </data>
   <data name="SummaryView_Burned" xml:space="preserve">
-    <value>已烧录</value>
+    <value>Intarsiatu</value>
   </data>
   <data name="SummaryView_Chapters" xml:space="preserve">
-    <value>章节标记</value>
+    <value>Marcatori di capitulu</value>
   </data>
   <data name="SummaryView_Deblock" xml:space="preserve">
-    <value>去块滤波</value>
+    <value>Sblucchime</value>
   </data>
   <data name="SummaryView_Detelecine" xml:space="preserve">
-    <value>反胶卷过带</value>
+    <value>Detelesinema</value>
   </data>
   <data name="SummaryView_display" xml:space="preserve">
-    <value>显示</value>
+    <value>affissera</value>
   </data>
   <data name="SummaryView_Grayscale" xml:space="preserve">
-    <value>灰度</value>
+    <value>Scala di grisgiu</value>
   </data>
   <data name="SummaryView_NoAudioTracks" xml:space="preserve">
-    <value>没有音频轨道</value>
+    <value>Alcuna traccia audio</value>
   </data>
   <data name="SummaryView_NoChapters" xml:space="preserve">
-    <value>没有章节标记</value>
+    <value>Alcunu marcatore di capitulu</value>
   </data>
   <data name="SummaryView_NoFilters" xml:space="preserve">
-    <value>无滤镜</value>
+    <value>Alcunu filtru</value>
   </data>
   <data name="SummaryView_NoSource" xml:space="preserve">
-    <value>没有源</value>
+    <value>Alcuna fonte</value>
   </data>
   <data name="SummaryView_NoSubtitleTracks" xml:space="preserve">
-    <value>没有字幕轨</value>
+    <value>Alcuna traccia di sottutitulu</value>
   </data>
   <data name="SummaryView_NoTracks" xml:space="preserve">
-    <value>无轨道</value>
+    <value>Alcuna traccia</value>
   </data>
   <data name="SummaryView_PreviewInfo" xml:space="preserve">
-    <value>预览 {0} / {1}</value>
+    <value>Previsualizazione {0} nant’à {1}</value>
   </data>
   <data name="SummaryView_Rotation" xml:space="preserve">
-    <value>旋转</value>
+    <value>Rotazione</value>
   </data>
   <data name="SummaryView_storage" xml:space="preserve">
-    <value>存储空间</value>
+    <value>allucamentu</value>
   </data>
   <data name="VideoView_2Pass" xml:space="preserve">
-    <value>二次编码</value>
+    <value>Cudificazione à 2 passi</value>
   </data>
   <data name="VideoView_AverageBitrate" xml:space="preserve">
-    <value>平均码率(kbps)：</value>
+    <value>Ghjettu medianu (kbps) :</value>
   </data>
   <data name="VideoView_Codec" xml:space="preserve">
-    <value>视频编解码器：</value>
+    <value>Cudecu video :</value>
   </data>
   <data name="VideoView_ConstantFramerate" xml:space="preserve">
-    <value>固定帧率</value>
+    <value>Frequenza di fiure custente</value>
   </data>
   <data name="VideoView_ConstantQuality" xml:space="preserve">
-    <value>固定质量：</value>
+    <value>Qualità custente :</value>
   </data>
   <data name="VideoView_EncoderLevel" xml:space="preserve">
-    <value>编码器级别：</value>
+    <value>Livellu di u cudificatore :</value>
   </data>
   <data name="VideoView_EncoderPreset" xml:space="preserve">
-    <value>编码器预设：</value>
+    <value>Prerigatura di u cudificatore :</value>
   </data>
   <data name="VideoView_EncoderProfile" xml:space="preserve">
-    <value>编码器配置文件：</value>
+    <value>Prufilu di u cudificatore :</value>
   </data>
   <data name="VideoView_EncodeTune" xml:space="preserve">
-    <value>编码器调优：</value>
+    <value>Rigatura di u cudificatore :</value>
   </data>
   <data name="VideoView_ExtraOptions" xml:space="preserve">
-    <value>高级选项：</value>
+    <value>Ozzioni d’espertu :</value>
   </data>
   <data name="VideoView_FastDecode" xml:space="preserve">
-    <value>快速解码</value>
+    <value>Discudificazione rapida</value>
   </data>
   <data name="VideoView_Framerate" xml:space="preserve">
-    <value>帧率 (FPS):</value>
+    <value>Frequenza di fiure (FPS) :</value>
   </data>
   <data name="VideoView_OptimiseVideo" xml:space="preserve">
-    <value>优化视频：</value>
+    <value>Migliurà a video :</value>
   </data>
   <data name="VideoView_PeakFramerate" xml:space="preserve">
-    <value>峰值帧率</value>
+    <value>Frequenza di fiure di cresta</value>
   </data>
   <data name="VideoView_Quality" xml:space="preserve">
-    <value>质量</value>
+    <value>Qualità</value>
   </data>
   <data name="VideoView_TurboFirstPass" xml:space="preserve">
-    <value>Turbo 一次通过</value>
+    <value>Primu passagiu in modu Turbo</value>
   </data>
   <data name="VideoView_VariableFramerate" xml:space="preserve">
-    <value>可变帧率</value>
+    <value>Frequenza di fiure variabile</value>
   </data>
   <data name="VideoView_Video" xml:space="preserve">
-    <value>视频</value>
+    <value>Video</value>
   </data>
   <data name="OptionsView_Language" xml:space="preserve">
-    <value>语言：</value>
+    <value>Lingua :</value>
   </data>
   <data name="Language_UseSystem" xml:space="preserve">
-    <value>使用系统语言</value>
+    <value>Impiegà a lingua di u sistema</value>
   </data>
   <data name="SourceSelection_AboutHandBrake" xml:space="preserve">
-    <value>关于 HandBrake</value>
+    <value>Apprupositu d’HandBrake</value>
   </data>
   <data name="SourceSelection_DropFileHere" xml:space="preserve">
-    <value>或者将文件或文件夹拖放到这里...</value>
+    <value>Osinnò depone un schedariu o un cartulare quì…</value>
   </data>
   <data name="SourceSelection_Help" xml:space="preserve">
-    <value>帮助</value>
+    <value>Aiutu</value>
   </data>
   <data name="Preferences" xml:space="preserve">
-    <value>首选项</value>
+    <value>Preferenze</value>
   </data>
   <data name="AudioDefaultsView_AddTrack" xml:space="preserve">
-    <value>添加轨道</value>
+    <value>Aghjunghje una traccia</value>
   </data>
   <data name="AudioDefaultsView_AutoAddTracks" xml:space="preserve">
-    <value>为每个轨道设置音频码器：</value>
+    <value>Preferenze di u cudificatore audio per ogni traccia scelta :</value>
   </data>
   <data name="AudioDefaultsView_Clear" xml:space="preserve">
-    <value>清除</value>
+    <value>Nettà</value>
   </data>
   <data name="SubtitlesView_BurnIn" xml:space="preserve">
-    <value>烧入</value>
+    <value>Intarsiatu</value>
   </data>
   <data name="SubtitlesView_Default" xml:space="preserve">
-    <value>默认</value>
+    <value>Predefinitu</value>
   </data>
   <data name="SubtitlesView_ForcedOnly" xml:space="preserve">
-    <value>仅限强制</value>
+    <value>Sfurzatu solu</value>
   </data>
   <data name="MainView_About" xml:space="preserve">
-    <value>_关于...</value>
+    <value>_Apprupositu…</value>
   </data>
   <data name="MainView_ActivityLogMenu" xml:space="preserve">
-    <value>_活动日志</value>
+    <value>_Ghjurnale d’attività</value>
   </data>
   <data name="MainView_CheckForUpdates" xml:space="preserve">
-    <value>_检查更新</value>
+    <value>_Cuntrollà e nove versioni</value>
   </data>
   <data name="MainView_Exit" xml:space="preserve">
-    <value>_退出</value>
+    <value>_Esce</value>
   </data>
   <data name="MainView_ExportToFile" xml:space="preserve">
-    <value>_导出到文件</value>
+    <value>_Espurtà ver di un schedariu</value>
   </data>
   <data name="MainView_FileMenu" xml:space="preserve">
-    <value>_文件</value>
+    <value>_Schedariu</value>
   </data>
   <data name="MainView_HandBrakeDocs" xml:space="preserve">
-    <value>_HandBrake 文档 (HTTPS)</value>
+    <value>_Documentazione HandBrake (HTTPS)</value>
   </data>
   <data name="MainView_HelpMenu" xml:space="preserve">
-    <value>_帮助</value>
+    <value>_Aiutu</value>
   </data>
   <data name="MainView_ImportFromFile" xml:space="preserve">
-    <value>_从文件导入</value>
+    <value>_Impurtà da un schedariu</value>
   </data>
   <data name="MainView_PreferencesMenu" xml:space="preserve">
-    <value>_首选项</value>
+    <value>_Preferenze</value>
   </data>
   <data name="MainView_PresetsMenu" xml:space="preserve">
-    <value>_预设</value>
+    <value>_Prerigature</value>
   </data>
   <data name="MainView_QueueMenu" xml:space="preserve">
-    <value>_队列</value>
+    <value>_Fila d’attesa</value>
   </data>
   <data name="MainView_ResetPresets" xml:space="preserve">
-    <value>_重置内置预设</value>
+    <value>_Reinizià e prerigature integrate</value>
   </data>
   <data name="MainView_SetCurrentAsDefault" xml:space="preserve">
-    <value>_将当前设置为默认值</value>
+    <value>_Sceglie cum’è valore predefinitu</value>
   </data>
   <data name="MainView_ShowPresetPanel" xml:space="preserve">
-    <value>_显示预设面板</value>
+    <value>A_ffissà u pannellu di e prerigature</value>
   </data>
   <data name="MainView_ShowQueueMenu" xml:space="preserve">
-    <value>_显示队列</value>
+    <value>Affissà a _fila d'attesa</value>
   </data>
   <data name="MainView_ToolsMenu" xml:space="preserve">
-    <value>_工具</value>
+    <value>Attre_zzi</value>
   </data>
   <data name="OptionsView_CheckingForUpdates" xml:space="preserve">
-    <value>检查更新 ...</value>
+    <value>Cuntrollu di e nove versioni…</value>
   </data>
   <data name="OptionsView_ClearLogDirConfirm" xml:space="preserve">
-    <value>您确定要清除日志文件目录吗？</value>
+    <value>Site sicuru di vulè viutà u cartulare di i ghjurnali ?</value>
   </data>
   <data name="OptionsView_ClearLogs" xml:space="preserve">
-    <value>清除日志</value>
+    <value>Viutà i ghjurnali</value>
   </data>
   <data name="OptionsView_Downloading" xml:space="preserve">
-    <value>正在下载...</value>
+    <value>Scaricamentu…</value>
   </data>
   <data name="OptionsView_LogsCleared" xml:space="preserve">
-    <value>HandBrake 的日志文件目录已被清除！</value>
+    <value>U cartulare di i ghjurnali hè statu viotu !</value>
   </data>
   <data name="OptionsView_Notice" xml:space="preserve">
-    <value>注意</value>
+    <value>Avertimentu</value>
   </data>
   <data name="OptionsView_PreparingUpdate" xml:space="preserve">
-    <value>准备更新...</value>
+    <value>Preparazione di a nova versione…</value>
   </data>
   <data name="OptionsView_SelectFolder" xml:space="preserve">
-    <value>请选择一个文件夹。</value>
+    <value>Ci vole à selezziunà un cartulare.</value>
   </data>
   <data name="OptionsView_SetDefaultLocationOutputFIle" xml:space="preserve">
-    <value>单击“浏览”以设置默认位置</value>
+    <value>Sciglite « Navigà » per sceglie u locu predefinitu</value>
   </data>
   <data name="MainView_Hide" xml:space="preserve">
-    <value>隐藏</value>
+    <value>Piattà</value>
   </data>
   <data name="MainView_Show" xml:space="preserve">
-    <value>显示</value>
+    <value>Affissà</value>
   </data>
   <data name="MainView_ShowAddAllToQueue" xml:space="preserve">
-    <value>“添加所有”至队列</value>
+    <value>« Tuttu aghjunghje » à a fila d’attesa</value>
   </data>
   <data name="MainView_ShowAddSelectionToQueue" xml:space="preserve">
-    <value>“添加选中”至队列</value>
+    <value>« Aghjunghje a selezzione » à a fila d’attesa</value>
   </data>
   <data name="QueueView_PlayMediaFile" xml:space="preserve">
-    <value>播放文件</value>
+    <value>Sunà u schedariu</value>
   </data>
   <data name="Options_ApplicaitonToolbar" xml:space="preserve">
-    <value>应用程序工具栏</value>
+    <value>Barra d’attrezzi d’appiecazione</value>
   </data>
   <data name="Options_ShowToolbarAddAll" xml:space="preserve">
-    <value>在工具栏中显示“添加所有至队列”</value>
+    <value>Affissà « Tuttu aghjunghje à a fila d’attesa » nant’à a barra d’attrezzi</value>
   </data>
   <data name="Options_ShowToolbarAddSelection" xml:space="preserve">
-    <value>在工具栏中显示“添加选中至队列”</value>
+    <value>Affissà « Aghjunghje a selezzione à a fila d’attesa » nant’à a barra d’attrezzi</value>
   </data>
   <data name="OptionsView_HardwareDetectFailed" xml:space="preserve">
-    <value>目前禁用硬件编码支持。 请确保您为此系统中的所有图形适配器运行最新的驱动程序。
-这不会对软件编码器产生任何影响。</value>
+    <value>L’adopru di a cudificazione materiale hè attualmente disattivatu. Assicuratevvi chì voi impiegate l’ultimi piloti per tutte e carte grafiche di stu sistema.
+
+Què ùn affetterà micca i cudificatori d’appiecazione.</value>
   </data>
   <data name="Main_PleaseFixSubtitleSettings" xml:space="preserve">
-    <value>请更正您的字幕设置然后再继续。</value>
+    <value>Ci vole à currege e vostre preferenze nanzu di cuntinuà. </value>
   </data>
   <data name="Generic_Apply" xml:space="preserve">
-    <value>应用</value>
+    <value>Appiecà</value>
   </data>
   <data name="Main_ResumeEncode" xml:space="preserve">
-    <value>继续编码</value>
+    <value>Ripiglià a cudificazione</value>
   </data>
   <data name="QueueView_Actions" xml:space="preserve">
-    <value>活动</value>
+    <value>Azzioni</value>
   </data>
   <data name="QueueView_Import" xml:space="preserve">
-    <value>导入列队</value>
+    <value>Impurtà una fila d’attesa</value>
   </data>
   <data name="QueueViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
-    <value>Encoding: Pass {0} of {1},  {2:00.00}%, FPS: {3:000.0},  Avg FPS: {4:000.0}
-Time Remaining: {5},  Elapsed: {6} {7}</value>
+    <value>Cudificazione : Passu {0} nant’à {1},  {2:00.00}%, FPS : {3:000.0},  FPS mediana : {4:000.0}
+Tempu rimanente : {5}, Trascorsu : {6} {7}</value>
   </data>
   <data name="QueueView_DeleteSelected" xml:space="preserve">
-    <value>删除所选</value>
+    <value>Squassà a selezzione</value>
   </data>
   <data name="Portable_TmpNotWritable" xml:space="preserve">
-    <value>便携模式：无法创建TMP目录。请检查路径是否正确且可写。
+    <value>Modu purtabile : Impussibule di creà u cartulare timpurariu. Ci vole à verificà chì u chjassu hè currettu è accessibile in scrittura.
 
     {0}</value>
   </data>
   <data name="Portable_StorageNotWritable" xml:space="preserve">
-    <value>便携模式：无法创建存储目录。请检查路径是否正确且可写。
+    <value>Modu purtabile : Impussibule di creà u cartulare d’allucamentu. Ci vole à verificà chì u chjassu hè currettu è accessibile in scrittura.
 
     {0}</value>
   </data>
   <data name="Portable_IniFileError" xml:space="preserve">
-    <value>便携模式：无法读取 portable.ini。此文件可能存在错误。请使用 portable.ini.template 作为模版重试。</value>
+    <value>Modu purtabile : Impussibule di leghje portable.ini. Forse ci hè qualchì sbagliu in stu schedariu. Ci vole à pruvà torna impieghendu portable.ini.template cum’è esempiu.</value>
   </data>
   <data name="Startup_InitFailed" xml:space="preserve">
-    <value>HandBrake 无法初始化引擎。这通常是由过时的GPU驱动程序引起的。\n 请更新显卡驱动程序。</value>
+    <value>U mutore d’HandBrake ùn hà micca pussutu inizziasi. Ghjè aspessu cagiunatu da piloti GPU troppu anziani.\nCi vole à rinnovà sti piloti per tutte e carte grafiche integrate è specificate di u vostru sistema.</value>
   </data>
   <data name="OptionsView_FormatOptions" xml:space="preserve">
-    <value>实时更新选项：{source} {title} {chapters} 
-非实时更新选项：{date} {time} {creation-date} {creation-time} {quality} {bitrate} （只有扫描新源、更改标题或章节时才会更改）</value>
+    <value>Ozzioni mudificate direttamente : {source} {title} {chapters} 
+Ozzioni tramandate : {date} {time} {creation-date} {creation-time} {quality} {bitrate} (Quesse cambianu solu quandu voi analizate una nova fonte, cambiate di titulu o di capitulu)</value>
   </data>
   <data name="OptionsView_PathOptions" xml:space="preserve">
-    <value>可用的附加选项: {source_path} {source_folder_name} {source}</value>
+    <value>Ozzioni dispunibule : {source_path} {source_folder_name} {source}</value>
   </data>
   <data name="FileOverwriteBehaviours_Ask" xml:space="preserve">
-    <value>询问是否覆盖文件</value>
+    <value>Dumandà per rimpiazzà u schedariu</value>
   </data>
   <data name="FileOverwriteBehaviours_Autoname" xml:space="preserve">
-    <value>自动重命名文件</value>
+    <value>Pruvà di rinumà autumaticamente u schedariu</value>
   </data>
   <data name="FileOverwriteBehaviours_Overwrite" xml:space="preserve">
-    <value>覆盖文件</value>
+    <value>Rimpiazzà u schedariu</value>
   </data>
   <data name="Options_UIBehaviour" xml:space="preserve">
-    <value>用户界面操作</value>
+    <value>Cumpurtamentu di l’interfaccia d’utilizatore</value>
   </data>
   <data name="OptionsView_FileOverwriteBehaviour" xml:space="preserve">
-    <value>文件覆盖操作</value>
+    <value>Cosa fà in casu di rimpiazzamentu di schedariu</value>
   </data>
   <data name="Options_EncodeCompleted" xml:space="preserve">
-    <value>编码完成</value>
+    <value>Cudificazione compia</value>
   </data>
   <data name="Options_Notifications" xml:space="preserve">
-    <value>通知</value>
+    <value>Nutificazioni</value>
   </data>
   <data name="Options_QueueCompleted" xml:space="preserve">
-    <value>队列已完成</value>
+    <value>Fila d’attesa compia</value>
   </data>
   <data name="Options_WhenDoneColon" xml:space="preserve">
-    <value>当完成时：</value>
+    <value>Quandu hè compiu :</value>
   </data>
   <data name="OptionsView_FileCollisionBehaviour" xml:space="preserve">
-    <value>文件名冲突操作</value>
+    <value>Cosa fà in casu di cunflittu di nome di schedariu :</value>
   </data>
   <data name="CollisionBehaviour_Post" xml:space="preserve">
-    <value>后缀</value>
+    <value>Suffissu</value>
   </data>
   <data name="CollisionBehaviour_Pre" xml:space="preserve">
-    <value>前缀</value>
+    <value>Prefissu</value>
   </data>
   <data name="CollisionBehaviour_AppendNumber" xml:space="preserve">
-    <value>添加编号</value>
+    <value>Aghjunghje un numeru à a fine</value>
   </data>
   <data name="FiltersViewAuto_DeblockPreset" xml:space="preserve">
-    <value>过滤器视图——去块效应滤波器预设</value>
+    <value>FiltersView_DeblockPreset</value>
   </data>
   <data name="FiltersViewAuto_DeblockTune" xml:space="preserve">
-    <value>去块效应滤波器调整</value>
+    <value>Rigatura di sblucchime</value>
   </data>
   <data name="OptionsView_ChoiceOfEncoderHint" xml:space="preserve">
-    <value>编码器的选择将在“视频”选项卡上提供。</value>
+    <value>A scelta di u cudificatore serà dispunibule in l’unghjetta « Video ».</value>
   </data>
   <data name="Queue_RecoverQueueQuestionPlural" xml:space="preserve">
-    <value>HandBrake 检测到多个未完成的队列文件。恢复这些文件将使 HandBrake 运行多个实例。 你想恢复所有未完成的工作吗？</value>
+    <value>HandBrake hà trovu parechji schedarii di fila d’attesa micca compii. Quelli venenu da parechje instanze d’HandBrake. Vulete ricuperà tutti sti travaglii micca compii ?</value>
   </data>
   <data name="Queue_RecoverQueueQuestionSingular" xml:space="preserve">
-    <value>HandBrake 检测到上次启动时队列中尚有未完成的项目。你想恢复这些项目吗？</value>
+    <value>HandBrake hà trovu elementi micca compii in a fila d’attesa di l’ultima sessione di l’appiecazione. Vulete ricuperalli ?</value>
   </data>
   <data name="Queue_RecoveryPossible" xml:space="preserve">
-    <value>有可恢复的队列</value>
+    <value>Ricuperazione pussibule di fila d’attesa</value>
   </data>
   <data name="PresetService_ImportingBuiltInWarning" xml:space="preserve">
-    <value>您的预设文件包含内置预设，但导入功能不支持导入内置预设。请使用“预设菜单  -&gt; 重置内置预设”来恢复标准预设。
+    <value>U vostru schedariu di prerigature cuntinia prerigature integrate. A funzione d’impurtazione ùn e accetteghja micca. Ci vole à impiegà « Prerigature -&gt; Reinizià e prerigature integrate » per risturà e prerigature predefinite.
 
-将导入所有支持的用户预设。</value>
+Induve hè accettatu, tutte e prerigature persunalizate seranu state impurtate.</value>
   </data>
   <data name="Options_PromptBeforeAction" xml:space="preserve">
-    <value>立即执行操作。（这将禁用60秒确认对话框）</value>
+    <value>Effettuà st’azzione subitu subitu. (Què disattiverà u dialogu di cunfirmazione di 60 seconde)</value>
   </data>
   <data name="Browse" xml:space="preserve">
-    <value>浏览</value>
+    <value>Navigà</value>
   </data>
   <data name="OptionsView_MediaFileNotSet" xml:space="preserve">
-    <value>没有设置音频文件。请单击“浏览”以选择要播放的wav或mp3文件。</value>
+    <value>Alcunu schedariu audio ùn hè statu definitu. Ci vole sceglie « Navigà » per selezziunà un schedariu wav o mp3 à sunà.</value>
   </data>
   <data name="OptionsView_Play" xml:space="preserve">
-    <value>播放</value>
+    <value>Sunà</value>
   </data>
   <data name="QueueView_ExportCLI" xml:space="preserve">
-    <value>导出列队（仅限命令行界面）</value>
+    <value>Espurtà a fila d’attesa  (CLI solu)</value>
   </data>
   <data name="Options_DarkTheme" xml:space="preserve">
-    <value>使用黑暗主题。（需要重启软件，仅支持 Windows 10）</value>
+    <value>Impiegà u tema scuru (Richiede un rilanciu, solu cù Windows 10)</value>
   </data>
   <data name="QueueView_NotAvailable" xml:space="preserve">
-    <value>不可用</value>
+    <value>Indispunibule</value>
   </data>
   <data name="Options_LowDiskspaceSizeGB" xml:space="preserve">
-    <value>GB</value>
+    <value>Go</value>
   </data>
   <data name="SystemService_ACMains" xml:space="preserve">
-    <value>已检测到交流电源。正在恢复编码... ({0} %)</value>
+    <value>Alimentazione settore abbentata. Ripigliu di a cudificazione… ({0} %)</value>
   </data>
   <data name="SystemService_CriticalBattery" xml:space="preserve">
-    <value>系统电量严重不足! ({0} %)</value>
+    <value>Livellu d’energia di batteria criticu ! ({0} %)</value>
   </data>
   <data name="SystemService_LowBatteryLog" xml:space="preserve">
-    <value>System Battery Low! ({0} %). Your encode has been paused.</value>
+    <value>Livellu d’energia di batteria debule ! ({0} %). A vostra cudificazione hè stata interrotta.</value>
   </data>
   <data name="SystemService_LowDiskSpaceLog" xml:space="preserve">
-    <value>目标磁盘剩余存储容量少于 {0} GB。正在暂停编码...</value>
+    <value>A capacità d’allucamentu hè falata sottu {0} Go nant’à u lettore di destinazione. Interruzzione di a cudificazione…</value>
   </data>
   <data name="AudioDefaultsView_PaneTitle" xml:space="preserve">
-    <value>配置自动音频选择</value>
+    <value>Cunfigurà e selezzioni audio autumatiche</value>
   </data>
   <data name="SubtitlesDefaultsView_PaneTitle" xml:space="preserve">
-    <value>配置自动字幕选择</value>
+    <value>Cunfigurà e selezzioni di sottutituli autumatiche</value>
   </data>
   <data name="Options_SystemOptions" xml:space="preserve">
-    <value>系统</value>
+    <value>Sistema</value>
   </data>
   <data name="MetadataView_Actors" xml:space="preserve">
-    <value>演员：</value>
+    <value>Attori :</value>
   </data>
   <data name="MetadataView_Comments" xml:space="preserve">
-    <value>评论：</value>
+    <value>Cummenti :</value>
   </data>
   <data name="MetadataView_Description" xml:space="preserve">
-    <value>描述：</value>
+    <value>Discrizzione :</value>
   </data>
   <data name="MetadataView_Director" xml:space="preserve">
-    <value>导演：</value>
+    <value>Direttore :</value>
   </data>
   <data name="MetadataView_Genre" xml:space="preserve">
-    <value>类型：</value>
+    <value>Generu :</value>
   </data>
   <data name="MetadataView_Plot" xml:space="preserve">
-    <value>剧情：</value>
+    <value>Intricu :</value>
   </data>
   <data name="MetadataView_ReleaseDate" xml:space="preserve">
-    <value>发行日期：</value>
+    <value>Data d’esciuta :</value>
   </data>
   <data name="MetadataView_TitleTag" xml:space="preserve">
-    <value>标题：</value>
+    <value>Titulu :</value>
   </data>
   <data name="StaticPreviewView_PreviewRotationFlip" xml:space="preserve">
-    <value>预览旋转和翻转</value>
+    <value>Previsualizazione di a rotazione è di u rivoltamentu</value>
   </data>
   <data name="LogViewModel_Title" xml:space="preserve">
-    <value>日志查看器</value>
+    <value>Fighjata di u ghjurnale</value>
   </data>
   <data name="MainView_Aspect" xml:space="preserve">
-    <value>详情：</value>
+    <value>Furmatu :</value>
   </data>
   <data name="MainView_Filters" xml:space="preserve">
-    <value>滤镜：</value>
+    <value>Filtri :</value>
   </data>
   <data name="MainView_Size" xml:space="preserve">
-    <value>大小：</value>
+    <value>Dimensione :</value>
   </data>
   <data name="MainView_Tracks" xml:space="preserve">
-    <value>轨道：</value>
+    <value>Traccie :</value>
   </data>
   <data name="OptionsTab_General" xml:space="preserve">
-    <value>常规</value>
+    <value>Generale</value>
   </data>
   <data name="OptionsViewModel_CheckForUpdatesMsg" xml:space="preserve">
-    <value>点击“检查更新”检查新版本</value>
+    <value>Sciglite « Cuntrollà e nove versioni » per sapè s’ella esiste una nova versione di l’appiecazione</value>
   </data>
   <data name="OptionsView_BackButton" xml:space="preserve">
-    <value>&lt; 返回</value>
+    <value>&lt; Precedente</value>
   </data>
   <data name="QueueView_CurrentlyPaused" xml:space="preserve">
-    <value>目前已暂停</value>
+    <value>Attualmente interrotta</value>
   </data>
   <data name="Options_OutputFiles" xml:space="preserve">
-    <value>输出文件</value>
+    <value>Schedarii d’esciuta</value>
   </data>
   <data name="PointToPointMode_Chapters" xml:space="preserve">
-    <value>章节</value>
+    <value>Capituli</value>
   </data>
   <data name="PointToPointMode_Frames" xml:space="preserve">
-    <value>帧数</value>
+    <value>Fiure</value>
   </data>
   <data name="PointToPointMode_Preview" xml:space="preserve">
-    <value>预览</value>
+    <value>Previsualizazione</value>
   </data>
   <data name="PointToPointMode_Seconds" xml:space="preserve">
-    <value>秒</value>
+    <value>Seconde</value>
   </data>
   <data name="SubtitleBehaviourModes_AllMatching" xml:space="preserve">
-    <value>所有匹配选中的语言</value>
+    <value>Tutte e lingue chì currispundenu</value>
   </data>
   <data name="SubtitleBehaviourModes_FirstMatching" xml:space="preserve">
-    <value>第一个匹配选中的语言</value>
+    <value>Prima lingua chì currispunde</value>
   </data>
   <data name="SubtitleBehaviourModes_None" xml:space="preserve">
-    <value>无</value>
+    <value>Alcunu</value>
   </data>
   <data name="SubtitleBurnInBehaviourModes_FirstTrack" xml:space="preserve">
-    <value>第一个轨道</value>
+    <value>Prima traccia</value>
   </data>
   <data name="SubtitleBurnInBehaviourModes_ForeignAudioPreferredElseFirst" xml:space="preserve">
-    <value>外部音频优先，否则第一个优先</value>
+    <value>Traccia audio straniera preferita, osinnò Prima traccia</value>
   </data>
   <data name="SubtitleBurnInBehaviourModes_ForeignAudioTrack" xml:space="preserve">
-    <value>外部音轨</value>
+    <value>Traccia audio straniera</value>
   </data>
   <data name="SubtitleBurnInBehaviourModes_None" xml:space="preserve">
-    <value>无</value>
+    <value>Alcunu</value>
   </data>
   <data name="SubtitleViewModel_ForeignAudioSearch" xml:space="preserve">
-    <value>外部音频搜索</value>
+    <value>Ricerca di traccia audio straniera</value>
   </data>
   <data name="Subtitle_ForeignAudioScan" xml:space="preserve">
-    <value>外部音频扫描</value>
+    <value>Analisa di traccia audio straniera</value>
   </data>
   <data name="AudioBehaviourModes_AllMatching" xml:space="preserve">
-    <value>所有匹配选中的语言</value>
+    <value>Tutte e lingue chì currispundenu</value>
   </data>
   <data name="AudioBehaviourModes_AllTracks" xml:space="preserve">
-    <value>使用所有轨道作为模板</value>
+    <value>Impiegà tutte e traccie cum’è mudellu</value>
   </data>
   <data name="AudioBehaviourModes_FirstMatch" xml:space="preserve">
-    <value>第一个匹配选中的语言</value>
+    <value>Prima lingua chì currispunde</value>
   </data>
   <data name="AudioBehaviourModes_FirstTrack" xml:space="preserve">
-    <value>使用首轨作为模板</value>
+    <value>Impiegà a prima traccia cum’è mudellu</value>
   </data>
   <data name="AudioBehaviourModes_None" xml:space="preserve">
-    <value>无音频</value>
+    <value>Alcuna traccia audio</value>
   </data>
   <data name="ChapterViewModel_Chapter" xml:space="preserve">
-    <value>章节 {0}</value>
+    <value>Capitulu {0}</value>
   </data>
   <data name="Mp4Behaviour_Auto" xml:space="preserve">
-    <value>自动</value>
+    <value>Autumaticu</value>
   </data>
   <data name="Mp4Behaviour_UseM4v" xml:space="preserve">
-    <value>始终使用 M4V</value>
+    <value>Sempre impiegà M4V</value>
   </data>
   <data name="Mp4Behaviour_UseMp4" xml:space="preserve">
-    <value>始终使用 MP4</value>
+    <value>Sempre impiegà MP4</value>
   </data>
   <data name="PresetPictureSettingsMode_Custom" xml:space="preserve">
-    <value>自定义</value>
+    <value>Persunalizatu</value>
   </data>
   <data name="PresetPictureSettingsMode_None" xml:space="preserve">
-    <value>无</value>
+    <value>Alcunu</value>
   </data>
   <data name="PresetPictureSettingsMode_SourceMaximum" xml:space="preserve">
-    <value>始终使用源分辨率</value>
+    <value>Sempre impiegà a risuluzione di a video di a fonte</value>
   </data>
   <data name="ProcessPriority_AboveNormal" xml:space="preserve">
-    <value>高于标准</value>
+    <value>Più altu chì a nurmale</value>
   </data>
   <data name="ProcessPriority_BelowNormal" xml:space="preserve">
-    <value>低于标准</value>
+    <value>Più bassu chì a nurmale</value>
   </data>
   <data name="ProcessPriority_High" xml:space="preserve">
-    <value>高</value>
+    <value>Altu</value>
   </data>
   <data name="ProcessPriority_Low" xml:space="preserve">
-    <value>低</value>
+    <value>Bassu</value>
   </data>
   <data name="ProcessPriority_Normal" xml:space="preserve">
-    <value>标准</value>
+    <value>Nurmale</value>
   </data>
   <data name="UpdateCheck_Monthly" xml:space="preserve">
-    <value>每月</value>
+    <value>Misinca</value>
   </data>
   <data name="UpdateCheck_Weekly" xml:space="preserve">
-    <value>每周</value>
+    <value>Settimanale</value>
   </data>
   <data name="OptionsView_AlwaysUseDefaultPath" xml:space="preserve">
-    <value>始终为生成的每个新名称使用默认路径。</value>
+    <value>Sempre impiegà u chjassu predefinitu per ogni novu nome ingeneratu.</value>
   </data>
   <data name="OptionsView_RemotePortLimit" xml:space="preserve">
-    <value>端口范围必须在5000到32767之间</value>
+    <value>A stesa di porti deve esse scelta trà 5000 è 32767</value>
   </data>
   <data name="OptionsView_SendFileToArgPlaceholders" xml:space="preserve">
-    <value>替换占位符: {source} {destination}</value>
+    <value>Campi di sustituzione : {source} {destination}</value>
     <comment>Note: {source} and {destination} are not translatable. </comment>
   </data>
   <data name="SourceSelection_UpdateAvailable" xml:space="preserve">
-    <value>有新版本的 HandBrake 可供使用！</value>
+    <value>Una nova versione d’HandBrake hè dispunibule !</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
     <value>Copyright (C) 2003-2020 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
-    <value>Low battery level:</value>
+    <value>Livellu di batteria debule :</value>
   </data>
   <data name="Options_PauseOnLowBattery" xml:space="preserve">
-    <value>Pause any running jobs when the battery gets low.</value>
+    <value>Interrompe tuttu travagliu in corsu quandu u livellu di batteria hè debule.</value>
   </data>
   <data name="SubtitleView_AddRemainingCC" xml:space="preserve">
-    <value>添加所有剩余的隐藏式字幕</value>
+    <value>Aghjunghje tutti i sottutituli ditagliati chì fermanu</value>
   </data>
   <data name="QueueService_DuplicatesQuestion" xml:space="preserve">
-    <value>Duplicate jobs were detected in the queue file that you are trying to import. Do you wish to overwrite the existing records? 
-This will also stop any existing running jobs.</value>
+    <value>Travaglii in doppiu sò stati trovi in u schedariu di fila d’attesa chì voi pruvate d’impurtà. Vulete rimpiazzà l’arregistramenti chì esistenu ? 
+Què pianterà tuttu travagliu in corsu.</value>
   </data>
   <data name="QueueService_DuplicatesTitle" xml:space="preserve">
-    <value>Duplicates Detected</value>
+    <value>Duppioni trovi</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Enable Low Power QuickSync Hardware (where supported).</value>
+    <value>Attivà u QuickSync di bassa cunsumazione.</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
-    <value>Please select a single job to view summary information.</value>
+    <value>Ci vole à selezziunà un travagliu solu per fighjà l’infurmazioni di sintesi.</value>
   </data>
   <data name="OptionsView_EnableWorkerProcesses" xml:space="preserve">
-    <value>Run each queued job in a separate worker process. (Experimental)</value>
+    <value>Eseguisce ogni travagliu di a fila d’attesa in un trattamentu di travagliu distintu. (Esperimentale)</value>
   </data>
   <data name="OptionsView_WorkerDefaultPort" xml:space="preserve">
-    <value>Default network port for worker:</value>
+    <value>Portu di reta predefinitu per u trattamentu di travagliu :</value>
   </data>
   <data name="Presets_NotAvailableForUse" xml:space="preserve">
-    <value>The preset you have selected is not available for use on this system.
+    <value>A prerigatura selezziunata ùn hè micca dispunibule nant’à stu sistema.
 
-This is typically an indication that your system does not support the hardware required to utilise it.
+Da bona regula, vole si dì chì u vostru sistema ùn accetteghja micca u materiale richiestu per impiegalla.
 
-Please choose a different preset.</value>
+Ci vole à sceglie una prerigatura sfarente.</value>
   </data>
   <data name="OptionsView_ProcessIsolation" xml:space="preserve">
-    <value>Process Isolation</value>
+    <value>Isulamentu di i trattamenti</value>
   </data>
   <data name="OptionsView_ProcessIsolation_Warning1" xml:space="preserve">
-    <value>Please note, using this feature will start an HTTP server bound to 127.0.0.1 on the port stated.</value>
+    <value>Nota : L’adopru di sta funzione lancerà un servitore HTTP ligatu à l’indirizzu 127.0.0.1 nant’à u portu sceltu.</value>
   </data>
   <data name="OptionsView_ProcessIsolation_Warning2" xml:space="preserve">
-    <value>If the set port is in use, it will find the first free port within +100 from the defined port.</value>
+    <value>S’è u portu definitu hè dighjà impiegatu, si truverà u primu portu liberu in un intervallu massimu di 100 à partesi di u portu definitu.</value>
   </data>
   <data name="OptionsView_SimultaneousEncodes" xml:space="preserve">
-    <value>Number of simultaneous encodes:</value>
+    <value>Numeru di cudificazioni simultanei :</value>
   </data>
   <data name="StaticPreviewView_CancelPreview" xml:space="preserve">
-    <value>取消</value>
+    <value>Abbandunà</value>
   </data>
   <data name="MainView_SelectedPresets" xml:space="preserve">
-    <value>预设：</value>
+    <value>Prerigatura :</value>
   </data>
   <data name="SummaryView_SameAsSource" xml:space="preserve">
-    <value>Same as source</value>
+    <value>Listessa chè a fonte</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrake" xml:space="preserve">
-    <value>Reset Settings</value>
+    <value>Reinizializazione di e preferenze</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
-    <value>Are you sure you wish to reset HandBrake to default settings?</value>
+    <value>Site sicuru di vulè reinizià e preferenze d’HandBrake à i so valori predefiniti ?</value>
   </data>
   <data name="PaddingMode_Custom" xml:space="preserve">
-    <value>Custom (Not Limited)</value>
+    <value>Persunalizatu (Micca ristrintu)</value>
   </data>
   <data name="PaddingMode_Fill" xml:space="preserve">
-    <value>Fill (pad to resolution limit)</value>
+    <value>Riempie (imburrà fine à a cunfina di a risuluzione)</value>
   </data>
   <data name="PaddingMode_Height" xml:space="preserve">
-    <value>Height (pad up to res limit)</value>
+    <value>Altezza (imburrà fine à a cunfina di a risuluzione)</value>
   </data>
   <data name="PaddingMode_None" xml:space="preserve">
-    <value>无</value>
+    <value>Alcunu</value>
   </data>
   <data name="PaddingMode_Width" xml:space="preserve">
-    <value>Width (pad up to res limit)</value>
+    <value>Larghezza (imburrà fine à a cunfina di a risuluzione)</value>
   </data>
   <data name="PictureSettingsView_Padding" xml:space="preserve">
-    <value>Padding:</value>
+    <value>Imburrera :</value>
   </data>
   <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
-    <value>Padding Colour:</value>
+    <value>Culore d’imburrera :</value>
   </data>
   <data name="PictureSettingsView_Borders" xml:space="preserve">
-    <value>Borders</value>
+    <value>Bordi</value>
   </data>
   <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
-    <value>Resolution and Scaling</value>
+    <value>Risuluzione è messa à a scala</value>
   </data>
   <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
-    <value>Rotate and Crop</value>
+    <value>Girà è runzicà</value>
   </data>
   <data name="OptionsView_Win10Only" xml:space="preserve">
-    <value>( Windows 10 Only! )</value>
+    <value>( Windows 10 solu ! )</value>
   </data>
   <data name="QueueView_FilterSettings" xml:space="preserve">
-    <value>滤镜：</value>
+    <value>Filtri :</value>
   </data>
   <data name="SummaryView_Default" xml:space="preserve">
-    <value>默认</value>
+    <value>Predefinitu</value>
   </data>
   <data name="SummaryView_Forced" xml:space="preserve">
-    <value>Forced</value>
+    <value>Sfurzatu</value>
   </data>
   <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
     <value>1080p HD</value>
@@ -2289,89 +2291,89 @@ Please choose a different preset.</value>
     <value>4320p 8K Ultra HD</value>
   </data>
   <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
-    <value>自定义</value>
+    <value>Persunalizatu</value>
   </data>
   <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
-    <value>Max Height:</value>
+    <value>Altezza massima :</value>
   </data>
   <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
-    <value>Max Width:</value>
+    <value>Larghezza massima :</value>
   </data>
   <data name="PictureSettingsView_ResLimit" xml:space="preserve">
-    <value>Resolution Limit:</value>
+    <value>Cunfina di risuluzione :</value>
   </data>
   <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
-    <value>无</value>
+    <value>Alcunu</value>
   </data>
   <data name="PresetManger_Title" xml:space="preserve">
-    <value>Manage Presets</value>
+    <value>Ghjestione di e prerigature</value>
   </data>
   <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
-    <value>Delete Built-in Presets</value>
+    <value>Squassà e prerigature integrate</value>
   </data>
   <data name="ManagePresetView_Export" xml:space="preserve">
-    <value>Export selected preset</value>
+    <value>Espurtà a prerigatura selezziunata</value>
   </data>
   <data name="ManagePresetView_Import" xml:space="preserve">
-    <value>Import Preset(s) from file</value>
+    <value>Impurtà a/e prerigatura(e) da un schedariu</value>
   </data>
   <data name="ManagePresetView_PresetInfo" xml:space="preserve">
-    <value>Preset Information:</value>
+    <value>Infurmazione nant’à a prerigatura :</value>
   </data>
   <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
-    <value>Build in presets can not be modified.</value>
+    <value>E prerigature integrate ùn ponu micca esse mudificate.</value>
   </data>
   <data name="ManagePresetView_SetDefault" xml:space="preserve">
-    <value>Set selected preset as default</value>
+    <value>Sceglie a prerigatura selezziunata cum’è predefinita</value>
   </data>
   <data name="PresetManagerView_Delete" xml:space="preserve">
-    <value>删除预设</value>
+    <value>Squassà a prerigatura</value>
   </data>
   <data name="OptionsView_NotSupported" xml:space="preserve">
-    <value>(Not supported on this system)</value>
+    <value>(Micca accettatu nant’à stu sistema)</value>
   </data>
   <data name="QueueView_Stop" xml:space="preserve">
-    <value>停止</value>
+    <value>Piantà</value>
   </data>
   <data name="Options_Metadata" xml:space="preserve">
-    <value>元数据</value>
+    <value>Metadati</value>
   </data>
   <data name="Options_PassthruMetadata" xml:space="preserve">
-    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+    <value>Passeghju di i metadati basichi da a fonte ver di u schedariu di destinazione (quand’ellu hè accettatu)</value>
   </data>
   <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
-    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
-Fields are limited to:
-- Name
-- Artist
-- Album Artist
-- Composer
-- Release Date
-- Comment
-- Album
-- Genre
-- Description
-- Long Description</value>
+    <value>St’ozzione permette à i campi metadati basichi d’esse cupiati da a fonte ver di u schedariu di destinazione.
+I campi sò limitati à :
+- Nome
+- Artista
+- Artista di l’albumu
+- Cumpositore
+- Data d’esciuta
+- Cummentu
+- Albumu
+- Generu
+- Discrizzione
+- Discrizzione longa</value>
   </data>
   <data name="String1" xml:space="preserve">
     <value/>
   </data>
   <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
-    <value>(Default Preset)</value>
+    <value>(Prerigatura predefinita)</value>
   </data>
   <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
-    <value>The category name you entered already exists. Please choose a different name.</value>
+    <value>U nome di categuria scrittu esiste dighjà. Ci vole à sceglie un nome sfarente.</value>
   </data>
   <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
-    <value>The category name was empty. Please provide a name.</value>
+    <value>U nome di categuria era viotu. Ci vole à pruvede un nome.</value>
   </data>
   <data name="TextEntryView_EnterName" xml:space="preserve">
-    <value>Enter a name: </value>
+    <value>Scrivite un nome :</value>
   </data>
   <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
-    <value>There is no preset selected.</value>
+    <value>Ùn ci hè alcuna prerigatura selezziunata.</value>
   </data>
   <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
-    <value>Export all user presets</value>
+    <value>Espurtà tutte e prerigature persunalizate</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.de.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.de.resx
@@ -209,7 +209,7 @@ Trotzdem fortfahren?</value>
     <value>HandBrake encodiert bereits.</value>
   </data>
   <data name="Main_DuplicateDestinationOnQueue" xml:space="preserve">
-    <value>Es sind Aufgaben mit demselben Zielpfad in der Warteschlange. Bitte einen anderen Pfad für die Aufgabe wählen.</value>
+    <value>Es sind Aufgaben mit demselben Ausgabepfad in der Warteschlange. Bitte einen anderen Pfad für die Aufgabe wählen.</value>
   </data>
   <data name="Main_JobsPending_addon" xml:space="preserve">
     <value>Anstehende Aufgaben {0}</value>
@@ -322,7 +322,7 @@ Trotzdem fortfahren?</value>
     <value>Vor dem Hinzufügen zur Warteschlange, muss der Zielpfad für die Ausgabedatei angegeben werden.</value>
   </data>
   <data name="Main_InvalidDestination" xml:space="preserve">
-    <value>Der eingegebene Zielpfad enthält ungültige Zeichen und wird nicht aktualisiert.</value>
+    <value>Der eingegebene Ausgabepfad enthält ungültige Zeichen und wird nicht aktualisiert.</value>
   </data>
   <data name="Preview" xml:space="preserve">
     <value>Vorschau {0}</value>
@@ -343,7 +343,7 @@ Nicht-Live-Optionen: {date} {time} {creation-date} {creation-time} {quality} {bi
     <value>Verfügbare zusätzliche Optionen: {source_path} oder {source_folder_name} oder {source}</value>
   </data>
   <data name="Main_MatchingFileOverwriteWarning" xml:space="preserve">
-    <value>Es kann keine Datei mit demselben Pfad und Dateinamen wie die Quelldatei encodiert werden. Bitte den Namen der Zieldatei ändern, so dass er nicht der Quelldatei entspricht.</value>
+    <value>Es kann keine Datei mit demselben Pfad und Dateinamen wie die Quelldatei encodiert werden. Bitte den Namen der Ausgabedatei ändern, so dass er nicht der Quelldatei entspricht.</value>
   </data>
   <data name="Main_UnableToLoadHelpMessage" xml:space="preserve">
     <value>Das System hat HandBrake daran gehindert einen Webbrowser zu starten.</value>
@@ -665,10 +665,10 @@ Die Voreinstellungsdatei wird archiviert und eine neue erstellt. Die eigenen Vor
 {0}</value>
   </data>
   <data name="MainViewModel_UnableToLaunchDestDir" xml:space="preserve">
-    <value>Öffnen des Zielverzeichnises fehlgeschlagen.</value>
+    <value>Öffnen des Ausgabeverzeichnises fehlgeschlagen.</value>
   </data>
   <data name="MainViewModel_UnableToLaunchDestDirSolution" xml:space="preserve">
-    <value>Bitte überprüfen, dass das Zielverzeichnis gültig ist.</value>
+    <value>Bitte überprüfen, dass das Ausgabeverzeichnis gültig ist.</value>
   </data>
   <data name="MainViewModel_EncodeStatusChanged_SubScan_StatusLabel" xml:space="preserve">
     <value>Durchgang {0} von {1} wird verarbeitet, (Untertitelprüfung) {2:00.00} %, verbleibende Prüfungszeit: {3}, vergangen: {4}</value>
@@ -692,7 +692,7 @@ Die Voreinstellungsdatei wird archiviert und eine neue erstellt. Die eigenen Vor
     <value>Warteschlange angehalten</value>
   </data>
   <data name="Main_LowDiskspace" xml:space="preserve">
-    <value>Das Zielverzeichnis hat wenig freien Speicherplatz.
+    <value>Das Ausgabeverzeichnis hat wenig freien Speicherplatz.
 
 In den Einstellungen kann definiert werden, ab welchem Batterielevel diese Warnung erscheint.
 
@@ -991,7 +991,7 @@ Soll sie überschrieben werden?</value>
     <value>Container</value>
   </data>
   <data name="MainView_Destination" xml:space="preserve">
-    <value>Ziel</value>
+    <value>Ausgabe</value>
   </data>
   <data name="MainView_Duration" xml:space="preserve">
     <value>Dauer:</value>
@@ -1248,6 +1248,9 @@ Soll sie überschrieben werden?</value>
   <data name="Options_Path" xml:space="preserve">
     <value>Pfad:</value>
   </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Pfad zum Media-Player</value>
+  </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Das System daran hindern während der Encodierung in den Ruhezustand zu fahren</value>
   </data>
@@ -1297,7 +1300,8 @@ Soll sie überschrieben werden?</value>
     <value>Video</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Dieser Pfad wird nur für die Videovorschaufunktion verwendet.</value>
+    <value>Dieser Pfad wird nur für die Videovorschaufunktion verwendet.
+Es werden VLC und MPC-HC unterstützt. Andere Media-Player können auch funktionieren, sind aber nicht validiert.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Verzeichnis des Aktivitätsprotokolls zeigen</value>
@@ -1405,7 +1409,7 @@ Soll sie überschrieben werden?</value>
     <value>Löschen</value>
   </data>
   <data name="QueueView_Destination" xml:space="preserve">
-    <value>Ziel:</value>
+    <value>Ausgabe:</value>
   </data>
   <data name="WhenDone_DoNothing" xml:space="preserve">
     <value>Nichts tun</value>
@@ -1438,7 +1442,7 @@ Soll sie überschrieben werden?</value>
     <value>Ausloggen</value>
   </data>
   <data name="QueueView_OpenDestDir" xml:space="preserve">
-    <value>Zielpfad öffnen</value>
+    <value>Ausgabeverzeichnis öffnen</value>
   </data>
   <data name="QueueView_OpenSourceDir" xml:space="preserve">
     <value>Pfad der Quelle öffnen</value>
@@ -1447,7 +1451,7 @@ Soll sie überschrieben werden?</value>
     <value>Einstellungen</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Warteschlange anhalten</value>
+    <value>Anhalten</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Angehalten:</value>
@@ -1991,7 +1995,7 @@ Falls unterstützt, wird jede benutzerdefinierte Voreinstellung übernommen. </v
     <value>Systembatterie schwach! ({0} %). Die Encodierung wurde angehalten.</value>
   </data>
   <data name="SystemService_LowDiskSpaceLog" xml:space="preserve">
-    <value>Der verfügbare Speicherplatz auf dem Ziellaufwerk ist unter {0} GB gefallen. Encodierung angehalten …</value>
+    <value>Der verfügbare Speicherplatz auf dem Ausgabelaufwerk ist unter {0} GB gefallen. Encodierung angehalten …</value>
   </data>
   <data name="AudioDefaultsView_PaneTitle" xml:space="preserve">
     <value>Automatische Tonauswahl konfigurieren</value>
@@ -2169,7 +2173,7 @@ Falls unterstützt, wird jede benutzerdefinierte Voreinstellung übernommen. </v
     <value>Eine neue Version von HandBrake ist verfügbar!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003–2020 Das HandBrake-Team</value>
+    <value>Copyright (C) 2003–2020 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Geringe Batteriekapazität:</value>
@@ -2188,7 +2192,7 @@ Dadurch werden auch alle bereits laufenden Aufgaben gestoppt.</value>
     <value>Duplikate erkannt</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Low Power QuickSync-Hardware aktivieren.</value>
+    <value>Low Power QuickSync-Hardware aktivieren (wo unterstützt).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Bitte nur eine Aufgabe auswählen um die Übersichtsinformationen anzuzeigen.</value>
@@ -2262,5 +2266,121 @@ Bitte eine andere Voreinstellung auswählen.</value>
   </data>
   <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
     <value>Drehen und Beschneiden</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Nur Windows 10! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Filter:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Standard</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Erzwungen</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Eigene</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Maximale Höhe:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Maximale Breite:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Auflösunglimit:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Keine</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Voreinstellungen verwalten</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Offizielle Voreinstellungen löschen</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Ausgewählte Voreinstellung exportieren</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Voreinstellung(en) aus Datei importieren</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Voreinstellungsinformation:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Offizielle Voreinstellungen können nicht verändert werden.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Ausgewählte Voreinstellung zum Standard machen</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Voreinstellung löschen</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Auf diesem System nicht unterstützt)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Stop</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Metadaten</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru der Standard-Metadaten von der Quelle zur Ausgabedatei (wo unterstützt)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>Diese Einstellung erlaubt das Durchreichen von Standard-Metadatenfeldern von der Quelle zur Ausgabedatei.
+Dies ist auf folgende Felder begrenzt:
+- Name
+- Künstler
+- Albumkünstler
+- Komponist
+- Erscheinungsdatum
+- Kommentar
+- Album
+- Genre
+- Beschreibung
+- Lange Beschreibung</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Standardvoreinstellung)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>Der eingegebene Name der Kategorie existiert schon. Bitte einen anderen Namen wählen.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>Der Name der Kategorie war leer. Bitte einen Namen eingeben.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Gebe einen Namen ein:</value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>Es ist keine Voreinstellung ausgewählt.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Alle eigenen Voreinstellungen exportieren</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.es.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.es.resx
@@ -119,29 +119,32 @@
   </resheader>
   <data name="Video_EncoderExtraArgs" xml:space="preserve">
     <value>Lista completa de parámetros del codificador: 
-{0} </value>
+{0}</value>
   </data>
   <data name="Video_x264FastDecode" xml:space="preserve">
     <value>Reducir el uso de CPU del decodificador.
 
-Activelo si a su dispositivo le cuesta reproducir la salida. (Por Ej: pierde cuadros)</value>
+Actívelo si a su dispositivo le cuesta reproducir la salida. (Por ej.: pierde cuadros)</value>
   </data>
   <data name="Video_LosslessWarning" xml:space="preserve">
     <value>Advertencia: RF 0 no tiene perdida</value>
   </data>
   <data name="Video_LosslessWarningTooltip" xml:space="preserve">
-    <value>Un valor de 0 significa sin perdida y resultará en un tamaño de archivo mas grande que el original,
-a menos que la fuente también sea sin perdida.
+    <value>Un valor de 0 significa sin pérdida y resultará en un tamaño de archivo más grande que el original,
+a menos que el origen también sea sin pérdida.
 
-La escala de x264 y x265 es logarítmica y valor mas bajos corresponden a mayor calidad.
+La escala de x264 y x265 es logarítmica y valores más bajos corresponden a mayor calidad.
 
-Entonces pequeños incrementos en valor resultarán en incrementos progresivamente mas grandes del tamaño de archivo.</value>
+Pequeños incrementos en valor resultarán en incrementos progresivamente más grandes del tamaño de archivo.</value>
   </data>
   <data name="AddPreset_PictureSizeMode" xml:space="preserve">
-    <value>Opcionalmente, puede guardar una configuracion de imagen con este ajuste preestablecido. Hay 3 modos de hacerlo:
-Ninguna: La configuracion de la imagen no se guarda en este ajuste preestablecido. Al leer una fuente, permanecera tal como está dentro de los limites de resolucion de dicha fuente. Esto tambien afecta a Anamorficos, modulos, recortes, etc.
-Personalizada: Opcionalmente puede establecer un Ancho y Alto maximo. Al hacer esto la codificacion se realizara con valores iguales o inferiores a estos. Mantener Relacion de Aspecto se activara automaticamente.
-Fuente Maxima: Siempre codifica con la resolucion de la fuente si es posible.</value>
+    <value>Opcionalmente, puede guardar una configuración de imagen con este ajuste preestablecido. Hay 3 modos de hacerlo:
+
+Ninguno: La configuración de la imagen no se guarda en este ajuste preestablecido. Al leer un origen, permanecerá tal como está dentro de los límites de resolución del mismo. Esto también afecta a Anamórficos, módulos, recortes, etc.
+
+Personalizado: Opcionalmente puede establecer un Ancho y Alto máximo. Al hacer esto la codificación se realizará con valores iguales o inferiores a estos. Mantener Relación de Aspecto se activará automáticamente.
+
+Origen Máximo: Siempre que sea posible, codificar con la resolución original.</value>
   </data>
   <data name="About_GPL" xml:space="preserve">
     <value>Este programa es software libre; puedes redistribuirlo y/o
@@ -177,7 +180,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, EE. UU
     <value>| Menor calidad</value>
   </data>
   <data name="Video_PlaceboQuality" xml:space="preserve">
-    <value>Calidad placebo</value>
+    <value>Calidad placebo |</value>
   </data>
   <data name="Error" xml:space="preserve">
     <value>Error</value>
@@ -188,22 +191,22 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, EE. UU
 ¿Desea continuar?</value>
   </data>
   <data name="Main_TurnOnAutoFileNaming" xml:space="preserve">
-    <value>Debe activar el nombrado automático de archivos Y establecer un directorio por defecto en los ajustes antes de poder agregar a la cola.</value>
+    <value>Debe activar el nombrado automático de archivos Y TAMBIÉN establecer un directorio por defecto en los ajustes antes de poder agregar a la cola.</value>
   </data>
   <data name="Warning" xml:space="preserve">
     <value>Advertencia</value>
   </data>
   <data name="AreYouSure" xml:space="preserve">
-    <value>¿Esta seguro?</value>
+    <value>¿Está seguro?</value>
   </data>
   <data name="HandBrake_Title" xml:space="preserve">
     <value>HandBrake</value>
   </data>
   <data name="Main_AlreadyEncoding" xml:space="preserve">
-    <value>HandBrake ya esta codificando.</value>
+    <value>HandBrake ya está codificando.</value>
   </data>
   <data name="Main_DuplicateDestinationOnQueue" xml:space="preserve">
-    <value>Hay trabajos en la cola el mismo directorio de destino. Por favor elija un directorio distinto para este trabajo.</value>
+    <value>Hay trabajos en la cola el mismo directorio de destino. Por favor, elija un directorio distinto para este trabajo.</value>
   </data>
   <data name="Main_JobsPending_addon" xml:space="preserve">
     <value>Trabajos pendientes {0}</value>
@@ -263,23 +266,23 @@ Barra de herramientas &gt; Opciones</value>
     <value>Búsqueda fallida... Por favor mire el registro de actividad para mas detalles</value>
   </data>
   <data name="Main_ScanningPleaseWait" xml:space="preserve">
-    <value>Escaneando fuente, por favor espere...</value>
+    <value>Escaneando origen, por favor espere...</value>
   </data>
   <data name="Main_ScanningTitleXOfY" xml:space="preserve">
     <value>Escaneando título {0} de {1}({2}%)</value>
   </data>
   <data name="Main_ScanSource" xml:space="preserve">
-    <value>Primero debe escanear una fuente y configurar su trabajo antes de codificar. Pulse el botón 'Fuente' en la barra de herramientas para continuar</value>
+    <value>Primero debe escanear un origen y configurar su trabajo antes de codificar. Pulse el botón 'Origen' en la barra de herramientas para continuar</value>
   </data>
   <data name="Main_SelectPreset" xml:space="preserve">
-    <value>Por favor asegurese de haber seleccionado uno de sus propios ajustes. 
-No puede exportar los ajustes integrados</value>
+    <value>Por favor asegúrese de haber seleccionado uno de sus propios ajustes. 
+No puede exportar los ajustes predefinidos.</value>
   </data>
   <data name="Main_SelectPresetForUpdate" xml:space="preserve">
     <value>Por favor seleccione un ajuste a actualizar</value>
   </data>
   <data name="Main_SelectSource" xml:space="preserve">
-    <value>Seleccione 'Fuente' para continuar</value>
+    <value>Seleccione 'Origen' para continuar</value>
   </data>
   <data name="Main_XEncodesPending" xml:space="preserve">
     <value>{0} Trabajos pendientes</value>
@@ -300,7 +303,7 @@ No puede exportar los ajustes integrados</value>
     <value>Actualizado</value>
   </data>
   <data name="Preset_OldVersion_Header" xml:space="preserve">
-    <value>Versión de ajuste</value>
+    <value>Versión de ajuste predefinido</value>
   </data>
   <data name="Preset_OldVersion_Message" xml:space="preserve">
     <value>El ajuste que desea importar es de una versión diferente de HandBrake.
@@ -312,7 +315,7 @@ Puede no ser posible el importar todos los valores de este ajuste.
     <value>No se pudo importar el ajuste</value>
   </data>
   <data name="Preset_UnableToImport_Message" xml:space="preserve">
-    <value>No se pudo importar el ajuste porque parece corrupto o de una versión mas antigua de HandBrake</value>
+    <value>No se pudo importar el ajuste porque parece corrupto o de una versión más antigua de HandBrake</value>
   </data>
   <data name="Main_SetDestination" xml:space="preserve">
     <value>Primero debe seleccionar la ubicación destino del archivo antes de agregarlo a la cola</value>
@@ -333,7 +336,7 @@ Puede no ser posible el importar todos los valores de este ajuste.
     <value>El formato del archivo de salida.  Además de cualquier carácter de sistema de archivos compatible, puede utilizar los siguientes marcadores de posición que se reemplazarán al cambiar el título o escanear un origen.
     
      Opciones de actualización en vivo: {source} {title} {chapters} 
-	 Opciones no en vivo:  {date} {time} {creation-date} {creation-time} {quality} {bitrate} ( Estos solo cambiaran si escanea una nueva fuente, cambia el título o los capítulos) </value>
+	 Opciones no en vivo:  {date} {time} {creation-date} {creation-time} {quality} {bitrate} ( Estos solo cambiarán si escanea un nuevo origen, cambia el título o los capítulos) </value>
   </data>
   <data name="Options_DefaultPathAdditionalParams" xml:space="preserve">
     <value>Opciones adicionales disponibles: {source_path} o {source_folder_name} o {source}</value>
@@ -345,7 +348,7 @@ Puede no ser posible el importar todos los valores de este ajuste.
     <value>Su sistema evitó que HandBrake abra el navegador</value>
   </data>
   <data name="Main_UnableToLoadHelpSolution" xml:space="preserve">
-    <value>Puede acceder a las paginas de ayuda visitando la web directamente: https://handbrake.fr</value>
+    <value>Puede acceder a las páginas de ayuda visitando la web directamente: https://handbrake.fr</value>
   </data>
   <data name="Main_PresetImportFailed" xml:space="preserve">
     <value>No se puede importar el preajuste seleccionado.</value>
@@ -377,7 +380,7 @@ Puede no ser posible el importar todos los valores de este ajuste.
     <value>No se han encontrado fuentes o títulos validos.</value>
   </data>
   <data name="Main_ScanNoTitlesFoundMessage" xml:space="preserve">
-    <value>HandBrake no podrá codificar la fuente seleccionada, ya que no encontró una fuente válida con títulos para codificar. 
+    <value>HandBrake no podrá codificar el origen seleccionado, ya que no encontró una fuente válida con títulos para codificar. 
 Esto podría deberse a una de las siguientes razones:
 - La duración de cada título de origen está por debajo de la opción de umbral "Duración mínima del título" en 'Preferencias &gt; Avanzadas'. 
 - El archivo de origen no es un archivo de vídeo válido o está en un formato que HandBrake no admite.
@@ -404,7 +407,7 @@ Puede encontrar más información en el registro de actividad.</value>
     <value>Codificación: Paso {0}de {1},  {2: 00.00}%, FPS: {3: 000.0}, Promedio de FPS: {4: 000.0},     Tiempo restante: {5}, Transcurrido: {6} {7}</value>
   </data>
   <data name="AddPresetViewModel_PresetMustProvideName" xml:space="preserve">
-    <value>Un ajuste preestablecido debe tener un nombre. Rellene el campo Nombre preestablecido. </value>
+    <value>Un ajuste preestablecido debe tener un nombre. Rellene el campo Nombre. </value>
   </data>
   <data name="AddPresetViewModel_PresetWithSameNameOverwriteWarning" xml:space="preserve">
     <value>Ya existe un ajuste preestablecido con este nombre. ¿Le gustaría sobrescribirlo? </value>
@@ -413,7 +416,7 @@ Puede encontrar más información en el registro de actividad.</value>
     <value>Primero debe escanear un origen para utilizar la opción 'Source Maximum'. </value>
   </data>
   <data name="AddPresetViewModel_CustomWidthHeightFieldsRequired" xml:space="preserve">
-    <value>Los campos Anchura  o Altura personalizada deben rellenarse para la opción "Personalizado". </value>
+    <value>Los campos Anchura o Altura personalizada deben rellenarse para la opción "Personalizado". </value>
   </data>
   <data name="AddPresetViewModel_UnableToAddPreset" xml:space="preserve">
     <value>No se puede añadir el ajuste preestablecido </value>
@@ -614,14 +617,14 @@ Puede encontrar más información en el registro de actividad.</value>
     <value>El número de capítulos no coincide entre el archivo de origen y el archivo de entrada</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg" xml:space="preserve">
-    <value> La duración obtenida de los capítulos del medio fuente y la duración de los capítulos en el archivo de entrada difiere mucho.
+    <value> La duración obtenida de los capítulos del medio original y la duración de los capítulos en el archivo de entrada difiere mucho.
 
 Es muy probable que este archivo de capítulo se haya producido a partir de un medio de origen diferente. 
 
 Está seguro de que desea importar los nombres de capítulo?</value>
   </data>
   <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning" xml:space="preserve">
-    <value>La duración del capitulo no coincide entre la fuente y el archivo de entrada</value>
+    <value>La duración del capitulo no coincide entre el original y el archivo de entrada</value>
   </data>
   <data name="ScanService_ScanStopFailed" xml:space="preserve">
     <value>Se ha producido un error al intentar detener el análisis. Reinicie HandBrake.</value>
@@ -1076,7 +1079,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Fuente:</value>
   </data>
   <data name="MainView_SourceOpen" xml:space="preserve">
-    <value>Código Abierto</value>
+    <value>Abrir Origen</value>
   </data>
   <data name="MainView_StartEncode" xml:space="preserve">
     <value>Iniciar Codificación</value>
@@ -1094,7 +1097,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Esta seguro que desea detener esta codificación?</value>
   </data>
   <data name="MainView_SubtitleBeforeScanError" xml:space="preserve">
-    <value>Elija una fuente para codificar antes de intentar importar un archivo de subtítulos.</value>
+    <value>Elija un origen para codificar antes de intentar importar un archivo de subtítulos.</value>
   </data>
   <data name="MainView_SubtitlesTab" xml:space="preserve">
     <value>Subtitulos</value>
@@ -1121,7 +1124,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Optimizado para Web</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>Administrar ajuste preestablecido</value>
+    <value>Administrar preajustes</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>Metadatos</value>
@@ -1160,7 +1163,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Avanzado</value>
   </data>
   <data name="Options_AdvancedOptions" xml:space="preserve">
-    <value>Optiones Avanzadas</value>
+    <value>Opciones avanzadas</value>
   </data>
   <data name="Options_Arguments" xml:space="preserve">
     <value>Argumentos:</value>
@@ -1190,7 +1193,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Version Actual</value>
   </data>
   <data name="Options_Decoding" xml:space="preserve">
-    <value>Decodificar</value>
+    <value>Decodificando</value>
   </data>
   <data name="Options_DefaultPath" xml:space="preserve">
     <value>Ruta predeterminada:</value>
@@ -1202,7 +1205,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Leyendo DVD</value>
   </data>
   <data name="Options_DvdRead" xml:space="preserve">
-    <value>Dishabilitar LibDVDNav. (libdvdread se utilizará en su lugar)</value>
+    <value>Deshabilitar LibDVDNav. (libdvdread se utilizará en su lugar)</value>
   </data>
   <data name="Options_Encoding" xml:space="preserve">
     <value>Codificando</value>
@@ -1242,6 +1245,9 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
   </data>
   <data name="Options_Path" xml:space="preserve">
     <value>Directorio:</value>
+  </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
   </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Evitar que el sistema hiberne mientras se codifica</value>
@@ -1292,7 +1298,8 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Video</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Esta ubicación es usada solo para la previsualización de video</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Ver carpeta de registro</value>
@@ -1316,7 +1323,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Abajo</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>Recorte</value>
+    <value>Cortando:</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>Personalizado</value>
@@ -1349,7 +1356,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Tamaño</value>
   </data>
   <data name="PictureSettingsView_Source" xml:space="preserve">
-    <value>Fuente:</value>
+    <value>Origen:</value>
   </data>
   <data name="PictureSettingsView_Top" xml:space="preserve">
     <value>Arriba</value>
@@ -1436,13 +1443,13 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Abrir carpeta de destino</value>
   </data>
   <data name="QueueView_OpenSourceDir" xml:space="preserve">
-    <value>Abrir carpeta fuente</value>
+    <value>Abrir carpeta origen</value>
   </data>
   <data name="QueueView_Options" xml:space="preserve">
     <value>Opciones</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Pausar Cola</value>
+    <value>Pausa</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Duración de pausa:</value>
@@ -1469,7 +1476,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Apagar</value>
   </data>
   <data name="QueueView_Source" xml:space="preserve">
-    <value>Fuente:</value>
+    <value>Origen</value>
   </data>
   <data name="QueueView_Start" xml:space="preserve">
     <value>Iniciar Cola</value>
@@ -1562,7 +1569,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Abrir un solo archivo de video.</value>
   </data>
   <data name="SourceSelection_SourceSelection" xml:space="preserve">
-    <value>Selección de fuente</value>
+    <value>Selección de origen</value>
   </data>
   <data name="StaticPreviewView_Duration" xml:space="preserve">
     <value>Duración:</value>
@@ -1574,7 +1581,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Seleccione una imagen de previzualización</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Usar el reproductor de video por defecto del sistema</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>Añadir subtítulos cuando estén disponibles</value>
@@ -1595,7 +1602,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value> Añadir todos los subtítulos restantes </value>
   </data>
   <data name="SubtitleView_SubtitleDefaultsDescription" xml:space="preserve">
-    <value>Configure como las pistas de subtítulos son seleccionadas automáticamente y configuradas cuando selecciona un nuevo titulo o video fuente.</value>
+    <value>Configure como las pistas de subtítulos son seleccionadas automáticamente y configuradas cuando selecciona un nuevo titulo o video origen.</value>
   </data>
   <data name="SummaryView_AdditionalAudioTracks" xml:space="preserve">
     <value>Pistas de audio adicionales</value>
@@ -1631,7 +1638,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Sin filtros</value>
   </data>
   <data name="SummaryView_NoSource" xml:space="preserve">
-    <value>Sin fuente</value>
+    <value>Sin origen</value>
   </data>
   <data name="SummaryView_NoSubtitleTracks" xml:space="preserve">
     <value>Sin pistas de subtítulos</value>
@@ -1676,7 +1683,7 @@ Puede configurar el nivel en el que aparece esta alerta en las preferencias.
     <value>Sintonizar Codificador:</value>
   </data>
   <data name="VideoView_ExtraOptions" xml:space="preserve">
-    <value>Opciones Avanzadas:</value>
+    <value>Opciones avanzadas:</value>
   </data>
   <data name="VideoView_FastDecode" xml:space="preserve">
     <value>Decodificación rápida</value>
@@ -1852,7 +1859,7 @@ Esto no afectará a ninguno de los codificadores de software.</value>
     <value>Aplicar</value>
   </data>
   <data name="Main_ResumeEncode" xml:space="preserve">
-    <value>Resume Encode</value>
+    <value>Continuar codificación</value>
   </data>
   <data name="QueueView_Actions" xml:space="preserve">
     <value>Acciones</value>
@@ -1882,26 +1889,26 @@ Tiempo restante: {5}, Transcurrido: {6} {7} </value>
   </data>
   <data name="Startup_InitFailed" xml:space="preserve">
     <value>El motor de HandBrake falló al inicializarse. Esto a menudo se debe a controladores de GPU obsoletos. 
-Actualice los controladores de GPU para cualquier gráfico integrado y discreto que tenga su sistema. </value>
+Actualice los controladores de GPU para cualquier gráfico integrado y/o discreto que tenga su sistema. </value>
   </data>
   <data name="OptionsView_FormatOptions" xml:space="preserve">
     <value>Opciones de actualización en vivo: {source} {title} {chapters} 
-Opciones no en vivo: {date} {time} {creation-date} {creation-time} {quality} {bitrate} (Estos solo cambian si escanea una nueva fuente, cambia el título o los capítulos)</value>
+Opciones no en vivo: {date} {time} {creation-date} {creation-time} {quality} {bitrate} (Estos solo cambian si escanea un nuevo origen, cambia el título o los capítulos)</value>
   </data>
   <data name="OptionsView_PathOptions" xml:space="preserve">
     <value>Opciones disponibles: {source_path} {source_folder_name} {source}</value>
   </data>
   <data name="FileOverwriteBehaviours_Ask" xml:space="preserve">
-    <value>Preguntar si se sobreescribe el archivo</value>
+    <value>Preguntar si se sobrescribe el archivo</value>
   </data>
   <data name="FileOverwriteBehaviours_Autoname" xml:space="preserve">
-    <value>Intentar renombrar el archivo automaticamente</value>
+    <value>Intentar renombrar el archivo automáticamente</value>
   </data>
   <data name="FileOverwriteBehaviours_Overwrite" xml:space="preserve">
     <value>Sobreescribir el archivo</value>
   </data>
   <data name="Options_UIBehaviour" xml:space="preserve">
-    <value>User Interface Behaviour</value>
+    <value>Comportamiento de la Interfaz de Usuario</value>
   </data>
   <data name="OptionsView_FileOverwriteBehaviour" xml:space="preserve">
     <value>Comportamiento de sobrescritura de archivos:</value>
@@ -1934,17 +1941,17 @@ Opciones no en vivo: {date} {time} {creation-date} {creation-time} {quality} {bi
     <value>FiltersView_DeblockPreset</value>
   </data>
   <data name="FiltersViewAuto_DeblockTune" xml:space="preserve">
-    <value>Deblock Tune</value>
+    <value>Ajuste de Deblock</value>
   </data>
   <data name="OptionsView_ChoiceOfEncoderHint" xml:space="preserve">
     <value>La elección del codificador estará disponible en la pestaña "Vídeo".</value>
   </data>
   <data name="Queue_RecoverQueueQuestionPlural" xml:space="preserve">
-    <value> HandBrake ha detectado varios archivos de cola inacabados. Estos serán de varias instancias de HandBrake en ejecución. 
+    <value>HandBrake ha detectado varios archivos de cola inacabados. Estos son de varias instancias de HandBrake en ejecución. 
 ¿Le gustaría recuperar todos los trabajos pendientes?</value>
   </data>
   <data name="Queue_RecoverQueueQuestionSingular" xml:space="preserve">
-    <value>HandBrake ha detectado elementos inacabados en la cola desde la última vez que se inició la aplicación. ¿Te gustaría recuperarlos?</value>
+    <value>HandBrake ha detectado elementos inacabados en la cola desde la última vez que se inició la aplicación. ¿Le gustaría recuperarlos?</value>
   </data>
   <data name="Queue_RecoveryPossible" xml:space="preserve">
     <value>Recuperación de cola posible</value>
@@ -1959,7 +1966,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value>Realizar la acción inmediatamente. (Esto desactivará el cuadro de diálogo de confirmación de 60 segundos)</value>
   </data>
   <data name="Browse" xml:space="preserve">
-    <value>Navegar</value>
+    <value>Examinar</value>
   </data>
   <data name="OptionsView_MediaFileNotSet" xml:space="preserve">
     <value>No se ha establecido ningún archivo de audio. Por favor, haga clic en 'Examinar' para seleccionar un archivo wav o mp3 para la reproducción.</value>
@@ -1983,7 +1990,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value>Alimentación de red de AC detectada. Reanudando la codificación... (-0- %) </value>
   </data>
   <data name="SystemService_CriticalBattery" xml:space="preserve">
-    <value>¡La batería del sistema es crítica! ({0} %)</value>
+    <value>¡El nivel de la batería del sistema es crítica! ({0} %)</value>
   </data>
   <data name="SystemService_LowBatteryLog" xml:space="preserve">
     <value>¡Batería del sistema baja! ({0}%). Su codificación ha sido pausada.</value>
@@ -1992,7 +1999,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value> El almacenamiento de la unidad restante ha caído por debajo de  {0} GB en la unidad de destino. Deteniendo la codificación...</value>
   </data>
   <data name="AudioDefaultsView_PaneTitle" xml:space="preserve">
-    <value>Configurar Selecciones de Audio Automaticas</value>
+    <value>Configurar Selecciones de Audio Automáticas</value>
   </data>
   <data name="SubtitlesDefaultsView_PaneTitle" xml:space="preserve">
     <value>Configurar Selecciones de Subtitulo Automaticas</value>
@@ -2007,7 +2014,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value>Comentarios:</value>
   </data>
   <data name="MetadataView_Description" xml:space="preserve">
-    <value>Descripcion:</value>
+    <value>Descripción:</value>
   </data>
   <data name="MetadataView_Director" xml:space="preserve">
     <value>Director:</value>
@@ -2022,7 +2029,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value>Fecha de publicación:</value>
   </data>
   <data name="MetadataView_TitleTag" xml:space="preserve">
-    <value>Titulo:</value>
+    <value>Título:</value>
   </data>
   <data name="StaticPreviewView_PreviewRotationFlip" xml:space="preserve">
     <value>Previsualizar Rotación y Voltear</value>
@@ -2037,7 +2044,7 @@ Cuando se admita, se habrán importado los ajustes preestablecidos de usuario.</
     <value>Filtros:</value>
   </data>
   <data name="MainView_Size" xml:space="preserve">
-    <value>Ramaño:</value>
+    <value>Tamaño:</value>
   </data>
   <data name="MainView_Tracks" xml:space="preserve">
     <value>Pistas:</value>
@@ -2186,7 +2193,7 @@ Esto también detendrá cualquier trabajo en ejecución existente.</value>
     <value>Duplicados detectados</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Habilite el hardware de sincronización rápida de baja potencia.</value>
+    <value>Habilite el hardware QuickSync de baja potencia (cuando sea soportado).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Seleccione un solo trabajo para ver información resumida.</value>
@@ -2208,27 +2215,173 @@ Por favor, elija un ajuste preestablecido diferente.</value>
     <value>Aislamiento de procesos</value>
   </data>
   <data name="OptionsView_ProcessIsolation_Warning1" xml:space="preserve">
-    <value>Please note, using this feature will start an HTTP server bound to 127.0.0.1 on the port stated.</value>
+    <value>Tenga en cuenta que esta función iniciará un servidor HTTP en 127.0.0.1 en el puerto indicado.</value>
   </data>
   <data name="OptionsView_ProcessIsolation_Warning2" xml:space="preserve">
-    <value>If the set port is in use, it will find the first free port within +100 from the defined port.</value>
+    <value>Si el puerto está en uso, se usará el primer puerto libre hasta un rango +100 del puerto configurado.</value>
   </data>
   <data name="OptionsView_SimultaneousEncodes" xml:space="preserve">
-    <value>Number of simultaneous encodes:</value>
+    <value>Número de procesos simultáneos:</value>
   </data>
   <data name="StaticPreviewView_CancelPreview" xml:space="preserve">
     <value>Cancelar</value>
   </data>
   <data name="MainView_SelectedPresets" xml:space="preserve">
-    <value>Ajuste Preestablecido:</value>
+    <value>Ajuste preestablecido:</value>
   </data>
   <data name="SummaryView_SameAsSource" xml:space="preserve">
-    <value>Igual que la fuente</value>
+    <value>Igual al original</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrake" xml:space="preserve">
     <value>Restablecer la configuración</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
-    <value>Are you sure you wish to reset HandBrake to default settings?</value>
+    <value>¿Está seguro de quere restablecer Handbrake a la configuración por defecto?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Personalizado (sin límite)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Llenar (hasta el límite de resolución)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Altura (hasta el límite de resolución)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Ancho (hasta el límite de resolución)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Relleno:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Color de relleno:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Bordes</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Resolución y escala</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Rotar y cortar</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>(Solo en Windows 10)</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Filtros:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Por defecto</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forzado</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Altura máxima:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Ancho máximo:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Resolución límite:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Ninguno</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Administrar preajustes</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Eliminar preajustes integrados</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Exportar preajuste seleccionado</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Importar preajuste(s) de archivo</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Información del preset</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Los presets por defecto no se pueden modificar.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Establecer el preset seleccionado como predeterminado.</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Borrar Oopciones Preestablecidas</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(No soportado en este sistema)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Detener</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Metadatos</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Pasa directamente la metadata basica desde el archivo de origen al archivo destino (cuando se pueda)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>Esta acción permite que los campos básicos de los metadatos sean pasados del archivo origen al archivo de salida.
+Los campos son:
+- Nombre
+- Artista
+- Artista del álbum
+- Compositor
+- Fecha de lanzamiento
+- Comentario
+- Álbum
+- Género
+- Descripción breve
+- Descripción larga</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Preset por defecto)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>El nombre que ingresaste para la categoría ya existe. Por favor, elige un nombre diferente.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>El nombre de la categoría esta vacío, por favor llene el nombre.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Ingresa un nombre:</value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>No hay preset seleccionado.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.fr.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.fr.resx
@@ -1246,6 +1246,9 @@ Souhaitez-vous l'écraser ?</value>
   <data name="Options_Path" xml:space="preserve">
     <value>Chemin d'accès :</value>
   </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
+  </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Empêcher le système de se mettre en veille pendant l'encodage</value>
   </data>
@@ -1295,7 +1298,8 @@ Souhaitez-vous l'écraser ?</value>
     <value>Vidéo</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Ce chemin est utilisé pour la fonctionnalité de prévisualisation vidéo uniquement.</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Voir le répertoire du journal</value>
@@ -1319,7 +1323,7 @@ Souhaitez-vous l'écraser ?</value>
     <value>Bas</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>Recadrage</value>
+    <value>Recadrage :</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>Personnalisé</value>
@@ -1445,7 +1449,7 @@ Souhaitez-vous l'écraser ?</value>
     <value>Options</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Mettre la liste d'attente en pause</value>
+    <value>Pause</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Durée de pause :</value>
@@ -1577,7 +1581,7 @@ Souhaitez-vous l'écraser ?</value>
     <value>Sélectionner un aperçu d'image</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Utiliser le lecteur vidéo par défaut du système</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>Ajouter les sous-titres si disponnibles</value>
@@ -2186,7 +2190,7 @@ Cela mettra également fin à tout travail en cours.</value>
     <value>Doublons détectés</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Activer le QuickSync basse consommation.</value>
+    <value>Activer le QuickSync basse consommation (si supporté).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Veuillez sélectionner un seul travail pour voir les informations de synthèse.</value>
@@ -2230,5 +2234,151 @@ Veuillez choisir un autre préréglage.</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
     <value>Êtes-vous sûr de vouloir réinitialiser HandBrake à ses paramètres par défaut ?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Personnalisé (Non limité)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Remplir (remplissage jusqu'à la limite de résolution)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Hauteur (remplissage jusqu'à la limite de résolution)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Largeur (remplissage jusqu'à la limite de résolution)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Remplissage :</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Couleur de remplissage :</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Bordures</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Résolution et mise à l'échelle</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Pivoter et recadrer</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Windows 10 uniquement ! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Filtres :</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Défaut</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forcé</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Personnalisé</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Hauteur maximale :</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Largeur maximale :</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Limite de résolution :</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Aucun</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Gérer les préréglages</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Supprimer les préréglages intégrés</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Exporter le préréglage sélectionné</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Importer des préréglages à partir d'un fichier</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Preset Information:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Les préréglages intégrés ne peuvent pas être modifiés.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Définir le préréglage sélectionné comme valeur par défaut</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Supprimer le préréglage</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Non supporté par ce système)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Arrêter</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Métadonnées</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Transmettre les métadonnées de base du fichier source au fichier de destination (lorsque cela est supporté)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>Cette option permettra de faire passer les champs de métadonnées de base du fichier source au fichier de destination.
+Les champs sont limités à :
+- Nom
+- Artiste
+- Artiste de l'album
+- Compositeur
+- Date de publication
+- Commentaire
+- Album
+- Genre
+- Description
+- Description longue</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Préréglage par défaut)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>Le nom de catégorie que vous avez saisi existe déjà. Veuillez choisir un autre nom.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>Le nom de la catégorie est vide. Veuillez fournir un nom.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Entrer un nom :</value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>Il n'y a pas de préréglage sélectionné.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ja.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ja.resx
@@ -1122,7 +1122,7 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>Web用に最適化</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>プリセットを管理</value>
+    <value>Manage Presets</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>メタデータ</value>
@@ -1244,6 +1244,9 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
   <data name="Options_Path" xml:space="preserve">
     <value>パス:</value>
   </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
+  </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>エンコード中にシステムがスリープ状態にならないようにする</value>
   </data>
@@ -1293,7 +1296,8 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>動画</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>このパスは、ビデオプレビュー機能でのみ使用されます。</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>ログディレクトリを見る</value>
@@ -1317,7 +1321,7 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>下</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>クロッピング</value>
+    <value>Cropping:</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>カスタム</value>
@@ -1443,7 +1447,7 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>オプション</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>キューを一時停止</value>
+    <value>一時停止</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>一時停止時間:</value>
@@ -1575,7 +1579,7 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>プレビュー画像を選択</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>システム既定のビデオプレイヤーを使う</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>可能ならクローズドキャプションを追加する</value>
@@ -2185,7 +2189,7 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
     <value>重複を検出しました</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Low Power QuickSyncハードウェアを有効にする。</value>
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>概要を見るにはジョブを一つ選択してください。</value>
@@ -2229,5 +2233,151 @@ Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  021
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
     <value>Are you sure you wish to reset HandBrake to default settings?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Custom (Not Limited)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Fill (pad to resolution limit)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Height (pad up to res limit)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Width (pad up to res limit)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Padding:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Padding Colour:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Borders</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Resolution and Scaling</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Rotate and Crop</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Windows 10 Only! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>フィルター:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>デフォルト</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forced</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>カスタム</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Max Height:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Max Width:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Resolution Limit:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>なし</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Manage Presets</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Delete Built-in Presets</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Export selected preset</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Import Preset(s) from file</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Preset Information:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Build in presets can not be modified.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Set selected preset as default</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>プリセットを削除</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Not supported on this system)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>停止</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>メタデータ</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ko.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ko.resx
@@ -1123,7 +1123,7 @@ HandBrake를 종료하시겠습니까?</value>
     <value>웹 최적화</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>환경 설정 관리</value>
+    <value>Manage Presets</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>메타데이터</value>
@@ -1245,6 +1245,9 @@ HandBrake를 종료하시겠습니까?</value>
   <data name="Options_Path" xml:space="preserve">
     <value>경로: </value>
   </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
+  </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>인코딩 중 시스템 절전 방지</value>
   </data>
@@ -1294,7 +1297,8 @@ HandBrake를 종료하시겠습니까?</value>
     <value>비디오</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>해당 경로는 비디오 미리보기 기능을 위해서만 사용됩니다.</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>로그 디렉토리 보기</value>
@@ -1318,7 +1322,7 @@ HandBrake를 종료하시겠습니까?</value>
     <value>맨 아래</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>자르기</value>
+    <value>Cropping:</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>사용자 설정</value>
@@ -1444,7 +1448,7 @@ HandBrake를 종료하시겠습니까?</value>
     <value>옵션</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>대기열 중지</value>
+    <value>중단</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>중단 지속 시간:</value>
@@ -1576,7 +1580,7 @@ HandBrake를 종료하시겠습니까?</value>
     <value>미리보기 이미지 선택</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>시스템 기본 비디오 플레이어 사용</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>사용 가능할 경우 내장 자막 추가</value>
@@ -2185,7 +2189,7 @@ Non-Live 옵션: {date} {time} {creation-date} {creation-time} {quality} {bitrat
     <value>중복 감지</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>저전력 QuickSync Hardware을 실행합니다.</value>
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Please select a single job to view summary information.</value>
@@ -2229,5 +2233,151 @@ Please choose a different preset.</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
     <value>Are you sure you wish to reset HandBrake to default settings?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Custom (Not Limited)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Fill (pad to resolution limit)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Height (pad up to res limit)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>없음</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Width (pad up to res limit)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Padding:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Padding Colour:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Borders</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Resolution and Scaling</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Rotate and Crop</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Windows 10 Only! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>필터:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>기본값</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forced</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>사용자 설정</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Max Height:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Max Width:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Resolution Limit:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>없음</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Manage Presets</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Delete Built-in Presets</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Export selected preset</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Import Preset(s) from file</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Preset Information:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Build in presets can not be modified.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Set selected preset as default</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>환경 설정 삭제</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Not supported on this system)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>멈춤</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>메타데이터</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.pt-BR.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.pt-BR.resx
@@ -1124,7 +1124,7 @@ Você gostaria de substituí-lo?</value>
     <value>Otimizado para a Web</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>Gerenciar Perfil</value>
+    <value>Gerenciar Pré-configuracões</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>Metadados</value>
@@ -1246,6 +1246,9 @@ Você gostaria de substituí-lo?</value>
   <data name="Options_Path" xml:space="preserve">
     <value>Caminho:</value>
   </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
+  </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Evitar que o sistema entre em modo de espera durante a conversão</value>
   </data>
@@ -1295,7 +1298,8 @@ Você gostaria de substituí-lo?</value>
     <value>Vídeo</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Este caminho é usado apenas para o recurso de pré-visualização de vídeo.</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Abrir Pasta de Log</value>
@@ -1319,7 +1323,7 @@ Você gostaria de substituí-lo?</value>
     <value>Inferior</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>Recorte</value>
+    <value>Cortando:</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>Personalizado</value>
@@ -1445,7 +1449,7 @@ Você gostaria de substituí-lo?</value>
     <value>Opções</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Pausar Fila</value>
+    <value>Pausar</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Duração da Pausa:</value>
@@ -1577,7 +1581,7 @@ Você gostaria de substituí-lo?</value>
     <value>Selecione uma imagem de pré-visualização</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Usar reprodutor de vídeo padrão do sistema</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>Adicionar Closed Captions quando disponível</value>
@@ -2186,7 +2190,7 @@ Isso também interromperá os trabalhos em execução existentes.</value>
     <value>Duplicados Detectados</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Habilita o Hardware QuickSync de Baixa Potência</value>
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Selecione um único trabalho para visualizar as informações resumidas.</value>
@@ -2229,5 +2233,151 @@ Por favor, escolha uma predefinição diferente.</value>
   </data>
   <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
     <value>Tem certeza de que deseja redefinir o HandBrake para as configurações originais?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Customizado (Não Limitado)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Preencher (clique para ir ao limite da resolução)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Altura (clique para ir ao limite da resolução)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Largura (clique para ir ao limite da resolução)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Preenchimento:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Cor de Preenchimento:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Bordas</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Resolução e Escala</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Rotacionar e Cortar</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Apenas Windows 10! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Filtros:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Padrão</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forçado</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Personalizado</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Altura Máxima:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Largura Máxima:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Limite de Resolução:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Nenhum</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Gerenciar Pré-configuracões</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Apagar Pré-configurações Padrão</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Exportar pré-configuração selecionada</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Importar pré-configuração(ões) de arquivo</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Informação de pré-configuração:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Pré-configuração padão não pode ser modificada.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Definir pré-configuração selecionada como padrão</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Excluir Perfil</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Não compatível neste sistema)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Parar</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Metadados</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ru.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ru.resx
@@ -148,21 +148,19 @@ Custom: при желании вы можете установить макси�
 Source maximum: кодирование всегда будет происходить из исходных файлов, когда это возможно.</value>
   </data>
   <data name="About_GPL" xml:space="preserve">
-    <value>Все права защищены (C) 2003-2019 The HandBrake Team
+    <value>This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
 
-Эта программа бесплатна; вы можете распространять ее/или
-изменять в соответствии с условиями GNU General Public License
-опубликованными Free Software Foundation; используя 2-ю версию
-лицензии, или (на ваш выбор) любой поздней версии.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
 
-Эта программа распространяется в надежде быть полезной,
-но БЕЗ КАКИХ-ЛИБО ГАРАНТИЙ; либо без каких-либо подразумевающихся гарантий
-ПРОДАЖИ или ИСПОЛЬЗОВАНИЯ В КОРЫСТНЫХ ЦЕЛЯХ. Посмотрите
-GNU General Public License для более детальной информации.
-
-Вы должны получить копию GNU General Public License
-вместе с этой программой; если нет, напишите Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</value>
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.</value>
   </data>
   <data name="QueueSelection_AutoNameWarning" xml:space="preserve">
     <value>ВНИМАНИЕ: У вас не включено автоматическое именование файлов. Включите его в настройках.</value>
@@ -284,7 +282,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</
     <value>Выберите 'Источник' для продолжения</value>
   </data>
   <data name="Main_XEncodesPending" xml:space="preserve">
-    <value>{0} Работ в ожидании</value>
+    <value>{0} Jobs Pending</value>
   </data>
   <data name="Notice" xml:space="preserve">
     <value>Внимание</value>
@@ -404,7 +402,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Вы уверены что хотите удалить пресет: </value>
   </data>
   <data name="MainViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
-    <value>Кодирование: Проход {0} из {1}, {2:00.00}%, Кадров в секунду: {3:000.0}, Среднее значение: {4:000.0}, Осталось времени: {5}, Прошло: {6:d\:hh\:mm\:ss} {7}</value>
+    <value>Encoding: Pass {0} of {1},  {2:00.00}%, FPS: {3:000.0},  Avg FPS: {4:000.0},  Time Remaining: {5},  Elapsed: {6} {7}</value>
   </data>
   <data name="AddPresetViewModel_PresetMustProvideName" xml:space="preserve">
     <value>Пресет должен иметь имя. Пожалуйста, заполните поле 'Название пресета'.</value>
@@ -670,7 +668,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Пожалуйста, проверьте правильность указанного путя назначения.</value>
   </data>
   <data name="MainViewModel_EncodeStatusChanged_SubScan_StatusLabel" xml:space="preserve">
-    <value>Обработка Прохода {0} из {1}, (Скан Субтитров)  {2:00.00}%, Оставшееся Время Сканирования: {3},  Прошло: {4:d\:hh\:mm\:ss}</value>
+    <value>Processing Pass {0} of {1}, (Subtitle Scan)  {2:00.00}%, Scan Time Remaining: {3},  Elapsed: {4}</value>
   </data>
   <data name="NoAdditionalInformation" xml:space="preserve">
     <value>Нет доп. информации</value>
@@ -692,7 +690,11 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Очередь приостановлена</value>
   </data>
   <data name="Main_LowDiskspace" xml:space="preserve">
-    <value>Ваш каталог назначений находится на диске, на котором мало свободного места. Пожалуйста, освободите немного места на вашем носителе. Или же вы можете изменить количество уведомлений в настройках.</value>
+    <value>Your destination directory is low on diskspace. 
+
+You can configure the level at which this alert appears in preferences. 
+
+Do you wish to continue? </value>
   </data>
   <data name="Queue_UnableToResetJob" xml:space="preserve">
     <value>Невозможно сбросить состояние задания, так как оно не в ошибочном или завершенном состоянии</value>
@@ -1122,7 +1124,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Оптимизирован для Веб</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>Управление пресетами</value>
+    <value>Manage Presets</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>Метаданные</value>
@@ -1152,7 +1154,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Показывать состояние кодирования в заголовке окна приложения.</value>
   </data>
   <data name="Options_7DayLogClear" xml:space="preserve">
-    <value>Очистить логи, существующие более 30 дней</value>
+    <value>Clear Log files older than 7 days</value>
   </data>
   <data name="Options_About" xml:space="preserve">
     <value>О HandBrake</value>
@@ -1224,7 +1226,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Путь лога:</value>
   </data>
   <data name="Options_LowDiskspaceSize" xml:space="preserve">
-    <value>Приостановить очередь, если на диске свободного пространства меньше, чем:</value>
+    <value>Pause queue if disk space is low</value>
   </data>
   <data name="Options_MinimiseTray" xml:space="preserve">
     <value>Минимизировать в системный трей (необходим перезапуск)</value>
@@ -1243,6 +1245,9 @@ Foreign Audio Preferred, else First - Если существует дорожк
   </data>
   <data name="Options_Path" xml:space="preserve">
     <value>Путь: </value>
+  </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
   </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Не давать системе уснуть, если происходит кодирование</value>
@@ -1293,7 +1298,8 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Видео</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Эта настройка используется только для предварительного просмотра видео.</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Посмотреть папку с логами</value>
@@ -1317,7 +1323,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Низ</value>
   </data>
   <data name="PictureSettingsView_Cropping" xml:space="preserve">
-    <value>Кадрирование</value>
+    <value>Cropping:</value>
   </data>
   <data name="PictureSettingsView_Custom" xml:space="preserve">
     <value>Пользовательский</value>
@@ -1443,7 +1449,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Опции</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Приостановить очередь</value>
+    <value>Пауза</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Время паузы:</value>
@@ -1575,7 +1581,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Выберите картинку для предварительного просмотра</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Использовать видеоплеер, установленный в системе по умолчанию</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>Добавлять скрытые субтитры, когда возможно</value>
@@ -1862,7 +1868,8 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Импортировать очередь</value>
   </data>
   <data name="QueueViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
-    <value>Кодирование: Проход {0} из {1}, {2:00.00}%, FPS: {3:000.0}, Среднее: {4:000.0}, Осталось времени: {5:hh\:mm\:ss} , Прошло: {6:d\:hh\:mm\:ss} {7}</value>
+    <value>Encoding: Pass {0} of {1},  {2:00.00}%, FPS: {3:000.0},  Avg FPS: {4:000.0}
+Time Remaining: {5},  Elapsed: {6} {7}</value>
   </data>
   <data name="QueueView_DeleteSelected" xml:space="preserve">
     <value>Удалить выбранное</value>
@@ -1983,7 +1990,7 @@ Foreign Audio Preferred, else First - Если существует дорожк
     <value>Критическое состояние батареи! ({0} %)</value>
   </data>
   <data name="SystemService_LowBatteryLog" xml:space="preserve">
-    <value>Низкий уровень заряда батареи ({0} %). Ваши задания кодирования были поставлены на паузу для защиты системы. Режим сна системы разрешен!</value>
+    <value>System Battery Low! ({0} %). Your encode has been paused.</value>
   </data>
   <data name="SystemService_LowDiskSpaceLog" xml:space="preserve">
     <value>Свободное пространство на указанном диске ниже {0} ГБ. Ставлю кодирование на паузу...</value>
@@ -2152,5 +2159,226 @@ Foreign Audio Preferred, else First - Если существует дорожк
   </data>
   <data name="OptionsView_AlwaysUseDefaultPath" xml:space="preserve">
     <value>Всегда использовать путь по умолчанию для каждого нового сгенерированного имени.</value>
+  </data>
+  <data name="OptionsView_RemotePortLimit" xml:space="preserve">
+    <value>Port range must be between 5000 and 32767</value>
+  </data>
+  <data name="OptionsView_SendFileToArgPlaceholders" xml:space="preserve">
+    <value>Replacement Placeholders: {source} {destination}</value>
+    <comment>Note: {source} and {destination} are not translatable. </comment>
+  </data>
+  <data name="SourceSelection_UpdateAvailable" xml:space="preserve">
+    <value>A new version of HandBrake is available!</value>
+  </data>
+  <data name="About_Copyright" xml:space="preserve">
+    <value>Copyright (C) 2003-2020 The HandBrake Team</value>
+  </data>
+  <data name="Options_LowBatteryLevel" xml:space="preserve">
+    <value>Low battery level:</value>
+  </data>
+  <data name="Options_PauseOnLowBattery" xml:space="preserve">
+    <value>Pause any running jobs when the battery gets low.</value>
+  </data>
+  <data name="SubtitleView_AddRemainingCC" xml:space="preserve">
+    <value>Добавить все оставшиеся субтитры</value>
+  </data>
+  <data name="QueueService_DuplicatesQuestion" xml:space="preserve">
+    <value>Duplicate jobs were detected in the queue file that you are trying to import. Do you wish to overwrite the existing records? 
+This will also stop any existing running jobs.</value>
+  </data>
+  <data name="QueueService_DuplicatesTitle" xml:space="preserve">
+    <value>Duplicates Detected</value>
+  </data>
+  <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
+  </data>
+  <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
+    <value>Please select a single job to view summary information.</value>
+  </data>
+  <data name="OptionsView_EnableWorkerProcesses" xml:space="preserve">
+    <value>Run each queued job in a separate worker process. (Experimental)</value>
+  </data>
+  <data name="OptionsView_WorkerDefaultPort" xml:space="preserve">
+    <value>Default network port for worker:</value>
+  </data>
+  <data name="Presets_NotAvailableForUse" xml:space="preserve">
+    <value>The preset you have selected is not available for use on this system.
+
+This is typically an indication that your system does not support the hardware required to utilise it.
+
+Please choose a different preset.</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation" xml:space="preserve">
+    <value>Process Isolation</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation_Warning1" xml:space="preserve">
+    <value>Please note, using this feature will start an HTTP server bound to 127.0.0.1 on the port stated.</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation_Warning2" xml:space="preserve">
+    <value>If the set port is in use, it will find the first free port within +100 from the defined port.</value>
+  </data>
+  <data name="OptionsView_SimultaneousEncodes" xml:space="preserve">
+    <value>Number of simultaneous encodes:</value>
+  </data>
+  <data name="StaticPreviewView_CancelPreview" xml:space="preserve">
+    <value>Отмена</value>
+  </data>
+  <data name="MainView_SelectedPresets" xml:space="preserve">
+    <value>Пресет:</value>
+  </data>
+  <data name="SummaryView_SameAsSource" xml:space="preserve">
+    <value>Same as source</value>
+  </data>
+  <data name="OptionsViewModel_ResetHandBrake" xml:space="preserve">
+    <value>Reset Settings</value>
+  </data>
+  <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
+    <value>Are you sure you wish to reset HandBrake to default settings?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Custom (Not Limited)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Fill (pad to resolution limit)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>Height (pad up to res limit)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>Нет</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>Width (pad up to res limit)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Padding:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Padding Colour:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Borders</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Resolution and Scaling</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Rotate and Crop</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Windows 10 Only! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Фильтры:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>По умолчанию</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forced</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Пользовательский</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Max Height:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Max Width:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Resolution Limit:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Нет</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Manage Presets</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Delete Built-in Presets</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Export selected preset</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Import Preset(s) from file</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Preset Information:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Build in presets can not be modified.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Set selected preset as default</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Удалить пресет</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Not supported on this system)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Стоп</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Метаданные</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.tr.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.tr.resx
@@ -174,10 +174,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</
     <value>Sıfırlama Tamamlandı</value>
   </data>
   <data name="Video_HigherQuality" xml:space="preserve">
-    <value>Yüksek Kalite |</value>
+    <value>Daha Yüksek Kalite |</value>
   </data>
   <data name="Video_LowQuality" xml:space="preserve">
-    <value>| Düşük Kalite</value>
+    <value>| Daha Düşük Kalite</value>
   </data>
   <data name="Video_PlaceboQuality" xml:space="preserve">
     <value>Plasebo Kalitesi |</value>
@@ -203,10 +203,10 @@ Devam etmek istiyor musun?</value>
     <value>HandBrake</value>
   </data>
   <data name="Main_AlreadyEncoding" xml:space="preserve">
-    <value>HandBrake zaten kodlanıyor.</value>
+    <value>HandBrake zaten kodlama yapıyor.</value>
   </data>
   <data name="Main_DuplicateDestinationOnQueue" xml:space="preserve">
-    <value>Aynı hedef yolunda, sırada işler var. Lütfen bu iş için farklı bir yol seçin.</value>
+    <value>Sırada aynı dizini hedefleyen işler var. Lütfen bu iş için farklı bir yol seçin.</value>
   </data>
   <data name="Main_JobsPending_addon" xml:space="preserve">
     <value>   Bekleyen İşler {0}</value>
@@ -215,7 +215,7 @@ Devam etmek istiyor musun?</value>
     <value>Yeni Varsayılan Ön Ayar Seti: {0}</value>
   </data>
   <data name="Main_NewUpdate" xml:space="preserve">
-    <value>Yeni Bir Güncelleme Var. Araçlar Menüsüne Git &gt; Yükleme Seçenekleri</value>
+    <value>Yeni Bir Güncelleme Var.  Yüklemek İçin Araçlar &gt; Ayarlar Menüsünü Ziyaret Edin. </value>
   </data>
   <data name="Main_NoPresetSelected" xml:space="preserve">
     <value>Ön Ayar seçilmedi.</value>
@@ -301,7 +301,7 @@ Devam etmek istiyor musun?</value>
     <value>Güncellenmiş</value>
   </data>
   <data name="Preset_OldVersion_Header" xml:space="preserve">
-    <value>Ön Ayarlı Sürüm</value>
+    <value>Ön Ayar Sürümü</value>
   </data>
   <data name="Preset_OldVersion_Message" xml:space="preserve">
     <value>Almaya çalıştığınız ön ayar, HandBrake'in farklı bir sürümünden. 
@@ -356,7 +356,7 @@ Canlı olmayan Seçenekler: {date} {time} {creation-date} {creation-time} {quali
 Eski sürümlerdeki ön ayarlar geçerli sürümde yeniden oluşturulmalıdır.</value>
   </data>
   <data name="Video_EncoderExtraArgsTooltip" xml:space="preserve">
-    <value>Video kodlayıcısına geçirilebilen ek gelişmiş bağımsız değişkenler.</value>
+    <value>Video kodlayıcısına aktarılabilen gelişmiş ek komutlar.</value>
   </data>
   <data name="Subtitles_BurnInBehaviourModes" xml:space="preserve">
     <value>Yok - Yalnızca kabın formatı desteklemediği parçalar yanacaktır.
@@ -490,7 +490,7 @@ Faaliyet günlüğü daha fazla bilgi içerebilir.</value>
     <value>Sırayı temizlemek istediğine emin misin?</value>
   </data>
   <data name="Confirm" xml:space="preserve">
-    <value>Onaylamak</value>
+    <value>Onayla</value>
   </data>
   <data name="QueueViewModel_JobsPending" xml:space="preserve">
     <value>{0} bekleyen işler</value>
@@ -785,10 +785,10 @@ Devam etmek istiyor musunuz? </value>
     <value>Saklamak</value>
   </data>
   <data name="AudioView_Mixdown" xml:space="preserve">
-    <value>Karıştırmak</value>
+    <value>Kanal Birleştirme</value>
   </data>
   <data name="AudioView_OtherwiseFallbackEncoder" xml:space="preserve">
-    <value>Geri dönüş kodlayıcı:</value>
+    <value>Yedek kodlayıcı:</value>
   </data>
   <data name="AudioView_ReloadDefaults" xml:space="preserve">
     <value>Tekrar yüklemek</value>
@@ -857,31 +857,31 @@ Devam etmek istiyor musunuz? </value>
     <value>Özel:</value>
   </data>
   <data name="FiltersView_Deblock" xml:space="preserve">
-    <value>Serbest bırakmak</value>
+    <value>Karelenme azaltıcı</value>
   </data>
   <data name="FiltersView_Decomb" xml:space="preserve">
     <value>Ayrıştırma</value>
   </data>
   <data name="FiltersView_Deinterlace" xml:space="preserve">
-    <value>Ayırma:</value>
+    <value>Binişiklik Giderme -Deinterlace-:</value>
   </data>
   <data name="FiltersView_DeinterlacePreset" xml:space="preserve">
     <value>Ön Ayar:</value>
   </data>
   <data name="FiltersView_DeinterlacePresetAuto" xml:space="preserve">
-    <value>Ayırma Ön Ayarı</value>
+    <value>Binişiklik Giderme -Deinterlace- Ön Ayarı</value>
   </data>
   <data name="FiltersView_Denoise" xml:space="preserve">
-    <value>İptal Et:</value>
+    <value>Parazit Azaltma:</value>
   </data>
   <data name="FiltersView_DenoisePresetAuto" xml:space="preserve">
-    <value>İptal Etme Ön Ayarı</value>
+    <value>Parazit Azaltma Ön Ayarı</value>
   </data>
   <data name="FiltersView_DenoiseTuneAuto" xml:space="preserve">
-    <value>Ayarlamayı İptal Et</value>
+    <value>Parazit Azaltma Ayarı</value>
   </data>
   <data name="FiltersView_Detelecine" xml:space="preserve">
-    <value>Telesine değil:</value>
+    <value>Telesine Etkisi Giderme:</value>
   </data>
   <data name="FiltersView_Filters" xml:space="preserve">
     <value>Filtreler</value>
@@ -1124,7 +1124,7 @@ Devam etmek istiyor musunuz? </value>
     <value>Web Optimize Edilmiş</value>
   </data>
   <data name="ManagePresetView_ManagePreset" xml:space="preserve">
-    <value>Ön Ayarı Yönet</value>
+    <value>Ön Ayarları Yönet</value>
   </data>
   <data name="MetaDataView_Title" xml:space="preserve">
     <value>Meta veri</value>
@@ -1232,7 +1232,7 @@ Devam etmek istiyor musunuz? </value>
     <value>Sistem tepsisine simge durumuna küçültme (Yeniden başlatma gerektirir)</value>
   </data>
   <data name="Options_MinTitleScanLength" xml:space="preserve">
-    <value>Minimum saniye cinsinden DVD ve Blu-ray başlık süresi. Daha kısa olan başlıklar atlanacak:</value>
+    <value>Saniye cinsinden en düşük DVD ve Blu-ray başlık süresi. Daha kısa olan başlıklar atlanacaktır:</value>
   </data>
   <data name="Options_MP4FileExtension" xml:space="preserve">
     <value>MP4 Dosya Uzantısı:</value>
@@ -1245,6 +1245,9 @@ Devam etmek istiyor musunuz? </value>
   </data>
   <data name="Options_Path" xml:space="preserve">
     <value>Yol:</value>
+  </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
   </data>
   <data name="Options_PreventSleep" xml:space="preserve">
     <value>Kodlama yaparken sistemin uyumasını önleyin</value>
@@ -1295,7 +1298,8 @@ Devam etmek istiyor musunuz? </value>
     <value>Video</value>
   </data>
   <data name="Options_VideoPreviewPath" xml:space="preserve">
-    <value>Bu yol yalnızca video önizleme özelliği için kullanılır.</value>
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
   </data>
   <data name="Options_ViewLogDirectory" xml:space="preserve">
     <value>Günlük Dizinini Görüntüle</value>
@@ -1445,7 +1449,7 @@ Devam etmek istiyor musunuz? </value>
     <value>Seçenekler</value>
   </data>
   <data name="QueueView_Pause" xml:space="preserve">
-    <value>Sırayı Duraklat</value>
+    <value>Duraklat</value>
   </data>
   <data name="QueueView_PausedDuration" xml:space="preserve">
     <value>Duraklatılan Süre:</value>
@@ -1541,7 +1545,7 @@ Devam etmek istiyor musunuz? </value>
     <value>İsteğe bağlı olarak belirli bir başlık seçin:</value>
   </data>
   <data name="SourceSelection_ChooseVideo" xml:space="preserve">
-    <value>Ardından kodlamak istediğiniz videoları seçin:</value>
+    <value>Ardından kodlamak istediğiniz video ya da videoları seçin:</value>
   </data>
   <data name="SourceSelection_File" xml:space="preserve">
     <value>Dosya</value>
@@ -1577,7 +1581,7 @@ Devam etmek istiyor musunuz? </value>
     <value>Bir önizleme resmi seçin</value>
   </data>
   <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
-    <value>Sistem varsayılan video oynatıcısını kullan</value>
+    <value>Prefer system default video player</value>
   </data>
   <data name="SubtitlesView_AddCC" xml:space="preserve">
     <value>Mümkün olduğunda Kapalı Başlıklar ekleyin</value>
@@ -1613,10 +1617,10 @@ Devam etmek istiyor musunuz? </value>
     <value>Bölüm İşaretleyicileri</value>
   </data>
   <data name="SummaryView_Deblock" xml:space="preserve">
-    <value>Serbest bırakmak</value>
+    <value>Karelenme azaltıcı</value>
   </data>
   <data name="SummaryView_Detelecine" xml:space="preserve">
-    <value>Telesine değil</value>
+    <value>Telesine etkisi giderme</value>
   </data>
   <data name="SummaryView_display" xml:space="preserve">
     <value>Görüntüle</value>
@@ -1936,7 +1940,7 @@ Canlı Olmayan Seçenekler: {date} {time} {creation-date} {creation-time} {quali
     <value>FiltersView_DeblockPreset</value>
   </data>
   <data name="FiltersViewAuto_DeblockTune" xml:space="preserve">
-    <value>Serbest Bırakma Ayarı</value>
+    <value>Karelenme Azaltıcı İnce Ayarı</value>
   </data>
   <data name="OptionsView_ChoiceOfEncoderHint" xml:space="preserve">
     <value>'Video' sekmesinde kodlayıcı seçimi yapılacaktır.</value>
@@ -2186,7 +2190,7 @@ Bu, mevcut çalışan işleri de durduracaktır.</value>
     <value>Yinelenenler Algılandı</value>
   </data>
   <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
-    <value>Düşük Güçlü QuickSync Donanımını etkinleştirin.</value>
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
   </data>
   <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
     <value>Özet bilgileri görüntülemek için lütfen tek bir iş seçin.</value>
@@ -2260,5 +2264,121 @@ Lütfen farklı bir ön ayar seçin.</value>
   </data>
   <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
     <value>Döndür ve Kırp</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Sadece Windows 10! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Filtreler:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Varsayılan</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Zorunlu</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Özel</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Azami Yükseklik:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Azami Genişlik:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Çözünürlük Sınırı:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Yok</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Ön Ayarları Yönet</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Hazır Ön Ayarları Sil</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Seçili ön ayarı dışarı aktar</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Dosyadan ön Ayar(lar)ı içeri aktar</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Ön Ayar Bilgisi:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Hazır ön ayarlar değiştirilemez</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Seçilen ön ayarı varsayılan yap</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Silme Ön Ayarı</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Bu sistemde desteklenmiyor)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Durdur</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Meta veri</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.uk.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.uk.resx
@@ -1,0 +1,2384 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="Video_EncoderExtraArgs" xml:space="preserve">
+    <value>Повний список параметрів кодувальника: 
+{0}</value>
+  </data>
+  <data name="Video_x264FastDecode" xml:space="preserve">
+    <value>Знижує навантаження декодера на процесор.
+
+Встановіть, якщо ваш пристрій не може впоратись з відтворенням кінцевого файлу (наприклад, випадання кадрів)</value>
+  </data>
+  <data name="Video_LosslessWarning" xml:space="preserve">
+    <value>Попередження: RF 0 — стиснення без втрат!</value>
+  </data>
+  <data name="Video_LosslessWarningTooltip" xml:space="preserve">
+    <value>Значення 0 означає якість без втрат і призведе до того, що розмір файлу перевищуватиме розмір джерела, 
+хіба що джерело також було без втрат. 
+
+Шкала x264 та x265 є логарифмічною, а нижчі значення відповідають вищій якості. 
+
+Таким чином, невелике збільшення значення призведе до значного збільшення розміру кінцевого файлу.</value>
+  </data>
+  <data name="AddPreset_PictureSizeMode" xml:space="preserve">
+    <value>Ви можете додатково зберігати налаштування зображення за допомогою цього набору. Існує 3 режими:
+
+None:  налаштування зображення не зберігаються в наборі. Під час завантаження джерела вони залишатимуться як є, в межах роздільної здатності джерела. Це також впливає на анаморфування, модуль, обрізання тощо.
+
+Custom: ви можете додатково встановити максимальну ширину та висоту. При цьому кодування буде відбуватись з меншими або рівними цьому значеннями. Зберігання пропорцій також буде автоматично увімкнено.
+
+Source Maximum: завжди кодує з роздільною здатністю джерела, де це можливо.</value>
+  </data>
+  <data name="About_GPL" xml:space="preserve">
+    <value>Ця програма є вільним програмним забезпеченням; ви можете розповсюджувати його та/або
+змінювати його відповідно до умов GNU General Public License
+опублікованої Free Software Foundation; версії 2
+або (за вашим бажанням) будь-якої пізнішої версії.
+
+Ця програма поширюється з надією, що вона принесе користь,
+але БЕЗ БУДЬ-ЯКИХ ГАРАНТІЙ; навіть не маючи на увазі гарантії
+ТОВАРНОЇ ПРИДАТНОСТІ чи ПРИДАТНОСТІ ДЛЯ БУДЬ-ЯКОЇ ІНШОЇ МЕТИ.
+Детальнішу інформацію дивись у GNU General Public License.
+
+Ви мали отримати копію GNU General Public License
+разом з цією програмою; якщо ні – пишіть до Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.</value>
+  </data>
+  <data name="QueueSelection_AutoNameWarning" xml:space="preserve">
+    <value>УВАГА: у вас не увімкнуто автоматичне іменування файлів. Увімкніть його в налаштуваннях.</value>
+  </data>
+  <data name="QueueSelection_AutoTrackSelectionWarning" xml:space="preserve">
+    <value>УВАГА: зараз у вас не налаштовано автоматичний вибір звукової доріжки та субтитрів. Ви можете налаштувати стандартну поведінку вибору доріжки у параметрах.</value>
+  </data>
+  <data name="Presets_ResetComplete" xml:space="preserve">
+    <value>Вбудовані набори було скинуто.</value>
+  </data>
+  <data name="Presets_ResetHeader" xml:space="preserve">
+    <value>Скидання завершено</value>
+  </data>
+  <data name="Video_HigherQuality" xml:space="preserve">
+    <value>Вища якість |</value>
+  </data>
+  <data name="Video_LowQuality" xml:space="preserve">
+    <value>| Нижча якість</value>
+  </data>
+  <data name="Video_PlaceboQuality" xml:space="preserve">
+    <value>Якість плацебо |</value>
+  </data>
+  <data name="Error" xml:space="preserve">
+    <value>Помилка</value>
+  </data>
+  <data name="Main_AutoAdd_AudioAndSubWarning" xml:space="preserve">
+    <value>Попередження: якщо ви хочете, щоб субтитри додались до кожного елемента що ви збираєтеся поставити в чергу, переконайтесь, що на вкладці субтитрів правильно налаштовано параметри за замовчуванням.
+    
+Хочете продовжити?</value>
+  </data>
+  <data name="Main_TurnOnAutoFileNaming" xml:space="preserve">
+    <value>Ви повинні увімкнути у налаштуваннях автоматичне іменування файлів ТА встановити стандартний шлях, перш ніж зможете додати в чергу.</value>
+  </data>
+  <data name="Warning" xml:space="preserve">
+    <value>Попередження</value>
+  </data>
+  <data name="AreYouSure" xml:space="preserve">
+    <value>Ви впевнені?</value>
+  </data>
+  <data name="HandBrake_Title" xml:space="preserve">
+    <value>HandBrake</value>
+  </data>
+  <data name="Main_AlreadyEncoding" xml:space="preserve">
+    <value>HandBrake вже кодує.</value>
+  </data>
+  <data name="Main_DuplicateDestinationOnQueue" xml:space="preserve">
+    <value>У черзі вже є завдання з таким шляхом призначення. Виберіть інший шлях для цього завдання.</value>
+  </data>
+  <data name="Main_JobsPending_addon" xml:space="preserve">
+    <value>   Завдань очікує {0}</value>
+  </data>
+  <data name="Main_NewDefaultPreset" xml:space="preserve">
+    <value>Встановлено новий набір за замовчуванням: {0}</value>
+  </data>
+  <data name="Main_NewUpdate" xml:space="preserve">
+    <value>Доступне оновлення. Перейдіть до меню Інструменти &gt; Параметри для встановлення</value>
+  </data>
+  <data name="Main_NoPresetSelected" xml:space="preserve">
+    <value>Не вибрано набір.</value>
+  </data>
+  <data name="Main_NoUpdateOfBuiltInPresets" xml:space="preserve">
+    <value>Ви не можете змінювати вбудовані набори. Виберіть один зі своїх власних наборів.</value>
+  </data>
+  <data name="Main_PleaseSelectFolder" xml:space="preserve">
+    <value>Виберіть папку.</value>
+  </data>
+  <data name="Main_PreparingToEncode" xml:space="preserve">
+    <value>Підготовка до кодування…</value>
+  </data>
+  <data name="Main_PresetErrorBuiltInName" xml:space="preserve">
+    <value>Ви не можете імпортувати набір з таким самим іменем, як і у вбудованого набору.</value>
+  </data>
+  <data name="Main_PresetOverwriteWarning" xml:space="preserve">
+    <value>Набір "{0}" вже існує. Ви хочете його перезаписати?</value>
+  </data>
+  <data name="Main_Presets" xml:space="preserve">
+    <value>Набори</value>
+  </data>
+  <data name="Main_PresetUpdateConfrimation" xml:space="preserve">
+    <value>Ви дійсно хочете оновити вибраний набір?</value>
+  </data>
+  <data name="Main_PresetUpdated" xml:space="preserve">
+    <value>Набір оновлено згідно з вашими поточними налаштуваннями.</value>
+  </data>
+  <data name="Main_PresetUpdateNotification" xml:space="preserve">
+    <value>HandBrake визначив, що ваші вбудовані набори застаріли… Ці набори будуть оновлені.
+Ваші користувацькі набори залишились без змін, тому вам, можливо, доведеться перестворити їх, видаливши та повторно додавши їх. 
+Створено резервну копію попередньої версії файлу user_presets.xml.</value>
+  </data>
+  <data name="Main_QueueFinished" xml:space="preserve">
+    <value>Чергу виконано</value>
+  </data>
+  <data name="Main_ScanCancelled" xml:space="preserve">
+    <value>Сканування скасовано</value>
+  </data>
+  <data name="Main_ScanCompleted" xml:space="preserve">
+    <value>Сканування виконано</value>
+  </data>
+  <data name="Main_ScanFailed_NoReason" xml:space="preserve">
+    <value>Помилка сканування:</value>
+  </data>
+  <data name="Main_ScanFailled_CheckLog" xml:space="preserve">
+    <value>Помилка сканування… За додатковою інформацією зверніться в журнал активності.</value>
+  </data>
+  <data name="Main_ScanningPleaseWait" xml:space="preserve">
+    <value>Сканування джерела, зачекайте…</value>
+  </data>
+  <data name="Main_ScanningTitleXOfY" xml:space="preserve">
+    <value>Сканування заголовка  {0} з {1} ({2}%)</value>
+  </data>
+  <data name="Main_ScanSource" xml:space="preserve">
+    <value>Перш ніж запускати кодування, потрібно просканувати джерело та налаштувати завдання. Щоб продовжити – натисніть кнопку «Джерело» на панелі інструментів.</value>
+  </data>
+  <data name="Main_SelectPreset" xml:space="preserve">
+    <value>Переконайтесь, що ви вибрали один зі своїх власних наборів. Зверніть увагу, що ви не можете експортувати вбудовані набори.</value>
+  </data>
+  <data name="Main_SelectPresetForUpdate" xml:space="preserve">
+    <value>Виберіть набір для оновлення.</value>
+  </data>
+  <data name="Main_SelectSource" xml:space="preserve">
+    <value>Виберіть «Джерело», щоб продовжити</value>
+  </data>
+  <data name="Main_XEncodesPending" xml:space="preserve">
+    <value>{0} завдань очікують</value>
+  </data>
+  <data name="Notice" xml:space="preserve">
+    <value>Повідомлення</value>
+  </data>
+  <data name="Overwrite" xml:space="preserve">
+    <value>Переписати?</value>
+  </data>
+  <data name="Question" xml:space="preserve">
+    <value>Питання</value>
+  </data>
+  <data name="State_Ready" xml:space="preserve">
+    <value>Готовий</value>
+  </data>
+  <data name="Updated" xml:space="preserve">
+    <value>Оновлено</value>
+  </data>
+  <data name="Preset_OldVersion_Header" xml:space="preserve">
+    <value>Версія набору</value>
+  </data>
+  <data name="Preset_OldVersion_Message" xml:space="preserve">
+    <value>Ви намагаєтеся імпортувати набір з іншої версії HandBrake. 
+Можливо не вдасться імпортувати усі значення з цього набору. 
+
+Хочете продовжити?</value>
+  </data>
+  <data name="Preset_UnableToImport_Header" xml:space="preserve">
+    <value>Неможливо імпортувати набір!</value>
+  </data>
+  <data name="Preset_UnableToImport_Message" xml:space="preserve">
+    <value>Неможливо імпортувати набір, схоже він пошкоджений, або зі старішої версії HandBrake.</value>
+  </data>
+  <data name="Main_SetDestination" xml:space="preserve">
+    <value>Перш ніж додати до черги, необхідно встановити шлях призначення для вихідного файлу.</value>
+  </data>
+  <data name="Main_InvalidDestination" xml:space="preserve">
+    <value>Введений шлях призначення містив недопустимі символи та не буде оновлений.</value>
+  </data>
+  <data name="Preview" xml:space="preserve">
+    <value>Попередній перегляд {0}</value>
+  </data>
+  <data name="Preview_Scaled" xml:space="preserve">
+    <value>Попередній перегляд (масштабований)</value>
+  </data>
+  <data name="PictureSettings_OutputResolution" xml:space="preserve">
+    <value>Вихід: {0}</value>
+  </data>
+  <data name="Options_AdditionalFormatOptions" xml:space="preserve">
+    <value>Формат вихідного файлу. На додаток до будь-якого підтримуваного символу файлової системи, ви можете використовувати наступні покажчики місця заповнення, що будуть замінені під час зміни заголовка чи сканування джерела.
+
+Динамічні опції оновлення: {source} {title} {chapters} 
+Нединамічні опції: {date} {time} {creation-date} {creation-time} {quality} {bitrate} (вони змінюються, лише при скануванні нового джерела, зміни назви чи глав)</value>
+  </data>
+  <data name="Options_DefaultPathAdditionalParams" xml:space="preserve">
+    <value>Доступні додаткові параметри: {source_path} чи {source_folder_name} чи {source}</value>
+  </data>
+  <data name="Main_MatchingFileOverwriteWarning" xml:space="preserve">
+    <value>Ви не можете кодувати в файл, що має той самий шлях та ім'я файлу, що і вихідний файл. Оновіть ім'я файлу призначення, щоб воно не збігалось з вихідним файлом.</value>
+  </data>
+  <data name="Main_UnableToLoadHelpMessage" xml:space="preserve">
+    <value>Ваша система не дозволила HandBrake запустити браузер.</value>
+  </data>
+  <data name="Main_UnableToLoadHelpSolution" xml:space="preserve">
+    <value>Ви все ще можете отримати доступ до сторінок довідки, безпосередньо відвідавши вебсайт за адресою: https://handbrake.fr</value>
+  </data>
+  <data name="Main_PresetImportFailed" xml:space="preserve">
+    <value>Неможливо імпортувати вибраний набір.</value>
+  </data>
+  <data name="Main_PresetImportFailedSolution" xml:space="preserve">
+    <value>Набір може бути пошкоджений, або зі старішої версії HandBrake, а це не підтримується.
+Набори зі старіших версій необхідно створити заново в поточній версії.</value>
+  </data>
+  <data name="Video_EncoderExtraArgsTooltip" xml:space="preserve">
+    <value>Додаткові розширені аргументи, що можна передати кодувальнику відео.</value>
+  </data>
+  <data name="Subtitles_BurnInBehaviourModes" xml:space="preserve">
+    <value>Немає – вбудовуються лише доріжки, де контейнер не підтримує формат.
+Іншомовна звукова доріжка – буде вбудована іншомовна звукова доріжка, при наявності.
+Перша доріжка – буде вбудована перша доріжка.
+Бажано іншомовне аудіо, інакше перше – якщо іншомовна звукова доріжка існує – вона буде вбудована, інакше буде обрана перша доріжка.</value>
+  </data>
+  <data name="Subtitles_WebmSubtitleIncompatibilityHeader" xml:space="preserve">
+    <value>Сумісність з субтитрами WebM</value>
+  </data>
+  <data name="Subtitles_WebmSubtitleIncompatibilityError" xml:space="preserve">
+    <value>WebM в HandBrake підтримує лише вбудовані субтитри.
+
+Ви повинні змінити свій вибір субтитрів.
+
+Якщо продовжите – ваші не вбудовані субтитри буде втрачено.</value>
+  </data>
+  <data name="Main_ScanNoTitlesFound" xml:space="preserve">
+    <value>Не знайдено дійсного джерела чи заголовків.</value>
+  </data>
+  <data name="Main_ScanNoTitlesFoundMessage" xml:space="preserve">
+    <value>HandBrake не зможе кодувати вибране джерело, оскільки не знайшов дійсного джерело із заголовками для кодування. 
+Причини можуть бути наступні:
+- Тривалість кожного заголовка джерела нижча за граничне значення «Мінімальна тривалість заголовка» в «Параметри &gt; Додатково». 
+- Вихідний файл не є дійсним відеофайлом, або формату що не підтримує HandBrake.
+- Джерело може бути захищено від копіювання або містити DRM. Зауважте, що HandBrake не підтримує зняття захисту від копіювання.
+
+У журналі активності може міститись додаткова інформація.</value>
+  </data>
+  <data name="Main_QueueLabel" xml:space="preserve">
+    <value>Черга {0}</value>
+  </data>
+  <data name="Main_Start" xml:space="preserve">
+    <value>Почати кодування</value>
+  </data>
+  <data name="Main_StartQueue" xml:space="preserve">
+    <value>Запустити чергу</value>
+  </data>
+  <data name="MainViewModel_CanNotDeleteDefaultPreset" xml:space="preserve">
+    <value>Ви не можете видалити набір за замовчуванням. Спершу встановіть за замовчуванням інший набір.</value>
+  </data>
+  <data name="MainViewModel_PresetRemove_AreYouSure" xml:space="preserve">
+    <value>Дійсно хочете видалити набір:</value>
+  </data>
+  <data name="MainViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
+    <value>Кодування: прохід {0} з {1},  {2:00.00}%, FPS: {3:000.0}, середній FPS: {4:000.0},  залишилося часу: {5},  пройшло: {6} {7}</value>
+  </data>
+  <data name="AddPresetViewModel_PresetMustProvideName" xml:space="preserve">
+    <value>Набір повинен мати назву. Заповніть назву набору.</value>
+  </data>
+  <data name="AddPresetViewModel_PresetWithSameNameOverwriteWarning" xml:space="preserve">
+    <value>Набір з цим іменем вже існує. Хочете його перезаписати?</value>
+  </data>
+  <data name="AddPresetViewModel_YouMustFirstScanSource" xml:space="preserve">
+    <value>Щоб використовувати параметр «Максимум джерела» потрібно спочатку просканувати джерело.</value>
+  </data>
+  <data name="AddPresetViewModel_CustomWidthHeightFieldsRequired" xml:space="preserve">
+    <value>Для параметра «Власне» потрібно заповнити користувацькі поля ширини чи висоти.</value>
+  </data>
+  <data name="AddPresetViewModel_UnableToAddPreset" xml:space="preserve">
+    <value>Неможливо додати набір</value>
+  </data>
+  <data name="UnknownError" xml:space="preserve">
+    <value>Невідома помилка</value>
+  </data>
+  <data name="AudioViewModel_AudioDefaults" xml:space="preserve">
+    <value>Стандартні параметри аудіо</value>
+  </data>
+  <data name="AudioViewModel_AudioTracks" xml:space="preserve">
+    <value>Звукові доріжки</value>
+  </data>
+  <data name="AudioViewModel_ConfigureDefaults" xml:space="preserve">
+    <value>Поведінка вибору</value>
+  </data>
+  <data name="AudioViewModel_SwitchBackToTracks" xml:space="preserve">
+    <value>Перемикнутися назад до доріжок</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToExportChaptersWarning" xml:space="preserve">
+    <value>Не вдається зберегти файл маркерів глав!</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToExportChaptersMsg" xml:space="preserve">
+    <value>Назви маркерів глав НЕ будуть збережені у вашому кодувальнику.</value>
+  </data>
+  <data name="CountdownAlertViewModel_NoticeMessage" xml:space="preserve">
+    <value>Наступна дія '{0}' відбудеться через {1} секунди.</value>
+  </data>
+  <data name="ErrorViewModel_IfTheProblemPersists" xml:space="preserve">
+    <value>Якщо проблема не зникає, спробуйте перезапустити HandBrake.</value>
+  </data>
+  <data name="ErrorViewModel_NoFurtherInformation" xml:space="preserve">
+    <value>Додаткової інформації про цю помилку немає.</value>
+  </data>
+  <data name="ErrorViewModel_UnknownError" xml:space="preserve">
+    <value>Сталася невідома помилка.</value>
+  </data>
+  <data name="OptionsViewModel_NewUpdate" xml:space="preserve">
+    <value>Доступне нове оновлення! Нотатки про випуск доступні на вебсайті.</value>
+  </data>
+  <data name="OptionsViewModel_64bitAvailable" xml:space="preserve">
+    <value>Ваша система підтримує 64-бітну версію HandBrake! Це покращить продуктивність та стабільність в порівнянні з 32-бітною версією.
+Нотатки про випуск доступні на вебсайті.</value>
+  </data>
+  <data name="OptionsViewModel_NoNewUpdates" xml:space="preserve">
+    <value>Наразі немає оновлень.</value>
+  </data>
+  <data name="OptionsViewModel_UpdateDownloaded" xml:space="preserve">
+    <value>Оновлення завантажено</value>
+  </data>
+  <data name="OptionsViewModel_UpdateServiceUnavailable" xml:space="preserve">
+    <value>Служба оновлення недоступна. Можете спробувати завантажити оновлення з https://handbrake.fr</value>
+  </data>
+  <data name="OptionsViewModel_UpdateFailed" xml:space="preserve">
+    <value>Помилка оновлення. Можете спробувати завантажити оновлення з https://handbrake.fr</value>
+  </data>
+  <data name="PictureSettingsViewModel_StorageDisplayLabel" xml:space="preserve">
+    <value>Розмір зображення: {0}x{1},  PAR {2}x{3}</value>
+  </data>
+  <data name="QueueSelectionViewModel_AddToQueue" xml:space="preserve">
+    <value>Додати до черги</value>
+  </data>
+  <data name="QueueViewModel_NoEncodesPending" xml:space="preserve">
+    <value>В очікуванні немає кодувань</value>
+  </data>
+  <data name="QueueViewModel_NoJobsPending" xml:space="preserve">
+    <value>Зараз немає завдань в процесі кодування</value>
+  </data>
+  <data name="QueueViewModel_Queue" xml:space="preserve">
+    <value>Черга</value>
+  </data>
+  <data name="QueueViewModel_ClearQueueConfrimation" xml:space="preserve">
+    <value>Дійсно хочете очистити чергу?</value>
+  </data>
+  <data name="Confirm" xml:space="preserve">
+    <value>Підтвердження</value>
+  </data>
+  <data name="QueueViewModel_JobsPending" xml:space="preserve">
+    <value>{0} завдань очікують</value>
+  </data>
+  <data name="QueueViewModel_QueuePending" xml:space="preserve">
+    <value>Черга призупинена</value>
+  </data>
+  <data name="QueueViewModel_DelSelectedJobConfirmation" xml:space="preserve">
+    <value>Дійсно хочете видалити вибрані завдання?</value>
+  </data>
+  <data name="QueueViewModel_JobCurrentlyRunningWarning" xml:space="preserve">
+    <value>Наразі це кодування триває. Якщо його видалити – кодування буде зупинено. Дійсно хочете продовжити?</value>
+  </data>
+  <data name="QueueViewModel_NoPendingJobs" xml:space="preserve">
+    <value>В очікуванні немає завдань</value>
+  </data>
+  <data name="QueueViewModel_EditConfrimation" xml:space="preserve">
+    <value>Дійсно змінити це завдання? Воно буде вилучене з черги та відправлене у головне вікно.</value>
+  </data>
+  <data name="QueueViewModel_QueueReady" xml:space="preserve">
+    <value>Черга готова</value>
+  </data>
+  <data name="QueueViewModel_QueueNotRunning" xml:space="preserve">
+    <value>Черга не запущена</value>
+  </data>
+  <data name="QueueViewModel_QueueCompleted" xml:space="preserve">
+    <value>Черга завершена</value>
+  </data>
+  <data name="QueueViewModel_LastJobFinished" xml:space="preserve">
+    <value>Завершено останнє завдання в черзі</value>
+  </data>
+  <data name="QueueViewModel_QueueStarted" xml:space="preserve">
+    <value>Черга запущена</value>
+  </data>
+  <data name="QueueViewModel_QueueStatusDisplay" xml:space="preserve">
+    <value>Кодування: прохід {0} з {1},  {2:00.00}%, FPS: {3:000.0},  середній FPS: {4:000.0},  залишилося часу: {5},  пройшло: {6:d\:hh\:mm\:ss}</value>
+  </data>
+  <data name="ShellViewModel_CanClose" xml:space="preserve">
+    <value>Триває кодування. Вихід з HandBrake зупинить це кодування.
+Дійсно хочете вийти з HandBrake?</value>
+  </data>
+  <data name="StaticPreviewViewModel_Title" xml:space="preserve">
+    <value>Попередній перегляд зображення</value>
+  </data>
+  <data name="StaticPreview_UnableToDeletePreview" xml:space="preserve">
+    <value>Не вдалося видалити наявний файл попереднього перегляду. Можливо, вам доведеться перезапустити програму.</value>
+  </data>
+  <data name="StaticPreviewViewModel_ScanFirst" xml:space="preserve">
+    <value>Перед створенням файлу попереднього перегляду слід просканувати джерело та налаштувати параметри кодування.</value>
+  </data>
+  <data name="StaticPreviewViewModel_UnableToPlayFile" xml:space="preserve">
+    <value>Не вдається знайти файл попереднього перегляду. Файл або видалений, або кодування не вдалося. За додатковою інформацією зверніться в журнал активності.</value>
+  </data>
+  <data name="StaticPreviewViewModel_AlreadyEncoding" xml:space="preserve">
+    <value>Handbrake уже кодує відео! Одночасно можна кодувати лише один файл.</value>
+  </data>
+  <data name="SubtitlesViewModel_SubDefaults" xml:space="preserve">
+    <value>Стандартні параметри субтитрів</value>
+  </data>
+  <data name="SubtitlesViewModel_SubTracks" xml:space="preserve">
+    <value>Доріжки субтитрів</value>
+  </data>
+  <data name="SubtitlesViewModel_SwitchToTracks" xml:space="preserve">
+    <value>Перемикнутися назад до доріжок</value>
+  </data>
+  <data name="SubtitlesViewModel_ConfigureDefaults" xml:space="preserve">
+    <value>Поведінка вибору</value>
+  </data>
+  <data name="PresetService_ArchiveFile" xml:space="preserve">
+    <value>Файлу архіву:</value>
+  </data>
+  <data name="PresetService_UnableToLoad" xml:space="preserve">
+    <value>Не вдалося завантажити набори.</value>
+  </data>
+  <data name="PresetService_UnableToLoadPresets" xml:space="preserve">
+    <value>HandBrake не вдалося завантажити файл наборів. Можливо, він зі старішої непідтримуваної версії HandBrake, або пошкоджений. 
+
+Ваш старий файл наборів заархівовано у:</value>
+  </data>
+  <data name="Main_QueueFinishedErrors" xml:space="preserve">
+    <value> помилок чи скасувань зафіксовано: {0}.</value>
+  </data>
+  <data name="MainViewModel_LowDiskSpace" xml:space="preserve">
+    <value>Бракує місця на диску</value>
+  </data>
+  <data name="MainViewModel_LowDiskSpaceWarning" xml:space="preserve">
+    <value>Попередження, у вас мало місця на диску. HandBrake не зможе завершити це кодування, якщо у вас не вистачить місця.</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersMalformedLineMsg" xml:space="preserve">
+    <value>Недійсний рядок {0}. Нічого не буде імпортовано.</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersWarning" xml:space="preserve">
+    <value>Не вдається імпортувати файл глав</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersLineDoesNotHaveAtLeastTwoColumns" xml:space="preserve">
+    <value>Усі рядки у файлі глав повинні мати не менше 2 стовпців даних</value>
+  </data>
+  <data name="ChaptersViewModel_UnableToImportChaptersFirstColumnMustContainOnlyIntegerNumber" xml:space="preserve">
+    <value>Перший стовпець у файлі глав повинен містити лише ціле число, більше за нуль (0)</value>
+  </data>
+  <data name="ChaptersViewModel_UnsupportedFileFormatMsg" xml:space="preserve">
+    <value>Файли глав типу '{0}' наразі не підтримуються.</value>
+  </data>
+  <data name="ChaptersViewModel_UnsupportedFileFormatWarning" xml:space="preserve">
+    <value>Непідтримуваний тип файлу глав</value>
+  </data>
+  <data name="ChaptersViewModel_ValidationFailedWarning" xml:space="preserve">
+    <value>Недійсна інформація глави для джерела мультимедійного вмісту</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatch" xml:space="preserve">
+    <value>Кількість глав у джерелі мультимедійного вмісту
+та кількість глав у вхідному файлі не збігаються ({0} проти {1}).
+
+Все ще хочете імпортувати назви глав?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchMsg" xml:space="preserve">
+    <value>Кількість глав у джерелі мультимедійного вмісту
+та кількість глав у вхідному файлі не збігаються ({0} проти {1}).
+
+Все ще хочете імпортувати назви глав?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterCountMismatchWarning" xml:space="preserve">
+    <value>Кількість глав не збігається у джерела та вхідного файлу</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchMsg" xml:space="preserve">
+    <value>Тривалість глав на джерелі мультимедійного вмісту 
+та тривалість глав у вхідному файлі сильно відрізняються.
+
+З великою ймовірністю цей файл глав створений з іншого джерела мультимедійного вмісту.
+
+Дійсно імпортувати назви глав?</value>
+  </data>
+  <data name="ChaptersViewModel_ValidateImportedChapters_ChapterDurationMismatchWarning" xml:space="preserve">
+    <value>Тривалість глав не збігається у джерела та вхідного файлу</value>
+  </data>
+  <data name="ScanService_ScanStopFailed" xml:space="preserve">
+    <value>Під час спроби зупинити сканування сталася помилка. Перезапустіть HandBrake.</value>
+  </data>
+  <data name="Presets_PresetForceReset" xml:space="preserve">
+    <value>HandBrake не в змозі оновити файл наборів до формату нової версії.
+Ваш файл наборів буде заархівовано та створено новий. Вам потрібно буде заново створити власні набори.</value>
+  </data>
+  <data name="SettingService_SaveErrorReset" xml:space="preserve">
+    <value>Any settings you changed may need to be reset the next time HandBrake launches.</value>
+  </data>
+  <data name="UserSettings_AnErrorOccured" xml:space="preserve">
+    <value>Виникла проблема при спробі зберегти налаштування.</value>
+  </data>
+  <data name="UserSettings_YourSettingsHaveBeenReset" xml:space="preserve">
+    <value>Увага, ваші налаштування скинуто!</value>
+  </data>
+  <data name="UserSettings_YourSettingsAreCorrupt" xml:space="preserve">
+    <value>Файл налаштувань користувача пошкоджений або недоступний. Налаштування скинуто до стандартних значень.</value>
+  </data>
+  <data name="UserSettings_UnableToLoad" xml:space="preserve">
+    <value>Не вдається завантажити файл налаштувань користувача: {0}</value>
+  </data>
+  <data name="UserSettings_UnableToLoadSolution" xml:space="preserve">
+    <value>Здається, файл налаштувань користувача недоступний чи пошкоджений. Можливо, вам доведеться видалити цей файл, щоб HandBrake зміг створити новий.</value>
+  </data>
+  <data name="Main_NoPermissionsOrMissingDirectory" xml:space="preserve">
+    <value>Вибраний каталог для виводу не існує, або у вас немає дозволу на запис файлів в нього.</value>
+  </data>
+  <data name="DirectoryUtils_CreateFolder" xml:space="preserve">
+    <value>Створити папку?</value>
+  </data>
+  <data name="DirectoryUtils_CreateFolderMsg" xml:space="preserve">
+    <value>Не існує папки в яку ви намагаєтеся записати. Хочете, щоб HandBrake створив її?
+{0}</value>
+  </data>
+  <data name="MainViewModel_UnableToLaunchDestDir" xml:space="preserve">
+    <value>Не вдається запустити каталог призначення.</value>
+  </data>
+  <data name="MainViewModel_UnableToLaunchDestDirSolution" xml:space="preserve">
+    <value>Перевірте, чи каталог призначення дійсний.</value>
+  </data>
+  <data name="MainViewModel_EncodeStatusChanged_SubScan_StatusLabel" xml:space="preserve">
+    <value>Прохід обробки {0} з {1}, (сканування субтитрів)  {2:00.00}%, залишилося часу сканування: {3},  пройшло: {4}</value>
+  </data>
+  <data name="NoAdditionalInformation" xml:space="preserve">
+    <value>Немає додаткової інформації</value>
+  </data>
+  <data name="WindowTitleStatus" xml:space="preserve">
+    <value>{0} - ({1}%, прохід {2} з {3})</value>
+  </data>
+  <data name="TaskTrayStatusTitle" xml:space="preserve">
+    <value>{1}%, прохід {2} з {3}
+Залишилося часу: {4}</value>
+  </data>
+  <data name="PauseOnLowDiskspace" xml:space="preserve">
+    <value>Черга призупинена. Попередження: бракує місця на накопичувачі, який ви використовуєте для призначення кодування. Щоб продовжити, звільніть місце і натисніть почати. Також можете задати значення мінімальної кількості вільного місця в налаштуваннях.</value>
+  </data>
+  <data name="Main_QueuePaused" xml:space="preserve">
+    <value>Черга призупинена</value>
+  </data>
+  <data name="QueueViewModel_QueuePaused" xml:space="preserve">
+    <value>Черга призупинена</value>
+  </data>
+  <data name="Main_LowDiskspace" xml:space="preserve">
+    <value>У каталозі призначення мало вільного дискового простору. 
+
+У налаштуваннях можете задати рівень, при якому з’являється це попередження. 
+
+Хочете продовжити?</value>
+  </data>
+  <data name="Queue_UnableToResetJob" xml:space="preserve">
+    <value>Неможливо скинути статус завдання, оскільки воно не знаходиться в стані «помилка» чи «завершено»</value>
+  </data>
+  <data name="Queue_UnableToRestoreFile" xml:space="preserve">
+    <value>Не вдається відновити файл черги.</value>
+  </data>
+  <data name="Queue_UnableToRestoreFileExtended" xml:space="preserve">
+    <value>Файл може бути пошкодженим або зі старішої, несумісної версії HandBrake</value>
+  </data>
+  <data name="Queue_AlreadyEncoding" xml:space="preserve">
+    <value>HandBrake вже кодує файл.</value>
+  </data>
+  <data name="Queue_AlreadyEncodingSolution" xml:space="preserve">
+    <value>Будь ласка, зупиніть поточне кодування. Якщо проблема не зникає – перезапустіть HandBrake.</value>
+  </data>
+  <data name="StaticPreviewView_Title" xml:space="preserve">
+    <value>Попередній перегляд ({0}% фактичного розміру)</value>
+  </data>
+  <data name="OsBitnessWarning" xml:space="preserve">
+    <value>Для запуску HandBrake потрібна 64-розрядна версія Windows 7 або пізніша версія.</value>
+  </data>
+  <data name="OsVersionWarning" xml:space="preserve">
+    <value>Для запуску HandBrake потрібна Windows 7 або пізніша версія. Версія 0.9.9 (XP) та 0.10.5 (Vista) були останніми версіями, що підтримували ці ОС.</value>
+  </data>
+  <data name="Main_ContinueAddingToQueue" xml:space="preserve">
+    <value>Хочете спробувати додати решту?</value>
+  </data>
+  <data name="Main_QueueOverwritePrompt" xml:space="preserve">
+    <value>Файл '{0}' вже існує!
+Ви хочете його перезаписати?</value>
+  </data>
+  <data name="Clipboard_Unavailable" xml:space="preserve">
+    <value>На цю мить системний буфер обміну недоступний.</value>
+  </data>
+  <data name="Clipboard_Unavailable_Solution" xml:space="preserve">
+    <value>Це може бути пов’язано з іншим додатком, що відстежує чи блокує буфер обміну для власного користування. Ви не зможете використовувати буфер обміну, поки він не буде розблокований.</value>
+  </data>
+  <data name="AboutView_License" xml:space="preserve">
+    <value>Ліцензія:</value>
+  </data>
+  <data name="AboutView_Version" xml:space="preserve">
+    <value>Версія: </value>
+  </data>
+  <data name="AddPresetView_AddNewCategory" xml:space="preserve">
+    <value>-- Додати нову категорію --</value>
+  </data>
+  <data name="AddPresetView_AddPreset" xml:space="preserve">
+    <value>Додати набір</value>
+  </data>
+  <data name="AddPresetView_Category" xml:space="preserve">
+    <value>Категорія:</value>
+  </data>
+  <data name="AddPresetView_Description" xml:space="preserve">
+    <value>Опис:</value>
+  </data>
+  <data name="AddPresetView_Name" xml:space="preserve">
+    <value>Назва:</value>
+  </data>
+  <data name="AddPresetView_SavePictureSize" xml:space="preserve">
+    <value>Розміри:</value>
+  </data>
+  <data name="AudioDefaultView_Behaviours" xml:space="preserve">
+    <value>Вибір доріжки джерела</value>
+  </data>
+  <data name="AudioView_AllowPassThruOf" xml:space="preserve">
+    <value>Дозволити передачу:</value>
+  </data>
+  <data name="AudioView_AudioDefaultsDescription" xml:space="preserve">
+    <value>Налаштуйте спосіб автоматичного вибору та налаштування звукових доріжок під час вибору нового заголовка чи джерела відео.</value>
+  </data>
+  <data name="AudioView_AutoPassthruBehaviour" xml:space="preserve">
+    <value>Поведінка «Автопередачі»:</value>
+  </data>
+  <data name="AudioView_Bitrate" xml:space="preserve">
+    <value>Бітрейт</value>
+  </data>
+  <data name="AudioView_Codec" xml:space="preserve">
+    <value>Кодек</value>
+  </data>
+  <data name="AudioView_DRC" xml:space="preserve">
+    <value>DRC</value>
+  </data>
+  <data name="AudioView_Gain" xml:space="preserve">
+    <value>Підсилення</value>
+  </data>
+  <data name="AudioView_Hide" xml:space="preserve">
+    <value>Приховати</value>
+  </data>
+  <data name="AudioView_Mixdown" xml:space="preserve">
+    <value>Мікшування</value>
+  </data>
+  <data name="AudioView_OtherwiseFallbackEncoder" xml:space="preserve">
+    <value>Резервний кодувальник:</value>
+  </data>
+  <data name="AudioView_ReloadDefaults" xml:space="preserve">
+    <value>Перезавантажити</value>
+  </data>
+  <data name="AudioView_Samplerate" xml:space="preserve">
+    <value>Частота дискретизації</value>
+  </data>
+  <data name="AudioView_Show" xml:space="preserve">
+    <value>Показати</value>
+  </data>
+  <data name="AudioView_TrackName" xml:space="preserve">
+    <value>Назва доріжки</value>
+  </data>
+  <data name="AudioView_TrackSelectionBehaviour" xml:space="preserve">
+    <value>Поведінка вибору доріжки:</value>
+  </data>
+  <data name="AudioView_TrackSettingDefaultBehaviour" xml:space="preserve">
+    <value>Для додаткових доріжок:</value>
+  </data>
+  <data name="AudioView_WhenAutoPassthru" xml:space="preserve">
+    <value>Коли як аудіокодек вибрано «Автопередача» (Auto Passthru).</value>
+  </data>
+  <data name="ChaptersView_ChapterMarkers" xml:space="preserve">
+    <value>Маркери глав</value>
+  </data>
+  <data name="ChaptersView_ChapterName" xml:space="preserve">
+    <value>Назва глави</value>
+  </data>
+  <data name="ChaptersView_ChapterNumber" xml:space="preserve">
+    <value>Номер глави</value>
+  </data>
+  <data name="ChaptersView_CreateChapterMarkers" xml:space="preserve">
+    <value>Створити маркери глав</value>
+  </data>
+  <data name="ChaptersView_Duration" xml:space="preserve">
+    <value>Тривалість</value>
+  </data>
+  <data name="ChaptersView_Export" xml:space="preserve">
+    <value>Екпортувати</value>
+  </data>
+  <data name="ChaptersView_Import" xml:space="preserve">
+    <value>Імпортувати</value>
+  </data>
+  <data name="ChapterView_ExportNames" xml:space="preserve">
+    <value>Експортувати назви</value>
+  </data>
+  <data name="ChapterView_ImportNames" xml:space="preserve">
+    <value>Імпортувати назви</value>
+  </data>
+  <data name="ChapterView_ResetChapterNames" xml:space="preserve">
+    <value>Скинути назви глав</value>
+  </data>
+  <data name="CountdownAlterView_CancelAction" xml:space="preserve">
+    <value>Скасувати дію</value>
+  </data>
+  <data name="CountdownAlterView_Proceed" xml:space="preserve">
+    <value>Продовжити</value>
+  </data>
+  <data name="CountdownAlterView_WhenDoneAction" xml:space="preserve">
+    <value>Дія після завершення</value>
+  </data>
+  <data name="ErrorView_ErrorDetails" xml:space="preserve">
+    <value>Відомості про помилку:</value>
+  </data>
+  <data name="FiltersView_Custom" xml:space="preserve">
+    <value>Власне:</value>
+  </data>
+  <data name="FiltersView_Deblock" xml:space="preserve">
+    <value>Deblock</value>
+  </data>
+  <data name="FiltersView_Decomb" xml:space="preserve">
+    <value>Видалення «гребінки»</value>
+  </data>
+  <data name="FiltersView_Deinterlace" xml:space="preserve">
+    <value>Деінтерлейсинг:</value>
+  </data>
+  <data name="FiltersView_DeinterlacePreset" xml:space="preserve">
+    <value>Набір:</value>
+  </data>
+  <data name="FiltersView_DeinterlacePresetAuto" xml:space="preserve">
+    <value>Набір деінтерлейсингу</value>
+  </data>
+  <data name="FiltersView_Denoise" xml:space="preserve">
+    <value>Усунення шумів:</value>
+  </data>
+  <data name="FiltersView_DenoisePresetAuto" xml:space="preserve">
+    <value>Набір усунення шумів</value>
+  </data>
+  <data name="FiltersView_DenoiseTuneAuto" xml:space="preserve">
+    <value>Настроювання усунення шумів</value>
+  </data>
+  <data name="FiltersView_Detelecine" xml:space="preserve">
+    <value>Видалення «гребінки»:</value>
+  </data>
+  <data name="FiltersView_Filters" xml:space="preserve">
+    <value>Фільтри</value>
+  </data>
+  <data name="FiltersView_FlipVideo" xml:space="preserve">
+    <value>Відбити</value>
+  </data>
+  <data name="FiltersView_Grayscale" xml:space="preserve">
+    <value>Відтінки сірого</value>
+  </data>
+  <data name="FiltersView_InterlaceDetection" xml:space="preserve">
+    <value>Виявлення інтерлейсингу:</value>
+  </data>
+  <data name="FiltersView_Preset" xml:space="preserve">
+    <value>Набір:</value>
+  </data>
+  <data name="FiltersView_Rotate" xml:space="preserve">
+    <value>Поворот:</value>
+  </data>
+  <data name="FiltersView_Sharpen" xml:space="preserve">
+    <value>Різкість</value>
+  </data>
+  <data name="FiltersView_SharpenPresetAuto" xml:space="preserve">
+    <value>Набір різкості</value>
+  </data>
+  <data name="FiltersView_SharpenTuneAuto" xml:space="preserve">
+    <value>Настроювання різкості</value>
+  </data>
+  <data name="FiltersView_Tune" xml:space="preserve">
+    <value>Настроювання:</value>
+  </data>
+  <data name="Generic_Add" xml:space="preserve">
+    <value>Додати</value>
+  </data>
+  <data name="Generic_Cancel" xml:space="preserve">
+    <value>Скасувати</value>
+  </data>
+  <data name="Generic_Clear" xml:space="preserve">
+    <value>Очистити</value>
+  </data>
+  <data name="Generic_Close" xml:space="preserve">
+    <value>Закрити</value>
+  </data>
+  <data name="Generic_CopyToClipboard" xml:space="preserve">
+    <value>Копіювати до буфера обміну</value>
+  </data>
+  <data name="Generic_MoveLeft" xml:space="preserve">
+    <value>Ліворуч</value>
+  </data>
+  <data name="Generic_MoveRight" xml:space="preserve">
+    <value>Праворуч</value>
+  </data>
+  <data name="Generic_Save" xml:space="preserve">
+    <value>Зберегти</value>
+  </data>
+  <data name="LogView_CopyClipboard" xml:space="preserve">
+    <value>Копіювати до буфера обміну</value>
+  </data>
+  <data name="LogView_EncodeLog" xml:space="preserve">
+    <value>Журнал кодування</value>
+  </data>
+  <data name="LogView_OpenLogDir" xml:space="preserve">
+    <value>Відкрити каталог журналів</value>
+  </data>
+  <data name="LogView_ScanLog" xml:space="preserve">
+    <value>Журнал сканування</value>
+  </data>
+  <data name="MainView_ActivityLog" xml:space="preserve">
+    <value>Журнал активності</value>
+  </data>
+  <data name="MainView_AddAll" xml:space="preserve">
+    <value>Додати все</value>
+  </data>
+  <data name="MainView_AddCurrent" xml:space="preserve">
+    <value>Додати поточний</value>
+  </data>
+  <data name="MainView_AddSelection" xml:space="preserve">
+    <value>Додати вибране</value>
+  </data>
+  <data name="MainView_AddToQueue" xml:space="preserve">
+    <value>Додати до черги</value>
+  </data>
+  <data name="MainView_AdvancedTab" xml:space="preserve">
+    <value>Додатково</value>
+  </data>
+  <data name="MainView_AlignAVStart" xml:space="preserve">
+    <value>Вирівняти початок A/V</value>
+  </data>
+  <data name="MainView_Angle" xml:space="preserve">
+    <value>Ракурс: </value>
+  </data>
+  <data name="MainView_AudioTab" xml:space="preserve">
+    <value>Аудіо</value>
+  </data>
+  <data name="MainView_AudioTrackCount" xml:space="preserve">
+    <value>Звукові доріжки</value>
+  </data>
+  <data name="MainView_Browser" xml:space="preserve">
+    <value>Огляд</value>
+  </data>
+  <data name="MainView_ChaptersTab" xml:space="preserve">
+    <value>Глави</value>
+  </data>
+  <data name="MainView_Container" xml:space="preserve">
+    <value>Контейнер</value>
+  </data>
+  <data name="MainView_Destination" xml:space="preserve">
+    <value>Шлях призначення</value>
+  </data>
+  <data name="MainView_Duration" xml:space="preserve">
+    <value>Тривалість: </value>
+  </data>
+  <data name="MainView_File" xml:space="preserve">
+    <value>Зберегти як:</value>
+  </data>
+  <data name="MainView_FiltersTab" xml:space="preserve">
+    <value>Фільтри</value>
+  </data>
+  <data name="MainView_Format" xml:space="preserve">
+    <value>Формат:</value>
+  </data>
+  <data name="MainView_Help" xml:space="preserve">
+    <value>Довідка</value>
+  </data>
+  <data name="MainView_iPod5G" xml:space="preserve">
+    <value>Підтримка iPod 5G</value>
+  </data>
+  <data name="MainView_MetaDataTab" xml:space="preserve">
+    <value>Метадані</value>
+  </data>
+  <data name="MainView_ModifiedPreset" xml:space="preserve">
+    <value>(Змінено)</value>
+  </data>
+  <data name="MainView_Muxing" xml:space="preserve">
+    <value>Мультиплексування: це може тривати певний час…</value>
+  </data>
+  <data name="MainView_Options" xml:space="preserve">
+    <value>Параметри</value>
+  </data>
+  <data name="MainView_OutputSettings" xml:space="preserve">
+    <value>Параметри виводу</value>
+  </data>
+  <data name="MainView_Pause" xml:space="preserve">
+    <value>Призупинити</value>
+  </data>
+  <data name="MainView_PictureTab" xml:space="preserve">
+    <value>Розміри</value>
+  </data>
+  <data name="MainView_PresetManage" xml:space="preserve">
+    <value>Перейменувати набір</value>
+  </data>
+  <data name="MainView_PresetOptionsContextMenu" xml:space="preserve">
+    <value>Контекстне меню опцій наборів</value>
+  </data>
+  <data name="MainView_PresetRemove" xml:space="preserve">
+    <value>Видалити набір</value>
+  </data>
+  <data name="MainView_Presets" xml:space="preserve">
+    <value>Набори</value>
+  </data>
+  <data name="MainView_Preview" xml:space="preserve">
+    <value>Попередній перегляд</value>
+  </data>
+  <data name="MainView_ProgressStatusWithTask" xml:space="preserve">
+    <value>Кодування: {0}, {1:00.00}%, Залишилося часу: {2}, {3}</value>
+  </data>
+  <data name="MainView_Range" xml:space="preserve">
+    <value>Діапазон:</value>
+  </data>
+  <data name="MainView_Reload" xml:space="preserve">
+    <value>Перезавантажити</value>
+  </data>
+  <data name="MainView_Remove" xml:space="preserve">
+    <value>Вилучити</value>
+  </data>
+  <data name="MainView_ResetBuiltInPresets" xml:space="preserve">
+    <value>Скинути вбудовані набори</value>
+  </data>
+  <data name="MainView_SaveNewPreset" xml:space="preserve">
+    <value>Зберегти новий набір</value>
+  </data>
+  <data name="MainView_Searching" xml:space="preserve">
+    <value>Пошук часу початку</value>
+  </data>
+  <data name="MainView_SetDefault" xml:space="preserve">
+    <value>Встановити за замовчуванням</value>
+  </data>
+  <data name="MainView_ShowPreview" xml:space="preserve">
+    <value>Попередній перегляд</value>
+  </data>
+  <data name="MainView_ShowQueue" xml:space="preserve">
+    <value>Черга</value>
+  </data>
+  <data name="MainView_Source" xml:space="preserve">
+    <value>Джерело:</value>
+  </data>
+  <data name="MainView_SourceOpen" xml:space="preserve">
+    <value>Відкрити джерело</value>
+  </data>
+  <data name="MainView_StartEncode" xml:space="preserve">
+    <value>Почати кодування</value>
+  </data>
+  <data name="MainView_StartQueue" xml:space="preserve">
+    <value>Запустити чергу</value>
+  </data>
+  <data name="MainView_Stop" xml:space="preserve">
+    <value>Перервати</value>
+  </data>
+  <data name="MainView_StopEncode" xml:space="preserve">
+    <value>Зупинити кодування</value>
+  </data>
+  <data name="MainView_StopEncodeConfirm" xml:space="preserve">
+    <value>Дійсно хочете зупинити це кодування?</value>
+  </data>
+  <data name="MainView_SubtitleBeforeScanError" xml:space="preserve">
+    <value>Перед спробою імпорту файлу субтитрів слід вибрати джерело для кодування.</value>
+  </data>
+  <data name="MainView_SubtitlesTab" xml:space="preserve">
+    <value>Субтитри</value>
+  </data>
+  <data name="MainView_SubtitleTracksCount" xml:space="preserve">
+    <value>Доріжки субтитрів</value>
+  </data>
+  <data name="MainView_SummaryTab" xml:space="preserve">
+    <value>Відомості</value>
+  </data>
+  <data name="MainView_through" xml:space="preserve">
+    <value> - </value>
+  </data>
+  <data name="MainView_Title" xml:space="preserve">
+    <value>Заголовок: </value>
+  </data>
+  <data name="MainView_UpdateSelectedPreset" xml:space="preserve">
+    <value>Оновити вибраний набір</value>
+  </data>
+  <data name="MainView_VideoTab" xml:space="preserve">
+    <value>Відео</value>
+  </data>
+  <data name="MainView_WebOptimized" xml:space="preserve">
+    <value>Оптимізований для веб-перегляду</value>
+  </data>
+  <data name="ManagePresetView_ManagePreset" xml:space="preserve">
+    <value>Управління наборами</value>
+  </data>
+  <data name="MetaDataView_Title" xml:space="preserve">
+    <value>Метадані</value>
+  </data>
+  <data name="OptionsView_EnableNvencEncoding" xml:space="preserve">
+    <value>Дозволити використання кодувальників Nvidia NVENC</value>
+  </data>
+  <data name="OptionsView_EnableQuicksyncEncoding" xml:space="preserve">
+    <value>Дозволити використання кодувальників Intel QuickSync</value>
+  </data>
+  <data name="OptionsView_EnableVceEncoding" xml:space="preserve">
+    <value>Дозволити використання кодувальників AMD VCE</value>
+  </data>
+  <data name="OptionsView_InvalidFileFormatChars" xml:space="preserve">
+    <value>Введений формат файлу містив недійсні символи. Вони були видалені.</value>
+  </data>
+  <data name="OptionsView_PlaySoundWhenDone" xml:space="preserve">
+    <value>Відтворювати звук після завершення кожного кодування</value>
+  </data>
+  <data name="OptionsView_PlaySoundWhenQueueDone" xml:space="preserve">
+    <value>Відтворювати звук після завершення черги</value>
+  </data>
+  <data name="OptionsView_ShowPreviewOnSummaryTab" xml:space="preserve">
+    <value>Показувати попередній перегляд на вкладці «Відомості»</value>
+  </data>
+  <data name="OptionsView_ShowStatusInTitleBar" xml:space="preserve">
+    <value>Показувати стан кодування в рядку заголовка програми</value>
+  </data>
+  <data name="Options_7DayLogClear" xml:space="preserve">
+    <value>Очищувати файли журналу старші за 7 днів</value>
+  </data>
+  <data name="Options_About" xml:space="preserve">
+    <value>Про HandBrake</value>
+  </data>
+  <data name="Options_Advanced" xml:space="preserve">
+    <value>Додатково</value>
+  </data>
+  <data name="Options_AdvancedOptions" xml:space="preserve">
+    <value>Розширені опції</value>
+  </data>
+  <data name="Options_Arguments" xml:space="preserve">
+    <value>Аргументи:</value>
+  </data>
+  <data name="Options_AutomaticFileNaming" xml:space="preserve">
+    <value>Автоматичне іменування файлів</value>
+  </data>
+  <data name="Options_AutoNameOutput" xml:space="preserve">
+    <value>Автоматично іменувати вихідні файли</value>
+  </data>
+  <data name="Options_CheckForUpdates" xml:space="preserve">
+    <value>Перевірити наявність оновлень</value>
+  </data>
+  <data name="Options_ClearCompleted" xml:space="preserve">
+    <value>Завжди очищати завершені елементи черги після закінчення кодування</value>
+  </data>
+  <data name="Options_ClearLogs" xml:space="preserve">
+    <value>Очистити журнали</value>
+  </data>
+  <data name="Options_CopyLogToDir" xml:space="preserve">
+    <value>Класти копію особистих журналів кодування у вказане місце:</value>
+  </data>
+  <data name="Options_CopyLogToEncDir" xml:space="preserve">
+    <value>Класти копію особистих журналів кодування в те ж місце, що і кодоване відео</value>
+  </data>
+  <data name="Options_CurVersion" xml:space="preserve">
+    <value>Поточна версія</value>
+  </data>
+  <data name="Options_Decoding" xml:space="preserve">
+    <value>Декодування</value>
+  </data>
+  <data name="Options_DefaultPath" xml:space="preserve">
+    <value>Стандартний шлях:</value>
+  </data>
+  <data name="Options_DownloadUpdates" xml:space="preserve">
+    <value>Завантажити оновлення</value>
+  </data>
+  <data name="Options_DVD" xml:space="preserve">
+    <value>Читання DVD</value>
+  </data>
+  <data name="Options_DvdRead" xml:space="preserve">
+    <value>Вимкнути LibDVDNav (натомість буде використовуватися libdvdread)</value>
+  </data>
+  <data name="Options_Encoding" xml:space="preserve">
+    <value>Кодування</value>
+  </data>
+  <data name="Options_Format" xml:space="preserve">
+    <value>Формат файлу:</value>
+  </data>
+  <data name="Options_General" xml:space="preserve">
+    <value>Загальні</value>
+  </data>
+  <data name="Options_Logging" xml:space="preserve">
+    <value>Журналювання</value>
+  </data>
+  <data name="Options_LogLevel" xml:space="preserve">
+    <value>Рівень детальності журналу:</value>
+  </data>
+  <data name="Options_LogPath" xml:space="preserve">
+    <value>Шлях журналу:</value>
+  </data>
+  <data name="Options_LowDiskspaceSize" xml:space="preserve">
+    <value>Призупиняти чергу при браку дискового простору</value>
+  </data>
+  <data name="Options_MinimiseTray" xml:space="preserve">
+    <value>Мінімізовувати в системний трей (потрібен перезапуск)</value>
+  </data>
+  <data name="Options_MinTitleScanLength" xml:space="preserve">
+    <value>Мінімальна тривалість заголовка DVD та Blu-ray у секундах. Коротші заголовки будуть пропущені:</value>
+  </data>
+  <data name="Options_MP4FileExtension" xml:space="preserve">
+    <value>Розширення файлу MP4:</value>
+  </data>
+  <data name="Options_OnStartup" xml:space="preserve">
+    <value>При запуску</value>
+  </data>
+  <data name="Options_Output" xml:space="preserve">
+    <value>Вихідні файли</value>
+  </data>
+  <data name="Options_Path" xml:space="preserve">
+    <value>Шлях: </value>
+  </data>
+  <data name="Options_PathToMediaPlayer" xml:space="preserve">
+    <value>Path to Media Player</value>
+  </data>
+  <data name="Options_PreventSleep" xml:space="preserve">
+    <value>Вимикати системний режим сну під час кодування</value>
+  </data>
+  <data name="Options_PreviewScanCount" xml:space="preserve">
+    <value>Скільки зображень сканувати для попереднього перегляду:</value>
+  </data>
+  <data name="Options_PriorityLevel" xml:space="preserve">
+    <value>Пріоритет процесу:</value>
+  </data>
+  <data name="Options_QsvDecode" xml:space="preserve">
+    <value>Віддавати перевагу використанню Intel QuickSync для декодування відео, якщо доступно</value>
+  </data>
+  <data name="Options_QsvDecodeForNonFullPath" xml:space="preserve">
+    <value>Також використовувати декодування QSV, коли не використовується кодувальник QuickSync (тобто x265)</value>
+  </data>
+  <data name="Options_RemovePunctuation" xml:space="preserve">
+    <value>Видаляти поширені розділові знаки</value>
+  </data>
+  <data name="Options_ReplaceUnderscores" xml:space="preserve">
+    <value>Замінювати символи підкреслення пробілом</value>
+  </data>
+  <data name="Options_ResetDoNothing" xml:space="preserve">
+    <value>Скидати до «Нічого не робити», коли додаток перезапущено</value>
+  </data>
+  <data name="Options_Scaler" xml:space="preserve">
+    <value>Choose Scaler:</value>
+  </data>
+  <data name="Options_Scaling" xml:space="preserve">
+    <value>Масштабування</value>
+  </data>
+  <data name="Options_SendFileTo" xml:space="preserve">
+    <value>Надіслати файл в:</value>
+  </data>
+  <data name="Options_TitleCase" xml:space="preserve">
+    <value>Замінювати регістр на Капіталізацію</value>
+  </data>
+  <data name="Options_Updates" xml:space="preserve">
+    <value>Оновлення</value>
+  </data>
+  <data name="Options_UserInterface" xml:space="preserve">
+    <value>Інтерфейс користувача</value>
+  </data>
+  <data name="Options_Version" xml:space="preserve">
+    <value>Версія:</value>
+  </data>
+  <data name="Options_Video" xml:space="preserve">
+    <value>Відео</value>
+  </data>
+  <data name="Options_VideoPreviewPath" xml:space="preserve">
+    <value>This path is used for the video preview feature only.
+VLC and MPC-HC are supported. Other players may also work but are not validated.</value>
+  </data>
+  <data name="Options_ViewLogDirectory" xml:space="preserve">
+    <value>Переглянути каталог журналів</value>
+  </data>
+  <data name="Options_WhenDone" xml:space="preserve">
+    <value>Після завершення</value>
+  </data>
+  <data name="Options_x264" xml:space="preserve">
+    <value>Налаштування x264/5</value>
+  </data>
+  <data name="Options_x264Granularity" xml:space="preserve">
+    <value>Дробовий крок для постійної якості:</value>
+  </data>
+  <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
+    <value>Анаморфування:</value>
+  </data>
+  <data name="PictureSettingsView_Automatic" xml:space="preserve">
+    <value>Автоматично</value>
+  </data>
+  <data name="PictureSettingsView_Bottom" xml:space="preserve">
+    <value>Знизу</value>
+  </data>
+  <data name="PictureSettingsView_Cropping" xml:space="preserve">
+    <value>Обрізання:</value>
+  </data>
+  <data name="PictureSettingsView_Custom" xml:space="preserve">
+    <value>Власне</value>
+  </data>
+  <data name="PictureSettingsView_DisplayWitdh" xml:space="preserve">
+    <value>Ширина відображення:</value>
+  </data>
+  <data name="PictureSettingsView_Height" xml:space="preserve">
+    <value>Висота:</value>
+  </data>
+  <data name="PictureSettingsView_KeepAR" xml:space="preserve">
+    <value>Зберігати пропорції</value>
+  </data>
+  <data name="PictureSettingsView_Left" xml:space="preserve">
+    <value>Зліва</value>
+  </data>
+  <data name="PictureSettingsView_Modulus" xml:space="preserve">
+    <value>Модуль:</value>
+  </data>
+  <data name="PictureSettingsView_Output" xml:space="preserve">
+    <value>Результат</value>
+  </data>
+  <data name="PictureSettingsView_PAR" xml:space="preserve">
+    <value>PAR:</value>
+  </data>
+  <data name="PictureSettingsView_Right" xml:space="preserve">
+    <value>Справа</value>
+  </data>
+  <data name="PictureSettingsView_Size" xml:space="preserve">
+    <value>Розмір</value>
+  </data>
+  <data name="PictureSettingsView_Source" xml:space="preserve">
+    <value>Джерело:</value>
+  </data>
+  <data name="PictureSettingsView_Top" xml:space="preserve">
+    <value>Зверху</value>
+  </data>
+  <data name="PictureSettingsView_Width" xml:space="preserve">
+    <value>Ширина:</value>
+  </data>
+  <data name="Preset_Custom" xml:space="preserve">
+    <value>Власне</value>
+  </data>
+  <data name="Preset_Export" xml:space="preserve">
+    <value>Експортувати до файлу</value>
+  </data>
+  <data name="Preset_Import" xml:space="preserve">
+    <value>Імпортувати з файлу</value>
+  </data>
+  <data name="Preset_Official" xml:space="preserve">
+    <value>Офіційний</value>
+  </data>
+  <data name="QueueSelectionView_ChooseTitles" xml:space="preserve">
+    <value>Виберіть заголовки:</value>
+  </data>
+  <data name="QueueSelectionView_Title" xml:space="preserve">
+    <value>Додати до черги</value>
+  </data>
+  <data name="QueueSelection_UsingPreset" xml:space="preserve">
+    <value>Вибрані заголовки будуть додані за допомогою набору  «{0}».</value>
+  </data>
+  <data name="QueueView_Advanced" xml:space="preserve">
+    <value>Додатково:</value>
+  </data>
+  <data name="QueueView_Audio" xml:space="preserve">
+    <value>Аудіо:</value>
+  </data>
+  <data name="QueueView_ClearAll" xml:space="preserve">
+    <value>Очистити все</value>
+  </data>
+  <data name="QueueView_ClearCompleted" xml:space="preserve">
+    <value>Очистити завершені</value>
+  </data>
+  <data name="QueueView_ClearQueue" xml:space="preserve">
+    <value>Очистити чергу</value>
+  </data>
+  <data name="QueueView_ClearSelected" xml:space="preserve">
+    <value>Очистити вибране</value>
+  </data>
+  <data name="QueueView_Delete" xml:space="preserve">
+    <value>Видалити</value>
+  </data>
+  <data name="QueueView_Destination" xml:space="preserve">
+    <value>Шлях призначення:</value>
+  </data>
+  <data name="WhenDone_DoNothing" xml:space="preserve">
+    <value>Нічого не робити</value>
+  </data>
+  <data name="QueueView_Duration" xml:space="preserve">
+    <value>Час кодування:</value>
+  </data>
+  <data name="QueueView_Edit" xml:space="preserve">
+    <value>Змінити</value>
+  </data>
+  <data name="QueueView_EndTime" xml:space="preserve">
+    <value>Час завершення:</value>
+  </data>
+  <data name="QueueView_Export" xml:space="preserve">
+    <value>Експортувати чергу</value>
+  </data>
+  <data name="QueueView_FileSize" xml:space="preserve">
+    <value>Розмір файлу:</value>
+  </data>
+  <data name="WhenDone_Hibernate" xml:space="preserve">
+    <value>Режим глибокого сну</value>
+  </data>
+  <data name="WhenDone_LockSystem" xml:space="preserve">
+    <value>Заблокувати систему</value>
+  </data>
+  <data name="QueueView_LogNotAvailableYet" xml:space="preserve">
+    <value>Журнал буде доступний після завершення кодування.</value>
+  </data>
+  <data name="WhenDone_Logoff" xml:space="preserve">
+    <value>Вийти із системи</value>
+  </data>
+  <data name="QueueView_OpenDestDir" xml:space="preserve">
+    <value>Відкрити каталог призначення</value>
+  </data>
+  <data name="QueueView_OpenSourceDir" xml:space="preserve">
+    <value>Відкрити каталог джерела</value>
+  </data>
+  <data name="QueueView_Options" xml:space="preserve">
+    <value>Параметри</value>
+  </data>
+  <data name="QueueView_Pause" xml:space="preserve">
+    <value>Призупинити</value>
+  </data>
+  <data name="QueueView_PausedDuration" xml:space="preserve">
+    <value>Тривалість паузи:</value>
+  </data>
+  <data name="QueueView_PictureSettings" xml:space="preserve">
+    <value>Налаштування зображення:</value>
+  </data>
+  <data name="WhenDone_QuitHandBrake" xml:space="preserve">
+    <value>Закрити HandBrake</value>
+  </data>
+  <data name="QueueView_ResetAllJobs" xml:space="preserve">
+    <value>Повторіть усі завдання</value>
+  </data>
+  <data name="QueueView_ResetFailed" xml:space="preserve">
+    <value>Повторити невдалі</value>
+  </data>
+  <data name="QueueView_ResetSelectedJobs" xml:space="preserve">
+    <value>Скинути вибрані завдання</value>
+  </data>
+  <data name="QueueView_Reset" xml:space="preserve">
+    <value>Скинути</value>
+  </data>
+  <data name="WhenDone_Shutdown" xml:space="preserve">
+    <value>Вимикання живлення</value>
+  </data>
+  <data name="QueueView_Source" xml:space="preserve">
+    <value>Джерело:</value>
+  </data>
+  <data name="QueueView_Start" xml:space="preserve">
+    <value>Запустити чергу</value>
+  </data>
+  <data name="QueueView_StartTime" xml:space="preserve">
+    <value>Час початку:</value>
+  </data>
+  <data name="QueueView_Statistics" xml:space="preserve">
+    <value>Статистика</value>
+  </data>
+  <data name="QueueView_StatsNotAvailableYet" xml:space="preserve">
+    <value>Статистика буде доступна після завершення кодування.</value>
+  </data>
+  <data name="QueueView_Subtitles" xml:space="preserve">
+    <value>Субтитри:</value>
+  </data>
+  <data name="QueueView_Summary" xml:space="preserve">
+    <value>Відомості</value>
+  </data>
+  <data name="WhenDone_Suspend" xml:space="preserve">
+    <value>Режим сну</value>
+  </data>
+  <data name="QueueView_Video" xml:space="preserve">
+    <value>Відео:</value>
+  </data>
+  <data name="QueueView_WhenDone" xml:space="preserve">
+    <value>Після завершення:</value>
+  </data>
+  <data name="Shared_AddAllForSelected" xml:space="preserve">
+    <value>Додати всі вибрані мови, що залишились</value>
+  </data>
+  <data name="Shared_AddAllRemaining" xml:space="preserve">
+    <value>Додати всі доріжки, що залишилися</value>
+  </data>
+  <data name="Shared_AddNewTrack" xml:space="preserve">
+    <value>Додати нову доріжку</value>
+  </data>
+  <data name="Shared_AddTrack" xml:space="preserve">
+    <value>Додати доріжку</value>
+  </data>
+  <data name="Shared_AvailableLanguages" xml:space="preserve">
+    <value>Доступні мови:</value>
+  </data>
+  <data name="Shared_ChooseLanguages" xml:space="preserve">
+    <value>Виберіть мови:</value>
+  </data>
+  <data name="Shared_ChosenLangages" xml:space="preserve">
+    <value>Вибрані мови:</value>
+  </data>
+  <data name="Shared_ConfigureDefaultBehaviours" xml:space="preserve">
+    <value>Налаштувати стандартну поведінку</value>
+  </data>
+  <data name="Shared_ReloadDefaults" xml:space="preserve">
+    <value>Перезавантажити</value>
+  </data>
+  <data name="SourceSelection_ChooseDisc" xml:space="preserve">
+    <value>Виберіть диск для сканування</value>
+  </data>
+  <data name="SourceSelection_ChooseFile" xml:space="preserve">
+    <value>Виберіть файл для сканування</value>
+  </data>
+  <data name="SourceSelection_ChooseFolder" xml:space="preserve">
+    <value>Виберіть папку для сканування</value>
+  </data>
+  <data name="SourceSelection_ChooseSpecificTitle" xml:space="preserve">
+    <value>За бажанням можете вибрати конкретний заголовок:</value>
+  </data>
+  <data name="SourceSelection_ChooseVideo" xml:space="preserve">
+    <value>Потім виберіть відео, яке ви хочете кодувати:</value>
+  </data>
+  <data name="SourceSelection_File" xml:space="preserve">
+    <value>Файл</value>
+  </data>
+  <data name="SourceSelection_FolderBatchScan" xml:space="preserve">
+    <value>Папка (пакетне сканування)</value>
+  </data>
+  <data name="SourceSelection_OpenDVDBluray" xml:space="preserve">
+    <value>Відкрийте цей DVD або Blu-ray диск</value>
+  </data>
+  <data name="SourceSelection_OpenFolderWIth" xml:space="preserve">
+    <value>Відкрийте папку з одним або кількома файлами.</value>
+  </data>
+  <data name="SourceSelection_QueueArchiveRecovery" xml:space="preserve">
+    <value>Відновити файли черги</value>
+  </data>
+  <data name="SourceSelection_QueueArchiveRecoveryDesc" xml:space="preserve">
+    <value>Доступний архів попередньої черги.</value>
+  </data>
+  <data name="SourceSelection_SingleVideoFile" xml:space="preserve">
+    <value>Відкрийте один відеофайл.</value>
+  </data>
+  <data name="SourceSelection_SourceSelection" xml:space="preserve">
+    <value>Вибір джерела</value>
+  </data>
+  <data name="StaticPreviewView_Duration" xml:space="preserve">
+    <value>Тривалість:</value>
+  </data>
+  <data name="StaticPreviewView_LivePreview" xml:space="preserve">
+    <value>Перегляд наживо</value>
+  </data>
+  <data name="StaticPreviewView_SelectPreviewImage" xml:space="preserve">
+    <value>Виберіть зображення для попереднього перегляду</value>
+  </data>
+  <data name="StaticPreviewView_UseSystemDefault" xml:space="preserve">
+    <value>Prefer system default video player</value>
+  </data>
+  <data name="SubtitlesView_AddCC" xml:space="preserve">
+    <value>Додавати приховані субтитри, при наявності</value>
+  </data>
+  <data name="SubtitlesView_AddForeignAudioSearch" xml:space="preserve">
+    <value>Додавати «Сканування іншомовного аудіо»</value>
+  </data>
+  <data name="SubtitlesView_BurnInBehaviour" xml:space="preserve">
+    <value>Поведінка вбудовування:</value>
+  </data>
+  <data name="SubtitlesView_ImportSubtitle" xml:space="preserve">
+    <value>Імпортувати субтитри</value>
+  </data>
+  <data name="SubtitlesView_TrackSelectionBehaviour" xml:space="preserve">
+    <value>Поведінка вибору доріжки:</value>
+  </data>
+  <data name="SubtitleView_AddAllCC" xml:space="preserve">
+    <value>Додати всі приховані субтитри, що залишилися</value>
+  </data>
+  <data name="SubtitleView_SubtitleDefaultsDescription" xml:space="preserve">
+    <value>Налаштуйте спосіб автоматичного вибору та налаштування доріжок субтитрів під час вибору нового заголовка чи джерела відео.</value>
+  </data>
+  <data name="SummaryView_AdditionalAudioTracks" xml:space="preserve">
+    <value>Додаткові звукові доріжки</value>
+  </data>
+  <data name="SummaryView_AdditionalSubtitleTracks" xml:space="preserve">
+    <value>Додаткові доріжки субтитрів</value>
+  </data>
+  <data name="SummaryView_Burned" xml:space="preserve">
+    <value>Burned</value>
+  </data>
+  <data name="SummaryView_Chapters" xml:space="preserve">
+    <value>Маркери глав</value>
+  </data>
+  <data name="SummaryView_Deblock" xml:space="preserve">
+    <value>Deblock</value>
+  </data>
+  <data name="SummaryView_Detelecine" xml:space="preserve">
+    <value>Видалення «гребінки»</value>
+  </data>
+  <data name="SummaryView_display" xml:space="preserve">
+    <value>display</value>
+  </data>
+  <data name="SummaryView_Grayscale" xml:space="preserve">
+    <value>Відтінки сірого</value>
+  </data>
+  <data name="SummaryView_NoAudioTracks" xml:space="preserve">
+    <value>Немає звукових доріжок</value>
+  </data>
+  <data name="SummaryView_NoChapters" xml:space="preserve">
+    <value>Немає маркерів глав</value>
+  </data>
+  <data name="SummaryView_NoFilters" xml:space="preserve">
+    <value>Немає фільтрів</value>
+  </data>
+  <data name="SummaryView_NoSource" xml:space="preserve">
+    <value>Немає джерела</value>
+  </data>
+  <data name="SummaryView_NoSubtitleTracks" xml:space="preserve">
+    <value>Немає доріжок субтитрів</value>
+  </data>
+  <data name="SummaryView_NoTracks" xml:space="preserve">
+    <value>Немає доріжок</value>
+  </data>
+  <data name="SummaryView_PreviewInfo" xml:space="preserve">
+    <value>Попередній перегляд {0} з {1}</value>
+  </data>
+  <data name="SummaryView_Rotation" xml:space="preserve">
+    <value>Поворот</value>
+  </data>
+  <data name="SummaryView_storage" xml:space="preserve">
+    <value>storage</value>
+  </data>
+  <data name="VideoView_2Pass" xml:space="preserve">
+    <value>2-прохідне кодування</value>
+  </data>
+  <data name="VideoView_AverageBitrate" xml:space="preserve">
+    <value>Середній бітрейт (кбіт/с):</value>
+  </data>
+  <data name="VideoView_Codec" xml:space="preserve">
+    <value>Відеокодек:</value>
+  </data>
+  <data name="VideoView_ConstantFramerate" xml:space="preserve">
+    <value>Постійна частота кадрів</value>
+  </data>
+  <data name="VideoView_ConstantQuality" xml:space="preserve">
+    <value>Постійна якість:</value>
+  </data>
+  <data name="VideoView_EncoderLevel" xml:space="preserve">
+    <value>Рівень кодувальника:</value>
+  </data>
+  <data name="VideoView_EncoderPreset" xml:space="preserve">
+    <value>Набір кодувальника:</value>
+  </data>
+  <data name="VideoView_EncoderProfile" xml:space="preserve">
+    <value>Профіль кодувальника:</value>
+  </data>
+  <data name="VideoView_EncodeTune" xml:space="preserve">
+    <value>Налаштування кодувальника:</value>
+  </data>
+  <data name="VideoView_ExtraOptions" xml:space="preserve">
+    <value>Розширені опції:</value>
+  </data>
+  <data name="VideoView_FastDecode" xml:space="preserve">
+    <value>Швидке декодування</value>
+  </data>
+  <data name="VideoView_Framerate" xml:space="preserve">
+    <value>Частота кадрів (FPS):</value>
+  </data>
+  <data name="VideoView_OptimiseVideo" xml:space="preserve">
+    <value>Оптимізація відео:</value>
+  </data>
+  <data name="VideoView_PeakFramerate" xml:space="preserve">
+    <value>Пікова частота кадрів</value>
+  </data>
+  <data name="VideoView_Quality" xml:space="preserve">
+    <value>Якість</value>
+  </data>
+  <data name="VideoView_TurboFirstPass" xml:space="preserve">
+    <value>Швидкий перший прохід</value>
+  </data>
+  <data name="VideoView_VariableFramerate" xml:space="preserve">
+    <value>Змінна частота кадрів</value>
+  </data>
+  <data name="VideoView_Video" xml:space="preserve">
+    <value>Відео</value>
+  </data>
+  <data name="OptionsView_Language" xml:space="preserve">
+    <value>Мова:</value>
+  </data>
+  <data name="Language_UseSystem" xml:space="preserve">
+    <value>Використовувати мову системи</value>
+  </data>
+  <data name="SourceSelection_AboutHandBrake" xml:space="preserve">
+    <value>Про HandBrake</value>
+  </data>
+  <data name="SourceSelection_DropFileHere" xml:space="preserve">
+    <value>Або перетягніть сюди файл чи папку…</value>
+  </data>
+  <data name="SourceSelection_Help" xml:space="preserve">
+    <value>Довідка</value>
+  </data>
+  <data name="Preferences" xml:space="preserve">
+    <value>Налаштування</value>
+  </data>
+  <data name="AudioDefaultsView_AddTrack" xml:space="preserve">
+    <value>Додати доріжку</value>
+  </data>
+  <data name="AudioDefaultsView_AutoAddTracks" xml:space="preserve">
+    <value>Налаштування кодувальника аудіо для кожної вибраної доріжки:</value>
+  </data>
+  <data name="AudioDefaultsView_Clear" xml:space="preserve">
+    <value>Очистити</value>
+  </data>
+  <data name="SubtitlesView_BurnIn" xml:space="preserve">
+    <value>Вбудовані</value>
+  </data>
+  <data name="SubtitlesView_Default" xml:space="preserve">
+    <value>Стандартно</value>
+  </data>
+  <data name="SubtitlesView_ForcedOnly" xml:space="preserve">
+    <value>Тільки примусово</value>
+  </data>
+  <data name="MainView_About" xml:space="preserve">
+    <value>_Про програму…</value>
+  </data>
+  <data name="MainView_ActivityLogMenu" xml:space="preserve">
+    <value>_Журнал активності</value>
+  </data>
+  <data name="MainView_CheckForUpdates" xml:space="preserve">
+    <value>Перевірити наявність _оновлень</value>
+  </data>
+  <data name="MainView_Exit" xml:space="preserve">
+    <value>_Вийти</value>
+  </data>
+  <data name="MainView_ExportToFile" xml:space="preserve">
+    <value>_Експортувати у файл</value>
+  </data>
+  <data name="MainView_FileMenu" xml:space="preserve">
+    <value>_Файл</value>
+  </data>
+  <data name="MainView_HandBrakeDocs" xml:space="preserve">
+    <value>_Документація HandBrake (HTTPS)</value>
+  </data>
+  <data name="MainView_HelpMenu" xml:space="preserve">
+    <value>_Довідка</value>
+  </data>
+  <data name="MainView_ImportFromFile" xml:space="preserve">
+    <value>_Імпортувати з файлу</value>
+  </data>
+  <data name="MainView_PreferencesMenu" xml:space="preserve">
+    <value>_Параметри</value>
+  </data>
+  <data name="MainView_PresetsMenu" xml:space="preserve">
+    <value>_Набори</value>
+  </data>
+  <data name="MainView_QueueMenu" xml:space="preserve">
+    <value>_Черга</value>
+  </data>
+  <data name="MainView_ResetPresets" xml:space="preserve">
+    <value>_Скинути вбудовані набори</value>
+  </data>
+  <data name="MainView_SetCurrentAsDefault" xml:space="preserve">
+    <value>_Встановити поточний за замовчуванням</value>
+  </data>
+  <data name="MainView_ShowPresetPanel" xml:space="preserve">
+    <value>_Показати панель наборів</value>
+  </data>
+  <data name="MainView_ShowQueueMenu" xml:space="preserve">
+    <value>Показати _чергу</value>
+  </data>
+  <data name="MainView_ToolsMenu" xml:space="preserve">
+    <value>_Інструменти</value>
+  </data>
+  <data name="OptionsView_CheckingForUpdates" xml:space="preserve">
+    <value>Перевірка наявності оновлень…</value>
+  </data>
+  <data name="OptionsView_ClearLogDirConfirm" xml:space="preserve">
+    <value>Дійсно хочете очистити каталог файлів журналу?</value>
+  </data>
+  <data name="OptionsView_ClearLogs" xml:space="preserve">
+    <value>Очистити журнали</value>
+  </data>
+  <data name="OptionsView_Downloading" xml:space="preserve">
+    <value>Завантаження…</value>
+  </data>
+  <data name="OptionsView_LogsCleared" xml:space="preserve">
+    <value>Каталог файлів журналу HandBrake очищений!</value>
+  </data>
+  <data name="OptionsView_Notice" xml:space="preserve">
+    <value>Повідомлення</value>
+  </data>
+  <data name="OptionsView_PreparingUpdate" xml:space="preserve">
+    <value>Підготовка до оновлення…</value>
+  </data>
+  <data name="OptionsView_SelectFolder" xml:space="preserve">
+    <value>Виберіть папку.</value>
+  </data>
+  <data name="OptionsView_SetDefaultLocationOutputFIle" xml:space="preserve">
+    <value>Клацніть «Огляд», щоб встановити стандартне розташування</value>
+  </data>
+  <data name="MainView_Hide" xml:space="preserve">
+    <value>Приховати</value>
+  </data>
+  <data name="MainView_Show" xml:space="preserve">
+    <value>Показати</value>
+  </data>
+  <data name="MainView_ShowAddAllToQueue" xml:space="preserve">
+    <value>«Додати все» до черги</value>
+  </data>
+  <data name="MainView_ShowAddSelectionToQueue" xml:space="preserve">
+    <value>«Додати вибране» до черги</value>
+  </data>
+  <data name="QueueView_PlayMediaFile" xml:space="preserve">
+    <value>Відтворити файл</value>
+  </data>
+  <data name="Options_ApplicaitonToolbar" xml:space="preserve">
+    <value>Панель інструментів програми</value>
+  </data>
+  <data name="Options_ShowToolbarAddAll" xml:space="preserve">
+    <value>Показувати «Додати усе до черги» на панелі інструментів</value>
+  </data>
+  <data name="Options_ShowToolbarAddSelection" xml:space="preserve">
+    <value>Показувати «Додати вибране до черги» на панелі інструментів</value>
+  </data>
+  <data name="OptionsView_HardwareDetectFailed" xml:space="preserve">
+    <value>Наразі підтримка апаратного кодування вимкнена. Переконайтеся, що ви використовуєте останні драйвери для всіх відеоадаптерів у цій системі.
+
+Це не вплине на жоден з програмних кодувальників.</value>
+  </data>
+  <data name="Main_PleaseFixSubtitleSettings" xml:space="preserve">
+    <value>Перш ніж продовжувати, виправте налаштування субтитрів.</value>
+  </data>
+  <data name="Generic_Apply" xml:space="preserve">
+    <value>Застосувати</value>
+  </data>
+  <data name="Main_ResumeEncode" xml:space="preserve">
+    <value>Продовжити кодування</value>
+  </data>
+  <data name="QueueView_Actions" xml:space="preserve">
+    <value>Дії</value>
+  </data>
+  <data name="QueueView_Import" xml:space="preserve">
+    <value>Імпортувати чергу</value>
+  </data>
+  <data name="QueueViewModel_EncodeStatusChanged_StatusLabel" xml:space="preserve">
+    <value>Кодування: прохід {0} з {1},  {2:00.00}%, FPS: {3:000.0},  середній FPS: {4:000.0}
+Залишилося часу: {5},  пройшло: {6} {7}</value>
+  </data>
+  <data name="QueueView_DeleteSelected" xml:space="preserve">
+    <value>Видалити вибране</value>
+  </data>
+  <data name="Portable_TmpNotWritable" xml:space="preserve">
+    <value>Портативний режим: неможливо створити каталог TMP. Перевірте правильність шляху та права запису.
+
+    {0}</value>
+  </data>
+  <data name="Portable_StorageNotWritable" xml:space="preserve">
+    <value>Портативний режим: неможливо каталог для зберігання. Перевірте правильність шляху та права запису.
+
+    {0}</value>
+  </data>
+  <data name="Portable_IniFileError" xml:space="preserve">
+    <value>Портативний режим: не вдається прочитати portable.ini. Можливо, виникла помилка у цьому файлі. Повторіть спробу, використовуючи portable.ini.template як основу.</value>
+  </data>
+  <data name="Startup_InitFailed" xml:space="preserve">
+    <value>Не вдалося ініціалізувати рушій HandBrake. Це часто викликано через застарілі драйвери GPU.\n  Оновіть драйвери GPU для будь-якої вбудованої та дискретної графіки, що містить ваша система.</value>
+  </data>
+  <data name="OptionsView_FormatOptions" xml:space="preserve">
+    <value>Динамічні опції оновлення: {source} {title} {chapters} 
+Нединамічні опції: {date} {time} {creation-date} {creation-time} {quality} {bitrate} (вони змінюються, лише при скануванні нового джерела, зміни назви чи глав)</value>
+  </data>
+  <data name="OptionsView_PathOptions" xml:space="preserve">
+    <value>Доступні опції: {source_path} {source_folder_name} {source}</value>
+  </data>
+  <data name="FileOverwriteBehaviours_Ask" xml:space="preserve">
+    <value>Запитувати про перезапис файлу</value>
+  </data>
+  <data name="FileOverwriteBehaviours_Autoname" xml:space="preserve">
+    <value>Пробувати автоматично перейменовувати файл</value>
+  </data>
+  <data name="FileOverwriteBehaviours_Overwrite" xml:space="preserve">
+    <value>Перезаписувати файл</value>
+  </data>
+  <data name="Options_UIBehaviour" xml:space="preserve">
+    <value>Поведінка інтерфейсу користувача</value>
+  </data>
+  <data name="OptionsView_FileOverwriteBehaviour" xml:space="preserve">
+    <value>Поведінка перезапису файлів:</value>
+  </data>
+  <data name="Options_EncodeCompleted" xml:space="preserve">
+    <value>Кодування завершено</value>
+  </data>
+  <data name="Options_Notifications" xml:space="preserve">
+    <value>Сповіщення</value>
+  </data>
+  <data name="Options_QueueCompleted" xml:space="preserve">
+    <value>Черга завершена</value>
+  </data>
+  <data name="Options_WhenDoneColon" xml:space="preserve">
+    <value>Після завершення:</value>
+  </data>
+  <data name="OptionsView_FileCollisionBehaviour" xml:space="preserve">
+    <value>Поведінка при конфлікті імен файлів:</value>
+  </data>
+  <data name="CollisionBehaviour_Post" xml:space="preserve">
+    <value>Постфікс</value>
+  </data>
+  <data name="CollisionBehaviour_Pre" xml:space="preserve">
+    <value>Префікс</value>
+  </data>
+  <data name="CollisionBehaviour_AppendNumber" xml:space="preserve">
+    <value>Додавати номер</value>
+  </data>
+  <data name="FiltersViewAuto_DeblockPreset" xml:space="preserve">
+    <value>FiltersView_DeblockPreset</value>
+  </data>
+  <data name="FiltersViewAuto_DeblockTune" xml:space="preserve">
+    <value>Deblock Tune</value>
+  </data>
+  <data name="OptionsView_ChoiceOfEncoderHint" xml:space="preserve">
+    <value>Вибір кодувальника буде доступний на вкладці «Відео».</value>
+  </data>
+  <data name="Queue_RecoverQueueQuestionPlural" xml:space="preserve">
+    <value>HandBrake виявив декілька незавершених файлів черги. Вони з декількох запущених екземплярів HandBrake. Хочете відновити всі незакінчені завдання?</value>
+  </data>
+  <data name="Queue_RecoverQueueQuestionSingular" xml:space="preserve">
+    <value>HandBrake виявив незавершені елементи в черзі з останнього запуску програми. Хочете їх відновити?</value>
+  </data>
+  <data name="Queue_RecoveryPossible" xml:space="preserve">
+    <value>Можливе відновлення черги</value>
+  </data>
+  <data name="PresetService_ImportingBuiltInWarning" xml:space="preserve">
+    <value>Ваш файл наборів містив вбудовані набори. Функція імпорту не підтримує імпорт такого типу. Будь ласка, використайте «меню Набори -&gt; Скинути вбудовані набори», щоб відновити стандартні набори.
+
+Будь-які набори користувача будуть імпортовані, якщо вони підтримуються.</value>
+  </data>
+  <data name="Options_PromptBeforeAction" xml:space="preserve">
+    <value>Виконувати дію негайно (це вимкне 60 секундне діалогове вікно підтвердження)</value>
+  </data>
+  <data name="Browse" xml:space="preserve">
+    <value>Огляд</value>
+  </data>
+  <data name="OptionsView_MediaFileNotSet" xml:space="preserve">
+    <value>Не встановлено жодного аудіофайлу. Клацніть «Огляд», щоб вибрати WAV або mp3 файл для відтворення.</value>
+  </data>
+  <data name="OptionsView_Play" xml:space="preserve">
+    <value>Відтворити</value>
+  </data>
+  <data name="QueueView_ExportCLI" xml:space="preserve">
+    <value>Експортувати чергу (тільки для CLI)</value>
+  </data>
+  <data name="Options_DarkTheme" xml:space="preserve">
+    <value>Використовувати темну тему (потрібен перезапуск, лише для Windows 10)</value>
+  </data>
+  <data name="QueueView_NotAvailable" xml:space="preserve">
+    <value>Недоступно</value>
+  </data>
+  <data name="Options_LowDiskspaceSizeGB" xml:space="preserve">
+    <value>ГБ</value>
+  </data>
+  <data name="SystemService_ACMains" xml:space="preserve">
+    <value>Виявлено живлення від мережі. Відновлення кодування… ({0} %)</value>
+  </data>
+  <data name="SystemService_CriticalBattery" xml:space="preserve">
+    <value>Критичний заряд акумулятора! ({0} %)</value>
+  </data>
+  <data name="SystemService_LowBatteryLog" xml:space="preserve">
+    <value>Низький заряд акумулятора! ({0} %). Кодування призупинено.</value>
+  </data>
+  <data name="SystemService_LowDiskSpaceLog" xml:space="preserve">
+    <value>Обсяг вільного дискового простору на диску, на якому розташований каталог призначення, зменшився нижче {0} ГБ. Призупиняємо кодування…</value>
+  </data>
+  <data name="AudioDefaultsView_PaneTitle" xml:space="preserve">
+    <value>Налаштування автоматичного вибору аудіо</value>
+  </data>
+  <data name="SubtitlesDefaultsView_PaneTitle" xml:space="preserve">
+    <value>Налаштування автоматичного вибору субтитрів</value>
+  </data>
+  <data name="Options_SystemOptions" xml:space="preserve">
+    <value>Система</value>
+  </data>
+  <data name="MetadataView_Actors" xml:space="preserve">
+    <value>Виконавці:</value>
+  </data>
+  <data name="MetadataView_Comments" xml:space="preserve">
+    <value>Коментарі:</value>
+  </data>
+  <data name="MetadataView_Description" xml:space="preserve">
+    <value>Опис:</value>
+  </data>
+  <data name="MetadataView_Director" xml:space="preserve">
+    <value>Режисер:</value>
+  </data>
+  <data name="MetadataView_Genre" xml:space="preserve">
+    <value>Жанр:</value>
+  </data>
+  <data name="MetadataView_Plot" xml:space="preserve">
+    <value>Сюжет:</value>
+  </data>
+  <data name="MetadataView_ReleaseDate" xml:space="preserve">
+    <value>Дата виходу:</value>
+  </data>
+  <data name="MetadataView_TitleTag" xml:space="preserve">
+    <value>Заголовок:</value>
+  </data>
+  <data name="StaticPreviewView_PreviewRotationFlip" xml:space="preserve">
+    <value>Попередній перегляд «Повороту» та «Відбиття»</value>
+  </data>
+  <data name="LogViewModel_Title" xml:space="preserve">
+    <value>Переглядач журналу</value>
+  </data>
+  <data name="MainView_Aspect" xml:space="preserve">
+    <value>Співвідношення сторін:</value>
+  </data>
+  <data name="MainView_Filters" xml:space="preserve">
+    <value>Фільтри:</value>
+  </data>
+  <data name="MainView_Size" xml:space="preserve">
+    <value>Розмір:</value>
+  </data>
+  <data name="MainView_Tracks" xml:space="preserve">
+    <value>Доріжки:</value>
+  </data>
+  <data name="OptionsTab_General" xml:space="preserve">
+    <value>Загальні</value>
+  </data>
+  <data name="OptionsViewModel_CheckForUpdatesMsg" xml:space="preserve">
+    <value>Клацніть «Перевірити наявність оновлень», щоб перевірити наявність нових версій</value>
+  </data>
+  <data name="OptionsView_BackButton" xml:space="preserve">
+    <value>&lt; Назад</value>
+  </data>
+  <data name="QueueView_CurrentlyPaused" xml:space="preserve">
+    <value>В даний час призупинено</value>
+  </data>
+  <data name="Options_OutputFiles" xml:space="preserve">
+    <value>Вихідні файли</value>
+  </data>
+  <data name="PointToPointMode_Chapters" xml:space="preserve">
+    <value>Глави</value>
+  </data>
+  <data name="PointToPointMode_Frames" xml:space="preserve">
+    <value>Кадри</value>
+  </data>
+  <data name="PointToPointMode_Preview" xml:space="preserve">
+    <value>Попередній перегляд</value>
+  </data>
+  <data name="PointToPointMode_Seconds" xml:space="preserve">
+    <value>Секунди</value>
+  </data>
+  <data name="SubtitleBehaviourModes_AllMatching" xml:space="preserve">
+    <value>Усі збіги вибраним мовам</value>
+  </data>
+  <data name="SubtitleBehaviourModes_FirstMatching" xml:space="preserve">
+    <value>Перший збіг вибраним мовам</value>
+  </data>
+  <data name="SubtitleBehaviourModes_None" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="SubtitleBurnInBehaviourModes_FirstTrack" xml:space="preserve">
+    <value>Перша доріжка</value>
+  </data>
+  <data name="SubtitleBurnInBehaviourModes_ForeignAudioPreferredElseFirst" xml:space="preserve">
+    <value>Бажано іншомовне аудіо, інакше перше</value>
+  </data>
+  <data name="SubtitleBurnInBehaviourModes_ForeignAudioTrack" xml:space="preserve">
+    <value>Іншомовна звукова доріжка</value>
+  </data>
+  <data name="SubtitleBurnInBehaviourModes_None" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="SubtitleViewModel_ForeignAudioSearch" xml:space="preserve">
+    <value>Пошук іншомовного аудіо</value>
+  </data>
+  <data name="Subtitle_ForeignAudioScan" xml:space="preserve">
+    <value>Сканування іншомовного аудіо</value>
+  </data>
+  <data name="AudioBehaviourModes_AllMatching" xml:space="preserve">
+    <value>Усі збіги вибраним мовам</value>
+  </data>
+  <data name="AudioBehaviourModes_AllTracks" xml:space="preserve">
+    <value>Використовувати усі доріжки як шаблони</value>
+  </data>
+  <data name="AudioBehaviourModes_FirstMatch" xml:space="preserve">
+    <value>Перша відповідність вибраній мові</value>
+  </data>
+  <data name="AudioBehaviourModes_FirstTrack" xml:space="preserve">
+    <value>Використовувати першу доріжку як шаблон</value>
+  </data>
+  <data name="AudioBehaviourModes_None" xml:space="preserve">
+    <value>Без звуку</value>
+  </data>
+  <data name="ChapterViewModel_Chapter" xml:space="preserve">
+    <value>Глава {0}</value>
+  </data>
+  <data name="Mp4Behaviour_Auto" xml:space="preserve">
+    <value>Автоматично</value>
+  </data>
+  <data name="Mp4Behaviour_UseM4v" xml:space="preserve">
+    <value>Завжди використовувати M4V</value>
+  </data>
+  <data name="Mp4Behaviour_UseMp4" xml:space="preserve">
+    <value>Завжди використовувати MP4</value>
+  </data>
+  <data name="PresetPictureSettingsMode_Custom" xml:space="preserve">
+    <value>Власне</value>
+  </data>
+  <data name="PresetPictureSettingsMode_None" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="PresetPictureSettingsMode_SourceMaximum" xml:space="preserve">
+    <value>Завжди використовувати роздільність джерела</value>
+  </data>
+  <data name="ProcessPriority_AboveNormal" xml:space="preserve">
+    <value>Вище середнього</value>
+  </data>
+  <data name="ProcessPriority_BelowNormal" xml:space="preserve">
+    <value>Нижче середнього</value>
+  </data>
+  <data name="ProcessPriority_High" xml:space="preserve">
+    <value>Високий</value>
+  </data>
+  <data name="ProcessPriority_Low" xml:space="preserve">
+    <value>Низький</value>
+  </data>
+  <data name="ProcessPriority_Normal" xml:space="preserve">
+    <value>Середній</value>
+  </data>
+  <data name="UpdateCheck_Monthly" xml:space="preserve">
+    <value>Щомісяця</value>
+  </data>
+  <data name="UpdateCheck_Weekly" xml:space="preserve">
+    <value>Щотижня</value>
+  </data>
+  <data name="OptionsView_AlwaysUseDefaultPath" xml:space="preserve">
+    <value>Завжди використовувати стандартний шлях для кожного створеного нового імені</value>
+  </data>
+  <data name="OptionsView_RemotePortLimit" xml:space="preserve">
+    <value>Діапазон порту повинна бути від 5000 до 32767</value>
+  </data>
+  <data name="OptionsView_SendFileToArgPlaceholders" xml:space="preserve">
+    <value>Заміна покажчиків місця заповнення: {source} {destination}</value>
+    <comment>Note: {source} and {destination} are not translatable. </comment>
+  </data>
+  <data name="SourceSelection_UpdateAvailable" xml:space="preserve">
+    <value>Доступна нова версія HandBrake!</value>
+  </data>
+  <data name="About_Copyright" xml:space="preserve">
+    <value>Copyright (C) 2003-2020 The HandBrake Team</value>
+  </data>
+  <data name="Options_LowBatteryLevel" xml:space="preserve">
+    <value>Низький рівень заряду акумулятора:</value>
+  </data>
+  <data name="Options_PauseOnLowBattery" xml:space="preserve">
+    <value>Призупиняти будь-які запущені завдання, коли акумулятор розрядиться.</value>
+  </data>
+  <data name="SubtitleView_AddRemainingCC" xml:space="preserve">
+    <value>Додати всі приховані субтитри, що залишилися</value>
+  </data>
+  <data name="QueueService_DuplicatesQuestion" xml:space="preserve">
+    <value>Ви намагаєтеся імпортувати файл черги, у якому виявлено дубльовані завдання. Хочете перезаписати наявні записи? 
+Також, це зупинить будь-які наявні запущені завдання.</value>
+  </data>
+  <data name="QueueService_DuplicatesTitle" xml:space="preserve">
+    <value>Виявлені дублікати</value>
+  </data>
+  <data name="OptionsView_EnableQuicksyncLowPower" xml:space="preserve">
+    <value>Enable Low Power QuickSync Hardware (where supported).</value>
+  </data>
+  <data name="QueueView_JobInformationNotAvailable" xml:space="preserve">
+    <value>Щоб переглянути відомості виберіть якесь завдання.</value>
+  </data>
+  <data name="OptionsView_EnableWorkerProcesses" xml:space="preserve">
+    <value>Запускати кожне завдання в черзі як окремий процес (експериментально)</value>
+  </data>
+  <data name="OptionsView_WorkerDefaultPort" xml:space="preserve">
+    <value>Стандартний мережевий порт для процесу:</value>
+  </data>
+  <data name="Presets_NotAvailableForUse" xml:space="preserve">
+    <value>Вибраний набір недоступний для використання у цій системі.
+
+Зазвичай це свідчить про те, що ваша система не підтримує обладнання, необхідне для використання цього набору.
+
+Будь ласка, оберіть інший набір.</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation" xml:space="preserve">
+    <value>Ізоляція процесів</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation_Warning1" xml:space="preserve">
+    <value>Зауважте, використання цієї функції запустить HTTP сервер, що буде прив’язаний до адреси 127.0.0.1 на вказаному порту.</value>
+  </data>
+  <data name="OptionsView_ProcessIsolation_Warning2" xml:space="preserve">
+    <value>Якщо порт вже використовується, програма знайде перший вільний порт у межі +100 від вказаного порту.</value>
+  </data>
+  <data name="OptionsView_SimultaneousEncodes" xml:space="preserve">
+    <value>Кількість одночасних кодувань:</value>
+  </data>
+  <data name="StaticPreviewView_CancelPreview" xml:space="preserve">
+    <value>Скасувати</value>
+  </data>
+  <data name="MainView_SelectedPresets" xml:space="preserve">
+    <value>Набір:</value>
+  </data>
+  <data name="SummaryView_SameAsSource" xml:space="preserve">
+    <value>Так само, як в джерелі</value>
+  </data>
+  <data name="OptionsViewModel_ResetHandBrake" xml:space="preserve">
+    <value>Скинути налаштування</value>
+  </data>
+  <data name="OptionsViewModel_ResetHandBrakeQuestion" xml:space="preserve">
+    <value>Дійсно хочете скинути налаштування HandBrake до стандартних?</value>
+  </data>
+  <data name="PaddingMode_Custom" xml:space="preserve">
+    <value>Спеціальне (без обмежень)</value>
+  </data>
+  <data name="PaddingMode_Fill" xml:space="preserve">
+    <value>Наповнити (заповнення до межі роздільності)</value>
+  </data>
+  <data name="PaddingMode_Height" xml:space="preserve">
+    <value>По висоті (заповнення до межі роздільності)</value>
+  </data>
+  <data name="PaddingMode_None" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="PaddingMode_Width" xml:space="preserve">
+    <value>По ширині (заповнення до межі роздільності)</value>
+  </data>
+  <data name="PictureSettingsView_Padding" xml:space="preserve">
+    <value>Заповнення:</value>
+  </data>
+  <data name="PictureSettingsView_PaddingColour" xml:space="preserve">
+    <value>Колір заповнення:</value>
+  </data>
+  <data name="PictureSettingsView_Borders" xml:space="preserve">
+    <value>Межі</value>
+  </data>
+  <data name="PictureSettingsView_ResAndScaling" xml:space="preserve">
+    <value>Роздільна здатність та масштабування</value>
+  </data>
+  <data name="PictureSettingsView_RotateAndCrop" xml:space="preserve">
+    <value>Поворот та обрізання</value>
+  </data>
+  <data name="OptionsView_Win10Only" xml:space="preserve">
+    <value>( Тільки Windows 10! )</value>
+  </data>
+  <data name="QueueView_FilterSettings" xml:space="preserve">
+    <value>Фільтри:</value>
+  </data>
+  <data name="SummaryView_Default" xml:space="preserve">
+    <value>Стандартно</value>
+  </data>
+  <data name="SummaryView_Forced" xml:space="preserve">
+    <value>Forced</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_1080p" xml:space="preserve">
+    <value>1080p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_480p" xml:space="preserve">
+    <value>480p NTSC SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_4K" xml:space="preserve">
+    <value>2160p 4K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_576p" xml:space="preserve">
+    <value>576p PAL SD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_720p" xml:space="preserve">
+    <value>720p HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_8K" xml:space="preserve">
+    <value>4320p 8K Ultra HD</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_custom" xml:space="preserve">
+    <value>Власне</value>
+  </data>
+  <data name="PictureSettingsView_MaxHeight" xml:space="preserve">
+    <value>Максимальна висота:</value>
+  </data>
+  <data name="PictureSettingsView_MaxWidth" xml:space="preserve">
+    <value>Максимальна ширина:</value>
+  </data>
+  <data name="PictureSettingsView_ResLimit" xml:space="preserve">
+    <value>Межа роздільності:</value>
+  </data>
+  <data name="PictureSettingsResLimitModes_none" xml:space="preserve">
+    <value>Немає</value>
+  </data>
+  <data name="PresetManger_Title" xml:space="preserve">
+    <value>Управління наборами</value>
+  </data>
+  <data name="ManagePresetView_DeleteBuiltIn" xml:space="preserve">
+    <value>Видалити вбудовані набори</value>
+  </data>
+  <data name="ManagePresetView_Export" xml:space="preserve">
+    <value>Експортувати вибраний набір</value>
+  </data>
+  <data name="ManagePresetView_Import" xml:space="preserve">
+    <value>Імпортувати набори з файлу</value>
+  </data>
+  <data name="ManagePresetView_PresetInfo" xml:space="preserve">
+    <value>Інформація про набір:</value>
+  </data>
+  <data name="ManagePresetView_RestrictedPreset" xml:space="preserve">
+    <value>Неможливо змінити вбудовані набори.</value>
+  </data>
+  <data name="ManagePresetView_SetDefault" xml:space="preserve">
+    <value>Встановити вибраний набір стандартним</value>
+  </data>
+  <data name="PresetManagerView_Delete" xml:space="preserve">
+    <value>Видалити набір</value>
+  </data>
+  <data name="OptionsView_NotSupported" xml:space="preserve">
+    <value>(Не підтримується в цій системі)</value>
+  </data>
+  <data name="QueueView_Stop" xml:space="preserve">
+    <value>Перервати</value>
+  </data>
+  <data name="Options_Metadata" xml:space="preserve">
+    <value>Метадані</value>
+  </data>
+  <data name="Options_PassthruMetadata" xml:space="preserve">
+    <value>Passthru basic metadata from the source to the destination file (where supported)</value>
+  </data>
+  <data name="Options_PassthruMetadataTooltip" xml:space="preserve">
+    <value>This option will allow basic metadata fields to be passed through from the source to destination file.
+Fields are limited to:
+- Name
+- Artist
+- Album Artist
+- Composer
+- Release Date
+- Comment
+- Album
+- Genre
+- Description
+- Long Description</value>
+  </data>
+  <data name="String1" xml:space="preserve">
+    <value/>
+  </data>
+  <data name="PresetManagerView_DefaultPreset" xml:space="preserve">
+    <value>(Default Preset)</value>
+  </data>
+  <data name="PresetService_CategoryAlreadyExists" xml:space="preserve">
+    <value>The category name you entered already exists. Please choose a different name.</value>
+  </data>
+  <data name="PresetService_CategoryNameEmpty" xml:space="preserve">
+    <value>The category name was empty. Please provide a name.</value>
+  </data>
+  <data name="TextEntryView_EnterName" xml:space="preserve">
+    <value>Enter a name: </value>
+  </data>
+  <data name="ManagePresetView_NoPresetSelected" xml:space="preserve">
+    <value>There is no preset selected.</value>
+  </data>
+  <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
+    <value>Export all user presets</value>
+  </data>
+</root>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.co.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.co.resx
@@ -1,0 +1,470 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterView_Deblock" xml:space="preserve">
+    <value>U filtru di sblucchime riduce l’effetti parassiti cagiunati da una cumpressione video di bassa qualità.</value>
+  </data>
+  <data name="FilterView_DecombDeinterlace" xml:space="preserve">
+    <value>Sceglie l’ozzioni di filtru decomb o disintricciamentu.
+
+U filtru « decomb » discioglie solu e fiure chì parenu intricciate.
+Què preserverà a qualità di e fiure chì ùn sò micca intricciate.
+
+U filtru classicu di disintricciamentu hè appiecatu à tutte e fiure.
+Quelle chì ùn sò micca intricciate averanu una perdita di qualità.</value>
+  </data>
+  <data name="FilterView_Denoise" xml:space="preserve">
+    <value>U filtru « denoise » riduce o caccia l’aspettu di rumore è di granellu d’una video. Què pò megliurà u rendimentu di a cumpressione è creà una video di più bella qualità cù schedarii più chjuchi. 
+Preferenze « denoise » troppu putente ponu dannighjà a qualità di a fiura scartendu i detaglii.
+         
+NLMeans hè un filtru « denoise » d’alta qualità chì fà dinù cresce a vitezza di a cudificazione. Impiegatelu quandu a qualità hè più impurtante chè a vitezza.
+         
+HQDN3D hè un filtru passu-bassu adattevule, più prestu chè NLMeans ma menu efficiente per preservà i detaglii i più fini.</value>
+  </data>
+  <data name="FilterView_Detelecine" xml:space="preserve">
+    <value>U filtru « detelecine » caccia l’effetti parassiti chì sò cagiunati da u telesinema, un trattamentu chì cunvertisce e frequenze di fiure d’un filmu ver di frequenze di fiure di televisiò.</value>
+  </data>
+  <data name="FilterView_Grayscale" xml:space="preserve">
+    <value>« Scala di grisgiu » caccia u cumpunente culore di a video. Di solitu, hè chjamata video di neru è biancu.</value>
+  </data>
+  <data name="MainView_Destination" xml:space="preserve">
+    <value>Chjassu di destinazione, inchjudendu u cartulare è u schedariu Ghjè induve a video serà creata è cumu serà chjamata.</value>
+  </data>
+  <data name="MainView_IpodAtom" xml:space="preserve">
+    <value>Aghjunghje un marcatore apposta per permette a lettura nant’à l’iPod di 5a generazione circa 2006. D’altre preferenze ponu affettà a cumpatibilità.</value>
+  </data>
+  <data name="MainView_Mux" xml:space="preserve">
+    <value>Furmatu di u cuntenentu. E traccie video, audio è altre sò addunite in un schedariu unicu di stu tipu. Què affetta a cumpatibilità.</value>
+  </data>
+  <data name="MainView_Optimise" xml:space="preserve">
+    <value>Perfezziunà u MP4 per u scaricamentu prugressivu. Dopu a cudificazione, i dati sò riorganizati è riscritti per permette una lettura istantanea nant’à una reta, senza avè à scaricà u schedariu sanu.</value>
+  </data>
+  <data name="MainView_Range" xml:space="preserve">
+    <value>Selezzione di a stesa di fonte. Senza precisà, tutti i capituli sò selezziunati è a fonte hè cudificata sana sana.</value>
+  </data>
+  <data name="MainView_Title" xml:space="preserve">
+    <value>Titulu, o video, à cudificà.
+I dischi di fonte Blu-ray è DVD anu aspessu parechji tituli ; da bona regula, u più longu hè l’elementu principale</value>
+  </data>
+  <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
+    <value>« Anamorficu » permette dimensioni arbitrarie d’allucamentu tuttu preservendu l’aspettu d’origine durante a ripruduzzione.
+
+« Off » disattiveghja « Anamorficu ». E dimensioni d’allucamentu di a video è quelle di l’affissera seranu uguale. Solu ghjuvevule per a cumpatibilità cù certi apparechji anziani.
+
+« Auto » megliureghja a risuluzione d’allucamentu tuttu preservendu e prupurzioni d’affissera d’origine. Ricumandatu.
+
+« Loose » hè simile à « Auto » ma prova di preservà e prupurzioni d’allucamentu. Què pò cagiunà una chjuca perdita di risuluzione d’allucamentu in pettu à « Auto ».
+
+« Persunalizatu » permette di definisce dapervoi tutte e preferenze. Ghjuvevule per currege un aspettu incurrettu d’affissera di a fonte è per i prufessiunali chì anu bisognu d’un cuntrollu espertu in post-pruduzzione.</value>
+  </data>
+  <data name="PictureSettingsView_AutoCrop" xml:space="preserve">
+    <value>Runzicà autumaticamente i bordi neri intornu à a video.</value>
+  </data>
+  <data name="PictureSettingsView_CropBottom" xml:space="preserve">
+    <value>Runzicà a video da u bassu.</value>
+  </data>
+  <data name="PictureSettingsView_CropLeft" xml:space="preserve">
+    <value>Runzicà a video da manu manca.</value>
+  </data>
+  <data name="PictureSettingsView_CropRight" xml:space="preserve">
+    <value>Runzicà a video da manu diritta.</value>
+  </data>
+  <data name="PictureSettingsView_CropTop" xml:space="preserve">
+    <value>Runzicà a video da l’altu.</value>
+  </data>
+  <data name="PictureSettingsView_Height" xml:space="preserve">
+    <value>Ghjè l’altezza impiegata per l’allucamentu di a video.
+E vere dimensioni d’affisera seranu sfarente s’è u raportu larghezza/altezza ùn hè micca 1:1.</value>
+  </data>
+  <data name="PictureSettingsView_ManualCrop" xml:space="preserve">
+    <value>Runzicà a video manualmente.</value>
+  </data>
+  <data name="PictureSettingsView_Modulus" xml:space="preserve">
+    <value>Alineà e dimensioni d’allucamentu nant’à multipli di stu valore.
+
+Sta preferenza hè di primura per a cumpatibilità cù certi apparechji.
+Duveriate impiegà 2 quandu ùn avete micca prublemi di cumpatibilità.</value>
+  </data>
+  <data name="PictureSettingsView_PAR" xml:space="preserve">
+    <value>Furmatu pixel definisce a forma, larghezza è altezza, di i punti elementarii d’una fiura (pixel).
+Un raportu 1:1 definisce un pixel quadratu.  D’altri valori definiscenu forme rettangulare.
+I lettori cambieranu e dimensioni di a fiura per currisponde à l’aspettu specificatu.</value>
+  </data>
+  <data name="PictureSettingsView_Width" xml:space="preserve">
+    <value>Ghjè a larghezza cù quella a video serà arregistrata.
+E vere dimensioni d’affisera seranu sfarente s’è u raportu larghezza/altezza ùn hè micca 1:1.</value>
+  </data>
+  <data name="QueueView_DeleteJob" xml:space="preserve">
+    <value>Squassà u travagliu da a fila d’attesa.</value>
+  </data>
+  <data name="QueueView_ResetJobStatus" xml:space="preserve">
+    <value>Reinizià u statu di u travagliu à « In attesa ».</value>
+  </data>
+  <data name="QueueView_SendJobBack" xml:space="preserve">
+    <value>Mandà u travagliu torna ver di a finestra principale per mudificalu.</value>
+  </data>
+  <data name="Video_AvgBitrate" xml:space="preserve">
+    <value>Definisce u ghjettu medianu.
+
+U ghjettu istantaneu pò esse assai più altu o assai più bassu à ogni stonda.
+Ma a mediana, nant’à una longa durata, serà u valore definitu quì.  S’ella hè bisognu
+di limità u ghjettu istantaneu, fighjate i parametri vbv-bufsize è vbv-maxrate di u x264.</value>
+  </data>
+  <data name="Video_ConstantFramerate" xml:space="preserve">
+    <value>Attiveghja una frequenza di fiure custente in esciuta.</value>
+  </data>
+  <data name="Video_Encoders" xml:space="preserve">
+    <value>Cudificatori video dispunibule.</value>
+  </data>
+  <data name="Video_EncoderTune" xml:space="preserve">
+    <value>Sciglite e preferenze per megliurà i scenarii classichi.
+
+Què pò megliurà a faccindaghjine di certe caratteristiche di a fonte
+o di e caratteristiche definite di u schedariu d’esciuta.  I cambiamenti
+seranu appiecati dopu a prerigatura ma nanzu tutti l’altri parametri.</value>
+  </data>
+  <data name="Video_ExtraOpts" xml:space="preserve">
+    <value>Preferenze addiziunale di u cudificatore.
+
+Lista d’ozzioni di u cudificatore staccati da dui punti.</value>
+  </data>
+  <data name="Video_FastDecode" xml:space="preserve">
+    <value>Riduce l’impiegu CPU di u discudificatore.
+
+Attivate st’ozzione s’è u vostru apparechju ùn leghje micca bè u schedariu d’esciuta (perdita di fiure).</value>
+  </data>
+  <data name="Video_Framerate" xml:space="preserve">
+    <value>Frequenza di fiure d’esciuta.
+
+« Listessa chè a fonte » hè ricumandatu. S’è a vostra video di fonte hà una frequenza di fiure variabile, st’ozzione a preserverà.</value>
+  </data>
+  <data name="Video_Level" xml:space="preserve">
+    <value>Definisce è assicureghja a cunfurmità cù u livellu specificatu.
+
+Rimpiazza tutte l’altre preferenze.</value>
+  </data>
+  <data name="Video_PeakFramerate" xml:space="preserve">
+    <value>Attiveghja una frequenza di fiure d’esciuta variabile cù una frequenza di cresta determinata da a preferenza di a frequenza di fiure.</value>
+  </data>
+  <data name="Video_Presets" xml:space="preserve">
+    <value>Adatteghja e preferenze di u cudificatore per bilancià trà a faccindaghjine di a cumpressione è a vitezza di cudificazione.
+
+Què definisce e vostre preferenze predefinite di cudificatore.
+Rigature, prufili, livelli è ozzioni d’espertu seranu appiecati à st’operazione.
+Da bona regula, duveriate definisce st’ozzione à u valore u più lentu
+chì voi siate capace d’accettà, perchè preferenze più lente vi danu
+una più bella qualità o schedarii più chjuchi.</value>
+  </data>
+  <data name="Video_Profile" xml:space="preserve">
+    <value>Definisce è assicureghja a cunfurmità cù u prufilu specificatu.
+
+Rimpiazza tutte l’altre preferenze.</value>
+  </data>
+  <data name="Video_Quality" xml:space="preserve">
+    <value>Definisce u fattore di qualità pregatu.
+U cudificatore sibuleghja una certa qualità.
+A scala impiegata da ogni cudificatore hè sfarenta.
+
+A scala di x264 hè logaritmica, è valori più chjuchi currispondenu à una
+qualità più maiò.
+Dunque, chjuchi aumenti di valore aumentanu prugressi-
+vamente a dimensione di u schedariu d’esciuta.  Un valore à 0 vole dì
+senza perdita è per què, u schedariu d’esciuta serà più maiò chì quellu
+di a fonte, for di s’è a fonte era dinù senza perdita.
+I valori suggerite sò : 18 à 20 per fonti à definizione classica è 20 à 23 per quelle à alta definizione.
+
+A scala di FFMpeg è Theora hè più lineare.
+Sti cudificatori ùn anu micca di modu senza perdita.</value>
+  </data>
+  <data name="Video_TurboFirstPass" xml:space="preserve">
+    <value>Durante u primu passu d’una cudificazione à 2 passi, impiegate preferenze chì acceleranu u trattamentu.</value>
+  </data>
+  <data name="Video_TwoPass" xml:space="preserve">
+    <value>Face una cudificazione à 2 passi.
+
+L’ozzione « Ghjettu » hè prerichiesta. Durante u primu passu, e statistiche
+sò cullettate.  Dopu, à u secondu passu, ste statistiche sò impiegate per fà
+a scelta di l’allucamentu di u ghjettu.</value>
+  </data>
+  <data name="Video_VariableFramerate" xml:space="preserve">
+    <value>Attiveghja una frequenza di fiure variabile (VFR) in esciuta.
+
+Què ùn hè micca cumpatibile cù certi lettori.</value>
+  </data>
+  <data name="MainView_WhenDone" xml:space="preserve">
+    <value>Quandu a fila d’attesa o a cudificazione currente hè compia, HandBrake effettuerà st’azzione.</value>
+  </data>
+  <data name="MainView_Browse" xml:space="preserve">
+    <value>Navigà per selezziunà un novu chjassu di destinazione è un novu nome di schedariu per a vostra cudificazione.</value>
+  </data>
+  <data name="MainView_Angle" xml:space="preserve">
+    <value>Angulu di video à cudificà. Cuncerne solu i dischi DVD è Blu-ray multi-anguli.</value>
+  </data>
+  <data name="MainView_AddPreset" xml:space="preserve">
+    <value>Aghjunghje una nova prerigatura.</value>
+  </data>
+  <data name="MainView_PresetAdditionalOptions" xml:space="preserve">
+    <value>Ozzioni addiziunale di prerigatura.</value>
+  </data>
+  <data name="MainView_Presets" xml:space="preserve">
+    <value>E prerigature sò gruppi di preferenze di cudificazione custruiti per scenarii specifichi. Selezziunate quella chì currispunde u più à u vostru bisognu.
+ 
+ Rimpiazzeghja tutte e preferenze di cudificazione. E preferenze ponu esse addattate dopu a selezzione di a prerigatura.</value>
+  </data>
+  <data name="MainView_RemovePreset" xml:space="preserve">
+    <value>Caccià a prerigatura selezziunata.</value>
+  </data>
+  <data name="SourceSelection_TitleSpecific" xml:space="preserve">
+    <value>Analizà solu u titulu specificatu invece di tutti i tituli.</value>
+  </data>
+  <data name="FilterView_CustomDenoiseParams" xml:space="preserve">
+    <value>Parametri « Denoise » persunalizati.
+ 
+Sintassa NLMeans : y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t
+
+Predefinizioni NLMeans : y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0
+
+Sintassa HQDN3D : y-spatial=y:cb-spatial=c:cr-spatial=c:y-temporal=y:cb-temporal=c:cr-temporal=c
+
+Predefinizioni HQDN3D : y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-temporal=3:cr-temporal=3</value>
+  </data>
+  <data name="FilterView_DenoisePreset" xml:space="preserve">
+    <value>Prerigatura di u filtru « Denoise ». Definisce a forza di u filtru.</value>
+  </data>
+  <data name="FilterView_DenoiseTune" xml:space="preserve">
+    <value>Rigatura « Denoise ». Adattazioni addiziunale di a prerigatura « Denoise » per megliurà e preferenze per scenarii specifichi.
+ 
+- « Alcunu » impiegheghja e preferenze di prerigatura predefinite.
+ 
+- « Filmu » affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione.
+ 
+- « Granellu » tratta solu i canali di culore. Ghjuvevule per preservà l’aspettu cinematograficu di u granellu di luminanza, tuttu riducendu o cacciendu u rumore di culore.
+
+- « Mossa presta » riduce u sparghjimentu di i culori in e scene rapide impediscendu u trattamentu tempurale di i canali di culore. Ghjuvevule per e video di sport è d’azzione.
+
+- « Animazione » hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa.
+
+- « Scagninu » hè ghjuvevule per e video nant’à un frisgiu magneticu analogicu di bassa qualità, cum’è e VHS, quandu « Filmu » ùn produce micca u risultatu aspettatu.
+
+- « Spiritibugliettu » hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Ùn hè micca previstu per e video di alta definizione.</value>
+  </data>
+  <data name="FilterView_Deinterlace" xml:space="preserve">
+    <value>« Disintricciamentu » caccia l’effetti parassiti da a fiura.
+
+Yadif hè un filtru di disintricciamentu populare è rapidu.
+
+« Decomb » bilanceghja trà parechje cudificazioni d’interpolazione per favurisce a vitezza è a qualità.</value>
+  </data>
+  <data name="FilterView_DeinterlaceCustom" xml:space="preserve">
+    <value>Parametri di disintricciamentu persunalizati.
+ 
+ Sintassa Yadif : mode=m:parity=p
+ 
+ Predefinizioni Yadif : mode=3
+ 
+ Sintassa Decomb : mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
+ 
+ Predefinizioni Decomb : mode=7</value>
+  </data>
+  <data name="FilterView_DeinterlacePreset" xml:space="preserve">
+    <value>Prerigatura di u filtru di disintricciamentu.
+
+A prerigatura predefinita hè ben equilibrata trà vitezza è a qualità.
+
+Ignurà a verificazione spaciale permette à Yadif d’ignurà a currezzione di certi effetti parassiti pudendu esse impediti per un legeru aumentu di a vitezza.
+
+EEDI2 impiegheghja una cudificazione d’interpolazione più lenta è di più bella qualità per Decomb. Ghjuvevule per e fonti e più difficiule.
+
+Bob pruva di preservà megliu a mossa per una chjuca penalità à a risuluzione percepita.</value>
+  </data>
+  <data name="FilterView_Flip" xml:space="preserve">
+    <value>Invertisce a fiura (cum’è un spechju) secondu à l’asse orizuntale.</value>
+  </data>
+  <data name="FilterView_InterlaceDetection" xml:space="preserve">
+    <value>L’ozzione Abbentata d’intricciamentu, quand’ella hè attiva, permette à u filtru di disintricciamentu di trattà solu e fiure video chì sò intricciate.</value>
+  </data>
+  <data name="FilterView_InterlaceDetectionCustom" xml:space="preserve">
+    <value>Parametri d’abbentata d’intricciamentu persunalizati.
+ 
+ Sintassa : mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d
+ 
+ Predefinizioni : mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16</value>
+  </data>
+  <data name="FilterView_Rotate" xml:space="preserve">
+    <value>Girà a fiura di 90 gradi in u sensu di e sfiere d’arilogiu.</value>
+  </data>
+  <data name="MainView_Duration" xml:space="preserve">
+    <value>Durata di a stesa di fonte selezziunata in Ore:Minuti:Seconde</value>
+  </data>
+  <data name="PictureSettingsView_KeepAR" xml:space="preserve">
+    <value>L’ozzione « Cunservà e prupurzioni » mantene e prupurzioni d’affissera originale di a fonte. Disattivà st’ozzione pò cagiunà una fiura stinzata o ristrinta.</value>
+  </data>
+  <data name="FilterView_CustomSharpenParams" xml:space="preserve">
+    <value>Parametri d’arrutata persunalizati.
+
+Sintassa Unsharp : y-strength=y:y-size=y:cb-strength=c:cb-size=c:cr-strength=c:cr-size=c
+
+Predefinizioni Unsharp : y-strength=0.25:y-size=7:cb-strength=0.25:cb-size=7
+
+SintassaLapsharp : y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
+
+Sintassa Lapsharp : y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap</value>
+  </data>
+  <data name="FilterView_Sharpen" xml:space="preserve">
+    <value>L’arrutata amendeghja l’aspettu di i detaglii, sopratuttu i bordi. Preferenze d’arrutata troppu forte ponu dannighjà a qualità di a fiura creendu effetti parassiti è aumentendu u rumore, ciò chì pò riduce a faccindaghjine di a cumpressione.
+
+Flosciu hè un filtru di maschera floscia à usu generale. Funziuneghja imbrugliendu, è dopu calculendu a sfarenza trà a fiura imbrugliata è a fiura d’origine.
+
+Lapsharp arruteghja impieghendu nocciuli di convuluzione s’avvicinendu di i filtri di bordu Laplacian, pruducendu ognitantu risultati di più bella qualità chì a maschera floscia.</value>
+  </data>
+  <data name="FilterView_SharpenPreset" xml:space="preserve">
+    <value>Prerigatura di u filtru d’arrutata. Definisce a forza di u filtru.</value>
+  </data>
+  <data name="FilterView_SharpenTune" xml:space="preserve">
+    <value>Rigatura d’arrutata. Adattazioni addiziunale di a prerigatura d’arrutata per megliurà e preferenze per scenarii specifichi.
+
+Alcunu impiegheghja e preferenze di prerigatura predefinite.
+
+Flosciu pò esse rigatu per un’arrutata Ultrafina, Fina, Mediana, Roza, o Assai roza. Selezziunate una rigatura secondu à a risuluzione di a fiura aspettata è a finezza di detaglii à amendà.
+
+A rigatura « Filmu » affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione. Impiegheghja un nocciulu Laplacianu isotropicu per rende più netti tutti i bordi d’una manera simile, è l’infurmazioni di luminanza (lucidezza) sò più arrutate chè quelle di u culore.
+
+A rigatura « Granellu » hè simile à Filmu, ma impiegheghja un Laplacianu isotropicu à nocciulu Gaussianu per riduce l’zffetti nant’à u rumore è granellu. Ghjuvevule per preservà u granellu è cum’è alternativa à Filmu.
+
+A rigatura « Animazione » hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa. Hè uguale à Filmu, ma a forza di u trattamentu hè ridutta per impedisce di creà effetti parassiti.
+
+A rigatura « Spiritibugliettu » hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Impiegheghja un nocciulu Laplacianu à 4 vicini chì amendeghja i cuntorni verticale è orizuntale più chì i cuntorni diagunale.</value>
+  </data>
+  <data name="MainView_AlignAVStart" xml:space="preserve">
+    <value>Alineeghja e stampiglie iniziale di tutti i flussi audio è video framittendu fiure viote o squassendu fiure. Què pò megliurà a sincrunizazione audio/video per i lettori disfunziunendu chì ùn rispettanu micca e liste di mudificazioni MP4.</value>
+  </data>
+  <data name="MainView_PresetOptionsContextMenu" xml:space="preserve">
+    <value>Ozzioni per cuntrollà e prerigature.</value>
+  </data>
+  <data name="MainView_EndPoint" xml:space="preserve">
+    <value>U puntu di fine di sta stesa.</value>
+  </data>
+  <data name="MainView_StartPoint" xml:space="preserve">
+    <value>U puntu di principiu di sta stesa.</value>
+  </data>
+  <data name="OptionsView_AlwaysUseDefaultPath" xml:space="preserve">
+    <value>Quandu st’ozzione hè attivata, u sistema di nome autumaticu impiegherà sempre u chjassu predefinitu. 
+Quand’ella hè disattivata, impiegherà u chjassu scrittu in a scatula di dialogu di a finestra principale, s’ellu hè indicatu ; osinnò impiegherà sempre u chjassu predefinitu.</value>
+  </data>
+</root>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.de.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.de.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.es.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.es.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -121,12 +121,12 @@
     <value>Deblock reduce los artefactos de bloques causados por la compresión de vídeo de baja calidad.</value>
   </data>
   <data name="FilterView_DecombDeinterlace" xml:space="preserve">
-    <value>Elija las opciones de filtro decomb o desentrelazado.
+    <value>Elija las opciones de filtro decomb o des-entrelazado.
 
-El filtro decomb desentrelaza selectivamente los fotogramas que parecen estar entrelazados.
+El filtro decomb des-entrelaza selectivamente los fotogramas que parecen estar entrelazados.
 Esto preservará la calidad de los fotogramas que no estén entrelazados.
 
-El filtro de desentrelazado tradicional se aplica a todos los fotogramas.
+El filtro de des-entrelazado tradicional se aplica a todos los fotogramas.
 Los fotogramas que no estén entrelazados sufrirán un deterioro de la calidad.</value>
   </data>
   <data name="FilterView_Denoise" xml:space="preserve">
@@ -147,7 +147,7 @@ HQDN3D es un filtro de paso bajo adaptativo, más rápido que NLMeans, pero meno
     <value>Ruta de destino, incluido el directorio y el nombre del archivo. Aquí es donde se creará su nuevo video, y cómo se llamará.</value>
   </data>
   <data name="MainView_IpodAtom" xml:space="preserve">
-    <value>Agregue un marcador MP4 especial para permitir la reproducción en los dispositivos de la quinta generación de iPod de la época del 2006. Otras configuraciones pueden afectar a la compatibilidad.</value>
+    <value>Agregue un marcador MP4 especial para permitir la reproducción en los dispositivos de la quinta generación de iPod cercanos al 2006. Otras configuraciones pueden afectar a la compatibilidad.</value>
   </data>
   <data name="MainView_Mux" xml:space="preserve">
     <value>Formato contenedor. El video, el audio y otras pistas se combinan en un solo archivo de este tipo. Afecta la compatibilidad.</value>
@@ -156,11 +156,11 @@ HQDN3D es un filtro de paso bajo adaptativo, más rápido que NLMeans, pero meno
     <value>Optimizar MP4 para una descarga progresiva. Después de la codificación, los datos se reorganizan y se vuelven a escribir para permitir la reproducción inmediata a través de una red, sin necesidad de descargar el archivo completo.</value>
   </data>
   <data name="MainView_Range" xml:space="preserve">
-    <value>Selección del rango de la fuente. Por defecto, se seleccionan todos los capítulos y se codifica toda la fuente.</value>
+    <value>Selección del rango del origen. Por defecto, se seleccionan todos los capítulos y se codifica todo el origen.</value>
   </data>
   <data name="MainView_Title" xml:space="preserve">
-    <value>Título, o clip de vodeo, a codificar.
-Las fuentes de Blu-ray y DVD a menudo tienen múltiples títulos, el más largo de los cuales es por lo general el principal.</value>
+    <value>Título, o clip de video a codificar.
+Los orígenes de Blu-ray y DVD a menudo tienen múltiples títulos, el más largo de los cuales es por lo general el principal.</value>
   </data>
   <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
     <value>Anamórfico permite dimensiones de almacenamiento indiferentes, conservando el aspecto original durante la reproducción.
@@ -171,7 +171,7 @@ Auto maximiza la resolución de almacenamiento al tiempo que preserva la relaci�
 
 Loose es similar a Auto, pero intenta conservar la relación de aspecto de almacenamiento. Esto puede resultar en una ligera pérdida de resolución de almacenamiento en comparación con Auto.
 
-Custom permite la configuración manual de todos los parámetros. Útil para corregir un aspecto incorrecto de la visualización de la fuente y para profesionales que necesitan un control avanzado en la postproducción.</value>
+Custom permite la configuración manual de todos los parámetros. Útil para corregir un aspecto incorrecto de la visualización del original y para profesionales que necesitan un control avanzado en la postproducción.</value>
   </data>
   <data name="PictureSettingsView_AutoCrop" xml:space="preserve">
     <value>Recortar automáticamente los bordes negros alrededor del video.</value>
@@ -252,7 +252,7 @@ Establezca esto si su dispositivo tiene dificultades para reproducir la salida (
   <data name="Video_Framerate" xml:space="preserve">
     <value>Velocidad de fotogramas de salida.
 
-Se recomienda 'Igual que la fuente'. Si su video fuente tiene una velocidad de fotogramas variable, 'Igual que la fuente' lo conservará.</value>
+Se recomienda 'Igual al original'. Si su video tiene una velocidad de fotogramas variable, esta opción lo conservará.</value>
   </data>
   <data name="Video_Level" xml:space="preserve">
     <value>Establece y garantiza el cumplimiento del nivel especificado.
@@ -283,9 +283,9 @@ La escala utilizada por cada codificador de video es diferente.
 La escala de x264 es logarítmica y los valores más bajos corresponden a una calidad más alta.
 Por lo tanto, pequeñas disminuciones en el valor resultarán en incrementos progresivamente
 mayores en el tamaño del archivo resultante. Un valor de 0 significa sin pérdidas y dará como
-resultado un tamaño de archivo que es mayor que la fuente original, a menos que la fuente
-también sea sin pérdidas.
-Los valores sugeridos son: 18 a 20 para fuentes de definición estándar y 20 a 23 para fuentes de alta definición.
+resultado un tamaño de archivo que es mayor al original, a menos que el
+mismo también sea sin pérdidas.
+Los valores sugeridos son: 18 a 20 para definición estándar y 20 a 23 para un origen de alta definición.
 
 La escala de FFMpeg y Theora es más lineal.
 Estos codificadores no tienen un modo sin pérdidas.</value>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.fr.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.fr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.ko.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.ko.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.ru.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.ru.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.tr.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.tr.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.uk.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.uk.resx
@@ -1,0 +1,467 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata" id="root">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"/>
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string"/>
+              <xsd:attribute name="type" type="xsd:string"/>
+              <xsd:attribute name="mimetype" type="xsd:string"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string"/>
+              <xsd:attribute name="name" type="xsd:string"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1"/>
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3"/>
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4"/>
+              <xsd:attribute ref="xml:space"/>
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1"/>
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required"/>
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <data name="FilterView_Deblock" xml:space="preserve">
+    <value>Deblock reduces blocky artifacts caused by low quality video compression.</value>
+  </data>
+  <data name="FilterView_DecombDeinterlace" xml:space="preserve">
+    <value>Choose decomb or deinterlace filter options.
+
+The decomb filter selectively deinterlaces frames that appear to be interlaced.
+This will preserve quality in frames that are not interlaced.
+
+The classic deinterlace filter is applied to all frames.
+Frames that are not interlaced will suffer some quality degradation.</value>
+  </data>
+  <data name="FilterView_Denoise" xml:space="preserve">
+    <value>Усунення шумів (denoise), зменшує або усуває появу шуму та зернистості. Це може підвищити ефективність стиснення даних та створити відео вищої якості при менших розмірах файлів. 
+Завеликі налаштування усунення шумів можуть погіршити якість зображення, знехтувавши деталізацією.
+         
+NLMeans – це високоякісний фільтр усунення шумів, але не швидкий. Використовуйте там, де якість важливіша, ніж швидкість.
+         
+HQDN3D – адаптивний низькочастотний фільтр. Він швидший, ніж NLMeans, але менш ефективний при збереженні дрібних деталей.</value>
+  </data>
+  <data name="FilterView_Detelecine" xml:space="preserve">
+    <value>Зворотна телекінопроекція (detelecine) видаляє ефекти «гребінки», які є результатом кінопроекції, процесу перетворення частоти кадрів фільму в частоту кадрів телебачення.</value>
+  </data>
+  <data name="FilterView_Grayscale" xml:space="preserve">
+    <value>Відтінки сірого видаляє кольоровий складову відео. Часто його називають чорно-білим відео.</value>
+  </data>
+  <data name="MainView_Destination" xml:space="preserve">
+    <value>Шлях призначення, включаючи назву каталогу та файлу. Тут буде створено ваше нове відео з вказаною назвою.</value>
+  </data>
+  <data name="MainView_IpodAtom" xml:space="preserve">
+    <value>Додає спеціальний маркер MP4, що дозволяє відтворення на старовинних пристроях iPod 5-го покоління близько 2006 року випуску. Інші налаштування можуть впливати на сумісність.</value>
+  </data>
+  <data name="MainView_Mux" xml:space="preserve">
+    <value>Формат контейнера. Відео, аудіо та інші доріжки об'єднуються в єдиний файл цього типу. Впливає на сумісність.</value>
+  </data>
+  <data name="MainView_Optimise" xml:space="preserve">
+    <value>Оптимізує MP4 для послідовного завантаження (progressive download). Після кодування дані реорганізуються та переписуються, щоб дозволити негайне відтворення через мережу, не потребуючи завантаження всього файлу.</value>
+  </data>
+  <data name="MainView_Range" xml:space="preserve">
+    <value>Вибір діапазону джерела. За замовчуванням вибираються всі глави та кодується все джерело.</value>
+  </data>
+  <data name="MainView_Title" xml:space="preserve">
+    <value>Заголовок, чи відеокліп для кодування.
+У джерелах Blu-ray та DVD часто є кілька заголовків, найдовший з яких, як правило, є основною частиною</value>
+  </data>
+  <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
+    <value>Анаморфування дозволяє вказувати довільні розміри зображення, зберігаючи початкове співвідношення сторін під час відтворення.
+
+Off (Вимк.) вимикає анаморфування. Розміри зображення та розміри показу будуть однаковими. Корисна лише для сумісності з певними застарілими пристроями.
+
+Auto (Авто) максимально збільшує роздільну здатність зображення, зберігаючи співвідношення сторін. Рекомендованою.
+
+Loose (Вільне) схоже на Auto (Авто), але намагається зберегти співвідношення сторін. Це може спричинити невелику втрату роздільної здатності в порівняні з Auto (Авто).
+
+Custom (Власне) дозволяє вручну встановлювати всі параметри. Корисно для виправлення неправильного співвідношення сторін джерела та для професіоналів, які потребують розширеного контролю в постпродукції.</value>
+  </data>
+  <data name="PictureSettingsView_AutoCrop" xml:space="preserve">
+    <value>Автоматично обрізає чорні рамки по краях відео.</value>
+  </data>
+  <data name="PictureSettingsView_CropBottom" xml:space="preserve">
+    <value>Обрізати відео знизу.</value>
+  </data>
+  <data name="PictureSettingsView_CropLeft" xml:space="preserve">
+    <value>Обрізати відео з лівого боку.</value>
+  </data>
+  <data name="PictureSettingsView_CropRight" xml:space="preserve">
+    <value>Обрізати відео з правого боку.</value>
+  </data>
+  <data name="PictureSettingsView_CropTop" xml:space="preserve">
+    <value>Обрізати відео зверху.</value>
+  </data>
+  <data name="PictureSettingsView_Height" xml:space="preserve">
+    <value>Це висота, з якою буде збережено відео.
+Фактичні розміри відображення будуть відрізнятися, якщо співвідношення сторін пікселів не буде 1:1.</value>
+  </data>
+  <data name="PictureSettingsView_ManualCrop" xml:space="preserve">
+    <value>Обрізання відео вручну.</value>
+  </data>
+  <data name="PictureSettingsView_Modulus" xml:space="preserve">
+    <value>Вирівнює розміри збереження кратних до цього значення.
+
+Цей параметр необхідний лише для сумісності з деякими пристроями.
+Ви повинні використовувати 2, доки у вас не виникнуть проблеми з сумісністю.</value>
+  </data>
+  <data name="PictureSettingsView_PAR" xml:space="preserve">
+    <value>Співвідношення сторін пікселя визначає їх форму.
+Співвідношення 1:1 відповідає квадратному пікселю. Інші значення відповідають прямокутним фігурам.
+Програвачі будуть масштабувати зображення для досягнення заданого співвідношення сторін.</value>
+  </data>
+  <data name="PictureSettingsView_Width" xml:space="preserve">
+    <value>Це ширина, з якою буде збережено відео.
+Фактичні розміри відображення будуть відрізнятися, якщо співвідношення сторін пікселів не буде 1:1.</value>
+  </data>
+  <data name="QueueView_DeleteJob" xml:space="preserve">
+    <value>Видаляє завдання з черги.</value>
+  </data>
+  <data name="QueueView_ResetJobStatus" xml:space="preserve">
+    <value>Скидає статус завдання на «Очікування».</value>
+  </data>
+  <data name="QueueView_SendJobBack" xml:space="preserve">
+    <value>Відправляє завдання для редагування назад у головне вікно.</value>
+  </data>
+  <data name="Video_AvgBitrate" xml:space="preserve">
+    <value>Встановлює середній бітрейт.
+
+Миттєвий бітрейт в певний момент часу може бути набагато вищим або нижчим.
+Але середній бітрейт протягом всієї тривалості буде значенням, встановленим тут.
+Якщо вам потрібно обмежити миттєвий бітрейт, погляньте на параметри x264 vbv-bufsize та vbv-maxrate.</value>
+  </data>
+  <data name="Video_ConstantFramerate" xml:space="preserve">
+    <value>Вмикає постійну частоту кадрів (constant framerate) для виводу.</value>
+  </data>
+  <data name="Video_Encoders" xml:space="preserve">
+    <value>Доступні кодувальники відео.</value>
+  </data>
+  <data name="Video_EncoderTune" xml:space="preserve">
+    <value>Налаштовує параметри оптимізації для загальних сценаріїв.
+
+Це може підвищити ефективність для окремих характеристик джерела,
+або встановити характеристики вихідного файлу. Зміни будуть застосовані
+після набору, але перед усіма іншими параметрами.</value>
+  </data>
+  <data name="Video_ExtraOpts" xml:space="preserve">
+    <value>Додаткові налаштування кодувальника.
+
+Список опцій кодувальника розділяти двокрапкою.</value>
+  </data>
+  <data name="Video_FastDecode" xml:space="preserve">
+    <value>Зменшує використання ЦП декодувальником.
+
+Встановіть цей параметр, якщо ваш пристрій має проблеми з відтворенням виводу (випадання кадрів).</value>
+  </data>
+  <data name="Video_Framerate" xml:space="preserve">
+    <value>Частота кадрів виводу (кадри в секунду).
+
+Рекомендується вибирати «Same as source» (Так само, як в джерелі). Якщо у джерела відео змінна частота кадрів – «Same as source» збереже її.</value>
+  </data>
+  <data name="Video_Level" xml:space="preserve">
+    <value>Встановлює та забезпечує відповідність заданому рівню.
+
+Перекриває всі інші налаштування.</value>
+  </data>
+  <data name="Video_PeakFramerate" xml:space="preserve">
+    <value>Вмикає змінну частоту кадрів (variable framerate) для виводу, з піковим значенням, що визначається налаштуванням частоти кадрів.</value>
+  </data>
+  <data name="Video_Presets" xml:space="preserve">
+    <value>Налаштовує параметри кодувальника, щоб встановити компроміс між ефективністю стиснення та швидкістю кодування.
+
+Цей параметр встановлює ваші параметри кодувальника за замовчуванням.
+Інші налаштування, профілі, рівні та рядок розширених опцій будуть застосовані до цих налаштувань.
+Як правило, варто встановити цю опцію в найповільніше значення, яке ви можете витримати,
+оскільки повільніші значення призводять до кращої якості або меншого розміру файлів.</value>
+  </data>
+  <data name="Video_Profile" xml:space="preserve">
+    <value>Встановлює та забезпечує відповідність заданому профілю.
+
+Перекриває всі інші налаштування.</value>
+  </data>
+  <data name="Video_Quality" xml:space="preserve">
+    <value>Встановіть бажаний коефіцієнт якості.
+Кодувальник намагатиметься досягнути вказаної якості.
+У кожного кодувальника своя шкала якості.
+
+Шкала для x264 є логарифмічною, а нижчі значення відповідають вищій якості.
+Невелике зменшення значення призведе до значного збільшення
+розміру вихідного файлу.  Значення 0 означає якість без втрат і призведе
+до того, що розмір файлу перевищуватиме розмір джерела, хіба що
+джерело також без втрат.
+Пропоновані значення: від 18 до 20 для джерел стандартної якості, та від 20 до 23 джерел високої якості.
+
+Шкала FFMpeg і Theora є більш лінійною.
+Ці кодувальники не мають режиму без втрат.</value>
+  </data>
+  <data name="Video_TurboFirstPass" xml:space="preserve">
+    <value>Під час 1-го проходу 2-прохідного кодування використовувати параметри, які прискорюють роботу.</value>
+  </data>
+  <data name="Video_TwoPass" xml:space="preserve">
+    <value>Виконує 2 проходи кодування.
+
+Необхідна опція «бітрейт». Під час 1-го проходу збирається статистика про відео.
+У другому проході ця статистика використовується для прийняття рішень щодо розподілу бітрейту.</value>
+  </data>
+  <data name="Video_VariableFramerate" xml:space="preserve">
+    <value>Вмикає змінну частоту кадрів (variable framerate, VFR) для виводу.
+
+VFR не сумісний з деякими програвачами.</value>
+  </data>
+  <data name="MainView_WhenDone" xml:space="preserve">
+    <value>Коли HandBrake закінчить поточну чергу чи кодування – виконається ця дія.</value>
+  </data>
+  <data name="MainView_Browse" xml:space="preserve">
+    <value>Натисніть кнопку «Огляд», щоб вибрати для кодування новий шлях призначення та назву файлу.</value>
+  </data>
+  <data name="MainView_Angle" xml:space="preserve">
+    <value>Ракурс відео для кодування. Застосовується лише для багаторакурсних DVD та Blu-ray.</value>
+  </data>
+  <data name="MainView_AddPreset" xml:space="preserve">
+    <value>Додайте новий набір.</value>
+  </data>
+  <data name="MainView_PresetAdditionalOptions" xml:space="preserve">
+    <value>Додаткові параметри набору.</value>
+  </data>
+  <data name="MainView_Presets" xml:space="preserve">
+    <value>Набори – це групи наперед визначених параметрів кодування, пристосовані до конкретних сценаріїв. Виберіть найближчий до ваших намірів.
+ 
+Перевизначає усі параметри кодування. Налаштування можуть бути додатково відрегульовані після вибору набору.</value>
+  </data>
+  <data name="MainView_RemovePreset" xml:space="preserve">
+    <value>Вилучити вибраний набір.</value>
+  </data>
+  <data name="SourceSelection_TitleSpecific" xml:space="preserve">
+    <value>Сканує лише вказаний заголовок замість усіх заголовків.</value>
+  </data>
+  <data name="FilterView_CustomDenoiseParams" xml:space="preserve">
+    <value>Власні параметри усунення шумів.
+ 
+Синтаксис NLMeans: y-strength=y:y-origin-tune=y:y-patch-size=y:y-range=y:y-frame-count=y:y-prefilter=y:cb-strength=c:cb-origin-tune=c:cb-patch-size=c:cb-range=c:cb-frame-count=c:cb-prefilter=c:cr-strength=c:cr-origin-tune=c:cr-patch-size=c:cr-range=c:cr-frame-count=c:cr-prefilter=c:threads=t
+
+Стандартні NLMeans: y-strength=6:y-origin-tune=1:y-patch-size=7:y-range=3:y-frame-count=2:y-prefilter=0:cb-strength=6:cb-origin-tune=1:cb-patch-size=7:cb-range=3:cb-frame-count=2:cb-prefilter=0
+
+Синтаксис HQDN3D: y-spatial=y:cb-spatial=c:cr-spatial=c:y-temporal=y:cb-temporal=c:cr-temporal=c
+
+Стандартні HQDN3D: y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-temporal=3:cr-temporal=3</value>
+  </data>
+  <data name="FilterView_DenoisePreset" xml:space="preserve">
+    <value>Попередньо встановлений фільтр усунення шумів. Встановлює потужність фільтра.</value>
+  </data>
+  <data name="FilterView_DenoiseTune" xml:space="preserve">
+    <value>Настроювання усунення шумів. Додатково коригує набір усунення шумів для оптимізації налаштувань під конкретні сценарії.
+ 
+- None використовує стандартні налаштування набору.
+ 
+- Film (фільм) удосконалює налаштування для використання з більшістю кіноконтенту.
+ 
+- Grain (зерно) обробляє лише колірні канали. Корисно для збереження плівкового вигляду зі світіннями зерна при зменшенні або видаленні колірного шуму.
+
+- High Motion (висока швидкість руху) зменшує розмазування кольорів у сценах з високою швидкістю руху, уникаючи тимчасової обробки колірних каналів. Корисно для спортивних відео та бойовиків.
+
+- Animation (анімація) корисний для мальованої анімації, такої як аніме та мультфільми.
+
+- Tape (стрічка) корисний для джерел як аналогові стрічки з низькою деталізацією, таких як VHS, де Film (фільм) не дає бажаного результату.
+
+- Sprite (спрайт) корисний для 1-/4-/8-/16-бітних 2D-ігор. Sprite не призначений для відео високої чіткості.</value>
+  </data>
+  <data name="FilterView_Deinterlace" xml:space="preserve">
+    <value>Деінтерлейсинг (deinterlace) видаляє із зображення артефакти «гребінки».
+
+Yadif – популярний і швидкий деінтерлейсер.
+
+Decomb перемикається між кількома алгоритмами інтерполяції для кращої швидкості та якості.</value>
+  </data>
+  <data name="FilterView_DeinterlaceCustom" xml:space="preserve">
+    <value>Власні параметри деінтерлейсингу.
+ 
+Синтаксис Yadif: mode=m:parity=p
+ 
+Стандартні Yadif: mode=3
+ 
+Синтаксис Decomb: mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
+ 
+Стандартні Decomb: mode=7</value>
+  </data>
+  <data name="FilterView_DeinterlacePreset" xml:space="preserve">
+    <value>Deinterlace filter preset.
+
+Default is well balanced for speed and quality.
+
+Skip Spatial Check lets Yadif skip correcting certain avoidable artifacts for a slight speed boost.
+
+EEDI2 uses a slower, higher quality interpolation algorithm for Decomb. Useful for the most difficult sources.
+
+Bob attempts to better preserve motion for a slight penalty to perceived resolution.</value>
+  </data>
+  <data name="FilterView_Flip" xml:space="preserve">
+    <value>Перевертає (дзеркально відображає) зображення по горизонтальній осі.</value>
+  </data>
+  <data name="FilterView_InterlaceDetection" xml:space="preserve">
+    <value>Виявлення інтерлейсингу (interlace detection), коли увімкнено – дозволяє фільтру деінтерлейсингу обробляти лише відеокадри з інтерлейсингом.</value>
+  </data>
+  <data name="FilterView_InterlaceDetectionCustom" xml:space="preserve">
+    <value>Власні параметри виявлення інтерлейсингу.
+ 
+Синтаксис: mode=m:spatial-metric=s:motion-thresh=m:spatial-thresh=s:filter-mode=f:block-thresh=b:block-width=b:block-height=b:disable=d
+ 
+Стандартні: mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16</value>
+  </data>
+  <data name="FilterView_Rotate" xml:space="preserve">
+    <value>Обертає зображення за годинниковою стрілкою з кроком 90 градусів.</value>
+  </data>
+  <data name="MainView_Duration" xml:space="preserve">
+    <value>Тривалість діапазону вибраного джерела в години:хвилини:секунди</value>
+  </data>
+  <data name="PictureSettingsView_KeepAR" xml:space="preserve">
+    <value>Зберігати пропорції (Keep Aspect Ratio) підтримує початкове співвідношення сторін джерела. Відключення цього налаштування може призвести до розтягування або стискання зображення.</value>
+  </data>
+  <data name="FilterView_CustomSharpenParams" xml:space="preserve">
+    <value>Власні параметри різкості.
+
+Синтаксис Unsharp: y-strength=y:y-size=y:cb-strength=c:cb-size=c:cr-strength=c:cr-size=c
+
+Стандартні Unsharp: y-strength=0.25:y-size=7:cb-strength=0.25:cb-size=7
+
+Синтаксис Lapsharp: y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
+
+Стандартні Lapsharp: y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap</value>
+  </data>
+  <data name="FilterView_Sharpen" xml:space="preserve">
+    <value>Збільшення різкості (sharpening) покращує зовнішній вигляд деталей, особливо по краях. Надто сильні налаштування різкості можуть погіршити якість зображення створюючи кільцеві артефакти та посилюючи шуми, це може знизити ефективність стиснення.
+
+Unsharp – це нерізкий маскувальний фільтр загального призначення. Він збільшує різкість за допомогою розмиття, розраховуючи різницю між розмитим зображенням та оригіналом.
+
+Lapsharp збільшує різкість за допомогою ядер згортки, апроксимуючи крайові фільтри Лапласа (Laplacian edge filters), іноді показує результати вищої якості, ніж Unsharp.</value>
+  </data>
+  <data name="FilterView_SharpenPreset" xml:space="preserve">
+    <value>Попередньо встановлений фільтр збільшення різкості. Встановлює потужність фільтра.</value>
+  </data>
+  <data name="FilterView_SharpenTune" xml:space="preserve">
+    <value>Sharpen tune. Further adjusts the Sharpen preset to optimize settings for specific scenarios.
+
+None uses the default preset settings.
+
+Unsharp can be tuned for Ultrafine, Fine, Medium, Coarse, or Very Coarse sharpening. Select one based on the output picture resolution and fineness of detail to enhance.
+
+Lapsharp's Film tune refines settings for use with most live action content. Film uses an isotropic Laplacian kernel to sharpen all edges similarly, and luminance (brightness) information is sharpened more than chrominance (color) information.
+
+Lapsharp's Grain tune is similar to Film, but uses an isotropic Laplacian of Gaussian kernel to reduce the effect on noise and grain. Useful for preserving grain and as a general alternative to the Film tune.
+
+Lapsharp's Animation tune is useful for cel animation such as anime and cartoons. Animation is identical to Film, but overall strength is reduced to avoid creating artifacts.
+
+Lapsharp's Sprite tune is useful for 1-/4-/8-/16-bit 2-dimensional games. Sprite uses a 4-neighbor Laplacian kernel that enhances vertical and horizontal edges more than diagonal edges.</value>
+  </data>
+  <data name="MainView_AlignAVStart" xml:space="preserve">
+    <value>Вирівнює початкові часові позначки всіх аудіо та відеопотоків, вставляючи порожні або пропускаючи кадри. Може покращити синхронізацію аудіо/відео для зламаних плеєрів, які не шанують списки редагування MP4.</value>
+  </data>
+  <data name="MainView_PresetOptionsContextMenu" xml:space="preserve">
+    <value>Опції для управління наборами.</value>
+  </data>
+  <data name="MainView_EndPoint" xml:space="preserve">
+    <value>Кінцева точка для цього діапазону.</value>
+  </data>
+  <data name="MainView_StartPoint" xml:space="preserve">
+    <value>Початкова точка для цього діапазону.</value>
+  </data>
+  <data name="OptionsView_AlwaysUseDefaultPath" xml:space="preserve">
+    <value>Якщо ввімкнено, система автоматичного іменування завжди використовуватиме стандартний шлях. 
+Якщо вимкнено – буде використовувати шлях у вікні призначення у головному вікні, якщо він вказаний, інакше використовуватиме стандартний шлях.</value>
+  </data>
+</root>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.zh.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.zh.resx
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 

--- a/win/CS/HandBrakeWPF/Utilities/InterfaceLanguageUtilities.cs
+++ b/win/CS/HandBrakeWPF/Utilities/InterfaceLanguageUtilities.cs
@@ -32,6 +32,7 @@ namespace HandBrakeWPF.Utilities
                        new InterfaceLanguage("ko", "Korean"),
                        new InterfaceLanguage("ja", "Japanese"),
                        new InterfaceLanguage("pt-BR", "Brazilian Portuguese"),
+                       new InterfaceLanguage("co", "Corsican"),
                    };
         }
 

--- a/win/CS/HandBrakeWPF/Utilities/InterfaceLanguageUtilities.cs
+++ b/win/CS/HandBrakeWPF/Utilities/InterfaceLanguageUtilities.cs
@@ -33,6 +33,7 @@ namespace HandBrakeWPF.Utilities
                        new InterfaceLanguage("ja", "Japanese"),
                        new InterfaceLanguage("pt-BR", "Brazilian Portuguese"),
                        new InterfaceLanguage("co", "Corsican"),
+                       new InterfaceLanguage("uk", "Ukrainian"),
                    };
         }
 


### PR DESCRIPTION
I've updated all current locale files regardless of their completeness. I also added initial support for co and uk locale.
Language tag is according to https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c?redirectedfrom=MSDN