### PR TITLE
WinGui: Fix several fields from presets not being properly applied

### DIFF
--- a/win/CS/HandBrakeWPF/Services/Encode/Model/EncodeTask.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Model/EncodeTask.cs
@@ -148,6 +148,7 @@ namespace HandBrakeWPF.Services.Encode.Model
             this.IPod5GSupport = task.IPod5GSupport;
             this.OutputFormat = task.OutputFormat;
             this.OptimizeMP4 = task.OptimizeMP4;
+            this.AlignAVStart = task.AlignAVStart;
 
             /* Other */
             this.MetaData = new MetaData(task.MetaData);

--- a/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
@@ -988,6 +988,10 @@ namespace HandBrakeWPF.ViewModels
                                          ?? VideoTune.None;
                     }
                 }
+                else if (preset.Task.VideoEncoder == VideoEncoder.VP8 || preset.Task.VideoEncoder == VideoEncoder.VP9)
+                {
+                    this.VideoPresetValue = preset.Task.VideoPreset != null ? this.VideoPresets.IndexOf(preset.Task.VideoPreset) : 0;
+                }
             }
 
             this.ExtraArguments = preset.Task.ExtraAdvancedArguments;
@@ -1515,19 +1519,14 @@ namespace HandBrakeWPF.ViewModels
             this.NotifyOfPropertyChange(() => this.IsTwoPassEnabled);
             this.NotifyOfPropertyChange(() => this.DisplayTwoPass);
 
-            // Handle some quicksync specific options.
-            if (selectedEncoder == VideoEncoder.QuickSync || selectedEncoder == VideoEncoder.QuickSyncH265 || selectedEncoder == VideoEncoder.QuickSyncH26510b)
-            {
-                this.TwoPass = false;
-                this.TurboFirstPass = false;
-                this.SelectedFramerate = null;
-            }
-
             if (selectedEncoder == VideoEncoder.NvencH264 || selectedEncoder == VideoEncoder.NvencH265 
                                                           || selectedEncoder == VideoEncoder.VceH264 
                                                           || selectedEncoder == VideoEncoder.VceH265
                                                           || selectedEncoder == VideoEncoder.MFH264
-                                                          || selectedEncoder == VideoEncoder.MFH265)
+                                                          || selectedEncoder == VideoEncoder.MFH265
+                                                          || selectedEncoder == VideoEncoder.QuickSync
+                                                          || selectedEncoder == VideoEncoder.QuickSyncH265
+                                                          || selectedEncoder == VideoEncoder.QuickSyncH26510b)
             {
                 this.TwoPass = false;
                 this.TurboFirstPass = false;


### PR DESCRIPTION
**Description of Change:**

Fixes the following issues found with the Preset system:

- When `EncodeTask` was rearranged/organized, it appears that the AlignAVStart field was [inadvertently removed](https://github.com/HandBrake/HandBrake/commit/ac0f91c4482d772d4ea1798182d1c9933e25de77#diff-004793ae5c85e8ead2a4a79f2cda61a07419d923890c14b3eebec5ee70344297L71) from being set in the constructor.
- For QuickSync encoders only, the framerate was being forcibly reset to `null`/Same As Source. It used to also set Constant Framerate as well, but that [was removed](https://github.com/HandBrake/HandBrake/commit/4f6165e1e9a00f73008a90f7135e66a0a7a2926b) while leaving the FPS reset intact. Removing that should fix #3645 
- The video encoder preset (fast, medium, slow) was not being read from the HB preset for VP8/9 encoders

