### PR TITLE
Fixed issue where HandBrakeEncoderHelpers threw exceptions after falling back to no hardware mode.

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeUtils.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeUtils.cs
@@ -42,7 +42,9 @@ namespace HandBrake.Interop.Interop
         /// </summary>
         private static bool globalInitialized;
 
-        private static bool initSuccess = false;
+        /// <summary>
+        /// True if we initialized without hardware support.
+        /// </summary>
         private static bool initNoHardware = false;
 
         /// <summary>
@@ -65,6 +67,7 @@ namespace HandBrake.Interop.Interop
         {
             if (!globalInitialized)
             {
+                bool initSuccess;
                 try
                 {
                     if (initNoHardwareMode)
@@ -94,6 +97,8 @@ namespace HandBrake.Interop.Interop
                     {
                         throw new InvalidOperationException("HB global init failed.");
                     }
+
+                    initNoHardware = true;
                 }
 
                 globalInitialized = true;
@@ -346,11 +351,19 @@ namespace HandBrake.Interop.Interop
             ErrorLogged?.Invoke(null, new MessageLoggedEventArgs(message));
         }
 
+        /// <summary>
+        /// Returns true if we have successfully run global initialization.
+        /// </summary>
+        /// <returns>True if we have successfully run global initialization.</returns>
         public static bool IsInitialised()
         {
-            return initSuccess;
+            return globalInitialized;
         }
 
+        /// <summary>
+        /// Returns true if we initialized without hardware support.
+        /// </summary>
+        /// <returns>True if we initialized without hardware support.</returns>
         public static bool IsInitNoHardware()
         {
             return initNoHardware;


### PR DESCRIPTION
It was checking initSuccess which had not been set to true. Changed initSuccess to a local variable and changed to check globalInitialized instead.
Also properly set initNoHardware flag when we do auto fallback to no hardware mode.