### PR TITLE
qsv: enable 10bit for hw scale/resize filters

### DIFF
--- a/contrib/ffmpeg/A22-qsv-scale-fix-green-stripes.patch
+++ b/contrib/ffmpeg/A22-qsv-scale-fix-green-stripes.patch
@@ -1,0 +1,35 @@
+diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
+index 82bb64eb42..2691d1a1fa 100644
+--- a/libavfilter/vf_scale_qsv.c
++++ b/libavfilter/vf_scale_qsv.c
+@@ -280,7 +280,7 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
+     return MFX_ERR_NONE;
+ }
+ 
+-static int init_out_session(AVFilterContext *ctx)
++static int init_out_session(AVFilterContext *ctx, int in_width, int in_height)
+ {
+ 
+     QSVScaleContext                   *s = ctx->priv;
+@@ -395,8 +395,11 @@ static int init_out_session(AVFilterContext *ctx)
+                                          sizeof(*s->mem_ids_in));
+         if (!s->mem_ids_in)
+             return AVERROR(ENOMEM);
+-        for (i = 0; i < in_frames_hwctx->nb_surfaces; i++)
++        for (i = 0; i < in_frames_hwctx->nb_surfaces; i++) {
++            in_frames_hwctx->surfaces[i].Info.CropW = in_width;
++            in_frames_hwctx->surfaces[i].Info.CropH = in_height;
+             s->mem_ids_in[i] = in_frames_hwctx->surfaces[i].Data.MemId;
++        }
+         s->nb_mem_ids_in = in_frames_hwctx->nb_surfaces;
+ 
+         s->mem_ids_out = av_mallocz_array(out_frames_hwctx->nb_surfaces,
+@@ -460,7 +463,7 @@ static int init_scale_session(AVFilterContext *ctx, int in_width, int in_height,
+     if (ret < 0)
+         return ret;
+ 
+-    ret = init_out_session(ctx);
++    ret = init_out_session(ctx, in_width, in_height);
+     if (ret < 0)
+         return ret;
+ 

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -97,7 +97,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
         hb_dict_set_int(avsettings, "w", width);
         hb_dict_set_int(avsettings, "h", height);
         hb_dict_set(avfilter, "scale_qsv", avsettings);
-        int result = hb_create_ffmpeg_pool(init->job, width, height, AV_PIX_FMT_NV12, HB_QSV_POOL_SURFACE_SIZE, 0, &init->job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
+        int result = hb_create_ffmpeg_pool(init->job, width, height, init->pix_fmt, HB_QSV_POOL_SURFACE_SIZE, 0, &init->job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
         if (result < 0)
         {
             hb_error("hb_create_ffmpeg_pool vpp allocation failed");

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -118,17 +118,17 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
     if (hb_qsv_hw_filters_are_enabled(graph->job))
     {
         par = av_buffersrc_parameters_alloc();
-        init->pix_fmt = AV_PIX_FMT_QSV;
         filter_args = hb_strdup_printf(
                 "video_size=%dx%d:pix_fmt=%d:sar=%d/%d:"
                 "time_base=%d/%d:frame_rate=%d/%d",
-                init->geometry.width, init->geometry.height, init->pix_fmt,
+                init->geometry.width, init->geometry.height, AV_PIX_FMT_QSV,
                 init->geometry.par.num, init->geometry.par.den,
                 init->time_base.num, init->time_base.den,
                 init->vrate.num, init->vrate.den);
 
         AVBufferRef *hb_hw_frames_ctx = NULL;
-        result = hb_create_ffmpeg_pool(graph->job, init->geometry.width, init->geometry.height, AV_PIX_FMT_NV12, 32, 0, &hb_hw_frames_ctx);
+
+        result = hb_create_ffmpeg_pool(graph->job, init->geometry.width, init->geometry.height, init->pix_fmt, 32, 0, &hb_hw_frames_ctx);
         if (result < 0)
         {
             hb_error("hb_create_ffmpeg_pool failed");

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3036,6 +3036,8 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
         mfxHDLPair* input_pair = (mfxHDLPair*)input_surface->Data.MemId;
         // copy all surface fields
         *output_surface = *input_surface;
+        output_surface->Info.CropW = frame->width;
+        output_surface->Info.CropH = frame->height;
         if (hb_qsv_hw_filters_are_enabled(job))
         {
             output_surface->Data.MemId = mid->handle_pair;
@@ -3077,6 +3079,8 @@ hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp)
         int output_index = (int)(intptr_t)mid->handle_pair->second == MFX_INFINITE ? 0 : (int)(intptr_t)mid->handle_pair->second;
         // copy all surface fields
         *output_surface = *input_surface;
+        output_surface->Info.CropW = frame->width;
+        output_surface->Info.CropH = frame->height;
         if (hb_qsv_hw_filters_are_enabled(job))
         {
             // Make sure that we pass handle_pair to scale_qsv

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1062,6 +1062,7 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
 {
     static int device_check_completed = 0;
     static int device_check_succeded = 0;
+    int codecs_exceptions = 0;
     int qsv_full_path_is_enabled = 0;
 
     if(!device_check_completed)
@@ -1070,9 +1071,11 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
        device_check_completed = 1;
     }
 
+    codecs_exceptions = (job->title->pix_fmt == AV_PIX_FMT_YUV420P10 && job->vcodec == HB_VCODEC_QSV_H264);
+
     qsv_full_path_is_enabled = (hb_qsv_decode_is_enabled(job) &&
         hb_qsv_info_get(job->vcodec) &&
-        device_check_succeded && !job->qsv.ctx->num_cpu_filters);
+        device_check_succeded && !job->qsv.ctx->num_cpu_filters) && !codecs_exceptions;
     return qsv_full_path_is_enabled;
 }
 


### PR DESCRIPTION
Tested on HEVC and AV1 content
[UPD] fix QSV pipeline after https://github.com/HandBrake/HandBrake/pull/3220
[UPD] add decode bit-depth information for QSV decode
[UPD] fixed corrupted images 10 bit 4K HEVC -> 8 bit 1080p HEVC when VDEnc is disabled
[UPD] fixed green stripes 10 bit 4K HEVC -> 10 bit 1080p HEVC
