### PR TITLE
new option "Use GPUs when possible" under Advanced tab for simultaneous encoding

### DIFF
--- a/win/CS/HandBrake.Interop/Model/HBConfiguration.cs
+++ b/win/CS/HandBrake.Interop/Model/HBConfiguration.cs
@@ -22,5 +22,7 @@ namespace HandBrake.Interop.Model
         public bool UseQSVDecodeForNonQSVEnc { get; set; }
 
         public bool EnableQsvLowPower { get; set; }
+
+        public bool EnableGPUs { get; set; }
     }
 }

--- a/win/CS/HandBrakeWPF/Factories/HBConfigurationFactory.cs
+++ b/win/CS/HandBrakeWPF/Factories/HBConfigurationFactory.cs
@@ -38,7 +38,8 @@ namespace HandBrakeWPF.Factories
                 PreviewScanCount = UserSettingService.GetUserSetting<int>(UserSettingConstants.PreviewScanCount),
                 EnableQuickSyncDecoding = UserSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncDecoding),
                 UseQSVDecodeForNonQSVEnc = UserSettingService.GetUserSetting<bool>(UserSettingConstants.UseQSVDecodeForNonQSVEnc),
-                EnableQsvLowPower = UserSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncLowPower)
+                EnableQsvLowPower = UserSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncLowPower),
+                EnableGPUs = UserSettingService.GetUserSetting<bool>(UserSettingConstants.UseGPUs)
             };
 
             return config;

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -3366,6 +3366,15 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use GPUs when possible.
+        /// </summary>
+        public static string Options_UseGPUs {
+            get {
+                return ResourceManager.GetString("Options_UseGPUs", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User Interface.
         /// </summary>
         public static string Options_UserInterface {

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2384,4 +2384,7 @@ Fields are limited to:
   <data name="Options_LowDiskspaceLevelText" xml:space="preserve">
     <value>Level at which low disk space alerts show:</value>
   </data>
+  <data name="Options_UseGPUs" xml:space="preserve">
+    <value>Use GPUs when possible</value>
+  </data>
 </root>

--- a/win/CS/HandBrakeWPF/Services/Queue/QueueResourceService.cs
+++ b/win/CS/HandBrakeWPF/Services/Queue/QueueResourceService.cs
@@ -24,6 +24,8 @@ namespace HandBrakeWPF.Services.Queue
 
         private HashSet<Guid> vceInstances = new HashSet<Guid>();
 
+        private static int gpuCount = 1;
+
         public Guid? GetHardwareLock(VideoEncoder encoder)
         {
             lock (this.lockOjb)
@@ -33,7 +35,7 @@ namespace HandBrakeWPF.Services.Queue
                     case VideoEncoder.QuickSync:
                     case VideoEncoder.QuickSyncH265:
                     case VideoEncoder.QuickSyncH26510b:
-                        if (this.qsvInstances.Count < 1)
+                        if (this.qsvInstances.Count < gpuCount)
                         {
                             Guid guid = Guid.NewGuid();
                             this.qsvInstances.Add(guid);
@@ -74,6 +76,12 @@ namespace HandBrakeWPF.Services.Queue
 
             return null;
         }
+
+        public void changeGPUCount(int count)
+        {
+            gpuCount = count;
+        }
+
 
         public void UnlockHardware(VideoEncoder encoder, Guid? unlockKey)
         {

--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -325,6 +325,7 @@ namespace HandBrakeWPF.Services
             defaults.Add(UserSettingConstants.ProcessIsolationEnabled, SystemInfo.IsWindows10() ? true : false);
             defaults.Add(UserSettingConstants.ProcessIsolationPort, 8037);
             defaults.Add(UserSettingConstants.SimultaneousEncodes, 1);
+            defaults.Add(UserSettingConstants.UseGPUs, false);
 
             // Misc
             defaults.Add(UserSettingConstants.ScalingMode, 0);

--- a/win/CS/HandBrakeWPF/UserSettingConstants.cs
+++ b/win/CS/HandBrakeWPF/UserSettingConstants.cs
@@ -78,5 +78,6 @@ namespace HandBrakeWPF
         public const string EnableQuickSyncLowPower = "EnableQuickSyncLowPower";
         public const string SimultaneousEncodes = "SimultaneousEncodes";
         public const string MetadataPassthru = "MetadataPassthru";
+        public const string UseGPUs = "UseGPUs";
     }
 }

--- a/win/CS/HandBrakeWPF/Views/OptionsView.xaml
+++ b/win/CS/HandBrakeWPF/Views/OptionsView.xaml
@@ -448,6 +448,10 @@
                             <TextBox Text="{Binding RemoteServicePort}" Width="100" IsEnabled="{Binding RemoteServiceEnabled}"  />
                         </StackPanel>
 
+                        <StackPanel Orientation="Horizontal" Margin="10,10,0,0">
+                            <CheckBox Content="{x:Static Properties:Resources.Options_UseGPUs}" IsChecked="{Binding UseGPUs}" IsEnabled="{Binding IsMultiGPUSupported}" />
+                        </StackPanel>
+
                         <StackPanel Orientation="Horizontal" Margin="10,10,0,0" IsEnabled="{Binding IsSimultaneousEncodesSupported}" >
                             <TextBlock Text="{x:Static Properties:Resources.OptionsView_SimultaneousEncodes}" VerticalAlignment="Center"/>
                             <ComboBox ItemsSource="{Binding SimultaneousEncodesList}" SelectedItem="{Binding SimultaneousEncodes}" IsEnabled="{Binding RemoteServiceEnabled}" />


### PR DESCRIPTION
This is only windows GUI change to allow use of Hardware acceleration/GPUs for simultaneous encoding.
The attempt is to split each next item of the queue to the next GPU.

![HB](https://user-images.githubusercontent.com/44644640/93486482-87b20e00-f904-11ea-9e81-41bb3636f9dc.png)

"gpu=" parameter is used to specify processing GPU.
![HB1](https://user-images.githubusercontent.com/44644640/93486556-a1535580-f904-11ea-81a2-72500bbb1764.png)
