### PR TITLE
sync: fix missing last subtitle in mp4, and first subtitle

### DIFF
--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -461,8 +461,19 @@ static void alignStream( sync_common_t * common, sync_stream_t * stream,
                 buf = hb_list_item(other_stream->in_queue, 0);
                 if (buf->s.start < pts)
                 {
-                    hb_list_rem(other_stream->in_queue, buf);
-                    hb_buffer_close(&buf);
+                    if (other_stream->type == SYNC_TYPE_SUBTITLE &&
+                        buf->s.stop > pts)
+                    {
+                        // Subtitle ends after start time, keep sub and
+                        // adjust it's start time
+                        buf->s.start = pts;
+                        break;
+                    }
+                    else
+                    {
+                        hb_list_rem(other_stream->in_queue, buf);
+                        hb_buffer_close(&buf);
+                    }
                 }
                 else
                 {
@@ -1419,8 +1430,7 @@ static int OutputBuffer( sync_common_t * common )
                 hb_list_count(stream->in_queue) > min)
             {
                 buf = hb_list_item(stream->in_queue, 0);
-                if (buf->s.start < pts &&
-                    !(buf->s.flags & HB_BUF_FLAG_EOF))
+                if (buf->s.start < pts)
                 {
                     pts = buf->s.start;
                     out_stream = stream;


### PR DESCRIPTION
A couple of fix for subtitles:
- when the mux format is mp4, the last subtitle was never retrieved from the subtitle sanitiser. #3142
- when align a/v option is enabled, adjust the first subtitle start timestamp if the stop timestamp ends after the common global start timestamp in alignStreams()

I can't find a reason for the "!(buf->s.flags & HB_BUF_FLAG_EOF))" line I removed, but I don't have a full understanding of the sync code yet, so probably there was one.