### PR TITLE
qsv: fix AVC encoding hang when LA is enabled on Windows

### DIFF
--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -212,7 +212,6 @@ typedef struct QSVFrame {
 
 #define HB_QSV_POOL_FFMPEG_SURFACE_SIZE (64)
 #define HB_QSV_POOL_SURFACE_SIZE (64)
-#define HB_QSV_POOL_ENCODER_SIZE (8)
 
 typedef struct HBQSVFramesContext {
     AVBufferRef *hw_frames_ctx;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3016,7 +3016,7 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
     }
     else
     {
-        hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_QSV_POOL_SURFACE_SIZE - HB_QSV_POOL_ENCODER_SIZE, &mid, &output_surface);
+        hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_QSV_POOL_SURFACE_SIZE, &mid, &output_surface);
     }
 
     if (device_manager_handle_type == MFX_HANDLE_D3D9_DEVICE_MANAGER)
@@ -3228,7 +3228,9 @@ int hb_create_ffmpeg_pool(hb_job_t *job, int coded_width, int coded_height, enum
     frames_ctx->height            = FFALIGN(coded_height, 32);
     frames_ctx->format            = AV_PIX_FMT_QSV;
     frames_ctx->sw_format         = sw_pix_fmt;
-    frames_ctx->initial_pool_size = pool_size + extra_hw_frames;
+    frames_ctx->initial_pool_size = pool_size;
+    if (extra_hw_frames >= 0)
+        frames_ctx->initial_pool_size += extra_hw_frames;
     frames_hwctx->frame_type      = MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;
 
     ret = av_hwframe_ctx_init(hw_frames_ctx);

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -2296,6 +2296,13 @@ static int syncVideoInit( hb_work_object_t * w, hb_job_t * job)
     pv->stream->in_queue        = hb_list_init();
     pv->stream->scr_delay_queue = hb_list_init();
     pv->stream->max_len         = SYNC_MAX_VIDEO_QUEUE_LEN;
+#if HB_PROJECT_FEATURE_QSV
+    // Fix of LA case allowing use of LA up to 40 in full encode path,
+    // as currently for such support we cannot allocate >64 slices per texture
+    // due to MSFT limitation, not impacting other cases
+    if (hb_qsv_full_path_is_enabled(job))
+        pv->stream->max_len     = SYNC_MIN_VIDEO_QUEUE_LEN;
+#endif
     pv->stream->min_len         = SYNC_MIN_VIDEO_QUEUE_LEN;
     if (pv->stream->in_queue == NULL) goto fail;
     pv->stream->delta_list      = hb_list_init();


### PR DESCRIPTION
Allowing to use of LA up to 40 in full encode path as currently for such support we cannot allocate >64 slices per texture due to MSFT limitation, not impacting other cases