### PR TITLE
qsv: redesigned adapter capabilities collection and reporing

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -294,7 +294,7 @@ static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
 #if HB_PROJECT_FEATURE_QSV
         if (encoder & HB_VCODEC_QSV_MASK)
         {
-            return hb_qsv_video_encoder_is_enabled(encoder);
+            return hb_qsv_video_encoder_is_enabled(hb_qsv_get_adapter_index(), encoder);
         }
 #endif
 
@@ -3897,6 +3897,7 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->metadata = hb_metadata_copy( title->metadata );
 
 #if HB_PROJECT_FEATURE_QSV
+    job->qsv.ctx                   = hb_qsv_context_init();
     job->qsv.enc_info.is_init_done = 0;
     job->qsv.async_depth           = hb_qsv_param_default_async_depth();
     job->qsv.decode                = !!(title->video_decode_support &

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1423,7 +1423,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
         pv->qsv.config.io_pattern = MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
         if(hb_qsv_full_path_is_enabled(job))
         {
-            hb_qsv_info_t *info = hb_qsv_info_get(job->vcodec);
+            hb_qsv_info_t *info = hb_qsv_encoder_info_get(hb_qsv_get_adapter_index(), job->vcodec);
             if (info != NULL)
             {
                 // setup the QSV configuration
@@ -1443,6 +1443,7 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
                     hb_error( "decavcodecvInit: no context" );
                     return 1;
                 }
+                pv->job->qsv.ctx->full_path_is_enabled = 1;
                 if (!pv->job->qsv.ctx->hb_dec_qsv_frames_ctx)
                 {
                     pv->job->qsv.ctx->hb_dec_qsv_frames_ctx = av_mallocz(sizeof(HBQSVFramesContext));
@@ -2131,32 +2132,8 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
     info->video_decode_support = HB_DECODE_SUPPORT_SW;
 
 #if HB_PROJECT_FEATURE_QSV
-    if (avcodec_find_decoder_by_name(hb_qsv_decode_get_codec_name(pv->context->codec_id)))
-    {
-        switch (pv->context->codec_id)
-        {
-            case AV_CODEC_ID_HEVC:
-            case AV_CODEC_ID_H264:
-                if (pv->context->pix_fmt == AV_PIX_FMT_YUV420P  ||
-                    pv->context->pix_fmt == AV_PIX_FMT_YUVJ420P ||
-                    pv->context->pix_fmt == AV_PIX_FMT_YUV420P10LE)
-                {
-                    info->video_decode_support |= HB_DECODE_SUPPORT_QSV;
-                }
-                break;
-            case AV_CODEC_ID_AV1:
-                if ((qsv_hardware_generation(hb_get_cpu_platform()) >= QSV_G8) &&
-                    (pv->context->pix_fmt == AV_PIX_FMT_YUV420P  ||
-                    pv->context->pix_fmt == AV_PIX_FMT_YUVJ420P ||
-                    pv->context->pix_fmt == AV_PIX_FMT_YUV420P10LE))
-                {
-                    info->video_decode_support |= HB_DECODE_SUPPORT_QSV;
-                }
-                break;
-            default:
-                break;
-        }
-    }
+    if (hb_qsv_decode_codec_supported_codec(hb_qsv_get_adapter_index(), pv->context->codec_id, pv->context->pix_fmt))
+        info->video_decode_support |= HB_DECODE_SUPPORT_QSV;
 #endif
 
     return 1;

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -892,7 +892,7 @@ int qsv_enc_init(hb_work_private_t *pv)
             *job->die = 1;
             return -1;
         }
-        pv->loaded_plugins = hb_qsv_load_plugins(pv->qsv_info, qsv->mfx_session, version);
+        pv->loaded_plugins = hb_qsv_load_plugins(hb_qsv_get_adapter_index(), pv->qsv_info, qsv->mfx_session, version);
         if (pv->loaded_plugins == NULL)
         {
             hb_error("qsv_enc_init: hb_qsv_load_plugins failed");
@@ -998,35 +998,6 @@ int qsv_enc_init(hb_work_private_t *pv)
     return 0;
 }
 
-static mfxIMPL hb_qsv_dx_index_to_impl(int dx_index)
-{
-    mfxIMPL impl;
-
-    switch (dx_index)
-    {
-        {
-        case 0:
-            impl = MFX_IMPL_HARDWARE;
-            break;
-        case 1:
-            impl = MFX_IMPL_HARDWARE2;
-            break;
-        case 2:
-            impl = MFX_IMPL_HARDWARE3;
-            break;
-        case 3:
-            impl = MFX_IMPL_HARDWARE4;
-            break;
-
-        default:
-            // try searching on all display adapters
-            impl = MFX_IMPL_HARDWARE_ANY;
-            break;
-        }
-    }
-    return impl;
-}
-
 /***********************************************************************
  * encqsvInit
  ***********************************************************************
@@ -1039,7 +1010,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
 
     pv->is_sys_mem         = hb_qsv_full_path_is_enabled(job) ? 0 : 1; // TODO: re-implement QSV VPP filtering support
     pv->job                = job;
-    pv->qsv_info           = hb_qsv_info_get(job->vcodec);
+    pv->qsv_info           = hb_qsv_encoder_info_get(hb_qsv_get_adapter_index(), job->vcodec);
     pv->delayed_processing = hb_list_init();
     pv->last_start         = INT64_MIN;
     hb_buffer_list_clear(&pv->encoded_frames);
@@ -1104,12 +1075,12 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
         }
         hb_dict_free(&options_list);
     }
-#if !defined(SYS_LINUX) && !defined(SYS_FREEBSD)
-    if (pv->is_sys_mem)
+#if defined(_WIN32) || defined(__MINGW32__)
+    if (pv->is_sys_mem && hb_qsv_implementation_is_hardware(pv->qsv_info->implementation))
     {
         // select the right hardware implementation based on dx index
         if (!job->qsv.ctx->qsv_device)
-            hb_qsv_param_parse_dx_index(pv->job, -1);
+            hb_qsv_param_parse_dx_index(pv->job, hb_qsv_get_adapter_index());
         mfxIMPL hw_preference = MFX_IMPL_VIA_D3D11;
         pv->qsv_info->implementation = hb_qsv_dx_index_to_impl(job->qsv.ctx->dx_index) | hw_preference;
     }
@@ -1465,7 +1436,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     }
 
     /* Load required MFX plug-ins */
-    pv->loaded_plugins = hb_qsv_load_plugins(pv->qsv_info, session, version);
+    pv->loaded_plugins = hb_qsv_load_plugins(hb_qsv_get_adapter_index(), pv->qsv_info, session, version);
     if (pv->loaded_plugins == NULL)
     {
         hb_error("encqsvInit: hb_qsv_load_plugins failed");

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -44,7 +44,7 @@ void hb_qsv_force_workarounds(); // for developers only
 typedef struct hb_qsv_info_s
 {
     // each info struct only corresponds to one CodecId and implementation combo
-    const mfxU32  codec_id;
+    mfxU32  codec_id;
     mfxIMPL implementation;
 
     // whether the encoder is available for this implementation
@@ -82,16 +82,19 @@ typedef struct hb_qsv_info_s
 
 /* Intel Quick Sync Video utilities */
 hb_display_t * hb_qsv_display_init(void);
-int            hb_qsv_video_encoder_is_enabled(int encoder);
+int            hb_qsv_video_encoder_is_enabled(int adapter_index, int encoder);
 int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();
 void           hb_qsv_info_print();
 hb_list_t*     hb_qsv_adapters_list();
-hb_qsv_info_t* hb_qsv_info_get(int encoder);
-int qsv_hardware_generation(int cpu_platform);
+hb_qsv_info_t* hb_qsv_encoder_info_get(int adapter_index, int encoder);
+int            hb_qsv_hardware_generation(int cpu_platform);
+int            hb_qsv_get_platform(int adapter_index);
+int            hb_qsv_get_adapter_index();
+int            hb_qsv_implementation_is_hardware(mfxIMPL implementation);
 
 /* Automatically load and unload any required MFX plug-ins */
-hb_list_t* hb_qsv_load_plugins  (hb_qsv_info_t *info, mfxSession session, mfxVersion version);
+hb_list_t* hb_qsv_load_plugins  (int adapter_index, hb_qsv_info_t *info, mfxSession session, mfxVersion version);
 void       hb_qsv_unload_plugins(hb_list_t     **_l,  mfxSession session, mfxVersion version);
 
 /* Intel Quick Sync Video DECODE utilities */
@@ -247,6 +250,14 @@ enum AVPixelFormat hb_qsv_get_format(AVCodecContext *s, const enum AVPixelFormat
 int hb_qsv_preset_is_zero_copy_enabled(const hb_dict_t *job_dict);
 void hb_qsv_uninit_dec(AVCodecContext *s);
 void hb_qsv_uninit_enc(hb_job_t *job);
+mfxIMPL hb_qsv_dx_index_to_impl(int dx_index);
+int hb_qsv_parse_adapter_index(hb_job_t *job);
+int hb_qsv_setup_job(hb_job_t *job);
+int hb_qsv_decode_h264_is_supported(int adapter_index);
+int hb_qsv_decode_h265_is_supported(int adapter_index);
+int hb_qsv_decode_h265_10_bit_is_supported(int adapter_index);
+int hb_qsv_decode_av1_is_supported(int adapter_index);
+int hb_qsv_decode_codec_supported_codec(int adapter_index, int video_codec_param, int pix_fmt);
 
 #endif // __LIBHB__
 #endif // HB_PROJECT_FEATURE_QSV

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -333,6 +333,7 @@ typedef struct hb_qsv_context {
     int num_cpu_filters;
     int la_is_enabled;
     int qsv_filters_are_enabled;
+    int full_path_is_enabled;
     char *vpp_scale_mode;
     char *vpp_interpolation_method;
     char *qsv_device;

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1830,10 +1830,9 @@ int hb_global_init()
 #if HB_PROJECT_FEATURE_QSV
     if (!disable_hardware)
     {
-        result = hb_qsv_info_init();
-        if (result < 0)
+        if (hb_qsv_available() < 0)
         {
-            hb_error("hb_qsv_info_init failed!");
+            hb_error("hb_qsv_available failed!");
             return -1;
         }
         hb_param_configure_qsv();

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -530,6 +530,13 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     json_error_t error;
     int subtitle_search_burn;
     int ii;
+    int adapter_index;
+
+#if HB_PROJECT_FEATURE_QSV
+    adapter_index = job->qsv.ctx->dx_index;
+#else
+    adapter_index = 0;
+#endif
 
     if (job == NULL || job->title == NULL)
         return NULL;
@@ -538,7 +545,6 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     // necessary PAR value
 
     subtitle_search_burn = job->select_subtitle_config.dest == RENDERSUB;
-
     dict = json_pack_ex(&error, 0,
     "{"
     // SequenceID
@@ -550,8 +556,8 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     "s:{s:o, s:o, s:o,},"
     // PAR {Num, Den}
     "s:{s:o, s:o},"
-    // Video {Encoder, QSV {Decode, AsyncDepth}}
-    "s:{s:o, s:{s:o, s:o}},"
+    // Video {Encoder, QSV {Decode, AsyncDepth, AdapterIndex}}
+    "s:{s:o, s:{s:o, s:o, s:o}},"
     // Audio {CopyMask, FallbackEncoder, AudioList []}
     "s:{s:[], s:o, s:[]},"
     // Subtitles {Search {Enable, Forced, Default, Burn}, SubtitleList []}
@@ -580,6 +586,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
             "QSV",
                 "Decode",       hb_value_bool(job->qsv.decode),
                 "AsyncDepth",   hb_value_int(job->qsv.async_depth),
+                "AdapterIndex", hb_value_int(adapter_index),
         "Audio",
             "CopyMask",
             "FallbackEncoder",  hb_value_int(job->acodec_fallback),
@@ -1094,6 +1101,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     json_int_t         range_start = -1, range_end = -1, range_seek_points = -1;
     int                vbitrate = -1;
     double             vquality = HB_INVALID_VIDEO_QUALITY;
+    int                adapter_index = -1;
 
     result = json_unpack_ex(dict, &error, 0,
     "{"
@@ -1114,7 +1122,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     //       Mastering,
     //       ContentLightLevel,
     //       ColorPrimariesOverride, ColorTransferOverride, ColorMatrixOverride,
-    //       QSV {Decode, AsyncDepth}}
+    //       QSV {Decode, AsyncDepth, AdapterIndex}}
     "s:{s:o, s?F, s?i, s?s, s?s, s?s, s?s, s?s,"
     "   s?b, s?b,"
     "   s?i, s?i,"
@@ -1122,7 +1130,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     "   s?o,"
     "   s?o,"
     "   s?i, s?i, s?i,"
-    "   s?{s?b, s?i}},"
+    "   s?{s?b, s?i, s?i}},"
     // Audio {CopyMask, FallbackEncoder, AudioList}
     "s?{s?o, s?o, s?o},"
     // Subtitle {Search {Enable, Forced, Default, Burn}, SubtitleList}
@@ -1177,6 +1185,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             "QSV",
                 "Decode",           unpack_b(&job->qsv.decode),
                 "AsyncDepth",       unpack_i(&job->qsv.async_depth),
+                "AdapterIndex",     unpack_i(&adapter_index),
         "Audio",
             "CopyMask",             unpack_o(&acodec_copy_mask),
             "FallbackEncoder",      unpack_o(&acodec_fallback),
@@ -1197,15 +1206,6 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
         hb_error("hb_dict_to_job: failed to parse dict: %s", error.text);
         goto fail;
     }
-    // Make sure QSV Decode is only True if the hardware is available.
-    job->qsv.decode = job->qsv.decode && hb_qsv_available();
-#if HB_PROJECT_FEATURE_QSV
-    int async_depth_default = hb_qsv_param_default_async_depth();
-    if(job->qsv.async_depth <= 0 || job->qsv.async_depth > async_depth_default)
-    {
-        job->qsv.async_depth = async_depth_default;
-    }
-#endif
     // Lookup mux id
     if (hb_value_type(mux) == HB_VALUE_TYPE_STRING)
     {
@@ -1275,6 +1275,9 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     hb_job_set_encoder_level(job, video_level);
     hb_job_set_encoder_options(job, video_options);
 
+#if HB_PROJECT_FEATURE_QSV
+    job->qsv.ctx->dx_index = adapter_index;
+#endif
     // If both vbitrate and vquality were specified, vbitrate is used;
     // we need to ensure the unused rate contro mode is always set to an
     // invalid value, as if both values are valid, behavior is undefined

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1825,7 +1825,11 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(qsv, "AsyncDepth",
                     hb_value_xform(value, HB_VALUE_TYPE_INT));
     }
-
+    if ((value = hb_dict_get(preset, "VideoQSVAdapterIndex")) != NULL)
+    {
+        hb_dict_set(qsv, "AdapterIndex",
+                    hb_value_xform(value, HB_VALUE_TYPE_INT));
+    }
     return 0;
 }
 

--- a/libhb/qsv_libav.c
+++ b/libhb/qsv_libav.c
@@ -236,8 +236,11 @@ int hb_qsv_context_clean(hb_qsv_context * qsv, int full_job)
             hb_qsv_pipe_list_clean(&qsv->pipes);
 
         if (qsv->mfx_session && !full_job) {
+            // MFXClose() fails in the media_driver under Linux when encoding interrupted
+#if defined(_WIN32) || defined(__MINGW32__)
             sts = MFXClose(qsv->mfx_session);
             HB_QSV_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
+#endif
             qsv->mfx_session = 0;
         }
     }

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -2915,7 +2915,7 @@ static int syncVideoWork( hb_work_object_t * w, hb_buffer_t ** buf_in,
     // as currently for such support we cannot allocate >64 slices per texture
     // due to MSFT limitation, not impacting other cases
     if (pv->common->job->qsv.ctx && (pv->common->job->qsv.ctx->la_is_enabled == 1)
-        && hb_qsv_full_path_is_enabled(pv->common->job))
+        && pv->common->job->qsv.ctx->full_path_is_enabled)
     {
         pv->stream->max_len = SYNC_MIN_VIDEO_QUEUE_LEN;
         pv->common->job->qsv.ctx->la_is_enabled++;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -141,6 +141,9 @@ static void work_func( void * _work )
             hb_job_close(&job);
             job = new_job;
         }
+#if HB_PROJECT_FEATURE_QSV
+        hb_qsv_setup_job(job);
+#endif
         hb_job_setup_passes(job->h, job, passes);
         hb_job_close(&job);
 
@@ -871,7 +874,7 @@ static int get_best_pix_ftm(hb_job_t * job)
 {
     int bit_depth = hb_get_bit_depth(job->title->pix_fmt);
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
-    if (hb_qsv_info_get(job->vcodec))
+    if (hb_qsv_encoder_info_get(hb_qsv_get_adapter_index(), job->vcodec))
     {
         if (hb_qsv_full_path_is_enabled(job))
         {
@@ -1461,7 +1464,6 @@ static void do_job(hb_job_t *job)
 #if HB_PROJECT_FEATURE_QSV
     if (hb_qsv_is_enabled(job))
     {
-        job->qsv.ctx = hb_qsv_context_init();
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
         if (hb_qsv_full_path_is_enabled(job))
         {

--- a/test/test.c
+++ b/test/test.c
@@ -199,6 +199,7 @@ static int      stop_at_frame = 0;
 static uint64_t min_title_duration = 10;
 #if HB_PROJECT_FEATURE_QSV
 static int      qsv_async_depth    = -1;
+static int      qsv_adapter        = -1;
 static int      qsv_decode         = -1;
 #endif
 
@@ -1938,8 +1939,15 @@ if (hb_qsv_available())
 "                           explicitly synchronized.\n"
 "                           Omit 'number' for zero.\n"
 "                           (default: 4)\n"
+    );
+#if defined(_WIN32) || defined(__MINGW32__)
+    fprintf( out,
+"   --qsv-adapter[=index]\n"
+"                           Set QSV hardware graphics adapter index\n"
+"                           (default: QSV hardware graphics adapter with highest hardware generation)\n"
 "\n"
     );
+#endif
 }
 #endif
 }
@@ -2146,36 +2154,36 @@ static int ParseOptions( int argc, char ** argv )
     #define AUDIO_DITHER         294
     #define QSV_BASELINE         295
     #define QSV_ASYNC_DEPTH      296
-    #define QSV_IMPLEMENTATION   297
-    #define FILTER_NLMEANS       298
-    #define FILTER_NLMEANS_TUNE  299
-    #define AUDIO_LANG_LIST      300
-    #define SUBTITLE_LANG_LIST   301
-    #define PRESET_EXPORT        302
-    #define PRESET_EXPORT_DESC   303
-    #define PRESET_EXPORT_FILE   304
-    #define PRESET_IMPORT        305
-    #define PRESET_IMPORT_GUI    306
-    #define VERSION              307
-    #define DESCRIBE             308
-    #define PAD                  309
-    #define FILTER_COMB_DETECT   310
-    #define QUEUE_IMPORT         311
-    #define FILTER_UNSHARP       312
-    #define FILTER_UNSHARP_TUNE  313
-    #define FILTER_LAPSHARP      314
-    #define FILTER_LAPSHARP_TUNE 315
-    #define JSON_LOGGING         316
-    #define SSA_FILE             317
-    #define SSA_OFFSET           318
-    #define SSA_LANG             319
-    #define SSA_DEFAULT          320
-    #define SSA_BURN             321
-    #define FILTER_CHROMA_SMOOTH      322
-    #define FILTER_CHROMA_SMOOTH_TUNE 323
-    #define FILTER_DEBLOCK_TUNE       324
-    #define FILTER_COLORSPACE         325
-
+    #define QSV_ADAPTER          297
+    #define QSV_IMPLEMENTATION   298
+    #define FILTER_NLMEANS       299
+    #define FILTER_NLMEANS_TUNE  300
+    #define AUDIO_LANG_LIST      301
+    #define SUBTITLE_LANG_LIST   302
+    #define PRESET_EXPORT        303
+    #define PRESET_EXPORT_DESC   304
+    #define PRESET_EXPORT_FILE   305
+    #define PRESET_IMPORT        306
+    #define PRESET_IMPORT_GUI    307
+    #define VERSION              308
+    #define DESCRIBE             309
+    #define PAD                  310
+    #define FILTER_COMB_DETECT   311
+    #define QUEUE_IMPORT         312
+    #define FILTER_UNSHARP       313
+    #define FILTER_UNSHARP_TUNE  314
+    #define FILTER_LAPSHARP      315
+    #define FILTER_LAPSHARP_TUNE 316
+    #define JSON_LOGGING         317
+    #define SSA_FILE             318
+    #define SSA_OFFSET           319
+    #define SSA_LANG             320
+    #define SSA_DEFAULT          321
+    #define SSA_BURN             322
+    #define FILTER_CHROMA_SMOOTH      323
+    #define FILTER_CHROMA_SMOOTH_TUNE 324
+    #define FILTER_DEBLOCK_TUNE  325
+    #define FILTER_COLORSPACE    326
     for( ;; )
     {
         static struct option long_options[] =
@@ -2189,6 +2197,7 @@ static int ParseOptions( int argc, char ** argv )
 #if HB_PROJECT_FEATURE_QSV
             { "qsv-baseline",         no_argument,       NULL,        QSV_BASELINE,       },
             { "qsv-async-depth",      required_argument, NULL,        QSV_ASYNC_DEPTH,    },
+            { "qsv-adapter",          required_argument, NULL,        QSV_ADAPTER         },
             { "qsv-implementation",   required_argument, NULL,        QSV_IMPLEMENTATION, },
             { "disable-qsv-decoding", no_argument,       &qsv_decode, 0,                  },
             { "enable-qsv-decoding",  no_argument,       &qsv_decode, 1,                  },
@@ -3107,6 +3116,9 @@ static int ParseOptions( int argc, char ** argv )
                 break;
             case QSV_ASYNC_DEPTH:
                 qsv_async_depth = atoi(optarg);
+                break;
+            case QSV_ADAPTER:
+                qsv_adapter = atoi(optarg);
                 break;
             case QSV_IMPLEMENTATION:
                 hb_qsv_impl_set_preferred(optarg);
@@ -4211,6 +4223,11 @@ static hb_dict_t * PreparePreset(const char *preset_name)
     {
         hb_dict_set(preset, "VideoQSVAsyncDepth",
                         hb_value_int(qsv_async_depth));
+    }
+    if (qsv_adapter >= 0)
+    {
+        hb_dict_set(preset, "VideoQSVAdapterIndex",
+                        hb_value_int(qsv_adapter));
     }
     if (qsv_decode != -1)
     {

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeHardwareEncoderHelper.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeHardwareEncoderHelper.cs
@@ -99,8 +99,9 @@ namespace HandBrake.Interop.Interop
             {
                 try
                 {
-                    int cpu_platform = HBFunctions.hb_get_cpu_platform();
-                    int hardware = HBFunctions.qsv_hardware_generation(cpu_platform);
+                    int adapter_index = HBFunctions.hb_qsv_get_adapter_index();
+                    int qsv_platform = HBFunctions.hb_qsv_get_platform(adapter_index);
+                    int hardware = HBFunctions.hb_qsv_hardware_generation(qsv_platform);
                     return hardware;
                 }
                 catch (Exception exc)

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -305,8 +305,14 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_get_cpu_platform", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_get_cpu_platform();
 
-        [DllImport("hb", EntryPoint = "qsv_hardware_generation", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int qsv_hardware_generation(int cpu_platform);
+        [DllImport("hb", EntryPoint = "hb_qsv_get_platform", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_qsv_get_platform(int adapter_index);
+
+        [DllImport("hb", EntryPoint = "hb_qsv_hardware_generation", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_qsv_hardware_generation(int cpu_platform);
+
+        [DllImport("hb", EntryPoint = "hb_qsv_get_adapter_index", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_qsv_get_adapter_index();
 
         [DllImport("hb", EntryPoint = "hb_qsv_adapters_list", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr hb_qsv_adapters_list();


### PR DESCRIPTION
* Now it properly supports multiple QSV adapters with different HW generations
* For Windows adapter enumeration is based on DirectX API information, not CPU flags.
* Reporting
```
[18:46:21] Compile-time hardening features are enabled
Cannot load nvEncodeAPI64.dll
Cannot load nvEncodeAPI64.dll
Cannot load nvEncodeAPI64.dll
Cannot load nvEncodeAPI64.dll
[18:46:23] hb_init: starting libhb thread
[18:46:23] thread 1 started ("libhb")
HandBrake 20210211132219-662c477f0-caps (2021021101) - MinGW x86_64 - https://handbrake.fr
8 CPUs detected
Opening bbb_sunflower_2160p_60fps_normal.mp4...
[18:46:23] CPU: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
[18:46:23]  - Intel microarchitecture Tiger Lake
[18:46:23]  - logical processor count: 8
[18:46:23] Intel Quick Sync Video support: yes, gpu list: 0, 1
[18:46:23] Intel Quick Sync Video integrated adapter with index 0
[18:46:23]  - Intel Media SDK hardware: API 1.34 (minimum: 1.3)
[18:46:23]  - Decode support:  h264 hevc (8bit: yes, 10bit: yes) av1 (8bit: yes, 10bit: yes)
[18:46:23]  - H.264 encoder: yes
[18:46:23]     - preferred implementation: hardware (1) via D3D11
[18:46:23]     - capabilities (hardware):  breftype icq+la+i+downs vsinfo opt1 opt2+mbbrc+extbrc+trellis+ib_adapt+nmpslice
[18:46:23]  - H.265 encoder: yes (8bit: yes, 10bit: yes)
[18:46:23]     - preferred implementation: hardware (1) via D3D11
[18:46:23]     - capabilities (hardware):  lowpower bpyramid icq vsinfo opt1
[18:46:23] Intel Quick Sync Video discrete adapter with index 1
[18:46:23]  - Intel Media SDK hardware: API 1.34 (minimum: 1.3)
[18:46:23]  - Decode support:  h264 hevc (8bit: yes, 10bit: yes) av1 (8bit: yes, 10bit: yes)
[18:46:23]  - H.264 encoder: yes
[18:46:23]     - preferred implementation: hardware (2) via D3D11
[18:46:23]     - capabilities (hardware):  breftype icq+la+i+downs vsinfo opt1 opt2+mbbrc+extbrc+trellis+ib_adapt+nmpslice
[18:46:23]  - H.265 encoder: yes (8bit: yes, 10bit: yes)
[18:46:23]     - preferred implementation: hardware (2) via D3D11
[18:46:23]     - capabilities (hardware):  lowpower bpyramid icq vsinfo opt1
[18:46:23] hb_scan: path=bbb_sunflower_2160p_60fps_normal.mp4, title_index=1
```
* Adapter selection exposed via new --qsv-adapter command line option for better job allocation
```
HandBrakeCLI.exe --help
-- Intel Quick Sync Video Options --------------------------------------------

   --enable-qsv-decoding   Allow QSV hardware decoding of the video track
   --disable-qsv-decoding  Disable QSV hardware decoding of the video track,
                           forcing software decoding instead
   --qsv-async-depth[=number]
                           Set the number of asynchronous operations that
                           should be performed before the result is
                           explicitly synchronized.
                           Omit 'number' for zero.
                           (default: 4)
   --qsv-adapter[=index]
                           Set QSV hardware graphics adapter index
                           (default: QSV hardware graphics adapter with highest hardware generation)
```

```
HandBrakeCLI.exe --qsv-adapter=0 -i bbb_sunflower_2160p_60fps_normal.mp4 --enable-qsv-decoding -e qsv_h265 -o out.mp4
```

* Windows GUI interop aligned with new API functions: 
    
    // Get QSV platform by adapter index, fallback for hb_get_cpu_platform() under Linux
    int hb_qsv_get_platform(int adapter_index);

    // Return the current selected adapter index
    int hb_qsv_get_adapter_index();

    int qsv_hardware_generation(int cpu_platform) was renamed to int hb_qsv_hardware_generation(int cpu_platform);

* Fixed multiple Linux issues and crash when jobs was interrripted
