### PR TITLE
qsv: fix platform message

### DIFF
--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2857,7 +2857,6 @@ int hb_qsv_get_platform(int adapter_index)
             return qsv_map_mfx_platform_codename(info->Platform.CodeName);
         }
     }
-    hb_error("qsv: hb_qsv_get_platform incorrect qsv device index %d", adapter_index);
     return HB_CPU_PLATFORM_UNSPECIFIED;
 }
 

--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -255,7 +255,7 @@ namespace HandBrakeWPF.Services.Encode.Factories
             
             video.Options = job.ExtraAdvancedArguments;
 
-            if (HandBrakeHardwareEncoderHelper.QsvHardwareGeneration > 6 && (job.VideoEncoder == VideoEncoder.QuickSync || job.VideoEncoder == VideoEncoder.QuickSyncH265 || job.VideoEncoder == VideoEncoder.QuickSyncH26510b))
+            if (HandBrakeHardwareEncoderHelper.IsQsvAvailable && (HandBrakeHardwareEncoderHelper.QsvHardwareGeneration > 6) && (job.VideoEncoder == VideoEncoder.QuickSync || job.VideoEncoder == VideoEncoder.QuickSyncH265 || job.VideoEncoder == VideoEncoder.QuickSyncH26510b))
             {
                 if (configuration.EnableQsvLowPower && !video.Options.Contains("lowpower"))
                 {


### PR DESCRIPTION
HandBrakeHardwareEncoderHelper.QsvHardwareGeneration calls hb_qsv_get_platform. Need to make sure that QSV is available. 
Fix https://github.com/HandBrake/HandBrake/issues/3500