### PR TITLE
libhb: passhtru chroma location info.

### DIFF
--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -338,10 +338,11 @@ static int chroma_smooth_work_thread(hb_filter_object_t *filter,
     }
 
     out = hb_frame_buffer_init(in->f.fmt, in->f.width, in->f.height);
-    out->f.color_prim     = pv->output.color_prim;
-    out->f.color_transfer = pv->output.color_transfer;
-    out->f.color_matrix   = pv->output.color_matrix;
-    out->f.color_range    = pv->output.color_range ;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
 
     int c;
     for (c = 0; c < 3; c++)

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3935,12 +3935,13 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->pass_id    = HB_PASS_ENCODE;
     job->vrate      = title->vrate;
 
-    job->input_pix_fmt  = AV_PIX_FMT_YUV420P;
-    job->output_pix_fmt = AV_PIX_FMT_YUV420P;
-    job->color_prim     = title->color_prim;
-    job->color_transfer = title->color_transfer;
-    job->color_matrix   = title->color_matrix;
-    job->color_range    = title->color_range;
+    job->input_pix_fmt   = AV_PIX_FMT_YUV420P;
+    job->output_pix_fmt  = AV_PIX_FMT_YUV420P;
+    job->color_prim      = title->color_prim;
+    job->color_transfer  = title->color_transfer;
+    job->color_matrix    = title->color_matrix;
+    job->color_range     = title->color_range;
+    job->chroma_location = title->chroma_location;
     job->color_prim_override     = HB_COLR_PRI_UNDEF;
     job->color_transfer_override = HB_COLR_TRA_UNDEF;
     job->color_matrix_override   = HB_COLR_MAT_UNDEF;

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -2157,7 +2157,8 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
     info->color_transfer = get_color_transfer(pv->context->color_trc);
     info->color_matrix   = get_color_matrix(pv->context->colorspace,
                                             info->geometry);
-    info->color_range    = pv->context->color_range;
+    info->color_range     = pv->context->color_range;
+    info->chroma_location = pv->context->chroma_sample_location;
 
     info->video_decode_support = HB_DECODE_SUPPORT_SW;
 

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -1254,10 +1254,11 @@ static void process_frame( hb_filter_private_t * pv )
             buf = hb_frame_buffer_init(pv->ref[1]->f.fmt,
                                        pv->ref[1]->f.width,
                                        pv->ref[1]->f.height);
-            buf->f.color_prim     = pv->output.color_prim;
-            buf->f.color_transfer = pv->output.color_transfer;
-            buf->f.color_matrix   = pv->output.color_matrix;
-            buf->f.color_range    = pv->output.color_range ;
+            buf->f.color_prim      = pv->output.color_prim;
+            buf->f.color_transfer  = pv->output.color_transfer;
+            buf->f.color_matrix    = pv->output.color_matrix;
+            buf->f.color_range     = pv->output.color_range;
+            buf->f.chroma_location = pv->output.chroma_location;
             yadif_filter(pv, buf, parity, tff);
 
             /* Copy buffered settings to output buffer settings */

--- a/libhb/denoise.c
+++ b/libhb/denoise.c
@@ -319,11 +319,11 @@ static int hb_denoise_work( hb_filter_object_t * filter,
     }
 
     out = hb_frame_buffer_init(pv->output.pix_fmt, in->f.width, in->f.height);
-    out->f.color_prim     = pv->output.color_prim;
-    out->f.color_transfer = pv->output.color_transfer;
-    out->f.color_matrix   = pv->output.color_matrix;
-    out->f.color_range    = pv->output.color_range ;
-
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
 
     if( !pv->hqdn3d_line )
     {

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1032,10 +1032,11 @@ static int hb_detelecine_work( hb_filter_object_t * filter,
     }
 
     out = hb_frame_buffer_init(pv->output.pix_fmt, in->f.width, in->f.height);
-    out->f.color_prim     = pv->output.color_prim;
-    out->f.color_transfer = pv->output.color_transfer;
-    out->f.color_matrix   = pv->output.color_matrix;
-    out->f.color_range    = pv->output.color_range ;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
 
     /* Copy pullup frame buffer into output buffer */
     memcpy( out->plane[0].data, frame->buffer->planes[0], frame->buffer->size[0] );

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -881,6 +881,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     context->color_primaries = hb_output_color_prim(job);
     context->color_trc       = hb_output_color_transfer(job);
     context->colorspace      = hb_output_color_matrix(job);
+    context->chroma_sample_location = job->chroma_location;
 
     if (!job->inline_parameter_sets)
     {

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -387,11 +387,14 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
     param.i_keyint_max = 10 * param.i_keyint_min;
     param.i_log_level  = X264_LOG_INFO;
 
-    /* set up the VUI color model & gamma to match what the COLR atom
-     * set in muxmp4.c says. See libhb/muxmp4.c for notes. */
+    /* set up the VUI color model & gamma */
     param.vui.i_colorprim = hb_output_color_prim(job);
     param.vui.i_transfer  = hb_output_color_transfer(job);
     param.vui.i_colmatrix = hb_output_color_matrix(job);
+    if (job->chroma_location != AVCHROMA_LOC_UNSPECIFIED)
+    {
+        param.vui.i_chroma_loc = job->chroma_location - 1;
+    }
 
     /* place job->encoder_options in an hb_dict_t for convenience */
     hb_dict_t * x264_opts = NULL;
@@ -428,6 +431,7 @@ int encx264Init( hb_work_object_t * w, hb_job_t * job )
     job->color_prim_override     = param.vui.i_colorprim;
     job->color_transfer_override = param.vui.i_transfer;
     job->color_matrix_override   = param.vui.i_colmatrix;
+    job->chroma_location         = param.vui.i_chroma_loc + 1;
 
     /* For 25 fps sources, HandBrake's explicit keyints will match the x264 defaults:
      * min-keyint 25 (same as auto), keyint 250. */

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -618,6 +618,7 @@ struct hb_job_s
     int             color_transfer;
     int             color_matrix;
     int             color_range;
+    int             chroma_location;
 
     int             color_prim_override;
     int             color_transfer_override;
@@ -1130,6 +1131,7 @@ struct hb_title_s
     int             color_transfer;
     int             color_matrix;
     int             color_range;
+    int             chroma_location;
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t     coll;
     hb_rational_t   vrate;
@@ -1241,6 +1243,7 @@ typedef struct hb_work_info_s
             int           color_transfer;
             int           color_matrix;
             int           color_range;
+            int           chroma_location;
             int           video_decode_support;
         };
         struct
@@ -1342,6 +1345,7 @@ typedef struct hb_filter_init_s
     int             color_transfer;
     int             color_matrix;
     int             color_range;
+    int             chroma_location;
     hb_geometry_t   geometry;
     int             crop[4];
     hb_rational_t   vrate;

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -125,6 +125,7 @@ struct hb_image_format_s
     int           color_transfer;
     int           color_matrix;
     int           color_range;
+    int           chroma_location;
     int           max_plane;
     int           window_width;
     int           window_height;

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -594,10 +594,11 @@ hb_buffer_t * hb_read_preview(hb_handle_t * h, hb_title_t *title, int preview, i
     hb_buffer_t * buf;
     buf = hb_frame_buffer_init(AV_PIX_FMT_YUV420P,
                                title->geometry.width, title->geometry.height);
-    buf->f.color_prim     = title->color_prim;
-    buf->f.color_transfer = title->color_transfer;
-    buf->f.color_matrix   = title->color_matrix;
-    buf->f.color_range    = AVCOL_RANGE_MPEG;
+    buf->f.color_prim      = title->color_prim;
+    buf->f.color_transfer  = title->color_transfer;
+    buf->f.color_matrix    = title->color_matrix;
+    buf->f.color_range     = AVCOL_RANGE_MPEG;
+    buf->f.chroma_location = title->chroma_location;
 
     if (!buf)
     {
@@ -889,6 +890,7 @@ hb_image_t * hb_get_preview3(hb_handle_t * h, int picture,
     init.color_prim = title->color_prim;
     init.color_transfer = title->color_transfer;
     init.color_matrix = title->color_matrix;
+    init.chroma_location = title->chroma_location;
     init.geometry = title->geometry;
     memset(init.crop, 0, sizeof(int[4]));
     init.vrate = job->vrate;

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -235,8 +235,8 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
         "s:{s:o, s:o, s:{s:o, s:o}},"
         // Crop[Top, Bottom, Left, Right]}
         "s:[oooo],"
-        // Color {Format, Range, Primary, Transfer, Matrix}
-        "s:{s:o, s:o, s:o, s:o, s:o},"
+        // Color {Format, Range, Primary, Transfer, Matrix, ChromaLocation}
+        "s:{s:o, s:o, s:o, s:o, s:o, s:o},"
         // FrameRate {Num, Den}
         "s:{s:o, s:o},"
         // InterlaceDetected, VideoCodec
@@ -271,6 +271,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
         "Primary",          hb_value_int(title->color_prim),
         "Transfer",         hb_value_int(title->color_transfer),
         "Matrix",           hb_value_int(title->color_matrix),
+        "ChromaLocation",   hb_value_int(title->chroma_location),
     "FrameRate",
         "Num",              hb_value_int(title->vrate.num),
         "Den",              hb_value_int(title->vrate.den),
@@ -632,6 +633,8 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
                 hb_value_int(job->color_transfer));
     hb_dict_set(video_dict, "ColorMatrix",
                 hb_value_int(job->color_matrix));
+    hb_dict_set(video_dict, "ChromaLocation",
+                hb_value_int(job->chroma_location));
     if (job->color_prim_override != HB_COLR_PRI_UNDEF)
     {
         hb_dict_set(video_dict, "ColorPrimariesOverride",
@@ -1018,7 +1021,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     // Video {Codec, Quality, Bitrate, Preset, Tune, Profile, Level, Options
     //       TwoPass, Turbo,
     //       ColorInputFormat, ColorOutputFormat, ColorRange,
-    //       ColorPrimaries, ColorTransfer, ColorMatrix,
+    //       ColorPrimaries, ColorTransfer, ColorMatrix, ChromaLocation,
     //       Mastering,
     //       ContentLightLevel,
     //       ColorPrimariesOverride, ColorTransferOverride, ColorMatrixOverride,
@@ -1026,7 +1029,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
     "s:{s:o, s?F, s?i, s?s, s?s, s?s, s?s, s?s,"
     "   s?b, s?b,"
     "   s?i, s?i, s?i,"
-    "   s?i, s?i, s?i,"
+    "   s?i, s?i, s?i, s?i,"
     "   s?o,"
     "   s?o,"
     "   s?i, s?i, s?i,"
@@ -1078,6 +1081,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             "ColorPrimaries",       unpack_i(&job->color_prim),
             "ColorTransfer",        unpack_i(&job->color_transfer),
             "ColorMatrix",          unpack_i(&job->color_matrix),
+            "ChromaLocation",       unpack_i(&job->chroma_location),
             "Mastering",            unpack_o(&mastering_dict),
             "ContentLightLevel",    unpack_o(&coll_dict),
             "ColorPrimariesOverride", unpack_i(&job->color_prim_override),

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -43,6 +43,7 @@ void hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf)
     frame->color_trc       = hb_colr_tra_hb_to_ff(buf->f.color_transfer);
     frame->colorspace      = hb_colr_mat_hb_to_ff(buf->f.color_matrix);
     frame->color_range     = buf->f.color_range;
+    frame->chroma_location = buf->f.chroma_location;
 }
 
 void hb_avframe_set_video_buffer_flags(hb_buffer_t * buf, AVFrame *frame,
@@ -76,12 +77,13 @@ void hb_avframe_set_video_buffer_flags(hb_buffer_t * buf, AVFrame *frame,
     {
         buf->s.flags |= PIC_FLAG_REPEAT_FRAME;
     }
-    buf->s.frametype      = get_frame_type(frame->pict_type);
-    buf->f.fmt            = frame->format;
-    buf->f.color_prim     = hb_colr_pri_ff_to_hb(frame->color_primaries);
-    buf->f.color_transfer = hb_colr_tra_ff_to_hb(frame->color_trc);
-    buf->f.color_matrix   = hb_colr_mat_ff_to_hb(frame->colorspace);
-    buf->f.color_range    = frame->color_range;
+    buf->s.frametype       = get_frame_type(frame->pict_type);
+    buf->f.fmt             = frame->format;
+    buf->f.color_prim      = hb_colr_pri_ff_to_hb(frame->color_primaries);
+    buf->f.color_transfer  = hb_colr_tra_ff_to_hb(frame->color_trc);
+    buf->f.color_matrix    = hb_colr_mat_ff_to_hb(frame->colorspace);
+    buf->f.color_range     = frame->color_range;
+    buf->f.chroma_location = frame->chroma_location;
 }
 
 hb_buffer_t * hb_avframe_to_video_buffer(AVFrame *frame, AVRational time_base)

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -291,10 +291,11 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
 
     hb_frame_buffer_mirror_stride(in);
     out = hb_frame_buffer_init(pv->output.pix_fmt, in->f.width, in->f.height);
-    out->f.color_prim     = pv->output.color_prim;
-    out->f.color_transfer = pv->output.color_transfer;
-    out->f.color_matrix   = pv->output.color_matrix;
-    out->f.color_range    = pv->output.color_range ;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
 
     int c;
     for (c = 0; c < 3; c++)

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -488,6 +488,7 @@ static int avformatInit( hb_mux_object_t * m )
     track->st->codecpar->color_trc       = hb_output_color_transfer(job);
     track->st->codecpar->color_space     = hb_output_color_matrix(job);
     track->st->codecpar->color_range     = job->color_range;
+    track->st->codecpar->chroma_location = job->chroma_location;
 
     if (job->color_transfer == HB_COLR_TRA_SMPTEST2084)
     {

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -1104,11 +1104,11 @@ static void nlmeans_filter_thread(void *thread_args_v)
         hb_buffer_t *buf;
         buf = hb_frame_buffer_init(pv->output.pix_fmt,
                                    frame->width, frame->height);
-        buf->f.color_prim     = pv->output.color_prim;
-        buf->f.color_transfer = pv->output.color_transfer;
-        buf->f.color_matrix   = pv->output.color_matrix;
-        buf->f.color_range    = pv->output.color_range ;
-
+        buf->f.color_prim      = pv->output.color_prim;
+        buf->f.color_transfer  = pv->output.color_transfer;
+        buf->f.color_matrix    = pv->output.color_matrix;
+        buf->f.color_range     = pv->output.color_range;
+        buf->f.chroma_location = pv->output.chroma_location;
 
         NLMeansFunctions *functions = &pv->functions;
 
@@ -1241,10 +1241,11 @@ static hb_buffer_t * nlmeans_filter_flush(hb_filter_private_t *pv)
         hb_buffer_t *buf;
         buf = hb_frame_buffer_init(pv->output.pix_fmt,
                                    frame->width, frame->height);
-        buf->f.color_prim     = pv->output.color_prim;
-        buf->f.color_transfer = pv->output.color_transfer;
-        buf->f.color_matrix   = pv->output.color_matrix;
-        buf->f.color_range    = pv->output.color_range ;
+        buf->f.color_prim      = pv->output.color_prim;
+        buf->f.color_transfer  = pv->output.color_transfer;
+        buf->f.color_matrix    = pv->output.color_matrix;
+        buf->f.color_range     = pv->output.color_range;
+        buf->f.chroma_location = pv->output.chroma_location;
 
         NLMeansFunctions *functions = &pv->functions;
 

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1037,6 +1037,7 @@ skip_preview:
         title->color_transfer = vid_info.color_transfer;
         title->color_matrix = vid_info.color_matrix;
         title->color_range = vid_info.color_range;
+        title->chroma_location = vid_info.chroma_location;
 
         title->video_decode_support = vid_info.video_decode_support;
 
@@ -1084,13 +1085,14 @@ skip_preview:
         }
 
         hb_log( "scan: %d previews, %dx%d, %.3f fps, autocrop = %d/%d/%d/%d, "
-                "aspect %s, PAR %d:%d, color profile: %d-%d-%d",
+                "aspect %s, PAR %d:%d, color profile: %d-%d-%d, chroma location: %s",
                 npreviews, title->geometry.width, title->geometry.height,
                 (float)title->vrate.num / title->vrate.den,
                 title->crop[0], title->crop[1], title->crop[2], title->crop[3],
                 aspect_to_string(&title->dar),
                 title->geometry.par.num, title->geometry.par.den,
-                title->color_prim, title->color_transfer, title->color_matrix);
+                title->color_prim, title->color_transfer, title->color_matrix,
+                av_chroma_location_name(title->chroma_location));
 
         if (title->mastering.has_primaries || title->mastering.has_luminance)
         {

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -387,6 +387,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
             buf->f.color_transfer = stream->common->job->title->color_transfer;
             buf->f.color_matrix = stream->common->job->title->color_matrix;
             buf->f.color_range = stream->common->job->color_range;
+            buf->f.chroma_location = stream->common->job->chroma_location;
 #if HB_PROJECT_FEATURE_QSV
             if (hb_qsv_full_path_is_enabled(stream->common->job) && !hb_qsv_hw_filters_are_enabled(stream->common->job))
             {

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -326,10 +326,11 @@ static int unsharp_work_thread(hb_filter_object_t *filter,
     }
 
     out = hb_frame_buffer_init(pv->output.pix_fmt, in->f.width, in->f.height);
-    out->f.color_prim     = pv->output.color_prim;
-    out->f.color_transfer = pv->output.color_transfer;
-    out->f.color_matrix   = pv->output.color_matrix;
-    out->f.color_range    = pv->output.color_range ;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
 
     int c;
     for (c = 0; c < 3; c++)

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -616,6 +616,9 @@ void hb_display_job_info(hb_job_t *job)
 
         hb_log("     + color profile: %d-%d-%d",
                job->color_prim, job->color_transfer, job->color_matrix);
+        hb_log("     + chroma location: %s",
+               av_chroma_location_name(job->chroma_location));
+
 
         if (job->color_transfer == HB_COLR_TRA_SMPTEST2084)
         {
@@ -1461,11 +1464,12 @@ static void do_job(hb_job_t *job)
         init.time_base.den = 90000;
         init.job = job;
         init.pix_fmt = job->input_pix_fmt;
-        init.color_range = AVCOL_RANGE_MPEG;
 
         init.color_prim = title->color_prim;
         init.color_transfer = title->color_transfer;
         init.color_matrix = title->color_matrix;
+        init.color_range = AVCOL_RANGE_MPEG;
+        init.chroma_location = title->chroma_location;
         init.geometry = title->geometry;
         memset(init.crop, 0, sizeof(int[4]));
         init.vrate = job->vrate;
@@ -1491,6 +1495,7 @@ static void do_job(hb_job_t *job)
         job->color_transfer = init.color_transfer;
         job->color_matrix = init.color_matrix;
         job->color_range = init.color_range;
+        job->chroma_location = init.chroma_location;
         job->width = init.geometry.width;
         job->height = init.geometry.height;
         // job->par is supplied by the frontend.


### PR DESCRIPTION
Read the chroma location info and pass it to the encoder and muxer. HDR Bluray uses topleft instead of the usual left, passing the wrong value causes a slight shift in the chroma when rescaling or converting to rgb.

@galinart does qsv have a way to set this and the hdr10 mastering metadata?

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux