### PR TITLE
 Fix access to remote shares with gvfs 1.48

### DIFF
--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -12,6 +12,7 @@
         "--filesystem=host",
         "--filesystem=xdg-run/dconf",
         "--filesystem=xdg-run/gvfs",
+        "--filesystem=xdg-run/gvfsd",
         "--filesystem=~/.config/dconf:ro",
         "--talk-name=ca.desrt.dconf",
         "--talk-name=org.gtk.vfs.*",


### PR DESCRIPTION
The reason for the changes are explained in: https://gitlab.gnome.org/GNOME/gvfs/-/issues/515#note_919326


**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this. fixes #3509 
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

**Description of Change:**
gvfs 1.48 has made a change to improve sandboxed performance when trying to access network shares. The reason for the changes are explained in: https://gitlab.gnome.org/GNOME/gvfs/-/issues/515#note_919326 and the upshot is we need to add "--filesystem=xdg-run/gvfsd", to the flatpak manifest. This does that.

For more context - there's a flathub wide tracker bug to update all developers on this before the change becomes widespread https://github.com/flathub/flathub/issues/2180

**Test on:**
Tested on the latest fedora 34 beta.