### PR TITLE
CI: Maintenance

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-20.04
     if: github.repository == 'HandBrake/HandBrake'
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
 
     - name: Setup Environment

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev
-        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make nasm ninja-build patch pkg-config tar yasm zlib1g-dev
+        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build patch tar yasm zlib1g-dev
         sudo pip3 install meson
         sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -24,8 +24,8 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake build-essential cmake git libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev
-        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make nasm ninja-build patch pkg-config python tar yasm zlib1g-dev
+        sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev
+        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make nasm ninja-build patch pkg-config tar yasm zlib1g-dev
         sudo pip3 install meson
         sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -19,14 +19,13 @@ jobs:
     if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@master
+    - uses: actions/setup-python@v2
 
     - name: Setup Environment
       run: |
         sudo apt-get update
         sudo apt-get install autoconf automake build-essential cmake git libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev
         sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make nasm ninja-build patch pkg-config python tar yasm zlib1g-dev
-        sudo apt-get install python3-pip
-        sudo apt-get install python3-setuptools
         sudo pip3 install meson
         sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgtk-3-dev libgudev-1.0-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,20 +3,9 @@ name: Linux Build
 on: [push, pull_request]
 
 jobs:
-
-  handle_forks:
-    name: Forked Repo
-    runs-on: ubuntu-20.04
-    if: github.repository != 'HandBrake/HandBrake'
-    steps:
-    - name: Print Warning
-      run: |
-        echo "Builds are disabled for forked repositories."
-
   build:
     name: Build on Ubuntu
     runs-on: ubuntu-20.04
-    if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
 
   build:
     name: Build on Ubuntu
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -6,19 +6,9 @@ env:
   DEVELOPER_DIR: /Applications/Xcode_12.2.app/Contents/Developer
 
 jobs:
-  handle_forks:
-    name: Forked Repo
-    runs-on: ubuntu-latest
-    if: github.repository != 'HandBrake/HandBrake'
-    steps:
-    - name: Print Warning
-      run: |
-        echo "Builds are disabled for forked repositories."
-
   build:
     name: Build on macOS
     runs-on: macos-11.0
-    if: github.repository == 'HandBrake/HandBrake'
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: macos-11.0
     if: github.repository == 'HandBrake/HandBrake'
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Toolchain Cache
       id: mac-toolchain

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -96,10 +96,10 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: HandBrake-x86_64-Win_GUI-EXE
-        path: win/CS/HandBrakeWPF/bin/x64/Debug/HandBrake-Nightly-x86_64-Win_GUI.exe
+        path: win/CS/HandBrakeWPF/bin/Debug/HandBrake-Nightly-x86_64-Win_GUI.exe
 
     - name: Upload HandBrake msi Installer
       uses: actions/upload-artifact@v2
       with:
         name:  HandBrake-x86_64-Win_GUI-MSI
-        path: win/CS/HandBrakeWPF/bin/x64/Debug/HandBrake-Nightly-x86_64-Win_GUI.msi
+        path: win/CS/HandBrakeWPF/bin/Debug/HandBrake-Nightly-x86_64-Win_GUI.msi

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -8,13 +8,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
 
     - name: Environment Setup
       run: |
-        sudo apt-get install automake autoconf build-essential cmake curl gcc git intltool libtool libtool-bin m4 make nasm patch pkg-config python tar yasm zlib1g-dev ninja-build zip
-        sudo apt-get install bison bzip2 flex g++ gzip pax
-        sudo apt-get install python3-pip
-        sudo apt-get install python3-setuptools
+        sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax
         sudo pip3 install meson
 
     - name: Setup Toolchain

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -7,7 +7,7 @@ jobs:
     name: CLI / LibHB
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: Environment Setup
       run: |
@@ -63,7 +63,7 @@ jobs:
       SigningCertificate: ${{ secrets.HandBrakeTeam_SignFile }}
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
 
     - name: NuGet Restore
       run: |


### PR DESCRIPTION
A bit of CI maintenance on the GitHub Actions workflows.

**Changed**
- Explicitly use Ubuntu 20.04 for the Windows build
- Setup Python with `actions/setup-python@v2` instead of apt-get
- Don't install pre-installed packages on Windows and Linux jobs
- Use a stable version of `actions/checkout`
- Fix the Windows GUI artifact paths
- Run the macOS and Linux jobs also on forks

**Test on:**
- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux