### PR TITLE
qsv: fix 10bit HDR HW decode

### DIFF
--- a/contrib/ffmpeg/A27-qsv-fix-decode-10bit-hdr.patch
+++ b/contrib/ffmpeg/A27-qsv-fix-decode-10bit-hdr.patch
@@ -1,0 +1,28 @@
+diff --git a/libavcodec/hevc_mp4toannexb_bsf.c b/libavcodec/hevc_mp4toannexb_bsf.c
+index 790dfb0394..3b3732bbd0 100644
+--- a/libavcodec/hevc_mp4toannexb_bsf.c
++++ b/libavcodec/hevc_mp4toannexb_bsf.c
+@@ -121,7 +121,7 @@ static int hevc_mp4toannexb_filter(AVBSFContext *ctx, AVPacket *out)
+     HEVCBSFContext *s = ctx->priv_data;
+     AVPacket *in;
+     GetByteContext gb;
+-
++    int has_sps = 0, has_pps = 0;
+     int got_irap = 0;
+     int i, ret = 0;
+ 
+@@ -155,10 +155,13 @@ static int hevc_mp4toannexb_filter(AVBSFContext *ctx, AVPacket *out)
+         }
+ 
+         nalu_type = (bytestream2_peek_byte(&gb) >> 1) & 0x3f;
++        has_sps = (has_sps || nalu_type == HEVC_NAL_SPS);
++        has_pps = (has_pps || nalu_type == HEVC_NAL_PPS);
+ 
+         /* prepend extradata to IRAP frames */
+         is_irap       = nalu_type >= 16 && nalu_type <= 23;
+-        add_extradata = is_irap && !got_irap;
++        /* ignore the extradata if IRAP frame has sps and pps */
++        add_extradata = is_irap && !got_irap && !(has_sps && has_pps);
+         extra_size    = add_extradata * ctx->par_out->extradata_size;
+         got_irap     |= is_irap;
+ 


### PR DESCRIPTION
Ignore VPS, SPS, PPS extra data for IRAP frame as not needed for out AVPacket. Patch for FFMPEG master will be sent later. 
Fixed https://github.com/HandBrake/HandBrake/issues/3787.

UPD: Increase robustness for decoder: hevc_qsv 10-bit (p010le) and video memory as output
UPD2:  Patch for FFMPEG master is under review  https://patchwork.ffmpeg.org/project/ffmpeg/patch/20210910040948.14186-1-haihao.xiang@intel.com/