### PR TITLE
build: link DiskArbitration framework for libbluray

### DIFF
--- a/test/module.defs
+++ b/test/module.defs
@@ -62,7 +62,7 @@ endif
 TEST.GCC.I += $(LIBHB.GCC.I)
 
 ifeq ($(HOST.system),darwin)
-    TEST.GCC.f += IOKit CoreServices CoreText CoreGraphics AudioToolbox VideoToolbox CoreMedia CoreVideo Foundation
+    TEST.GCC.f += IOKit CoreServices CoreText CoreGraphics AudioToolbox VideoToolbox CoreMedia CoreVideo Foundation DiskArbitration
     TEST.GCC.l += iconv
 else ifeq ($(HOST.system),linux)
     TEST.GCC.l += pthread dl m


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

The change adds missing linker flag for `DiskArbitration` framework to fix `disable-xcode`-configured macOS build.

This fixes issue seen in Homebrew where `handbrake` formula build failed for v1.4.0 (https://github.com/Homebrew/homebrew-core/pull/81482) and v1.4.1 (https://github.com/Homebrew/homebrew-core/pull/83421).

The issue was due to missing `DiskArbitration` framework link, which is used by `libbluray`.


**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+ _(Specifically, Homebrew CI on 10.14, 10.15, 11.0, and 11.0+M1)_
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**

Build failure seen on Homebrew CI:
```make
/usr/local/Homebrew/Library/Homebrew/shims/mac/super/clang++ -pipe -Wl,-S -fmessage-length=0 -Wall -arch x86_64 -g0 -O3 -mfpmath=sse -msse2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -I./libhb/ -I./contrib/include -I./contrib/include/libxml2 -o HandBrakeCLI test/parsecsv.o test/test.o ./libhb/libhandbrake.a -framework IOKit -framework CoreServices -framework CoreText -framework CoreGraphics -framework AudioToolbox -framework VideoToolbox -framework CoreMedia -framework CoreVideo -framework Foundation -L./contrib/lib -lass -lavformat -lavfilter -lavcodec -lavutil -lswresample -lpostproc -lmp3lame -ldvdnav -ldvdread -lfribidi -lswscale -lvpx -ltheoraenc -ltheoradec -lvorbis -lvorbisenc -logg -lx264 -lbluray -lfreetype -lxml2 -lbz2 -lz -ljansson -lharfbuzz -lopus -lspeex -llzma -ldav1d -lturbojpeg -lzimg -lx265 -liconv
Undefined symbols for architecture x86_64:
  "_DADiskCopyDescription", referenced from:
      _mount_get_mountpoint in libbluray.a(libbluray_la-mount_darwin.o)
  "_DADiskCreateFromBSDName", referenced from:
      _mount_get_mountpoint in libbluray.a(libbluray_la-mount_darwin.o)
  "_DASessionCreate", referenced from:
      _mount_get_mountpoint in libbluray.a(libbluray_la-mount_darwin.o)
  "_kDADiskDescriptionVolumePathKey", referenced from:
      _mount_get_mountpoint in libbluray.a(libbluray_la-mount_darwin.o)
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [HandBrakeCLI] Error 1
```