### PR TITLE
contrib: Added libspeexdsp dependency required since speex 1.2.0

### DIFF
--- a/contrib/libspeex/module.defs
+++ b/contrib/libspeex/module.defs
@@ -1,3 +1,5 @@
+__deps__ := LIBSPEEXDSP LIBOGG
+
 $(eval $(call import.MODULE.defs,LIBSPEEX,libspeex,LIBOGG))
 $(eval $(call import.CONTRIB.defs,LIBSPEEX))
 

--- a/contrib/libspeexdsp/module.defs
+++ b/contrib/libspeexdsp/module.defs
@@ -1,0 +1,8 @@
+__deps__ := LIBOGG
+
+$(eval $(call import.MODULE.defs,LIBSPEEXDSP,libspeexdsp,LIBOGG))
+$(eval $(call import.CONTRIB.defs,LIBSPEEXDSP))
+
+LIBSPEEXDSP.FETCH.url       = https://ftp.osuosl.org/pub/xiph/releases/speex/speexdsp-1.2.0.tar.gz
+LIBSPEEXDSP.FETCH.sha256    = 682042fc6f9bee6294ec453f470dadc26c6ff29b9c9e9ad2ffc1f4312fd64771
+LIBSPEEXDSP.EXTRACT.tarbase = speexdsp-1.2.0

--- a/contrib/libspeexdsp/module.rules
+++ b/contrib/libspeexdsp/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBSPEEXDSP))
+$(eval $(call import.CONTRIB.rules,LIBSPEEXDSP))

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -23,6 +23,7 @@ ifneq (,$(filter $(HOST.system),darwin cygwin mingw))
     MODULES += contrib/libvorbis
     MODULES += contrib/libopus
     MODULES += contrib/libspeex
+    MODULES += contrib/libspeexdsp
     MODULES += contrib/libtheora
     MODULES += contrib/lame
     MODULES += contrib/x264


### PR DESCRIPTION
**Description of Change:**

Fix for issue #3480

Xiph developers [split the DSP encoder in libspeex into its own library, libspeexdsp](https://gitlab.xiph.org/xiph/speexdsp/-/commit/5e4e3a2285b3ea8264129d2658335c4bc27d1645). Starting with libspeex 1.2.0, the contrib list in HandBrake will require this additional library to properly build libhb with Speex support.

This PR adds the new dependency and also adds libogg as a dep for both libspeex and libspeexdsp as this missing dep caused build failures when building with many threads (e.g. libogg wasn't installed yet when libspeex was built).

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
