### PR TITLE
qsv: added AV1 HW decoding capabilities

### DIFF
--- a/contrib/ffmpeg/A21-qsv-av1-decoder.patch
+++ b/contrib/ffmpeg/A21-qsv-av1-decoder.patch
@@ -1,0 +1,77 @@
+diff --git a/configure b/configure
+index 8569a60bf8..7be6c8f7e5 100755
+--- a/configure
++++ b/configure
+@@ -3128,6 +3128,7 @@ vp9_qsv_encoder_deps="libmfx MFX_CODEC_VP9"
+ vp9_qsv_encoder_select="qsvenc"
+ vp9_v4l2m2m_decoder_deps="v4l2_m2m vp9_v4l2_m2m"
+ wmv3_crystalhd_decoder_select="crystalhd"
++av1_qsv_decoder_select="qsvdec"
+ 
+ # parsers
+ aac_parser_select="adts_header"
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index 80f128cade..7176a36af9 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -808,6 +808,7 @@ extern AVCodec ff_vp9_mediacodec_decoder;
+ extern AVCodec ff_vp9_qsv_decoder;
+ extern AVCodec ff_vp9_vaapi_encoder;
+ extern AVCodec ff_vp9_qsv_encoder;
++extern AVCodec ff_av1_qsv_decoder;
+ 
+ // The iterate API is not usable with ossfuzz due to the excessive size of binaries created
+ #if CONFIG_OSSFUZZ
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index 1c9b649c10..616cc2462b 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -66,6 +66,10 @@ int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
+     case AV_CODEC_ID_VP9:
+         return MFX_CODEC_VP9;
+ #endif
++#if QSV_VERSION_ATLEAST(1, 34)
++    case AV_CODEC_ID_AV1:
++        return MFX_CODEC_AV1;
++#endif
+ 
+     default:
+         break;
+diff --git a/libavcodec/qsvdec_other.c b/libavcodec/qsvdec_other.c
+index b4df76739c..0629fc710c 100644
+--- a/libavcodec/qsvdec_other.c
++++ b/libavcodec/qsvdec_other.c
+@@ -327,3 +327,32 @@ AVCodec ff_vp9_qsv_decoder = {
+     .wrapper_name   = "qsv",
+ };
+ #endif
++
++#if CONFIG_AV1_QSV_DECODER
++static const AVClass av1_qsv_class = {
++    .class_name = "av1_qsv",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++AVCodec ff_av1_qsv_decoder = {
++    .name           = "av1_qsv",
++    .long_name      = NULL_IF_CONFIG_SMALL("AV1 video (Intel Quick Sync Video acceleration)"),
++    .priv_data_size = sizeof(QSVOtherContext),
++    .type           = AVMEDIA_TYPE_VIDEO,
++    .id             = AV_CODEC_ID_AV1,
++    .init           = qsv_decode_init,
++    .decode         = qsv_decode_frame,
++    .flush          = qsv_decode_flush,
++    .close          = qsv_decode_close,
++    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_DR1 | AV_CODEC_CAP_AVOID_PROBING | AV_CODEC_CAP_HYBRID,
++    .priv_class     = &av1_qsv_class,
++    .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_NV12,
++                                                    AV_PIX_FMT_P010,
++                                                    AV_PIX_FMT_QSV,
++                                                    AV_PIX_FMT_NONE },
++    .hw_configs     = ff_qsv_hw_configs,
++    .wrapper_name   = "qsv",
++};
++#endif
+\ No newline at end of file

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -2113,7 +2113,15 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
                     info->video_decode_support |= HB_DECODE_SUPPORT_QSV;
                 }
                 break;
-
+            case AV_CODEC_ID_AV1:
+                if ((qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G8) &&
+                    (pv->context->pix_fmt == AV_PIX_FMT_YUV420P  ||
+                    pv->context->pix_fmt == AV_PIX_FMT_YUVJ420P ||
+                    pv->context->pix_fmt == AV_PIX_FMT_YUV420P10LE))
+                {
+                    info->video_decode_support |= HB_DECODE_SUPPORT_QSV;
+                }
+                break;
             default:
                 break;
         }

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -74,6 +74,7 @@ enum hb_cpu_platform
     HB_CPU_PLATFORM_INTEL_SKL,
     HB_CPU_PLATFORM_INTEL_KBL,
     HB_CPU_PLATFORM_INTEL_ICL,
+    HB_CPU_PLATFORM_INTEL_TGL,
 };
 int         hb_get_cpu_count(void);
 int         hb_get_cpu_platform(void);

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -127,6 +127,7 @@ enum
     QSV_G5, // Skylake or equivalent
     QSV_G6, // Kaby Lake or equivalent
     QSV_G7, // Ice Lake or equivalent
+    QSV_G8, // Tiger Lake or equivalent
     QSV_FU, // always last (future processors)
 };
 

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -285,6 +285,8 @@ const char* hb_get_cpu_platform_name()
             return "Intel microarchitecture Kaby Lake";
         case HB_CPU_PLATFORM_INTEL_ICL:
             return "Intel microarchitecture Ice Lake";
+        case HB_CPU_PLATFORM_INTEL_TGL:
+            return "Intel microarchitecture Tiger Lake";
         default:
             return NULL;
     }
@@ -377,6 +379,10 @@ static void init_cpu_info()
                         break;
                     case 0x7E:
                         hb_cpu_info.platform = HB_CPU_PLATFORM_INTEL_ICL;
+                        break;
+                    case 0x8C:
+                        hb_cpu_info.platform = HB_CPU_PLATFORM_INTEL_TGL;
+                        break;
                     default:
                         break;
                 }

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -133,6 +133,8 @@ int qsv_hardware_generation(int cpu_platform)
             return QSV_G6;
         case HB_CPU_PLATFORM_INTEL_ICL:
             return QSV_G7;
+        case HB_CPU_PLATFORM_INTEL_TGL:
+            return QSV_G8;
         default:
             return QSV_FU;
     }
@@ -387,10 +389,6 @@ static int query_capabilities(mfxSession session, mfxVersion version, hb_qsv_inf
                     {
                         info->capabilities |= HB_QSV_CAP_LOWPOWER_ENCODE;
                     }
-                }
-                else
-                {
-                    hb_error("query_capabilities: adapters_info->NumActual=%d", adapters_info->NumActual);
                 }
 #endif
             }
@@ -1030,6 +1028,9 @@ const char* hb_qsv_decode_get_codec_name(enum AVCodecID codec_id)
 
         case AV_CODEC_ID_MPEG2VIDEO:
             return "mpeg2_qsv";
+
+        case AV_CODEC_ID_AV1:
+            return "av1_qsv";
 
         default:
             return NULL;


### PR DESCRIPTION
Required mandatory [mfx_dispatch update to 1.34](https://github.com/lu-zero/mfx_dispatch/releases/tag/1.34 ) in contrib directory

AV1 HW decoder is available since Intel Tiger Lake. [Family/Model IDs](https://github.com/torvalds/linux/blob/master/arch/x86/include/asm/intel-family.h).
Tested on [AV1 public streams]( https://www.elecard.com/videos )
