### PR TITLE
libhb: passthru mastering display metadata and content light metadata.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3844,6 +3844,8 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->color_prim_override     = HB_COLR_PRI_UNDEF;
     job->color_transfer_override = HB_COLR_TRA_UNDEF;
     job->color_matrix_override   = HB_COLR_MAT_UNDEF;
+    job->mastering      = title->mastering;
+    job->coll           = title->coll;
 
     job->mux = HB_MUX_MP4;
 

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1098,6 +1098,29 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
         }
     }
 
+    // Check for HDR mastering data
+    sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+    if (sd != NULL)
+    {
+        if (!pv->job && pv->title && sd->size > 0)
+        {
+            AVMasteringDisplayMetadata *mastering = (AVMasteringDisplayMetadata *)sd->data;
+            pv->title->mastering = hb_mastering_ff_to_hb(*mastering);
+        }
+    }
+
+    // Check for HDR content light level data
+    sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+    if (sd != NULL)
+    {
+        if (!pv->job && pv->title && sd->size > 0)
+        {
+            AVContentLightMetadata *coll = (AVContentLightMetadata *)sd->data;
+            pv->title->coll.max_cll = coll->MaxCLL;
+            pv->title->coll.max_fall = coll->MaxFALL;
+        }
+    }
+
     return out;
 }
 

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -254,6 +254,16 @@ struct hb_rational_s
     int den;
 };
 
+static inline hb_rational_t hb_make_q(int num, int den)
+{
+    hb_rational_t r = { num, den };
+    return r;
+}
+
+static inline double hb_q2d(hb_rational_t a){
+    return a.num / (double) a.den;
+}
+
 struct hb_geometry_s
 {
     int width;
@@ -307,6 +317,20 @@ struct hb_subtitle_config_s
     const char * src_filename;
     char         src_codeset[40];
     int64_t      offset;
+};
+
+struct hb_mastering_display_metadata_s {
+    hb_rational_t display_primaries[3][2];
+    hb_rational_t white_point[2];
+    hb_rational_t min_luminance;
+    hb_rational_t max_luminance;
+    int has_primaries;
+    int has_luminance;
+};
+
+struct hb_content_light_metadata_s {
+    unsigned max_cll;
+    unsigned max_fall;
 };
 
 /*******************************************************************************
@@ -625,6 +649,9 @@ struct hb_job_s
 #define HB_COLR_MAT_CD_CL        13 // chromaticity derived constant lum
 #define HB_COLR_MAT_ICTCP        14 // ITU-R BT.2100-0, ICtCp
 // 0, 3-5, 8, 11-65535: reserved/not implemented
+
+    hb_mastering_display_metadata_t mastering;
+    hb_content_light_metadata_t coll;
 
     hb_list_t     * list_chapter;
 
@@ -1090,6 +1117,8 @@ struct hb_title_s
     int             color_transfer;
     int             color_matrix;
     int             color_range;
+    hb_mastering_display_metadata_t mastering;
+    hb_content_light_metadata_t     coll;
     hb_rational_t   vrate;
     int             crop[4];
     enum {HB_DVD_DEMUXER, HB_TS_DEMUXER, HB_PS_DEMUXER, HB_NULL_DEMUXER} demuxer;

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -19,6 +19,7 @@
 #include "libavutil/avutil.h"
 #include "libavutil/downmix_info.h"
 #include "libavutil/display.h"
+#include "libavutil/mastering_display_metadata.h"
 #include "libswscale/swscale.h"
 #include "libswresample/swresample.h"
 #include "handbrake/common.h"
@@ -40,6 +41,9 @@ int hb_colr_mat_hb_to_ff(int colr_mat);
 int hb_colr_pri_ff_to_hb(int colr_prim);
 int hb_colr_tra_ff_to_hb(int colr_tra);
 int hb_colr_mat_ff_to_hb(int colr_mat);
+
+hb_mastering_display_metadata_t hb_mastering_ff_to_hb(AVMasteringDisplayMetadata mastering);
+AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t mastering);
 
 struct SwsContext*
 hb_sws_get_context(int srcW, int srcH, enum AVPixelFormat srcFormat,

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -43,5 +43,7 @@ typedef struct hb_buffer_settings_s hb_buffer_settings_t;
 typedef struct hb_image_format_s hb_image_format_t;
 typedef struct hb_fifo_s hb_fifo_t;
 typedef struct hb_lock_s hb_lock_t;
+typedef struct hb_mastering_display_metadata_s hb_mastering_display_metadata_t;
+typedef struct hb_content_light_metadata_s hb_content_light_metadata_t;
 
 #endif // HANDBRAKE_TYPES_H

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -423,6 +423,62 @@ int hb_colr_mat_ff_to_hb(int colr_mat)
     }
 }
 
+static hb_rational_t hb_rational_ff_to_hb(AVRational rational)
+{
+    hb_rational_t hb_rational = {rational.num, rational.den};
+    return hb_rational;
+}
+
+static AVRational hb_rational_hb_to_ff(hb_rational_t rational)
+{
+    AVRational ff_rational = {rational.num, rational.den};
+    return ff_rational;
+}
+
+hb_mastering_display_metadata_t hb_mastering_ff_to_hb(AVMasteringDisplayMetadata mastering)
+{
+    hb_mastering_display_metadata_t hb_mastering;
+
+    for (int i = 0; i < 3; i++)
+    {
+        hb_mastering.display_primaries[i][0] = hb_rational_ff_to_hb(mastering.display_primaries[i][0]);
+        hb_mastering.display_primaries[i][1] = hb_rational_ff_to_hb(mastering.display_primaries[i][1]);
+    }
+
+    hb_mastering.white_point[0] = hb_rational_ff_to_hb(mastering.white_point[0]);
+    hb_mastering.white_point[1] = hb_rational_ff_to_hb(mastering.white_point[1]);
+
+    hb_mastering.min_luminance = hb_rational_ff_to_hb(mastering.min_luminance);
+    hb_mastering.max_luminance = hb_rational_ff_to_hb(mastering.max_luminance);
+
+    hb_mastering.has_primaries = mastering.has_primaries;
+    hb_mastering.has_luminance = mastering.has_luminance;
+
+    return hb_mastering;
+}
+
+AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t mastering)
+{
+    AVMasteringDisplayMetadata ff_mastering;
+
+    for (int i = 0; i < 3; i++)
+    {
+        ff_mastering.display_primaries[i][0] = hb_rational_hb_to_ff(mastering.display_primaries[i][0]);
+        ff_mastering.display_primaries[i][1] = hb_rational_hb_to_ff(mastering.display_primaries[i][1]);
+    }
+
+    ff_mastering.white_point[0] = hb_rational_hb_to_ff(mastering.white_point[0]);
+    ff_mastering.white_point[1] = hb_rational_hb_to_ff(mastering.white_point[1]);
+
+    ff_mastering.min_luminance = hb_rational_hb_to_ff(mastering.min_luminance);
+    ff_mastering.max_luminance = hb_rational_hb_to_ff(mastering.max_luminance);
+
+    ff_mastering.has_primaries = mastering.has_primaries;
+    ff_mastering.has_luminance = mastering.has_luminance;
+
+    return ff_mastering;
+}
+
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
     uint64_t ff_layout = 0;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1084,12 +1084,33 @@ skip_preview:
         }
 
         hb_log( "scan: %d previews, %dx%d, %.3f fps, autocrop = %d/%d/%d/%d, "
-                "aspect %s, PAR %d:%d",
+                "aspect %s, PAR %d:%d, color profile: %d-%d-%d",
                 npreviews, title->geometry.width, title->geometry.height,
                 (float)title->vrate.num / title->vrate.den,
                 title->crop[0], title->crop[1], title->crop[2], title->crop[3],
                 aspect_to_string(&title->dar),
-                title->geometry.par.num, title->geometry.par.den);
+                title->geometry.par.num, title->geometry.par.den,
+                title->color_prim, title->color_transfer, title->color_matrix);
+
+        if (title->mastering.has_primaries || title->mastering.has_luminance)
+        {
+            hb_log("scan: mastering display metadata: r(%5.4f,%5.4f) g(%5.4f,%5.4f) b(%5.4f %5.4f) wp(%5.4f, %5.4f) min_luminance=%f, max_luminance=%f",
+                   hb_q2d(title->mastering.display_primaries[0][0]),
+                   hb_q2d(title->mastering.display_primaries[0][1]),
+                   hb_q2d(title->mastering.display_primaries[1][0]),
+                   hb_q2d(title->mastering.display_primaries[1][1]),
+                   hb_q2d(title->mastering.display_primaries[2][0]),
+                   hb_q2d(title->mastering.display_primaries[2][1]),
+                   hb_q2d(title->mastering.white_point[0]), hb_q2d(title->mastering.white_point[1]),
+                   hb_q2d(title->mastering.min_luminance), hb_q2d(title->mastering.max_luminance));
+        }
+
+        if (title->coll.max_cll || title->coll.max_fall)
+        {
+            hb_log("scan: content light level: max_cll=%u, max_fall=%u",
+                   title->coll.max_cll,
+                   title->coll.max_fall);
+        }
 
         if (title->video_decode_support != HB_DECODE_SUPPORT_SW)
         {

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5831,6 +5831,19 @@ static hb_title_t *ffmpeg_title_scan( hb_stream_t *stream, hb_title_t *title )
                         }
                         break;
                     }
+                    case AV_PKT_DATA_MASTERING_DISPLAY_METADATA:
+                    {
+                        AVMasteringDisplayMetadata *mastering = (AVMasteringDisplayMetadata *)sd.data;
+                        title->mastering = hb_mastering_ff_to_hb(*mastering);
+                        break;
+                    }
+                    case AV_PKT_DATA_CONTENT_LIGHT_LEVEL:
+                    {
+                        AVContentLightMetadata *coll = (AVContentLightMetadata *)sd.data;
+                        title->coll.max_cll = coll->MaxCLL;
+                        title->coll.max_fall = coll->MaxFALL;
+                        break;
+                    }
                     default:
                         break;
                 }

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -593,6 +593,28 @@ void hb_display_job_info(hb_job_t *job)
 
         hb_log("     + color profile: %d-%d-%d",
                job->color_prim, job->color_transfer, job->color_matrix);
+
+        if (job->color_transfer == HB_COLR_TRA_SMPTEST2084)
+        {
+            if (job->mastering.has_primaries || job->mastering.has_luminance)
+            {
+                hb_log("     + mastering display metadata: r(%5.4f,%5.4f) g(%5.4f,%5.4f) b(%5.4f %5.4f) wp(%5.4f, %5.4f) min_luminance=%f, max_luminance=%f",
+                       hb_q2d(job->mastering.display_primaries[0][0]),
+                       hb_q2d(job->mastering.display_primaries[0][1]),
+                       hb_q2d(job->mastering.display_primaries[1][0]),
+                       hb_q2d(job->mastering.display_primaries[1][1]),
+                       hb_q2d(job->mastering.display_primaries[2][0]),
+                       hb_q2d(job->mastering.display_primaries[2][1]),
+                       hb_q2d(job->mastering.white_point[0]), hb_q2d(job->mastering.white_point[1]),
+                       hb_q2d(job->mastering.min_luminance), hb_q2d(job->mastering.max_luminance));
+            }
+            if (job->coll.max_cll && job->coll.max_fall)
+            {
+                hb_log("     + content light level: max_cll=%u, max_fall=%u",
+                       job->coll.max_cll,
+                       job->coll.max_fall);
+            }
+        }
     }
 
     if (job->indepth_scan)


### PR DESCRIPTION
Pass the common HDR10 metadata thru the pipeline. Added two structs and boring conversion methods to avoid FFmpeg contamination.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
