### PR TITLE
qsv: add patch for MFXQueryAdapters function in libmfx dispatcher

### DIFF
--- a/contrib/libmfx/A00-fix-dummy-session.patch
+++ b/contrib/libmfx/A00-fix-dummy-session.patch
@@ -1,11 +1,11 @@
 diff --git a/src/mfx_dispatcher.cpp b/src/mfx_dispatcher.cpp
-index 163f53e..0365057 100644
+index 163f53e..6ffa595 100644
 --- a/src/mfx_dispatcher.cpp
 +++ b/src/mfx_dispatcher.cpp
-@@ -354,27 +354,7 @@ static mfxStatus InitDummySession(mfxU32 adapter_n, MFXVideoSession & dummy_sess
+@@ -354,27 +354,28 @@ static mfxStatus InitDummySession(mfxU32 adapter_n, MFXVideoSession & dummy_sess
      initPar.Version.Major = 1;
      initPar.Version.Minor = 0;
-
+ 
 -    switch (adapter_n)
 -    {
 -    case 0:
@@ -27,7 +27,177 @@ index 163f53e..0365057 100644
 -        break;
 -    }
 -
++    // switch (adapter_n)
++    // {
++    // case 0:
++    //     initPar.Implementation = MFX_IMPL_HARDWARE;
++    //     break;
++    // case 1:
++    //     initPar.Implementation = MFX_IMPL_HARDWARE2;
++    //     break;
++    // case 2:
++    //     initPar.Implementation = MFX_IMPL_HARDWARE3;
++    //     break;
++    // case 3:
++    //     initPar.Implementation = MFX_IMPL_HARDWARE4;
++    //     break;
++
++    // default:
++    //     // try searching on all display adapters
++    //     initPar.Implementation = MFX_IMPL_HARDWARE_ANY;
++    //     break;
++    // }
++
 +    initPar.Implementation = MFX_IMPL_HARDWARE_ANY;
      initPar.Implementation |= MFX_IMPL_VIA_D3D11;
-
+ 
      return dummy_session.InitEx(initPar);
+@@ -449,7 +450,10 @@ static inline bool QueryAdapterInfo(mfxU32 adapter_n, mfxU32& VendorID, mfxU32&
+ {
+     MFX::DXVA2Device dxvaDevice;
+ 
+-    if (!dxvaDevice.InitD3D9(adapter_n) && !dxvaDevice.InitDXGI1(adapter_n))
++    //if (!dxvaDevice.InitD3D9(adapter_n) && !dxvaDevice.InitDXGI1(adapter_n))
++    //    return false;
++
++    if (!dxvaDevice.InitDXGI1(adapter_n))
+         return false;
+ 
+     VendorID = dxvaDevice.GetVendorID();
+diff --git a/src/mfx_dxva2_device.cpp b/src/mfx_dxva2_device.cpp
+index 9935574..f2c98db 100644
+--- a/src/mfx_dxva2_device.cpp
++++ b/src/mfx_dxva2_device.cpp
+@@ -22,6 +22,7 @@
+ #define INITGUID
+ #include <d3d9.h>
+ #include <dxgi.h>
++#include <dxgi1_2.h>
+ 
+ #include "mfx_dxva2_device.h"
+ 
+@@ -286,8 +287,8 @@ HRESULT (WINAPI *DXGICreateFactoryFunc) (REFIID riid, void **ppFactory);
+ 
+ DXGI1Device::DXGI1Device(void)
+ {
+-    m_pDXGIFactory1 = (void *) 0;
+-    m_pDXGIAdapter1 = (void *) 0;
++    m_pDXGIFactory2 = (void *) 0;
++    m_pDXGIAdapter2 = (void *) 0;
+ 
+ } // DXGI1Device::DXGI1Device(void)
+ 
+@@ -300,18 +301,18 @@ DXGI1Device::~DXGI1Device(void)
+ void DXGI1Device::Close(void)
+ {
+     // release the interfaces
+-    if (m_pDXGIAdapter1)
++    if (m_pDXGIAdapter2)
+     {
+-        ((IDXGIAdapter1 *) m_pDXGIAdapter1)->Release();
++        ((IDXGIAdapter2 *) m_pDXGIAdapter2)->Release();
+     }
+ 
+-    if (m_pDXGIFactory1)
++    if (m_pDXGIFactory2)
+     {
+-        ((IDXGIFactory1 *) m_pDXGIFactory1)->Release();
++        ((IDXGIFactory2 *) m_pDXGIFactory2)->Release();
+     }
+ 
+-    m_pDXGIFactory1 = (void *) 0;
+-    m_pDXGIAdapter1 = (void *) 0;
++    m_pDXGIFactory2 = (void *) 0;
++    m_pDXGIAdapter2 = (void *) 0;
+ 
+ } // void DXGI1Device::Close(void)
+ 
+@@ -320,9 +321,9 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+     // release the object before initialization
+     Close();
+ 
+-    IDXGIFactory1 *pFactory = NULL;
+-    IDXGIAdapter1 *pAdapter = NULL;
+-    DXGI_ADAPTER_DESC1 desc = { 0 };
++    IDXGIFactory2 *pFactory = NULL;
++    IDXGIAdapter2 *pAdapter = NULL;
++    DXGI_ADAPTER_DESC2 desc = { 0 };
+     mfxU32 curAdapter = 0;
+     mfxU32 maxAdapters = 0;
+     HRESULT hRes = E_FAIL;
+@@ -338,7 +339,7 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+     if (m_hModule)
+     {
+         // load address of procedure to create DXGI 1.1 factory
+-        pFunc = (DXGICreateFactoryFunc)GetProcAddress(m_hModule, "CreateDXGIFactory1");
++        pFunc = (DXGICreateFactoryFunc)GetProcAddress(m_hModule, "CreateDXGIFactory");
+     }
+ 
+     if (NULL == pFunc)
+@@ -348,16 +349,16 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+ 
+     // create the factory
+ #if _MSC_VER >= 1400
+-    hRes = pFunc(__uuidof(IDXGIFactory1), (void**)(&pFactory));
++    hRes = pFunc(__uuidof(IDXGIFactory2), (void**)(&pFactory));
+ #else
+-    hRes = pFunc(IID_IDXGIFactory1, (void**)(&pFactory));
++    hRes = pFunc(IID_IDXGIFactory2, (void**)(&pFactory));
+ #endif
+ 
+     if (FAILED(hRes))
+     {
+         return false;
+     }
+-    m_pDXGIFactory1 = pFactory;
++    m_pDXGIFactory2 = pFactory;
+ 
+     // get the number of adapters
+     curAdapter = 0;
+@@ -365,7 +366,7 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+     do
+     {
+         // get the required adapted
+-        hRes = pFactory->EnumAdapters1(curAdapter, &pAdapter);
++        hRes = pFactory->EnumAdapters(curAdapter, (IDXGIAdapter **)&pAdapter);
+         if (FAILED(hRes))
+         {
+             break;
+@@ -374,7 +375,7 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+         // if it is the required adapter, save the interface
+         if (curAdapter == adapterNum)
+         {
+-            m_pDXGIAdapter1 = pAdapter;
++            m_pDXGIAdapter2 = pAdapter;
+         }
+         else
+         {
+@@ -392,10 +393,10 @@ bool DXGI1Device::Init(const mfxU32 adapterNum)
+     {
+         return false;
+     }
+-    pAdapter = (IDXGIAdapter1 *) m_pDXGIAdapter1;
++    pAdapter = (IDXGIAdapter2 *) m_pDXGIAdapter2;
+ 
+     // get the adapter's parameters
+-    hRes = pAdapter->GetDesc1(&desc);
++    hRes = pAdapter->GetDesc2(&desc);
+     if (FAILED(hRes))
+     {
+         return false;
+diff --git a/src/mfx_dxva2_device.h b/src/mfx_dxva2_device.h
+index f35e76c..7e87fc2 100644
+--- a/src/mfx_dxva2_device.h
++++ b/src/mfx_dxva2_device.h
+@@ -164,9 +164,9 @@ public:
+ protected:
+ 
+     // Pointer to the DXGI1 factory
+-    void *m_pDXGIFactory1;
++    void *m_pDXGIFactory2;
+     // Pointer to the current DXGI1 adapter
+-    void *m_pDXGIAdapter1;
++    void *m_pDXGIAdapter2;
+ 
+ };
+ #endif // #if defined(_WIN32) || defined(_WIN64) || defined(__CYGWIN__)

--- a/contrib/libmfx/A00-fix-dummy-session.patch
+++ b/contrib/libmfx/A00-fix-dummy-session.patch
@@ -1,0 +1,33 @@
+diff --git a/src/mfx_dispatcher.cpp b/src/mfx_dispatcher.cpp
+index 163f53e..0365057 100644
+--- a/src/mfx_dispatcher.cpp
++++ b/src/mfx_dispatcher.cpp
+@@ -354,27 +354,7 @@ static mfxStatus InitDummySession(mfxU32 adapter_n, MFXVideoSession & dummy_sess
+     initPar.Version.Major = 1;
+     initPar.Version.Minor = 0;
+
+-    switch (adapter_n)
+-    {
+-    case 0:
+-        initPar.Implementation = MFX_IMPL_HARDWARE;
+-        break;
+-    case 1:
+-        initPar.Implementation = MFX_IMPL_HARDWARE2;
+-        break;
+-    case 2:
+-        initPar.Implementation = MFX_IMPL_HARDWARE3;
+-        break;
+-    case 3:
+-        initPar.Implementation = MFX_IMPL_HARDWARE4;
+-        break;
+-
+-    default:
+-        // try searching on all display adapters
+-        initPar.Implementation = MFX_IMPL_HARDWARE_ANY;
+-        break;
+-    }
+-
++    initPar.Implementation = MFX_IMPL_HARDWARE_ANY;
+     initPar.Implementation |= MFX_IMPL_VIA_D3D11;
+
+     return dummy_session.InitEx(initPar);


### PR DESCRIPTION
Fix incorrect behaviour of MFXQueryAdapters function in libmfx dispatcher.
Helps for #3155