### PR TITLE
qsv: add scaling modes and interpolation methods for qsv scale filter

### DIFF
--- a/contrib/ffmpeg/A23-qsv-interpolation.patch
+++ b/contrib/ffmpeg/A23-qsv-interpolation.patch
@@ -1,0 +1,49 @@
+diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
+index 82bb64eb42..2305797450 100644
+--- a/libavfilter/vf_scale_qsv.c
++++ b/libavfilter/vf_scale_qsv.c
+@@ -70,6 +70,7 @@ enum var_name {
+ };
+ 
+ #define QSV_HAVE_SCALING_CONFIG  QSV_VERSION_ATLEAST(1, 19)
++#define QSV_HAVE_INTERPOLATION_METHOD QSV_VERSION_ATLEAST(1, 33)
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
+ 
+ typedef struct QSVScaleContext {
+@@ -96,6 +97,7 @@ typedef struct QSVScaleContext {
+     mfxExtVPPScaling         scale_conf;
+ #endif
+     int                      mode;
++    int                      method;
+ 
+     mfxExtBuffer             *ext_buffers[1 + QSV_HAVE_SCALING_CONFIG];
+     int                      num_ext_buf;
+@@ -419,6 +421,10 @@ static int init_out_session(AVFilterContext *ctx)
+     s->scale_conf.Header.BufferId     = MFX_EXTBUFF_VPP_SCALING;
+     s->scale_conf.Header.BufferSz     = sizeof(mfxExtVPPScaling);
+     s->scale_conf.ScalingMode         = s->mode;
++#if QSV_HAVE_INTERPOLATION_METHOD
++    s->scale_conf.InterpolationMethod = s->method;
++    av_log(ctx, AV_LOG_VERBOSE, "Interpolation method: %d\n", s->method);
++#endif
+     s->ext_buffers[s->num_ext_buf++]  = (mfxExtBuffer*)&s->scale_conf;
+     av_log(ctx, AV_LOG_VERBOSE, "Scaling mode: %d\n", s->mode);
+ #endif
+@@ -634,6 +640,17 @@ static const AVOption options[] = {
+     { "low_power", "",                      0,             AV_OPT_TYPE_CONST,  { .i64 = 1}, 0,   0,     FLAGS, "mode"},
+     { "hq",        "",                      0,             AV_OPT_TYPE_CONST,  { .i64 = 2}, 0,   0,     FLAGS, "mode"},
+ #endif
++#if QSV_HAVE_INTERPOLATION_METHOD
++    { "method",    "set interpolation method", OFFSET(method), AV_OPT_TYPE_INT,   { .i64 = MFX_INTERPOLATION_DEFAULT}, MFX_INTERPOLATION_DEFAULT, MFX_INTERPOLATION_ADVANCED, FLAGS, "method"},
++    { "nearest",   "nearest neighbor method",  0,              AV_OPT_TYPE_CONST, { .i64 = MFX_INTERPOLATION_NEAREST_NEIGHBOR}, INT_MIN, INT_MAX, FLAGS, "method"},
++    { "bilinear",  "bilinear method",          0,              AV_OPT_TYPE_CONST, { .i64 = MFX_INTERPOLATION_BILINEAR},  INT_MIN, INT_MAX, FLAGS, "method"},
++    { "advanced",  "advanced method",          0,              AV_OPT_TYPE_CONST, { .i64 = MFX_INTERPOLATION_ADVANCED},  INT_MIN, INT_MAX, FLAGS, "method"},
++#else
++    { "method",    "(not supported)",          OFFSET(method), AV_OPT_TYPE_INT,   { .i64 = 0}, 0, INT_MAX, FLAGS, "method"},
++    { "nearest",   "",                         0,              AV_OPT_TYPE_CONST, { .i64 = 1}, 0, 0, FLAGS, "method"},
++    { "bilinear",  "",                         0,              AV_OPT_TYPE_CONST, { .i64 = 2}, 0, 0, FLAGS, "method"},
++    { "advanced",  "",                         0,              AV_OPT_TYPE_CONST, { .i64 = 3}, 0, 0, FLAGS, "method"},
++#endif
+ 
+     { NULL },
+ };

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -94,15 +94,26 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
     if (hb_qsv_hw_filters_are_enabled(init->job))
     {
-        hb_dict_set_int(avsettings, "w", width);
-        hb_dict_set_int(avsettings, "h", height);
-        hb_dict_set(avfilter, "scale_qsv", avsettings);
         int result = hb_create_ffmpeg_pool(init->job, width, height, init->pix_fmt, HB_QSV_POOL_SURFACE_SIZE, 0, &init->job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
         if (result < 0)
         {
             hb_error("hb_create_ffmpeg_pool vpp allocation failed");
             return result;
         }
+
+        hb_dict_set_int(avsettings, "w", width);
+        hb_dict_set_int(avsettings, "h", height);
+        if (init->job->qsv.ctx->vpp_scale_mode)
+        {
+            hb_dict_set_string(avsettings, "mode", init->job->qsv.ctx->vpp_scale_mode);
+        }
+        if (init->job->qsv.ctx->vpp_interpolation_method)
+        {
+            hb_dict_set_string(avsettings, "method", init->job->qsv.ctx->vpp_interpolation_method);
+        }
+        hb_log("qsv: scaling filter mode %s", init->job->qsv.ctx->vpp_scale_mode ? init->job->qsv.ctx->vpp_scale_mode : "default");
+        hb_log("qsv: scaling filter interpolation method %s", init->job->qsv.ctx->vpp_interpolation_method ? init->job->qsv.ctx->vpp_interpolation_method : "default");
+        hb_dict_set(avfilter, "scale_qsv", avsettings);
 
         AVHWFramesContext *frames_ctx;
         AVQSVFramesContext *frames_hwctx;

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -74,6 +74,8 @@ typedef struct hb_qsv_info_s
 #define HB_QSV_CAP_OPTION2_IB_ADAPT  (1LL << 35)
 #define HB_QSV_CAP_OPTION2_LA_DOWNS  (1LL << 36)
 #define HB_QSV_CAP_OPTION2_NMPSLICE  (1LL << 37)
+#define HB_QSV_CAP_VPP_SCALING       (1LL << 38)
+#define HB_QSV_CAP_VPP_INTERPOLATION (1LL << 39)
 
     // TODO: add maximum encode resolution, etc.
 } hb_qsv_info_t;

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -333,6 +333,8 @@ typedef struct hb_qsv_context {
     int num_cpu_filters;
     int la_is_enabled;
     int qsv_filters_are_enabled;
+    char *vpp_scale_mode;
+    char *vpp_interpolation_method;
     char *qsv_device;
     int dx_index;
     AVBufferRef *hb_hw_device_ctx;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -66,6 +66,19 @@ static hb_triplet_t hb_qsv_h265_profiles[] =
     { "Main Still Picture", "mainstillpicture", MFX_PROFILE_HEVC_MAINSP, },
     { NULL,                                                              },
 };
+static hb_triplet_t hb_qsv_vpp_scale_modes[] =
+{
+    { "lowpower",          "low_power",         MFX_SCALING_MODE_LOWPOWER, },
+    { "hq",                "hq",                MFX_SCALING_MODE_QUALITY,  },
+    { NULL,                                                                },
+};
+static hb_triplet_t hb_qsv_vpp_interpolation_methods[] =
+{
+    { "nearest",            "nearest",          MFX_INTERPOLATION_NEAREST_NEIGHBOR, },
+    { "bilinear",           "bilinear",         MFX_INTERPOLATION_BILINEAR,         },
+    { "advanced",           "advanced",         MFX_INTERPOLATION_ADVANCED,         },
+    { NULL,                                                                         },
+};
 static hb_triplet_t hb_qsv_h264_levels[] =
 {
     { "1.0", "1.0", MFX_LEVEL_AVC_1,  },
@@ -646,6 +659,20 @@ static int query_capabilities(mfxSession session, mfxVersion version, hb_qsv_inf
                 fprintf(stderr,
                         "hb_qsv_info_init: mfxExtCodingOption2 check failed (0x%"PRIX32", 0x%"PRIX32", %d)\n",
                         info->codec_id, info->implementation, status);
+            }
+        }
+        if (HB_CHECK_MFX_VERSION(version, 1, 19))
+        {
+            if (qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G7)
+            {
+                info->capabilities |= HB_QSV_CAP_VPP_SCALING;
+            }
+        }
+        if (HB_CHECK_MFX_VERSION(version, 1, 33))
+        {
+            if (qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G7)
+            {
+                info->capabilities |= HB_QSV_CAP_VPP_INTERPOLATION;
             }
         }
     }
@@ -1720,7 +1747,42 @@ int hb_qsv_param_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, hb_job_t *job
                 hb_qsv_param_parse_dx_index(job, gpu_index);
             }
         }
-        return HB_QSV_PARAM_OK;
+    }
+    else if (!strcasecmp(key, "scalingmode") ||
+             !strcasecmp(key, "vpp-sm"))
+    {
+        // Already parsed it in decoder but need to check support
+        if (info->capabilities & HB_QSV_CAP_VPP_SCALING)
+        {
+            hb_triplet_t *mode = NULL;
+            mode = hb_triplet4key(hb_qsv_vpp_scale_modes, value);
+            if (!mode)
+            {
+                error = HB_QSV_PARAM_BAD_VALUE;
+            }
+        }
+        else
+        {
+            return HB_QSV_PARAM_UNSUPPORTED;
+        }
+    }
+    else if (!strcasecmp(key, "interpolationmethod") ||
+             !strcasecmp(key, "vpp-im"))
+    {
+        // Already parsed it in decoder but need to check support
+        if (info->capabilities & HB_QSV_CAP_VPP_INTERPOLATION)
+        {
+            hb_triplet_t *method = NULL;
+            method = hb_triplet4key(hb_qsv_vpp_interpolation_methods, value);
+            if (!method)
+            {
+                error = HB_QSV_PARAM_BAD_VALUE;
+            }
+        }
+        else
+        {
+            return HB_QSV_PARAM_UNSUPPORTED;
+        }
     }
     else
     {
@@ -3215,6 +3277,42 @@ int hb_create_ffmpeg_pool(hb_job_t *job, int coded_width, int coded_height, enum
                     if (!ret)
                     {
                         hb_qsv_param_parse_dx_index(job, dx_index);
+                    }
+                }
+                if ((!strcasecmp(key, "scalingmode") || !strcasecmp(key, "vpp-sm")) && hb_qsv_hw_filters_are_enabled(job))
+                {
+                    hb_qsv_info_t *info = hb_qsv_info_get(job->vcodec);
+                    if (info && (info->capabilities & HB_QSV_CAP_VPP_SCALING))
+                    {
+                        hb_value_t *value = hb_dict_iter_value(iter);
+                        char *mode_key = hb_value_get_string_xform(value);
+                        hb_triplet_t *mode = NULL;
+                        if (mode_key != NULL)
+                        {
+                            mode = hb_triplet4key(hb_qsv_vpp_scale_modes, mode_key);
+                        }
+                        if (mode != NULL)
+                        {
+                            job->qsv.ctx->vpp_scale_mode = mode->key;
+                        }
+                    }
+                }
+                if ((!strcasecmp(key, "interpolationmethod") || !strcasecmp(key, "vpp-im")) && hb_qsv_hw_filters_are_enabled(job))
+                {
+                    hb_qsv_info_t *info = hb_qsv_info_get(job->vcodec);
+                    if (info && (info->capabilities & HB_QSV_CAP_VPP_INTERPOLATION))
+                    {
+                        hb_value_t *value = hb_dict_iter_value(iter);
+                        char *mode_key = hb_value_get_string_xform(value);
+                        hb_triplet_t *mode = NULL;
+                        if (mode_key != NULL)
+                        {
+                            mode = hb_triplet4key(hb_qsv_vpp_interpolation_methods, mode_key);
+                        }
+                        if (mode != NULL)
+                        {
+                            job->qsv.ctx->vpp_interpolation_method = mode->key;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Interpolation methods are supported since 1.33 API
https://github.com/Intel-Media-SDK/MediaSDK/blob/master/api/include/mfxstructures.h#L2088

Command line:
 ./HandbrakeCLI.exe -i LG-Demo-DolbyVision-Trailer.mkv --enable-qsv-decoding -w 1920 -l 1080 --custom-anamorphic -xtu=7:lowpower=1:vpp-sm=low_power:vpp-im=advanced -e qsv_h265 -o out.mp4