### PR TITLE
Removed the code from CopyTo that prevented files and directories fro…

### DIFF
--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Source.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Source.cs
@@ -73,13 +73,10 @@ namespace HandBrakeWPF.Services.Scan.Model
                         this.SourceName = item.VolumeLabel;
                     }
                 }
-
-                // Otherwise, it may be a path of files.
-                if (string.IsNullOrEmpty(this.SourceName))
-                {
-                    this.SourceName = Path.GetFileName(this.ScanPath);
-                }
             }
+
+            source.SourceName = this.SourceName;
+
         }
     }
 }


### PR DESCRIPTION
Removed the code from CopyTo that prevented files and directories from using the {source} tag correctly and corrected an error where SourceName was not copied to the new object.


**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
Removed the code that was causing the SourceName to return the directory when the input was a file or directory.  The code that was removed was setting the SourceName to the directory and the file name was not being used for the {source} tag.  Also corrected (and submitted as a single file this time) the correction for the SourceName not being properly set for the CopyTo.




**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
