### PR TITLE
Update Corsican resources from Transifex on 2020-09-20

### DIFF
--- a/win/CS/HandBrakeWPF/Properties/Resources.co.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.co.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -440,7 +440,7 @@ U ghjurnale d’attività puderia cuntene infurmazioni addiziunale.</value>
     <value>L’azzione seguente « {0} » si farà in {1} seconde.</value>
   </data>
   <data name="ErrorViewModel_IfTheProblemPersists" xml:space="preserve">
-    <value>S'è stu penseru ùn smarisce micca, ci vole à pruvà di rilancià HandBrake.</value>
+    <value>S’è stu penseru ùn smarisce micca, ci vole à pruvà di rilancià HandBrake.</value>
   </data>
   <data name="ErrorViewModel_NoFurtherInformation" xml:space="preserve">
     <value>Ùn ci hè mancu un’altra infurmazione di dispunibule per stu sbagliu.</value>
@@ -570,7 +570,7 @@ U vostru vechju schedariu di prerigature hè statu archiviatu :</value>
     <value> cù {0} sbaglii o abbandoni abbentati.</value>
   </data>
   <data name="MainViewModel_LowDiskSpace" xml:space="preserve">
-    <value>Spaziu discu chjucu</value>
+    <value>Spaziu discu debule</value>
   </data>
   <data name="MainViewModel_LowDiskSpaceWarning" xml:space="preserve">
     <value>Avertimentu : ùn ci hè abbastanza spaziu di discu. HandBrake ùn puderà compie sta cudificazione s’ellu ùn ci hè abbastanza spaziu di discu. </value>
@@ -705,7 +705,7 @@ Vulete cuntinuà ? </value>
     <value>Ci hè dighjà una cudificazione di schedariu in corsu.</value>
   </data>
   <data name="Queue_AlreadyEncodingSolution" xml:space="preserve">
-    <value>Ci vole à piantà a cudificazione attuale. S'è stu penseru ùn smarisce micca, ci vole à rilancià HandBrake.</value>
+    <value>Ci vole à piantà a cudificazione attuale. S’è stu penseru ùn smarisce micca, ci vole à rilancià HandBrake.</value>
   </data>
   <data name="StaticPreviewView_Title" xml:space="preserve">
     <value>Previsualizazione ({0}% di a dimensione attuale)</value>
@@ -802,7 +802,7 @@ Vulete rimpiazzallu ?</value>
     <value>Cumpurtamentu di a selezzione di traccia :</value>
   </data>
   <data name="AudioView_TrackSettingDefaultBehaviour" xml:space="preserve">
-    <value>Per e traccie addiziunale :</value>
+    <value>Mudellu per e traccie addiziunale :</value>
   </data>
   <data name="AudioView_WhenAutoPassthru" xml:space="preserve">
     <value>Quandu l’« Auto Passthru » hè selezziunatu cum’è cudecu audio.</value>
@@ -925,10 +925,10 @@ Vulete rimpiazzallu ?</value>
     <value>Cupià ver di u preme’papei</value>
   </data>
   <data name="Generic_MoveLeft" xml:space="preserve">
-    <value>Dispiazzà à manca</value>
+    <value>Move à manca</value>
   </data>
   <data name="Generic_MoveRight" xml:space="preserve">
-    <value>Dispiazzà à diritta</value>
+    <value>Move à diritta</value>
   </data>
   <data name="Generic_Save" xml:space="preserve">
     <value>Arregistrà</value>
@@ -1171,7 +1171,7 @@ Vulete rimpiazzallu ?</value>
     <value>Numinà autumaticamente i schedarii d’esciuta</value>
   </data>
   <data name="Options_CheckForUpdates" xml:space="preserve">
-    <value>Cuntrollà e nove versioni</value>
+    <value>Circà e nove versioni</value>
   </data>
   <data name="Options_ClearCompleted" xml:space="preserve">
     <value>Sempre squassà l’elementi compii di a fila d’attesa dopu a cudificazione</value>
@@ -1207,13 +1207,13 @@ Vulete rimpiazzallu ?</value>
     <value>Cudificazione</value>
   </data>
   <data name="Options_Format" xml:space="preserve">
-    <value>Furmatu di Schedariu :</value>
+    <value>Furmatu di schedariu :</value>
   </data>
   <data name="Options_General" xml:space="preserve">
     <value>Generale</value>
   </data>
   <data name="Options_Logging" xml:space="preserve">
-    <value>Cunnettassi</value>
+    <value>Arregistramentu di i messaghji</value>
   </data>
   <data name="Options_LogLevel" xml:space="preserve">
     <value>Livellu di verbusità di u ghjurnale :</value>
@@ -1222,7 +1222,7 @@ Vulete rimpiazzallu ?</value>
     <value>Chjassu d’accessu à i ghjurnali :</value>
   </data>
   <data name="Options_LowDiskspaceSize" xml:space="preserve">
-    <value>Interrompe a fila d’attesa s’ella ùn basta u spaziu discu</value>
+    <value>Interrompe fila d’attesa s’è spaziu discu hè debule</value>
   </data>
   <data name="Options_MinimiseTray" xml:space="preserve">
     <value>Impuculì in lu spaziu di nutificazione di u sistema (Richiede un rilanciu)</value>
@@ -1372,7 +1372,7 @@ Vulete rimpiazzallu ?</value>
     <value>Officiale</value>
   </data>
   <data name="QueueSelectionView_ChooseTitles" xml:space="preserve">
-    <value>Sciglite tituli :</value>
+    <value>Sciglite i tituli :</value>
   </data>
   <data name="QueueSelectionView_Title" xml:space="preserve">
     <value>Aghjunghje à a fila d’attesa</value>
@@ -1747,7 +1747,7 @@ Vulete rimpiazzallu ?</value>
     <value>_Ghjurnale d’attività</value>
   </data>
   <data name="MainView_CheckForUpdates" xml:space="preserve">
-    <value>_Cuntrollà e nove versioni</value>
+    <value>_Circà e nove versioni</value>
   </data>
   <data name="MainView_Exit" xml:space="preserve">
     <value>_Esce</value>
@@ -1762,7 +1762,7 @@ Vulete rimpiazzallu ?</value>
     <value>_Documentazione HandBrake (HTTPS)</value>
   </data>
   <data name="MainView_HelpMenu" xml:space="preserve">
-    <value>_Aiutu</value>
+    <value>Ai_utu</value>
   </data>
   <data name="MainView_ImportFromFile" xml:space="preserve">
     <value>_Impurtà da un schedariu</value>
@@ -1786,10 +1786,10 @@ Vulete rimpiazzallu ?</value>
     <value>A_ffissà u pannellu di e prerigature</value>
   </data>
   <data name="MainView_ShowQueueMenu" xml:space="preserve">
-    <value>Affissà a _fila d'attesa</value>
+    <value>Affissà a _fila d’attesa</value>
   </data>
   <data name="MainView_ToolsMenu" xml:space="preserve">
-    <value>Attre_zzi</value>
+    <value>_Attrezzi</value>
   </data>
   <data name="OptionsView_CheckingForUpdates" xml:space="preserve">
     <value>Cuntrollu di e nove versioni…</value>
@@ -1825,10 +1825,10 @@ Vulete rimpiazzallu ?</value>
     <value>Affissà</value>
   </data>
   <data name="MainView_ShowAddAllToQueue" xml:space="preserve">
-    <value>« Tuttu aghjunghje » à a fila d’attesa</value>
+    <value>« Tuttu aghjunghje » (à a fila d’attesa)</value>
   </data>
   <data name="MainView_ShowAddSelectionToQueue" xml:space="preserve">
-    <value>« Aghjunghje a selezzione » à a fila d’attesa</value>
+    <value>« Aghjunghje a selezzione » (à a fila d’attesa)</value>
   </data>
   <data name="QueueView_PlayMediaFile" xml:space="preserve">
     <value>Sunà u schedariu</value>
@@ -1837,10 +1837,10 @@ Vulete rimpiazzallu ?</value>
     <value>Barra d’attrezzi d’appiecazione</value>
   </data>
   <data name="Options_ShowToolbarAddAll" xml:space="preserve">
-    <value>Affissà « Tuttu aghjunghje à a fila d’attesa » nant’à a barra d’attrezzi</value>
+    <value>Affissà « Tuttu aghjunghje » (à a fila d’attesa) nant’à a barra d’attrezzi</value>
   </data>
   <data name="Options_ShowToolbarAddSelection" xml:space="preserve">
-    <value>Affissà « Aghjunghje a selezzione à a fila d’attesa » nant’à a barra d’attrezzi</value>
+    <value>Affissà « Aghjunghje a selezzione » (à a fila d’attesa) nant’à a barra d’attrezzi</value>
   </data>
   <data name="OptionsView_HardwareDetectFailed" xml:space="preserve">
     <value>L’adopru di a cudificazione materiale hè attualmente disattivatu. Assicuratevvi chì voi impiegate l’ultimi piloti per tutte e carte grafiche di stu sistema.
@@ -1893,19 +1893,19 @@ Ozzioni tramandate : {date} {time} {creation-date} {creation-time} {quality} {bi
     <value>Ozzioni dispunibule : {source_path} {source_folder_name} {source}</value>
   </data>
   <data name="FileOverwriteBehaviours_Ask" xml:space="preserve">
-    <value>Dumandà per rimpiazzà u schedariu</value>
+    <value>Dumandà nanzu di rimpiazzà</value>
   </data>
   <data name="FileOverwriteBehaviours_Autoname" xml:space="preserve">
     <value>Pruvà di rinumà autumaticamente u schedariu</value>
   </data>
   <data name="FileOverwriteBehaviours_Overwrite" xml:space="preserve">
-    <value>Rimpiazzà u schedariu</value>
+    <value>Rimpiazzà senza dumandà</value>
   </data>
   <data name="Options_UIBehaviour" xml:space="preserve">
     <value>Cumpurtamentu di l’interfaccia d’utilizatore</value>
   </data>
   <data name="OptionsView_FileOverwriteBehaviour" xml:space="preserve">
-    <value>Cosa fà in casu di rimpiazzamentu di schedariu</value>
+    <value>Cosa fà in casu di rimpiazzamentu di schedariu :</value>
   </data>
   <data name="Options_EncodeCompleted" xml:space="preserve">
     <value>Cudificazione compia</value>
@@ -1920,7 +1920,7 @@ Ozzioni tramandate : {date} {time} {creation-date} {creation-time} {quality} {bi
     <value>Quandu hè compiu :</value>
   </data>
   <data name="OptionsView_FileCollisionBehaviour" xml:space="preserve">
-    <value>Cosa fà in casu di cunflittu di nome di schedariu :</value>
+    <value>Cosa aghjunghje in casu di cunflittu di nome di schedariu :</value>
   </data>
   <data name="CollisionBehaviour_Post" xml:space="preserve">
     <value>Suffissu</value>
@@ -1929,7 +1929,7 @@ Ozzioni tramandate : {date} {time} {creation-date} {creation-time} {quality} {bi
     <value>Prefissu</value>
   </data>
   <data name="CollisionBehaviour_AppendNumber" xml:space="preserve">
-    <value>Aghjunghje un numeru à a fine</value>
+    <value>Numeru à a fine</value>
   </data>
   <data name="FiltersViewAuto_DeblockPreset" xml:space="preserve">
     <value>FiltersView_DeblockPreset</value>
@@ -2045,10 +2045,10 @@ Induve hè accettatu, tutte e prerigature persunalizate seranu state impurtate.<
     <value>Generale</value>
   </data>
   <data name="OptionsViewModel_CheckForUpdatesMsg" xml:space="preserve">
-    <value>Sciglite « Cuntrollà e nove versioni » per sapè s’ella esiste una nova versione di l’appiecazione</value>
+    <value>Sciglite « Circà e nove versioni » per sapè s’ella esiste una nova versione di l’appiecazione</value>
   </data>
   <data name="OptionsView_BackButton" xml:space="preserve">
-    <value>&lt; Precedente</value>
+    <value>&lt; Ritornu</value>
   </data>
   <data name="QueueView_CurrentlyPaused" xml:space="preserve">
     <value>Attualmente interrotta</value>
@@ -2099,13 +2099,13 @@ Induve hè accettatu, tutte e prerigature persunalizate seranu state impurtate.<
     <value>Tutte e lingue chì currispundenu</value>
   </data>
   <data name="AudioBehaviourModes_AllTracks" xml:space="preserve">
-    <value>Impiegà tutte e traccie cum’è mudellu</value>
+    <value>Impiegà tutte e traccie</value>
   </data>
   <data name="AudioBehaviourModes_FirstMatch" xml:space="preserve">
     <value>Prima lingua chì currispunde</value>
   </data>
   <data name="AudioBehaviourModes_FirstTrack" xml:space="preserve">
-    <value>Impiegà a prima traccia cum’è mudellu</value>
+    <value>Impiegà a prima traccia</value>
   </data>
   <data name="AudioBehaviourModes_None" xml:space="preserve">
     <value>Alcuna traccia audio</value>
@@ -2132,16 +2132,16 @@ Induve hè accettatu, tutte e prerigature persunalizate seranu state impurtate.<
     <value>Sempre impiegà a risuluzione di a video di a fonte</value>
   </data>
   <data name="ProcessPriority_AboveNormal" xml:space="preserve">
-    <value>Più altu chì a nurmale</value>
-  </data>
-  <data name="ProcessPriority_BelowNormal" xml:space="preserve">
-    <value>Più bassu chì a nurmale</value>
-  </data>
-  <data name="ProcessPriority_High" xml:space="preserve">
     <value>Altu</value>
   </data>
-  <data name="ProcessPriority_Low" xml:space="preserve">
+  <data name="ProcessPriority_BelowNormal" xml:space="preserve">
     <value>Bassu</value>
+  </data>
+  <data name="ProcessPriority_High" xml:space="preserve">
+    <value>U più altu</value>
+  </data>
+  <data name="ProcessPriority_Low" xml:space="preserve">
+    <value>U più bassu</value>
   </data>
   <data name="ProcessPriority_Normal" xml:space="preserve">
     <value>Nurmale</value>
@@ -2375,5 +2375,8 @@ I campi sò limitati à :
   </data>
   <data name="ManagePresetView_ExportUserPresets" xml:space="preserve">
     <value>Espurtà tutte e prerigature persunalizate</value>
+  </data>
+  <data name="Options_LowDiskspaceLevelText" xml:space="preserve">
+    <value>Livellu quandu l’alerte nant’à u spaziu discu debule s’affissenu :</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.co.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.co.resx
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -133,9 +133,9 @@ Quelle chì ùn sò micca intricciate averanu una perdita di qualità.</value>
     <value>U filtru « denoise » riduce o caccia l’aspettu di rumore è di granellu d’una video. Què pò megliurà u rendimentu di a cumpressione è creà una video di più bella qualità cù schedarii più chjuchi. 
 Preferenze « denoise » troppu putente ponu dannighjà a qualità di a fiura scartendu i detaglii.
          
-NLMeans hè un filtru « denoise » d’alta qualità chì fà dinù cresce a vitezza di a cudificazione. Impiegatelu quandu a qualità hè più impurtante chè a vitezza.
+- « NLMeans » hè un filtru « denoise » d’alta qualità chì fà dinù cresce a vitezza di a cudificazione. Impiegatelu quandu a qualità hè più impurtante chè a vitezza.
          
-HQDN3D hè un filtru passu-bassu adattevule, più prestu chè NLMeans ma menu efficiente per preservà i detaglii i più fini.</value>
+- « HQDN3D » hè un filtru passu-bassu adattevule, più prestu chè NLMeans ma menu efficiente per preservà i detaglii i più fini.</value>
   </data>
   <data name="FilterView_Detelecine" xml:space="preserve">
     <value>U filtru « detelecine » caccia l’effetti parassiti chì sò cagiunati da u telesinema, un trattamentu chì cunvertisce e frequenze di fiure d’un filmu ver di frequenze di fiure di televisiò.</value>
@@ -165,13 +165,13 @@ I dischi di fonte Blu-ray è DVD anu aspessu parechji tituli ; da bona regula, u
   <data name="PictureSettingsView_Anamorphic" xml:space="preserve">
     <value>« Anamorficu » permette dimensioni arbitrarie d’allucamentu tuttu preservendu l’aspettu d’origine durante a ripruduzzione.
 
-« Off » disattiveghja « Anamorficu ». E dimensioni d’allucamentu di a video è quelle di l’affissera seranu uguale. Solu ghjuvevule per a cumpatibilità cù certi apparechji anziani.
+- « None » disattiveghja « Anamorficu ». E dimensioni d’allucamentu di a video è quelle di l’affissera seranu uguale. Solu ghjuvevule per a cumpatibilità cù certi apparechji anziani.
 
-« Auto » megliureghja a risuluzione d’allucamentu tuttu preservendu e prupurzioni d’affissera d’origine. Ricumandatu.
+- « Automatic » megliureghja a risuluzione d’allucamentu tuttu preservendu e prupurzioni d’affissera d’origine. Ricumandatu.
 
-« Loose » hè simile à « Auto » ma prova di preservà e prupurzioni d’allucamentu. Què pò cagiunà una chjuca perdita di risuluzione d’allucamentu in pettu à « Auto ».
+- « Loose » hè simile à « Automatic » ma prova di preservà e prupurzioni d’allucamentu. Què pò cagiunà una chjuca perdita di risuluzione d’allucamentu in pettu à « Automatic ».
 
-« Persunalizatu » permette di definisce dapervoi tutte e preferenze. Ghjuvevule per currege un aspettu incurrettu d’affissera di a fonte è per i prufessiunali chì anu bisognu d’un cuntrollu espertu in post-pruduzzione.</value>
+- « Custom » permette di definisce dapervoi tutte e preferenze. Ghjuvevule per currege un aspettu incurrettu d’affissera di a fonte è per i prufessiunali chì anu bisognu d’un cuntrollu espertu in post-pruduzzione.</value>
   </data>
   <data name="PictureSettingsView_AutoCrop" xml:space="preserve">
     <value>Runzicà autumaticamente i bordi neri intornu à a video.</value>
@@ -350,26 +350,26 @@ Predefinizioni HQDN3D : y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-te
   <data name="FilterView_DenoiseTune" xml:space="preserve">
     <value>Rigatura « Denoise ». Adattazioni addiziunale di a prerigatura « Denoise » per megliurà e preferenze per scenarii specifichi.
  
-- « Alcunu » impiegheghja e preferenze di prerigatura predefinite.
+- « None » (Alcuna) impiegheghja e preferenze di prerigatura predefinite.
  
-- « Filmu » affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione.
+- « Film » (Filmu) affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione.
  
-- « Granellu » tratta solu i canali di culore. Ghjuvevule per preservà l’aspettu cinematograficu di u granellu di luminanza, tuttu riducendu o cacciendu u rumore di culore.
+- « Grain » (Granellu) tratta solu i canali di culore. Ghjuvevule per preservà l’aspettu cinematograficu di u granellu di luminanza, tuttu riducendu o cacciendu u rumore di culore.
 
-- « Mossa presta » riduce u sparghjimentu di i culori in e scene rapide impediscendu u trattamentu tempurale di i canali di culore. Ghjuvevule per e video di sport è d’azzione.
+- « High Motion » (Mossa presta) riduce u sparghjimentu di i culori in e scene rapide impediscendu u trattamentu tempurale di i canali di culore. Ghjuvevule per e video di sport è d’azzione.
 
-- « Animazione » hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa.
+- « Animation » (Animazione) hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa.
 
-- « Scagninu » hè ghjuvevule per e video nant’à un frisgiu magneticu analogicu di bassa qualità, cum’è e VHS, quandu « Filmu » ùn produce micca u risultatu aspettatu.
+- « Tape » (Scagninu) hè ghjuvevule per e video nant’à un frisgiu magneticu analogicu di bassa qualità, cum’è e VHS, quandu « Filmu » ùn produce micca u risultatu aspettatu.
 
-- « Spiritibugliettu » hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Ùn hè micca previstu per e video di alta definizione.</value>
+- « Sprite » (Spiritibugliettu) hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Ùn hè micca previstu per e video di alta definizione.</value>
   </data>
   <data name="FilterView_Deinterlace" xml:space="preserve">
-    <value>« Disintricciamentu » caccia l’effetti parassiti da a fiura.
+    <value>U filtru« Disintricciamentu » caccia l’effetti parassiti da a fiura.
 
-Yadif hè un filtru di disintricciamentu populare è rapidu.
+- « Yadif » hè un filtru di disintricciamentu populare è rapidu.
 
-« Decomb » bilanceghja trà parechje cudificazioni d’interpolazione per favurisce a vitezza è a qualità.</value>
+- « Decomb » bilanceghja trà parechje cudificazioni d’interpolazione per favurisce a vitezza è a qualità.</value>
   </data>
   <data name="FilterView_DeinterlaceCustom" xml:space="preserve">
     <value>Parametri di disintricciamentu persunalizati.
@@ -422,16 +422,16 @@ Sintassa Unsharp : y-strength=y:y-size=y:cb-strength=c:cb-size=c:cr-strength=c:c
 
 Predefinizioni Unsharp : y-strength=0.25:y-size=7:cb-strength=0.25:cb-size=7
 
-SintassaLapsharp : y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
+Sintassa Lapsharp : y-strength=y:y-kernel=y:cb-strength=c:cb-kernel=c:cr-strength=c:cr-kernel=c
 
-Sintassa Lapsharp : y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap</value>
+Predefinizioni Lapsharp : y-strength=0.2:y-kernel=isolap:cb-strength=0.2:cb-kernel=isolap</value>
   </data>
   <data name="FilterView_Sharpen" xml:space="preserve">
     <value>L’arrutata amendeghja l’aspettu di i detaglii, sopratuttu i bordi. Preferenze d’arrutata troppu forte ponu dannighjà a qualità di a fiura creendu effetti parassiti è aumentendu u rumore, ciò chì pò riduce a faccindaghjine di a cumpressione.
 
-Flosciu hè un filtru di maschera floscia à usu generale. Funziuneghja imbrugliendu, è dopu calculendu a sfarenza trà a fiura imbrugliata è a fiura d’origine.
+- « Unsharp » hè un filtru di maschera floscia à usu generale. Funziuneghja imbrugliendu, è dopu calculendu a sfarenza trà a fiura imbrugliata è a fiura d’origine.
 
-Lapsharp arruteghja impieghendu nocciuli di convuluzione s’avvicinendu di i filtri di bordu Laplacian, pruducendu ognitantu risultati di più bella qualità chì a maschera floscia.</value>
+- « Lapsharp » arruteghja impieghendu nocciuli di convuluzione s’avvicinendu di i filtri di bordu Laplacian, pruducendu ognitantu risultati di più bella qualità chì a maschera floscia.</value>
   </data>
   <data name="FilterView_SharpenPreset" xml:space="preserve">
     <value>Prerigatura di u filtru d’arrutata. Definisce a forza di u filtru.</value>
@@ -439,17 +439,17 @@ Lapsharp arruteghja impieghendu nocciuli di convuluzione s’avvicinendu di i fi
   <data name="FilterView_SharpenTune" xml:space="preserve">
     <value>Rigatura d’arrutata. Adattazioni addiziunale di a prerigatura d’arrutata per megliurà e preferenze per scenarii specifichi.
 
-Alcunu impiegheghja e preferenze di prerigatura predefinite.
+- « None » (Alcuna) impiegheghja e preferenze di prerigatura predefinite.
 
-Flosciu pò esse rigatu per un’arrutata Ultrafina, Fina, Mediana, Roza, o Assai roza. Selezziunate una rigatura secondu à a risuluzione di a fiura aspettata è a finezza di detaglii à amendà.
+- « Unsharp » pò esse rigatu per un’arrutata Ultrafina, Fina, Mediana, Roza, o Assai roza. Selezziunate una rigatura secondu à a risuluzione di a fiura aspettata è a finezza di detaglii à amendà.
 
-A rigatura « Filmu » affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione. Impiegheghja un nocciulu Laplacianu isotropicu per rende più netti tutti i bordi d’una manera simile, è l’infurmazioni di luminanza (lucidezza) sò più arrutate chè quelle di u culore.
+A rigatura « Film » (Filmu) affineghja e preferenze per un adopru cù a maiò parte di i cuntenuti d’azzione. Impiegheghja un nocciulu Laplacianu isotropicu per rende più netti tutti i bordi d’una manera simile, è l’infurmazioni di luminanza (lucidezza) sò più arrutate chè quelle di u culore.
 
-A rigatura « Granellu » hè simile à Filmu, ma impiegheghja un Laplacianu isotropicu à nocciulu Gaussianu per riduce l’zffetti nant’à u rumore è granellu. Ghjuvevule per preservà u granellu è cum’è alternativa à Filmu.
+A rigatura « Grain » (Granellu) hè simile à Film, ma impiegheghja un Laplacianu isotropicu à nocciulu Gaussianu per riduce l’zffetti nant’à u rumore è granellu. Ghjuvevule per preservà u granellu è cum’è alternativa à Film.
 
-A rigatura « Animazione » hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa. Hè uguale à Filmu, ma a forza di u trattamentu hè ridutta per impedisce di creà effetti parassiti.
+A rigatura « Animation » (Animazione) hè ghjuvevule per l’animazione in celluloide, cum’è a fiura mossa. Hè uguale à Film, ma a forza di u trattamentu hè ridutta per impedisce di creà effetti parassiti.
 
-A rigatura « Spiritibugliettu » hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Impiegheghja un nocciulu Laplacianu à 4 vicini chì amendeghja i cuntorni verticale è orizuntale più chì i cuntorni diagunale.</value>
+A rigatura « Sprite » (Spiritibugliettu) hè ghjuvevule per i ghjochi 2D in 1, 4, 8 o 16 bit. Impiegheghja un nocciulu Laplacianu à 4 vicini chì amendeghja i cuntorni verticale è orizuntale più chì i cuntorni diagunale.</value>
   </data>
   <data name="MainView_AlignAVStart" xml:space="preserve">
     <value>Alineeghja e stampiglie iniziale di tutti i flussi audio è video framittendu fiure viote o squassendu fiure. Què pò megliurà a sincrunizazione audio/video per i lettori disfunziunendu chì ùn rispettanu micca e liste di mudificazioni MP4.</value>


### PR DESCRIPTION
Hello,

This PR relates to issue #3136 in order to refresh the **Corsican** Ressource files from [Transifex](https://www.transifex.com/HandBrakeProject/WinUI/language/co/):

- `Resources.co.resx` latest update on Transifex on September 12th, 2020
- `ResourcesTooltips.co.resx` latest update on Transifex on September 11th, 2020

Cheers,
Patriccollu.