### PR TITLE
CLI: Replace anamorphic loose with auto

### DIFF
--- a/libhb/handbrake/preset_builtin.h
+++ b/libhb/handbrake/preset_builtin.h
@@ -9099,7 +9099,7 @@ const char hb_builtin_presets_json[] =
 "                    \"PictureLeftCrop\": 0,\n"
 "                    \"PictureLooseCrop\": false,\n"
 "                    \"PictureModulus\": 2,\n"
-"                    \"PicturePAR\": \"loose\",\n"
+"                    \"PicturePAR\": \"auto\",\n"
 "                    \"PicturePARHeight\": 720,\n"
 "                    \"PicturePARWidth\": 853,\n"
 "                    \"PictureRightCrop\": 0,\n"

--- a/preset/preset_cli_default.json
+++ b/preset/preset_cli_default.json
@@ -74,7 +74,7 @@
                     "PictureKeepRatio": true,
                     "PictureLooseCrop": false,
                     "PictureModulus": 2,
-                    "PicturePAR": "loose",
+                    "PicturePAR": "auto",
                     "PicturePARWidth": 853,
                     "PicturePARHeight": 720,
                     "PictureRotate": "angle=0:hflip=0",


### PR DESCRIPTION
Although loose is still supported in libhb, it's deprecated.
