### PR TITLE
libhb: partially remove hardcoded AV_PIX_FMT_YUV420P references.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5959,3 +5959,21 @@ const char * hb_get_color_range_name(int range)
             return "mpeg";
     }
 }
+
+int hb_get_bit_depth(int format)
+{
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(format);
+    int i, min, max;
+
+    if (!desc || !desc->nb_components) {
+        min = max = 0;
+    }
+
+    min = INT_MAX, max = -INT_MAX;
+    for (i = 0; i < desc->nb_components; i++) {
+        min = FFMIN(desc->comp[i].depth, min);
+        max = FFMAX(desc->comp[i].depth, max);
+    }
+
+    return max;
+}

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -172,9 +172,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     if (!hb_qsv_hw_filters_are_enabled(init->job))
 #endif
     {
-        // TODO: Support other pix formats
-        // Force output to YUV420P for until other formats are supported
-        hb_dict_set(avsettings, "pix_fmts", hb_value_string("yuv420p"));
+        hb_dict_set(avsettings, "pix_fmts", hb_value_string(hb_get_format_name(init->pix_fmt)));
         hb_dict_set(avfilter, "format", avsettings);
         hb_value_array_append(avfilters, avfilter);
     }

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1190,7 +1190,7 @@ int reinit_video_filters(hb_work_private_t * pv)
             hb_avfilter_append_dict(filters, "scale", settings);
 
             settings = hb_dict_init();
-            hb_dict_set(settings, "pix_fmts", hb_value_string("yuv420p"));
+            hb_dict_set(settings, "pix_fmts", hb_value_string(hb_get_format_name(pix_fmt)));
             hb_avfilter_append_dict(filters, "format", settings);
         }
     }

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -422,7 +422,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     }
     context->width     = job->width;
     context->height    = job->height;
-    context->pix_fmt   = AV_PIX_FMT_YUV420P;
+    context->pix_fmt   = job->pix_fmt;
 
     context->sample_aspect_ratio.num = job->par.num;
     context->sample_aspect_ratio.den = job->par.den;

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -755,7 +755,8 @@ static hb_buffer_t *x264_encode( hb_work_object_t *w, hb_buffer_t *in )
     hb_buffer_t       *tmp = NULL;
 
     /* Point x264 at our current buffers Y(UV) data.  */
-    if (pv->pic_in.img.i_csp & X264_CSP_HIGH_DEPTH)
+    if (pv->pic_in.img.i_csp & X264_CSP_HIGH_DEPTH &&
+        job->pix_fmt == AV_PIX_FMT_YUV420P)
     {
         tmp = expand_buf(pv->api->bit_depth, in);
         pv->pic_in.img.i_stride[0] = tmp->plane[0].stride;

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -60,6 +60,7 @@ struct hb_work_private_s
 
     // Multiple bit-depth
     const x265_api     * api;
+    int                  bit_depth;
 };
 
 static int param_parse(hb_work_private_t *pv, x265_param *param,
@@ -193,6 +194,9 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     {
         goto fail;
     }
+
+    /* Bit depth */
+    pv->bit_depth = hb_get_bit_depth(job->pix_fmt);
 
     /* iterate through x265_opts and parse the options */
     hb_dict_t *x265_opts;
@@ -477,7 +481,7 @@ static hb_buffer_t* x265_encode(hb_work_object_t *w, hb_buffer_t *in)
     pic_in.planes[2] = in->plane[2].data;
     pic_in.poc       = pv->frames_in++;
     pic_in.pts       = in->s.start;
-    pic_in.bitDepth  = 8;
+    pic_in.bitDepth  = pv->bit_depth;
 
     if (in->s.new_chap && job->chapter_markers)
     {

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1447,6 +1447,9 @@ int hb_output_color_prim(hb_job_t * job);
 int hb_output_color_transfer(hb_job_t * job);
 int hb_output_color_matrix(hb_job_t * job);
 
+const char * hb_get_format_name(int format);
+int hb_get_bit_depth(int format);
+
 #define HB_NEG_FLOAT_REG "(([-])?(([0-9]+([.,][0-9]+)?)|([.,][0-9]+))"
 #define HB_FLOAT_REG     "(([0-9]+([.,][0-9]+)?)|([.,][0-9]+))"
 #define HB_NEG_INT_REG   "(([-]?[0-9]+)"

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -371,7 +371,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
     {
         if (buf == NULL)
         {
-            buf = hb_frame_buffer_init(AV_PIX_FMT_YUV420P,
+            buf = hb_frame_buffer_init(stream->common->job->pix_fmt,
                                    stream->common->job->title->geometry.width,
                                    stream->common->job->title->geometry.height);
             memset(buf->plane[0].data, 0x00, buf->plane[0].size);


### PR DESCRIPTION
Removes some hardcoded pixel format values and make them depend on the job pixel format. This allows 10bit -> 10bit x265 and x265 encoding if no incompatible filter is enabled (and if job->pix_fmt is manually changed to AV_PIX_FMT_YUV420P10 in common.c).

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux