### PR TITLE
qsv: multiple fixes

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -962,7 +962,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
     if (pv->qsv.decode &&
         pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_VIDEO_MEMORY)
     {
-        out = hb_qsv_copy_frame(pv->job, pv->frame, 0);
+        out = hb_qsv_copy_avframe_to_video_buffer(pv->job, pv->frame, 0);
     }
     else
 #endif

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -2252,19 +2252,18 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
     {
 #if HB_PROJECT_FEATURE_QSV
         QSVMid *mid = NULL;
-        if(in->qsv_details.frame)
+        if (in->qsv_details.frame && in->qsv_details.frame->data[3])
         {
             surface = ((mfxFrameSurface1*)in->qsv_details.frame->data[3]);
             frames_ctx = in->qsv_details.qsv_frames_ctx;
             hb_qsv_get_mid_by_surface_from_pool(frames_ctx, surface, &mid);
+            hb_qsv_replace_surface_mid(frames_ctx, mid, surface);
         }
         else
         {
-            // Create black buffer in the beginning of the encoding, usually first 2 frames
-            hb_qsv_get_free_surface_from_pool_with_range(pv->job->qsv.ctx->hb_dec_qsv_frames_ctx, HB_QSV_POOL_SURFACE_SIZE - HB_QSV_POOL_ENCODER_SIZE, HB_QSV_POOL_SURFACE_SIZE, &mid, &surface);
-            frames_ctx = pv->job->qsv.ctx->hb_dec_qsv_frames_ctx;
+            hb_error("encqsv: in->qsv_details no surface available");
+            goto fail;
         }
-        hb_qsv_replace_surface_mid(frames_ctx, mid, surface);
 #endif
         // At this point, enc_qsv takes ownership of the QSV resources
         // in the 'in' buffer.

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -239,7 +239,9 @@ int hb_create_ffmpeg_pool(hb_job_t *job, int coded_width, int coded_height, enum
 int hb_qsv_hw_filters_are_enabled(hb_job_t *job);
 int hb_qsv_full_path_is_enabled(hb_job_t *job);
 AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref);
-hb_buffer_t* hb_qsv_copy_frame(hb_job_t *job, AVFrame *frame, int is_vpp);
+int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int is_vpp);
+int hb_qsv_copy_video_buffer_to_video_buffer(hb_job_t *job, hb_buffer_t* in, hb_buffer_t* out, int is_vpp);
+hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, int is_vpp);
 int hb_qsv_get_free_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, AVFrame* frame, QSVMid** out_mid);
 void hb_qsv_get_free_surface_from_pool_with_range(HBQSVFramesContext* hb_enc_qsv_frames_ctx, const int start_index, const int end_index, QSVMid** out_mid, mfxFrameSurface1** out_surface);
 int hb_qsv_get_mid_by_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, mfxFrameSurface1 *surface, QSVMid **out_mid);

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -228,6 +228,7 @@ uint8_t     hb_qsv_frametype_xlat(uint16_t qsv_frametype, uint16_t *out_flags);
 
 const char* hb_qsv_impl_get_name(int impl);
 const char* hb_qsv_impl_get_via_name(int impl);
+mfxIMPL     hb_qsv_dx_index_to_impl(int dx_index);
 
 /* Full QSV pipeline helpers */
 int hb_qsv_is_enabled(hb_job_t *job);
@@ -252,7 +253,6 @@ enum AVPixelFormat hb_qsv_get_format(AVCodecContext *s, const enum AVPixelFormat
 int hb_qsv_preset_is_zero_copy_enabled(const hb_dict_t *job_dict);
 void hb_qsv_uninit_dec(AVCodecContext *s);
 void hb_qsv_uninit_enc(hb_job_t *job);
-mfxIMPL hb_qsv_dx_index_to_impl(int dx_index);
 int hb_qsv_parse_adapter_index(hb_job_t *job);
 int hb_qsv_setup_job(hb_job_t *job);
 int hb_qsv_decode_h264_is_supported(int adapter_index);

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -212,7 +212,6 @@ typedef struct QSVFrame {
 
 #define HB_QSV_POOL_FFMPEG_SURFACE_SIZE (64)
 #define HB_QSV_POOL_SURFACE_SIZE (64)
-#define HB_QSV_POOL_ENCODER_SIZE (8)
 
 typedef struct HBQSVFramesContext {
     AVBufferRef *hw_frames_ctx;
@@ -341,6 +340,10 @@ typedef struct hb_qsv_context {
     AVBufferRef *hb_hw_device_ctx;
     HBQSVFramesContext *hb_dec_qsv_frames_ctx;
     HBQSVFramesContext *hb_vpp_qsv_frames_ctx;
+
+    mfxHDL device_manager_handle;
+    mfxHandleType device_manager_handle_type;
+    void *device_context;
 } hb_qsv_context;
 
 typedef enum {

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -317,7 +317,7 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
 #if HB_PROJECT_FEATURE_QSV
         if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
-            buf = hb_qsv_copy_frame(graph->job, graph->frame, 1);
+            buf = hb_qsv_copy_avframe_to_video_buffer(graph->job, graph->frame, 1);
             hb_avframe_set_video_buffer_flags(buf, graph->frame, graph->out_time_base);
         }
         else


### PR DESCRIPTION
* Fix green frames in the beginning of the stream https://github.com/HandBrake/HandBrake/issues/3520 when AVSync is enabled
  Video memory requires explicit surface copy
* Fix encqsvInit: MFXVideoENCODE_Init failed (-15) issue on Linux due to incorrect hw implementation

  