### PR TITLE
qsv: add initial selection gpu adapter by index 

### DIFF
--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -84,6 +84,7 @@ int            hb_qsv_video_encoder_is_enabled(int encoder);
 int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();
 void           hb_qsv_info_print();
+int            hb_qsv_query_adapters(hb_job_t *job);
 hb_qsv_info_t* hb_qsv_info_get(int encoder);
 int qsv_hardware_generation(int cpu_platform);
 
@@ -196,6 +197,7 @@ float hb_qsv_atof    (const char *str, int *err);
 int hb_qsv_param_default_async_depth();
 int hb_qsv_param_default_preset     (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info, const char *preset);
 int hb_qsv_param_default            (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info);
+int hb_qsv_param_parse_decoder      (hb_job_t *job, const char *key, const char *value);
 int hb_qsv_param_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, hb_job_t *job,  const char *key, const char *value);
 int hb_qsv_profile_parse            (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key, const int codec);
 int hb_qsv_level_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *level_key);

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -333,6 +333,8 @@ typedef struct hb_qsv_context {
     int num_cpu_filters;
     int qsv_filters_are_enabled;
     char *qsv_device;
+    mfxU32 num_adapters_available;
+    mfxAdaptersInfo adapters_info;
     AVBufferRef *hb_hw_device_ctx;
     HBQSVFramesContext *hb_dec_qsv_frames_ctx;
     HBQSVFramesContext *hb_vpp_qsv_frames_ctx;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1352,7 +1352,10 @@ static void do_job(hb_job_t *job)
 
 #if HB_PROJECT_FEATURE_QSV
     if (hb_qsv_is_enabled(job))
+    {
         job->qsv.ctx = hb_qsv_context_init();
+        hb_qsv_query_adapters(job);
+    }
 #endif
 
     // Filters have an effect on settings.


### PR DESCRIPTION
In case of several Intel GPU adapters with QSV support available in the system helps to select particular adapter by "gpu=X" option where X is QSV adapter index. 