### PR TITLE
contrib: update libdvdread.

### DIFF
--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
-LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdvdread-6.1.1.tar.bz2
-LIBDVDREAD.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdread/6.1.1/libdvdread-6.1.1.tar.bz2
-LIBDVDREAD.FETCH.sha256  = 3e357309a17c5be3731385b9eabda6b7e3fa010f46022a06f104553bf8e21796
+LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdvdread-6.1.2.tar.bz2
+LIBDVDREAD.FETCH.url    += https://download.videolan.org/pub/videolan/libdvdread/6.1.2/libdvdread-6.1.2.tar.bz2
+LIBDVDREAD.FETCH.sha256  = cc190f553758ced7571859e301f802cb4821f164d02bfacfd320c14a4e0da763
 
 ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
     LIBDVDREAD.CONFIGURE.extra = --enable-dlfcn


### PR DESCRIPTION
Should fix Win32 Unicode paths opening, and maybe #127

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux