### PR TITLE
libhb: improve pipeline pixel format selection.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5934,25 +5934,12 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
 
     if (job->title->video_decode_support & HB_DECODE_SUPPORT_QSV)
     {
-#if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
-        if (hb_qsv_full_path_is_enabled(job))
+        // Allow formats supported by QSV pipeline via system memory
+        // at that stage only, video memory formats will be reassigned later if allowed
+        if (pix_fmt != AV_PIX_FMT_YUV420P10 &&
+            pix_fmt != AV_PIX_FMT_YUV420P)
         {
-            // Formats supported in QSV pipeline via video memory
-            if (pix_fmt != AV_PIX_FMT_P010LE &&
-                pix_fmt != AV_PIX_FMT_NV12)
-            {
-                return 0;
-            }
-        }
-        else
-#endif
-        {
-            // Formats supported by QSV pipeline via system memory
-            if (pix_fmt != AV_PIX_FMT_YUV420P10 &&
-                pix_fmt != AV_PIX_FMT_YUV420P)
-            {
-                return 0;
-            }
+            return 0;
         }
     }
     else

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5934,7 +5934,7 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
 
     if (job->title->video_decode_support & HB_DECODE_SUPPORT_QSV)
     {
-#if defined(_WIN32) || defined(__MINGW32__)
+#if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
         if (hb_qsv_full_path_is_enabled(job))
         {
             // Formats supported in QSV pipeline via video memory

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5955,6 +5955,16 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
             }
         }
     }
+    else
+    {
+        // Allow biplanar formats only if
+        // hardware decoding is enabled.
+        if (pix_fmt == AV_PIX_FMT_P010LE ||
+            pix_fmt == AV_PIX_FMT_NV12)
+        {
+            return 0;
+        }
+    }
 
     for (int i = 0; i < hb_list_count(job->list_filter); i++)
     {

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5932,14 +5932,27 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
         return 0;
     }
 
-    // Allow biplanar formats only if
-    // hardware decoding is enabled.
-    if (pix_fmt == AV_PIX_FMT_P010LE ||
-        pix_fmt == AV_PIX_FMT_NV12)
+    if (job->title->video_decode_support & HB_DECODE_SUPPORT_QSV)
     {
-        if (!(job->title->video_decode_support & HB_DECODE_SUPPORT_QSV))
+#if defined(_WIN32) || defined(__MINGW32__)
+        if (hb_qsv_full_path_is_enabled(job))
         {
-            return 0;
+            // Formats supported in QSV pipeline via video memory
+            if (pix_fmt != AV_PIX_FMT_P010LE &&
+                pix_fmt != AV_PIX_FMT_NV12)
+            {
+                return 0;
+            }
+        }
+        else
+#endif
+        {
+            // Formats supported by QSV pipeline via system memory
+            if (pix_fmt != AV_PIX_FMT_YUV420P10 &&
+                pix_fmt != AV_PIX_FMT_YUV420P)
+            {
+                return 0;
+            }
         }
     }
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5933,7 +5933,7 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
     }
 
     // Allow biplanar formats only if
-    // hardware decoder is supported.
+    // hardware decoding is enabled.
     if (pix_fmt == AV_PIX_FMT_P010LE ||
         pix_fmt == AV_PIX_FMT_NV12)
     {

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1174,7 +1174,7 @@ int reinit_video_filters(hb_work_private_t * pv)
             orig_width = pv->job->title->geometry.width;
             orig_height = pv->job->title->geometry.height;
         }
-        pix_fmt = pv->job->pix_fmt;
+        pix_fmt = pv->job->input_pix_fmt;
         color_range = pv->job->color_range;
     }
 

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1,3 +1,4 @@
+
 /* ********************************************************************* *\
 
 Copyright (C) 2013 Intel Corporation.  All rights reserved.
@@ -850,7 +851,7 @@ int qsv_enc_init(hb_work_private_t *pv)
         {
             pv->sws_context_to_nv12 = hb_sws_get_context(
                                         job->width, job->height,
-                                        AV_PIX_FMT_YUV420P, job->color_range,
+                                        job->pix_fmt, job->color_range,
                                         job->width, job->height,
                                         AV_PIX_FMT_P010LE, job->color_range,
                                         SWS_LANCZOS|SWS_ACCURATE_RND,
@@ -860,7 +861,7 @@ int qsv_enc_init(hb_work_private_t *pv)
         {
             pv->sws_context_to_nv12 = hb_sws_get_context(
                                         job->width, job->height,
-                                        AV_PIX_FMT_YUV420P, job->color_range,
+                                        job->pix_fmt, job->color_range,
                                         job->width, job->height,
                                         AV_PIX_FMT_NV12, job->color_range,
                                         SWS_LANCZOS|SWS_ACCURATE_RND,

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -851,7 +851,7 @@ int qsv_enc_init(hb_work_private_t *pv)
         {
             pv->sws_context_to_nv12 = hb_sws_get_context(
                                         job->width, job->height,
-                                        job->pix_fmt, job->color_range,
+                                        job->output_pix_fmt, job->color_range,
                                         job->width, job->height,
                                         AV_PIX_FMT_P010LE, job->color_range,
                                         SWS_LANCZOS|SWS_ACCURATE_RND,
@@ -861,7 +861,7 @@ int qsv_enc_init(hb_work_private_t *pv)
         {
             pv->sws_context_to_nv12 = hb_sws_get_context(
                                         job->width, job->height,
-                                        job->pix_fmt, job->color_range,
+                                        job->output_pix_fmt, job->color_range,
                                         job->width, job->height,
                                         AV_PIX_FMT_NV12, job->color_range,
                                         SWS_LANCZOS|SWS_ACCURATE_RND,

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -928,7 +928,6 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     {
         av_dict_set(&av_opts, "profile", "main10", 0);
         context->max_b_frames = 16;
-        context->pix_fmt = AV_PIX_FMT_P010LE;
     }
 
     if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H264)
@@ -1035,7 +1034,6 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         job->vcodec == HB_VCODEC_FFMPEG_MF_H265)
     {
         av_dict_set(&av_opts, "hw_encoding", "1", 0);
-        context->pix_fmt = AV_PIX_FMT_NV12;
     }
 
     if (job->vcodec == HB_VCODEC_FFMPEG_MF_H265)

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -756,7 +756,7 @@ static hb_buffer_t *x264_encode( hb_work_object_t *w, hb_buffer_t *in )
 
     /* Point x264 at our current buffers Y(UV) data.  */
     if (pv->pic_in.img.i_csp & X264_CSP_HIGH_DEPTH &&
-        job->pix_fmt == AV_PIX_FMT_YUV420P)
+        job->output_pix_fmt == AV_PIX_FMT_YUV420P)
     {
         tmp = expand_buf(pv->api->bit_depth, in);
         pv->pic_in.img.i_stride[0] = tmp->plane[0].stride;

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -260,7 +260,7 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     }
 
     /* Bit depth */
-    pv->bit_depth = hb_get_bit_depth(job->pix_fmt);
+    pv->bit_depth = hb_get_bit_depth(job->output_pix_fmt);
 
     /* iterate through x265_opts and parse the options */
     hb_dict_t *x265_opts;

--- a/libhb/format.c
+++ b/libhb/format.c
@@ -1,0 +1,74 @@
+/* format.c
+
+   Copyright (c) 2003-2015 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "handbrake/avfilter_priv.h"
+
+static int format_init(hb_filter_object_t * filter,
+                           hb_filter_init_t * init);
+
+const char format_template[] =
+    "format=^"HB_ALL_REG"$";
+
+hb_filter_object_t hb_filter_format =
+{
+    .id                = HB_FILTER_FORMAT,
+    .enforce_order     = 1,
+    .skip              = 1,
+    .name              = "Format",
+    .settings          = NULL,
+    .init              = format_init,
+    .work              = hb_avfilter_null_work,
+    .close             = hb_avfilter_alias_close,
+    .settings_template = format_template,
+};
+
+static int format_init(hb_filter_object_t * filter, hb_filter_init_t * init)
+{
+    hb_filter_private_t * pv = NULL;
+
+    pv = calloc(1, sizeof(struct hb_filter_private_s));
+    filter->private_data = pv;
+    if (pv == NULL)
+    {
+        return 1;
+    }
+    pv->input = *init;
+
+    hb_dict_t        * settings = filter->settings;
+
+    char * format = NULL;
+
+    hb_dict_extract_string(&format, settings, "format");
+
+    if (!format)
+    {
+        return 0;
+    }
+
+    hb_value_array_t * avfilters = hb_value_array_init();
+    hb_dict_t * avfilter   = NULL;
+    hb_dict_t * avsettings = NULL;
+
+    // Format
+    avfilter   = hb_dict_init();
+    avsettings = hb_dict_init();
+
+    hb_dict_set_string(avsettings, "pix_fmts", format);
+    hb_dict_set(avfilter, "format", avsettings);
+
+    hb_value_array_append(avfilters, avfilter);
+
+    pv->avfilters = avfilters;
+
+    init->pix_fmt = av_get_pix_fmt(format);
+    pv->output = *init;
+
+    return 0;
+}

--- a/libhb/format.c
+++ b/libhb/format.c
@@ -1,6 +1,6 @@
 /* format.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2021 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.
@@ -10,8 +10,8 @@
 #include "handbrake/common.h"
 #include "handbrake/avfilter_priv.h"
 
-static int format_init(hb_filter_object_t * filter,
-                           hb_filter_init_t * init);
+static int format_init(hb_filter_object_t *filter,
+                           hb_filter_init_t *init);
 
 const char format_template[] =
     "format=^"HB_ALL_REG"$";
@@ -29,9 +29,9 @@ hb_filter_object_t hb_filter_format =
     .settings_template = format_template,
 };
 
-static int format_init(hb_filter_object_t * filter, hb_filter_init_t * init)
+static int format_init(hb_filter_object_t *filter, hb_filter_init_t *init)
 {
-    hb_filter_private_t * pv = NULL;
+    hb_filter_private_t *pv = NULL;
 
     pv = calloc(1, sizeof(struct hb_filter_private_s));
     filter->private_data = pv;
@@ -41,24 +41,19 @@ static int format_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     }
     pv->input = *init;
 
-    hb_dict_t        * settings = filter->settings;
-
-    char * format = NULL;
+    hb_dict_t *settings = filter->settings;
+    char *format = NULL;
 
     hb_dict_extract_string(&format, settings, "format");
 
-    if (!format)
+    if (format == NULL)
     {
         return 0;
     }
 
-    hb_value_array_t * avfilters = hb_value_array_init();
-    hb_dict_t * avfilter   = NULL;
-    hb_dict_t * avsettings = NULL;
-
-    // Format
-    avfilter   = hb_dict_init();
-    avsettings = hb_dict_init();
+    hb_value_array_t *avfilters = hb_value_array_init();
+    hb_dict_t *avfilter   = hb_dict_init();
+    hb_dict_t *avsettings = hb_dict_init();
 
     hb_dict_set_string(avsettings, "pix_fmts", format);
     hb_dict_set(avfilter, "format", avsettings);

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -414,6 +414,7 @@ const char* const* hb_video_encoder_get_presets (int encoder);
 const char* const* hb_video_encoder_get_tunes   (int encoder);
 const char* const* hb_video_encoder_get_profiles(int encoder);
 const char* const* hb_video_encoder_get_levels  (int encoder);
+const int*         hb_video_encoder_get_pix_fmts(int encoder);
 
 void  hb_audio_quality_get_limits(uint32_t codec, float *low, float *high, float *granularity, int *direction);
 float hb_audio_quality_get_best(uint32_t codec, float quality);

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -409,6 +409,7 @@ const char* hb_video_quality_get_name(uint32_t codec);
 int         hb_video_quality_is_supported(uint32_t codec);
 
 int                hb_video_encoder_is_supported(int encoder);
+int                hb_video_encoder_pix_fmt_is_supported(int encoder, int pix_fmt);
 int                hb_video_encoder_get_depth   (int encoder);
 const char* const* hb_video_encoder_get_presets (int encoder);
 const char* const* hb_video_encoder_get_tunes   (int encoder);
@@ -609,7 +610,10 @@ struct hb_job_s
     char           *encoder_level;
     int             areBframes;
 
-    int             pix_fmt;
+    // Pixel format from decoder to the end of the filters chain
+    int             input_pix_fmt;
+    // Pixel format from the end of filters chain to the encoder
+    int             output_pix_fmt;
     int             color_prim;
     int             color_transfer;
     int             color_matrix;
@@ -1422,6 +1426,7 @@ enum
     HB_FILTER_GRAYSCALE,
     HB_FILTER_PAD,
     HB_FILTER_COLORSPACE,
+    HB_FILTER_FORMAT,
 
     // Finally filters that don't care what order they are in,
     // except that they must be after the above filters

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -62,5 +62,6 @@ void            hb_avframe_set_video_buffer_flags(hb_buffer_t * buf,
 int hb_av_encoder_present(int encoder);
 const char* const* hb_av_profile_get_names(int encoder);
 const char* const* hb_av_level_get_names(int encoder);
+const int* hb_av_get_pix_fmts(int encoder);
 
 #endif // HANDBRAKE_FFMPEG_H

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -476,6 +476,7 @@ extern hb_filter_object_t hb_filter_unsharp;
 extern hb_filter_object_t hb_filter_avfilter;
 extern hb_filter_object_t hb_filter_mt_frame;
 extern hb_filter_object_t hb_filter_colorspace;
+extern hb_filter_object_t hb_filter_format;
 
 #if HB_PROJECT_FEATURE_QSV
 extern hb_filter_object_t hb_filter_qsv;

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -186,6 +186,7 @@ static const char* const hb_qsv_preset_names2[] = { "speed", "balanced", "qualit
 const char* const* hb_qsv_preset_get_names();
 const char* const* hb_qsv_profile_get_names(int encoder);
 const char* const* hb_qsv_level_get_names(int encoder);
+const int* hb_qsv_get_pix_fmts(int encoder);
 
 const char* hb_qsv_video_quality_get_name(uint32_t codec);
 void hb_qsv_video_quality_get_limits(uint32_t codec, float *low, float *high, float *granularity, int *direction);

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -945,7 +945,7 @@ hb_image_t * hb_get_preview3(hb_handle_t * h, int picture,
         ii++;
     }
 
-    job->pix_fmt = init.pix_fmt;
+    job->output_pix_fmt = init.pix_fmt;
     job->color_prim = init.color_prim;
     job->color_transfer = init.color_transfer;
     job->color_matrix = init.color_matrix;

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -620,8 +620,10 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     hb_dict_set(source_dict, "Range", range_dict);
 
     hb_dict_t *video_dict = hb_dict_get(dict, "Video");
-    hb_dict_set(video_dict, "ColorFormat",
-                hb_value_int(job->pix_fmt));
+    hb_dict_set(video_dict, "ColorInputFormat",
+                hb_value_int(job->input_pix_fmt));
+    hb_dict_set(video_dict, "ColorOutputFormat",
+                hb_value_int(job->output_pix_fmt));
     hb_dict_set(video_dict, "ColorRange",
                 hb_value_int(job->color_range));
     hb_dict_set(video_dict, "ColorPrimaries",
@@ -1015,7 +1017,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     "s?{s:i, s:i},"
     // Video {Codec, Quality, Bitrate, Preset, Tune, Profile, Level, Options
     //       TwoPass, Turbo,
-    //       ColorFormat, ColorRange,
+    //       ColorInputFormat, ColorOutputFormat, ColorRange,
     //       ColorPrimaries, ColorTransfer, ColorMatrix,
     //       Mastering,
     //       ContentLightLevel,
@@ -1023,7 +1025,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     //       QSV {Decode, AsyncDepth, AdapterIndex}}
     "s:{s:o, s?F, s?i, s?s, s?s, s?s, s?s, s?s,"
     "   s?b, s?b,"
-    "   s?i, s?i,"
+    "   s?i, s?i, s?i,"
     "   s?i, s?i, s?i,"
     "   s?o,"
     "   s?o,"
@@ -1070,7 +1072,8 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             "Options",              unpack_s(&video_options),
             "TwoPass",              unpack_b(&job->twopass),
             "Turbo",                unpack_b(&job->fastfirstpass),
-            "ColorFormat",          unpack_i(&job->pix_fmt),
+            "ColorInputFormat",     unpack_i(&job->input_pix_fmt),
+            "ColorOutputFormat",    unpack_i(&job->output_pix_fmt),
             "ColorRange",           unpack_i(&job->color_range),
             "ColorPrimaries",       unpack_i(&job->color_prim),
             "ColorTransfer",        unpack_i(&job->color_transfer),

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -99,12 +99,6 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         hb_error("hb_avfilter_graph_init: avfilter_graph_alloc failed");
         goto fail;
     }
-#if HB_PROJECT_FEATURE_QSV
-    if (!hb_qsv_hw_filters_are_enabled(graph->job))
-#endif
-    {
-        av_opt_set(graph->avgraph, "scale_sws_opts", "lanczos+accurate_rnd", 0);
-    }
     result = avfilter_graph_parse2(graph->avgraph, settings_str, &in, &out);
     if (result < 0 || in == NULL || out == NULL)
     {
@@ -351,6 +345,7 @@ void hb_avfilter_combine( hb_list_t * list)
             case HB_FILTER_PAD:
             case HB_FILTER_ROTATE:
             case HB_FILTER_COLORSPACE:
+            case HB_FILTER_FORMAT:
             {
                 settings = pv->avfilters;
             } break;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4236,7 +4236,6 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
             }
         }
     }
-
     return 0;
 }
 

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4236,6 +4236,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
             }
         }
     }
+
     return 0;
 }
 

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1359,7 +1359,7 @@ int hb_qsv_decode_is_enabled(hb_job_t *job)
     return ((job != NULL && job->qsv.decode) &&
             (job->title->video_decode_support & HB_DECODE_SUPPORT_QSV)) &&
             hb_qsv_decode_codec_supported_codec(hb_qsv_get_adapter_index(),
-            job->title->video_codec_param, job->pix_fmt);
+            job->title->video_codec_param, job->input_pix_fmt);
 }
 
 static int hb_dxva2_device_check();
@@ -3612,17 +3612,17 @@ int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int i
         DXGI_FORMAT texture_format;
         ID3D11Texture2D* output_surface;
         D3D11_TEXTURE2D_DESC desc = { 0 };
-        if (job->pix_fmt == AV_PIX_FMT_NV12)
+        if (job->input_pix_fmt == AV_PIX_FMT_NV12)
         {
             texture_format = DXGI_FORMAT_NV12;
         }
-        else if(job->pix_fmt == AV_PIX_FMT_P010)
+        else if(job->input_pix_fmt == AV_PIX_FMT_P010)
         {
             texture_format = DXGI_FORMAT_P010;
         }
         else
         {
-            hb_error("hb_qsv_attach_surface_to_video_buffer: unsupported texture_format=%d", job->pix_fmt);
+            hb_error("hb_qsv_attach_surface_to_video_buffer: unsupported texture_format=%d", job->input_pix_fmt);
             return -1;
         }
         hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_QSV_POOL_SURFACE_SIZE, &mid, &surface);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -158,6 +158,16 @@ static hb_triplet_t hb_qsv_h265_levels[] =
     { NULL,                            },
 };
 
+static const enum AVPixelFormat hb_qsv_pix_fmts[] =
+{
+    AV_PIX_FMT_NV12, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+};
+
+static const enum AVPixelFormat hb_qsv_10bit_pix_fmts[] =
+{
+    AV_PIX_FMT_P010LE, AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+};
+
 #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
 
 // check available Intel Media SDK version against a minimum
@@ -2209,6 +2219,21 @@ const char* const* hb_qsv_level_get_names(int encoder)
         default:
             return NULL;
     }
+}
+
+const int* hb_qsv_get_pix_fmts(int encoder)
+{
+    switch (encoder)
+    {
+        case HB_VCODEC_QSV_H264:
+        case HB_VCODEC_QSV_H265:
+            return hb_qsv_pix_fmts;
+        case HB_VCODEC_QSV_H265_10BIT:
+            return hb_qsv_10bit_pix_fmts;
+
+         default:
+             return hb_qsv_pix_fmts;
+     }
 }
 
 const char* hb_qsv_video_quality_get_name(uint32_t codec)

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -158,6 +158,7 @@ static hb_triplet_t hb_qsv_h265_levels[] =
     { NULL,                            },
 };
 
+#if defined(_WIN32) || defined(__MINGW32__)
 static const enum AVPixelFormat hb_qsv_pix_fmts[] =
 {
     AV_PIX_FMT_NV12, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
@@ -167,6 +168,17 @@ static const enum AVPixelFormat hb_qsv_10bit_pix_fmts[] =
 {
     AV_PIX_FMT_P010LE, AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
 };
+#else
+static const enum AVPixelFormat hb_qsv_pix_fmts[] =
+{
+    AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+};
+
+static const enum AVPixelFormat hb_qsv_10bit_pix_fmts[] =
+{
+    AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+};
+#endif
 
 #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
 

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -371,7 +371,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
     {
         if (buf == NULL)
         {
-            buf = hb_frame_buffer_init(stream->common->job->pix_fmt,
+            buf = hb_frame_buffer_init(stream->common->job->input_pix_fmt,
                                    stream->common->job->title->geometry.width,
                                    stream->common->job->title->geometry.height);
             uint8_t *planes[4];
@@ -381,7 +381,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
                 planes[i] = buf->plane[i].data;
                 linesizes[i] = buf->plane[i].stride;
             }
-            av_image_fill_black(planes, linesizes, stream->common->job->pix_fmt,
+            av_image_fill_black(planes, linesizes, stream->common->job->input_pix_fmt,
                                 stream->common->job->color_range, buf->f.width, buf->f.height);
             buf->f.color_prim = stream->common->job->title->color_prim;
             buf->f.color_transfer = stream->common->job->title->color_transfer;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -444,13 +444,13 @@ void hb_display_job_info(hb_job_t *job)
 #if HB_PROJECT_FEATURE_QSV
     if (hb_qsv_decode_is_enabled(job))
     {
-        hb_log("   + decoder: %s %d-bit",
-               hb_qsv_decode_get_codec_name(title->video_codec_param), hb_get_bit_depth(job->pix_fmt));
+        hb_log("   + decoder: %s %d-bit (%s)",
+               hb_qsv_decode_get_codec_name(title->video_codec_param), hb_get_bit_depth(job->pix_fmt), av_get_pix_fmt_name(job->pix_fmt));
     }
     else
 #endif
     {
-        hb_log("   + decoder: %s %d-bit", title->video_codec_name, hb_get_bit_depth(job->pix_fmt));
+        hb_log("   + decoder: %s %d-bit (%s)", title->video_codec_name, hb_get_bit_depth(job->pix_fmt), av_get_pix_fmt_name(job->pix_fmt));
     }
 
     if( title->video_bitrate )

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1345,7 +1345,7 @@ static void sanitize_filter_list(hb_job_t *job, hb_geometry_t src_geo)
         const int *encoder_pix_fmts = hb_video_encoder_get_pix_fmts(job->vcodec);
         int encoder_pix_fmt = *encoder_pix_fmts;
 
-#if defined(_WIN32) || defined(__MINGW32__)
+#if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
         if (!hb_qsv_full_path_is_enabled(job))
         {
             // Formats supported by QSV pipeline via system memory

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1338,6 +1338,8 @@ static void sanitize_filter_list(hb_job_t *job, hb_geometry_t src_geo)
         }
     }
 
+    // Some encoders require a specific input pixel format
+    // that could be different from the current pipeline format.
     const int *encoder_pix_fmts = hb_video_encoder_get_pix_fmts(job->vcodec);
     const int encoder_pix_fmt = *encoder_pix_fmts;
 


### PR DESCRIPTION
Tries to simplify the pixel format selection, QSV changes are untested.
Removed the matrix selection code because all the buffer are already color tagged.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux