### PR TITLE
Flatpak fixes

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libturbojpeg0-dev libssl-dev
         sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build patch tar yasm zlib1g-dev appstream
         sudo pip3 install meson
-        sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgtk-3-dev libgudev-1.0-dev libnotify-dev
+        sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgtk-3-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev llvm clang
 
     - name: Setup Toolchain

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -158,16 +158,6 @@ HB_LIBS="$HB_LIBS $GHB_LIBS"
 HB_CPPFLAGS="$HB_CPPFLAGS $GHB_CFLAGS"
 
 
-pkg_gudev="gudev-1.0"
-PKG_CHECK_MODULES([gudev], [$pkg_gudev], have_gudev=yes, have_gudev=no)
-if test "x$have_gudev" = "xyes" ; then
-	HB_LIBS="$HB_LIBS $gudev_LIBS"
-	HB_CPPFLAGS="$HB_CPPFLAGS $gudev_CFLAGS"
-
-	CXXFLAGS="$CXXFLAGS -D_HAVE_GUDEV"
-	CFLAGS="$CFLAGS -D_HAVE_GUDEV"
-fi
-
 pkg_libxml2="libxml-2.0"
 PKG_CHECK_MODULES([libxml2], [$pkg_libxml2], have_libxml2=yes, have_libxml2=no)
 if test "x$have_libxml2" = "xyes" ; then

--- a/gtk/ghb.spec
+++ b/gtk/ghb.spec
@@ -11,7 +11,7 @@ Source0:	%{name}-%{version}.tar.bz2
 Prefix:		%{_prefix}
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: glib2-devel, gtk3-devel, webkitgtk3-devel
-BuildRequires: gstreamer1-devel, gstreamer1-plugins-base-devel, libgudev1-devel
+BuildRequires: gstreamer1-devel, gstreamer1-plugins-base-devel
 BuildRequires: bzip2-devel, intltool, libnotify-devel, libtool
 Requires:	gtk3, coreutils
 

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -5157,7 +5157,28 @@ ghb_is_cd(GDrive *gd)
 
     return FALSE;
 #else
-    return FALSE;
+    GIcon *gicon;
+    gboolean ret = FALSE;
+    char **names, **iter;
+
+    if (!g_drive_is_media_removable (gd))
+        return ret;
+
+    gicon = g_drive_get_icon (gd);
+    if (!gicon)
+        return ret;
+    if (!G_IS_THEMED_ICON (gicon))
+    {
+        g_object_unref (gicon);
+        return ret;
+    }
+
+    g_object_get (gicon, "names", &names, NULL);
+    ret = g_strv_contains (names, "drive-optical");
+    g_strfreev (names);
+    g_object_unref (gicon);
+
+    return ret;
 #endif
 }
 

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -39,10 +39,6 @@
 
 #if !defined(_WIN32)
 #include <poll.h>
-#define G_UDEV_API_IS_SUBJECT_TO_CHANGE 1
-#if defined(__linux__) && defined(_HAVE_GUDEV)
-#include <gudev/gudev.h>
-#endif
 
 #if defined( __FreeBSD__ ) || defined(__OpenBSD__)
 #include <sys/socket.h>
@@ -5122,41 +5118,9 @@ dvd_device_list (void)
     return dvd_devices;
 }
 
-#if defined(__linux__) && defined(_HAVE_GUDEV)
-static GUdevClient *udev_ctx = NULL;
-#endif
-
 gboolean
 ghb_is_cd(GDrive *gd)
 {
-#if defined(__linux__) && defined(_HAVE_GUDEV)
-    gchar *device;
-    GUdevDevice *udd;
-
-    if (udev_ctx == NULL)
-        return FALSE;
-
-    device = g_drive_get_identifier(gd, G_VOLUME_IDENTIFIER_KIND_UNIX_DEVICE);
-    if (device == NULL)
-        return FALSE;
-
-    udd = g_udev_client_query_by_device_file(udev_ctx, device);
-    if (udd == NULL)
-    {
-        g_message("udev: Failed to lookup device %s", device);
-        g_free(device);
-        return FALSE;
-    }
-    g_free(device);
-
-    gint val;
-    val = g_udev_device_get_property_as_int(udd, "ID_CDROM_DVD");
-    g_object_unref(udd);
-    if (val == 1)
-        return TRUE;
-
-    return FALSE;
-#else
     GIcon *gicon;
     gboolean ret = FALSE;
     char **names, **iter;
@@ -5179,15 +5143,6 @@ ghb_is_cd(GDrive *gd)
     g_object_unref (gicon);
 
     return ret;
-#endif
-}
-
-void
-ghb_udev_init (void)
-{
-#if defined(__linux__) && defined(_HAVE_GUDEV)
-    udev_ctx = g_udev_client_new(NULL);
-#endif
 }
 
 #if defined(_WIN32)

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -45,7 +45,6 @@ gboolean ghb_timer_cb(gpointer data);
 gboolean ghb_log_cb(GIOChannel *source, GIOCondition cond, gpointer data);
 void ghb_hbfd(signal_user_data_t *ud, gboolean hbfd);
 gboolean ghb_file_menu_add_dvd(signal_user_data_t *ud);
-void ghb_udev_init(void);
 void ghb_countdown_dialog(GtkMessageType type, const gchar *message,
     const gchar *action, const gchar *cancel, GSourceFunc action_func,
     signal_user_data_t *ud, gint timeout);

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -1062,8 +1062,6 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     ghb_resource_init();
     ghb_load_icons();
 
-    ghb_udev_init();
-
     // Override user config dir
     if (arg_config_dir != NULL)
     {

--- a/pkg/linux/debian/control
+++ b/pkg/linux/debian/control
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>=0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>=0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.artful
+++ b/pkg/linux/debian/control.artful
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.bionic
+++ b/pkg/linux/debian/control.bionic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.cosmic
+++ b/pkg/linux/debian/control.cosmic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.disco
+++ b/pkg/linux/debian/control.disco
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.eoan
+++ b/pkg/linux/debian/control.eoan
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.focal
+++ b/pkg/linux/debian/control.focal
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.karmic
+++ b/pkg/linux/debian/control.karmic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.lucid
+++ b/pkg/linux/debian/control.lucid
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.maverick
+++ b/pkg/linux/debian/control.maverick
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.natty
+++ b/pkg/linux/debian/control.natty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.oneiric
+++ b/pkg/linux/debian/control.oneiric
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.precise
+++ b/pkg/linux/debian/control.precise
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.quantal
+++ b/pkg/linux/debian/control.quantal
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.raring
+++ b/pkg/linux/debian/control.raring
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.saucy
+++ b/pkg/linux/debian/control.saucy
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.trusty
+++ b/pkg/linux/debian/control.trusty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.utopic
+++ b/pkg/linux/debian/control.utopic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.vivid
+++ b/pkg/linux/debian/control.vivid
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.wily
+++ b/pkg/linux/debian/control.wily
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.xenial
+++ b/pkg/linux/debian/control.xenial
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.yakkety
+++ b/pkg/linux/debian/control.yakkety
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.zesty
+++ b/pkg/linux/debian/control.zesty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, libgudev-1.0-dev, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -5,7 +5,7 @@
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [
-        "--device=dri",
+        "--device=all",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland",


### PR DESCRIPTION
This makes it possible to easily rip a DVD on a Linux system, and updates the Flatpak manifest to close a few sandbox holes.
If the libdvdcss commit isn't acceptable, I'm happy to remove it.