### PR TITLE
Bug Fix: Correct QP range when using AMF VCE H265

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -346,11 +346,8 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             //Work around an ffmpeg issue mentioned in issue #3447
             if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265)
             {
-               av_dict_set( &av_opts, "min_qp_i", 1, 0 );
-               av_dict_set( &av_opts, "min_qp_p", 1, 0 );
-               
-               av_dict_set( &av_opts, "max_qp_i", 51, 0 );
-               av_dict_set( &av_opts, "max_qp_p", 51, 0 );
+               av_dict_set( &av_opts, "qmin", 0, 0 );
+               av_dict_set( &av_opts, "qmax", 51, 0 );
             }
             hb_log( "encavcodec: encoding at rc=vbr_peak Bitrate %d", job->vbitrate );
         }

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -343,6 +343,15 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         
         if ( job->vcodec == HB_VCODEC_FFMPEG_VCE_H264 || job->vcodec == HB_VCODEC_FFMPEG_VCE_H265 ) {
             av_dict_set( &av_opts, "rc", "vbr_peak", 0 );
+            //Work around an ffmpeg issue mentioned in issue #3447
+            if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265)
+            {
+               av_dict_set( &av_opts, "min_qp_i", 1, 0 );
+               av_dict_set( &av_opts, "min_qp_p", 1, 0 );
+               
+               av_dict_set( &av_opts, "max_qp_i", 51, 0 );
+               av_dict_set( &av_opts, "max_qp_p", 51, 0 );
+            }
             hb_log( "encavcodec: encoding at rc=vbr_peak Bitrate %d", job->vbitrate );
         }
 

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -346,8 +346,8 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             //Work around an ffmpeg issue mentioned in issue #3447
             if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265)
             {
-               av_dict_set( &av_opts, "qmin", 0, 0 );
-               av_dict_set( &av_opts, "qmax", 51, 0 );
+               av_dict_set( &av_opts, "qmin",  "0", 0 );
+               av_dict_set( &av_opts, "qmax", "51", 0 );
             }
             hb_log( "encavcodec: encoding at rc=vbr_peak Bitrate %d", job->vbitrate );
         }


### PR DESCRIPTION
By default ffmpeg restricts qp factors to a range of 2 to 31, unless otherwise overwritten. This significantly constrains the low bitrate performance of VCE in H.264 mode.
This should fix issue #3447 and could also address parts of issue #2980.


**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

When using VCE H265 in bitrate mode, the default values for min_qp_p, min_qp_i are set to 2 and for max_qp_p, max_qp_i to 31. This severely constrains the encoder in the low bit rate regime and puts a hard lower limit on the bit rate, making the average bit rate mode effectively unusable. 

This change simply unlocks the full range of QP factors for VCE H.265 when using average bit rate mode.

While this may be addressed upstream, this change works around the issue.



**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
