### PR TITLE
WinGui: Fixing typos on OldOperatingSystem string

### DIFF
--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2463,7 +2463,7 @@ Fields are limited to:
   <data name="OldOperatingSystem" xml:space="preserve">
     <value>Please be aware that HandBrake is no longer supported on any version of Windows 7 or Windows 8.
 
-While you can continue using the applicaiton at your own risk, please be aware that certain freatures are non-functional and there may be other unknown issues. There is no support available when these issues occur. 
+While you can continue using the application at your own risk, please be aware that certain features are non-functional and there may be other unknown issues. There is no support available when these issues occur. 
 
 Support for Windows 7 and 8 was deprecated in the 1.3 series. This means there will be no further updates to correct issues on these platforms. 
 


### PR DESCRIPTION
Hello,

This PR relates to issue #3491 and fixes two typos on `OldOperatingSystem `string recently added:

> While you can continue using the **applicaiton** at your own risk, please be aware that certain **freatures** are non-functional and there may be other unknown issues.

If this isn't the right way to proceed, feel free to close this request.

Thanks,
Patriccollu.