### PR TITLE
Fix trivial source typos and whitespace 

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1349,7 +1349,7 @@ dvd_device_changed_cb(GtkComboBoxText *combo, signal_user_data_t *ud)
 
         dialog = GHB_WIDGET(ud->builder, "source_dialog");
         device = gtk_combo_box_text_get_active_text(combo);
-        // Protext against unexpected NULL return value
+        // Protects against unexpected NULL return value
         if (device != NULL)
         {
             name = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(dialog));
@@ -5395,7 +5395,7 @@ easter_egg_cb(
 
             case 3:
             {
-                // Its a tripple left mouse button click
+                // It's a triple left mouse button click
                 GtkWidget *widget;
                 widget = GHB_WIDGET(ud->builder, "allow_tweaks");
                 gtk_widget_show(widget);

--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -344,7 +344,7 @@ int decavsubWork( hb_avsub_context_t * ctx,
         if (usedBytes == 0)
         {
             // We expect avcodec_decode_subtitle2 to return the number
-            // of bytes consumed, or an error.  If for some unforseen reason
+            // of bytes consumed, or an error.  If for some unforeseen reason
             // it returns 0, lets not get stuck in an infinite loop!
             usedBytes = ctx->pkt->size;
         }

--- a/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Language.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Language.cs
@@ -65,7 +65,7 @@ namespace HandBrake.Interop.Interop.Interfaces.Model
         }
 
         /// <summary>
-        /// Returns the display string for this langauge.
+        /// Returns the display string for this language.
         /// </summary>
         /// <returns>The display string for this language.</returns>
         public override string ToString()


### PR DESCRIPTION
Found via `codespell -q 3 -S ./gtk/po,*.svg`