### PR TITLE
Add ToString() override for Language to improve screen reader behavior when used as ComboBox model

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Language.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Language.cs
@@ -63,5 +63,14 @@ namespace HandBrake.Interop.Interop.Interfaces.Model
                 return this.EnglishName;
             }
         }
+
+        /// <summary>
+        /// Returns the display string for this langauge.
+        /// </summary>
+        /// <returns>The display string for this language.</returns>
+        public override string ToString()
+        {
+            return this.Display;
+        }
     }
 }


### PR DESCRIPTION
With this change it will read out the language name rather than "HandBrake.Interop.Interop.Interfaces.Model.Language"