### PR TITLE
contrib: Update libdav1d to 0.8.0

### DIFF
--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.7.0.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.7.0/dav1d-0.7.0.tar.bz2
-LIBDAV1D.FETCH.sha256  = 8057149f5f08c5ca47e1344fba9046ff84ac85ca409d7adbec8268c707ec5c19
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-0.8.0.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/0.8.0/dav1d-0.8.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = b62eb846fd8af15b402c8f6615a74405fe4448cf16663efd0358d4124db0829f
 
 LIBDAV1D.build_dir     = build/
 


### PR DESCRIPTION
This PR updates dav1d to version 0.8.0, which improves AV1 decoding performance and compatibility with Apple Silicon Macs.

I checked the patches and it seems they're all still relevant based on the changes between dav1d 07.0 and 0.8.0.

[dav1d 0.8.0 changelog](https://code.videolan.org/videolan/dav1d/-/blob/master/NEWS)
> 0.8.0 is a major update for dav1d:
>  - Improve the performance by using a picture buffer pool;
>    The improvements can reach 10% on some cases on Windows.
>  - Support for Apple ARM Silicon
>  - ARM32 optimizations for 8bit bitdepth for ipred paeth, smooth, cfl
>  - ARM32 optimizations for 10/12/16bit bitdepth for mc_avg/mask/w_avg,
>    put/prep 8tap/bilin, wiener and CDEF filters
>  - ARM64 optimizations for cfl_ac 444 for all bitdepths
>  - x86 optimizations for MC 8-tap, mc_scaled in AVX2
>  - x86 optimizations for CDEF in SSE and {put/prep}_{8tap/bilin} in SSSE3

**Test on:**
- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
![Screenshot_546](https://user-images.githubusercontent.com/15776622/100495759-ff938480-314e-11eb-8a16-ad8f3421f6c2.png)