### PR TITLE
qsv: added hb_qsv_adapters_list function and make proper multiple gpu…

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1105,15 +1105,18 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
         hb_dict_free(&options_list);
     }
 
+    if (pv->is_sys_mem)
+    {
     // select the right hardware implementation based on dx index
-    if (!job->qsv.ctx->qsv_device)
-        hb_qsv_param_parse_dx_index(pv->job, -1);
+        if (!job->qsv.ctx->qsv_device)
+            hb_qsv_param_parse_dx_index(pv->job, -1);
 #if defined(SYS_LINUX) || defined(SYS_FREEBSD)
     mfxIMPL hw_preference = MFX_IMPL_VIA_ANY;
 #else
     mfxIMPL hw_preference = MFX_IMPL_VIA_D3D11;
 #endif
-    pv->qsv_info->implementation = hb_qsv_dx_index_to_impl(job->qsv.ctx->dx_index) | hw_preference;
+        pv->qsv_info->implementation = hb_qsv_dx_index_to_impl(job->qsv.ctx->dx_index) | hw_preference;
+    }
     // reload colorimetry in case values were set in encoder_options
     if (pv->param.videoSignalInfo.ColourDescriptionPresent)
     {
@@ -1434,7 +1437,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     err = MFXInit(pv->qsv_info->implementation, &version, &session);
     if (err != MFX_ERR_NONE)
     {
-        hb_error("encqsvInit: MFXInit failed (%d)", err);
+        hb_error("encqsvInit: MFXInit failed (%d) with implementation %d", err, pv->qsv_info->implementation);
         return -1;
     }
 

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -84,7 +84,7 @@ int            hb_qsv_video_encoder_is_enabled(int encoder);
 int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();
 void           hb_qsv_info_print();
-int            hb_qsv_query_adapters(hb_job_t *job);
+hb_list_t*     hb_qsv_adapters_list();
 hb_qsv_info_t* hb_qsv_info_get(int encoder);
 int qsv_hardware_generation(int cpu_platform);
 
@@ -197,10 +197,10 @@ float hb_qsv_atof    (const char *str, int *err);
 int hb_qsv_param_default_async_depth();
 int hb_qsv_param_default_preset     (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info, const char *preset);
 int hb_qsv_param_default            (hb_qsv_param_t *param, mfxVideoParam *videoParam, hb_qsv_info_t *info);
-int hb_qsv_param_parse_decoder      (hb_job_t *job, const char *key, const char *value);
 int hb_qsv_param_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, hb_job_t *job,  const char *key, const char *value);
 int hb_qsv_profile_parse            (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *profile_key, const int codec);
 int hb_qsv_level_parse              (hb_qsv_param_t *param,                            hb_qsv_info_t *info, const char *level_key);
+int hb_qsv_param_parse_dx_index     (hb_job_t *job, const int dx_index);
 
 typedef struct
 {

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -333,8 +333,7 @@ typedef struct hb_qsv_context {
     int num_cpu_filters;
     int qsv_filters_are_enabled;
     char *qsv_device;
-    mfxU32 num_adapters_available;
-    mfxAdaptersInfo adapters_info;
+    int dx_index;
     AVBufferRef *hb_hw_device_ctx;
     HBQSVFramesContext *hb_dec_qsv_frames_ctx;
     HBQSVFramesContext *hb_vpp_qsv_frames_ctx;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1354,7 +1354,6 @@ static void do_job(hb_job_t *job)
     if (hb_qsv_is_enabled(job))
     {
         job->qsv.ctx = hb_qsv_context_init();
-        hb_qsv_query_adapters(job);
     }
 #endif
 


### PR DESCRIPTION
Added hb_qsv_adapters_list() function that returns list of DirectX adapters numbers with QSV support in decreasing priority order.
Zero element of the list has highest priority.

[EDITED] encode-only mode fixed and fixed multi adapter configuration issues