### PR TITLE
Add compiler options to enable native CPU compilation, LTO and to pas…

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -71,6 +71,10 @@ FFMPEG.CONFIGURE.extra += \
     --enable-small
 endif
 
+ifeq (on,$(GCC.lto))
+    FFMPEG.CONFIGURE.extra += --enable-lto
+endif
+
 ifneq (,$(filter $(FEATURE.qsv)-$(HOST.system),1-linux 1-freebsd))
     FFMPEG.CONFIGURE.extra += --enable-vaapi
     FFMPEG.CONFIGURE.extra += --disable-xlib

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -26,6 +26,12 @@ else
     endif
 endif
 
+ifeq (on,$(GCC.lto))
+    SVT-AV1.CONFIGURE.extra += -DSVT_AV1_LTO=ON
+else ifeq (off,$(GCC.lto))
+    SVT-AV1.CONFIGURE.extra += -DSVT_AV1_LTO=OFF
+endif
+
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))
         SVT-AV1.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON

--- a/contrib/x264/module.defs
+++ b/contrib/x264/module.defs
@@ -11,6 +11,10 @@ X264.CONFIGURE.shared =
 
 X264.CONFIGURE.extra += --disable-lavf --disable-ffms --disable-avs --disable-swscale --disable-gpac --disable-lsmash --disable-cli
 
+ifeq (on,$(GCC.lto))
+    X264.CONFIGURE.extra += --enable-lto
+endif
+
 ifeq (1,$(HOST.cross))
     X264.CONFIGURE.build  =
     ifneq ($(HOST.system),darwin)

--- a/contrib/x265_10bit/module.defs
+++ b/contrib/x265_10bit/module.defs
@@ -38,6 +38,13 @@ else
     endif
 endif
 
+ifeq (on,$(GCC.lto))
+    X265_10.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE
+else ifeq (thin,$(GCC.lto))
+    X265_10.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_LTO_THIN=TRUE
+else ifeq (off,$(GCC.lto))
+    X265_10.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=FALSE
+endif
 
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))

--- a/contrib/x265_12bit/module.defs
+++ b/contrib/x265_12bit/module.defs
@@ -38,6 +38,14 @@ else
     endif
 endif
 
+ifeq (on,$(GCC.lto))
+    X265_12.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE
+else ifeq (thin,$(GCC.lto))
+    X265_12.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_LTO_THIN=TRUE
+else ifeq (off,$(GCC.lto))
+    X265_12.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=FALSE
+endif
+
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))
         X265_12.CONFIGURE.extra += -DWIN32=ON

--- a/contrib/x265_8bit/module.defs
+++ b/contrib/x265_8bit/module.defs
@@ -35,6 +35,14 @@ else
     endif
 endif
 
+ifeq (on,$(GCC.lto))
+    X265_8.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE
+else ifeq (thin,$(GCC.lto))
+    X265_8.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_LTO_THIN=TRUE
+else ifeq (off,$(GCC.lto))
+    X265_8.CONFIGURE.extra += -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=FALSE
+endif
+
 X265_8.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(X265_8.CONFIGURE.host)"
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))

--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -42,12 +42,21 @@ MACOSX.map.O.speed           = 3
 MACOSX.map.cpu.none   = $(GCC.args.cpu.none)
 MACOSX.map.cpu.native = $(GCC.args.cpu.native)
 
+## mapping from symbolic lto value to llvm lto value
+MACOSX.map.lto.none   =
+MACOSX.map.lto.on     = YES
+MACOSX.map.lto.thin   = YES_THIN
+MACOSX.map.lto.off    = NO
+
 ## xcconfig: must be one of macosx/xcconfig/*.xcconfig
 MACOSX.xcconfig = $(foreach x,$(XCODE.xcconfig),-xcconfig $(MACOSX.src/)xcconfig/$(x))
 MACOSX.sdk      = $(foreach sdk,$(GCC.sysroot),-sdk $(sdk))
 
 ## extra CFLAGS: macro definitions
 MACOSX.extra_cflags = $(MACOSX.GCC.D) $(MACOSX.map.cpu.$(MACOSX.GCC.cpu))
+
+## link time optimization
+MACOSX.lto = $(MACOSX.map.lto.$(MACOSX.GCC.lto))
 
 ## launch a build through xcode; which in turn will do a nested make against
 ## this build system with normal build rules enabled.
@@ -76,6 +85,7 @@ MACOSX.XCODE = $(strip \
         EXTERNAL_VARS='$(-*-command-variables-*-)' \
         \
         OTHER_CFLAGS='$(strip $(MACOSX.extra_cflags))' \
+        LLVM_LTO='$(MACOSX.lto)' \
         \
         $(2) )
 

--- a/macosx/module.defs
+++ b/macosx/module.defs
@@ -38,12 +38,16 @@ MACOSX.map.O.size            = s
 MACOSX.map.O.size-aggressive = z
 MACOSX.map.O.speed           = 3
 
+## mapping from symbolic cpu target value to cflags
+MACOSX.map.cpu.none   = $(GCC.args.cpu.none)
+MACOSX.map.cpu.native = $(GCC.args.cpu.native)
+
 ## xcconfig: must be one of macosx/xcconfig/*.xcconfig
 MACOSX.xcconfig = $(foreach x,$(XCODE.xcconfig),-xcconfig $(MACOSX.src/)xcconfig/$(x))
 MACOSX.sdk      = $(foreach sdk,$(GCC.sysroot),-sdk $(sdk))
 
 ## extra CFLAGS: macro definitions
-MACOSX.extra_cflags = OTHER_CFLAGS='$(MACOSX.GCC.D)'
+MACOSX.extra_cflags = $(MACOSX.GCC.D) $(MACOSX.map.cpu.$(MACOSX.GCC.cpu))
 
 ## launch a build through xcode; which in turn will do a nested make against
 ## this build system with normal build rules enabled.
@@ -71,7 +75,7 @@ MACOSX.XCODE = $(strip \
         EXTERNAL_O='$(MACOSX.map.O.$(MACOSX.GCC.O))' \
         EXTERNAL_VARS='$(-*-command-variables-*-)' \
         \
-        $(MACOSX.extra_cflags) \
+        OTHER_CFLAGS='$(strip $(MACOSX.extra_cflags))' \
         \
         $(2) )
 

--- a/make/configure.py
+++ b/make/configure.py
@@ -1374,6 +1374,7 @@ def createCLI( cross = None ):
     optimizeMode.cli_add_argument( grp, '--optimize' )
     arch.mode.cli_add_argument( grp, '--arch' )
     cpuMode.cli_add_argument( grp, '--cpu' )
+    ltoMode.cli_add_argument( grp, '--lto' )
     grp.add_argument( '--cross', default=None, action='store', metavar='SPEC',
         help='specify GCC cross-compilation spec' )
     cli.add_argument_group( grp )
@@ -1703,6 +1704,7 @@ try:
         optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), default='speed' )
 
     cpuMode = SelectMode( 'cpu', ('none','none'), ('native','native') )
+    ltoMode = SelectMode( 'lto', ('none','none'), ('off','off'), ('on','on'), ('thin','thin') )
 
     # run host tuple and arch actions
     host_tuple = HostTupleAction(cross,arch_gcc,xcode_opts)
@@ -2114,6 +2116,7 @@ int main()
     doc.add( 'GCC.g', debugMode.mode )
     doc.add( 'GCC.O', optimizeMode.mode )
     doc.add( 'GCC.cpu', cpuMode.mode )
+    doc.add( 'GCC.lto', ltoMode.mode )
     doc.addBlank()
     doc.addMake( '## include definitions' )
     doc.addMake( 'include $(SRC/)make/include/main.defs' )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1373,6 +1373,7 @@ def createCLI( cross = None ):
     debugMode.cli_add_argument( grp, '--debug' )
     optimizeMode.cli_add_argument( grp, '--optimize' )
     arch.mode.cli_add_argument( grp, '--arch' )
+    cpuMode.cli_add_argument( grp, '--cpu' )
     grp.add_argument( '--cross', default=None, action='store', metavar='SPEC',
         help='specify GCC cross-compilation spec' )
     cli.add_argument_group( grp )
@@ -1700,6 +1701,8 @@ try:
         optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), ('size-aggressive','size-aggressive'), default='speed' )
     else:
         optimizeMode = SelectMode( 'optimize', ('none','none'), ('speed','speed'), ('size','size'), default='speed' )
+
+    cpuMode = SelectMode( 'cpu', ('none','none'), ('native','native') )
 
     # run host tuple and arch actions
     host_tuple = HostTupleAction(cross,arch_gcc,xcode_opts)
@@ -2106,10 +2109,11 @@ int main()
             doc.add( 'HAS.strerror_r', 1 )
 
     doc.addMake( '' )
-    doc.addMake( '## define debug mode and optimize before other includes' )
-    doc.addMake( '## since it is tested in some module.defs' )
+    doc.addMake( '## define these before other includes' )
+    doc.addMake( '## since they are tested in some module.defs' )
     doc.add( 'GCC.g', debugMode.mode )
     doc.add( 'GCC.O', optimizeMode.mode )
+    doc.add( 'GCC.cpu', cpuMode.mode )
     doc.addBlank()
     doc.addMake( '## include definitions' )
     doc.addMake( 'include $(SRC/)make/include/main.defs' )

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -113,15 +113,15 @@ define import.CONTRIB.defs
     ## debug=max or optimizations=none.  Otherwise, use the contribs defaults
     ifeq (max,$$($(1).GCC.g))
         ifeq (none,$$($(1).GCC.O))
-            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .O .cpu *D)"
-            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .O .cpu *D)"
+            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .O .cpu .lto *D)"
+            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .O .cpu .lto *D)"
         else
-            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .cpu *D)"
-            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .cpu *D)"
+            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .cpu .lto *D)"
+            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .cpu .lto *D)"
         endif
     else
-        $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .cpu *D)"
-        $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .cpu *D)"
+        $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .cpu .lto *D)"
+        $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .cpu .lto *D)"
     endif
     $(1).CONFIGURE.env.CPPFLAGS = CPPFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver *D)"
     $(1).CONFIGURE.env.LDFLAGS  = LDFLAGS="-L$$(call fn.ABSOLUTE,$(CONTRIB.build/))lib $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?extra.exe *D)"

--- a/make/include/contrib.defs
+++ b/make/include/contrib.defs
@@ -113,15 +113,15 @@ define import.CONTRIB.defs
     ## debug=max or optimizations=none.  Otherwise, use the contribs defaults
     ifeq (max,$$($(1).GCC.g))
         ifeq (none,$$($(1).GCC.O))
-            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .O *D)"
-            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .O *D)"
+            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .O .cpu *D)"
+            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .O .cpu *D)"
         else
-            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g *D)"
-            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g *D)"
+            $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .g .cpu *D)"
+            $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .g .cpu *D)"
         endif
     else
-        $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra *D)"
-        $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra *D)"
+        $(1).CONFIGURE.env.CFLAGS   = CFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?c_std ?extra .cpu *D)"
+        $(1).CONFIGURE.env.CXXFLAGS = CXXFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?cxx_std ?extra .cpu *D)"
     endif
     $(1).CONFIGURE.env.CPPFLAGS = CPPFLAGS="-I$$(call fn.ABSOLUTE,$(CONTRIB.build/))include $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver *D)"
     $(1).CONFIGURE.env.LDFLAGS  = LDFLAGS="-L$$(call fn.ABSOLUTE,$(CONTRIB.build/))lib $$(call fn.ARGS,$(1).GCC,*archs *sysroot *minver ?extra.exe *D)"

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -74,11 +74,11 @@ GCC.args.L                 = -L$(1)
 GCC.args.l                 = -l$(1)
 GCC.args.end               = -Wl,--end-group
 
+GCC.args.extra         =
 ifeq ($(HOST.machine),$(filter $(HOST.machine),i686 x86_64))
-    GCC.args.extra = $(CFLAGS) $(CPPFLAGS) -mfpmath=sse -msse2
-else
-    GCC.args.extra = $(CFLAGS) $(CPPFLAGS)
+    GCC.args.extra    += -mfpmath=sse -msse2
 endif
+GCC.args.extra        += $(CPPFLAGS) $(CFLAGS)
 GCC.args.extra.h_o     =
 GCC.args.extra.c_o     =
 GCC.args.extra.dylib   = $(LDFLAGS)

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -20,6 +20,9 @@ endif
 ifndef GCC.O
     GCC.O       = none
 endif
+ifndef GCC.cpu
+    GCC.cpu     = none
+endif
 GCC.D       =
 GCC.I       =
 GCC.muldefs = 0
@@ -64,6 +67,11 @@ GCC.args.O.none            = -O0
 GCC.args.O.size            = -Os
 GCC.args.O.size-aggressive = -Oz
 GCC.args.O.speed           = -O3
+GCC.args.cpu.none          =
+GCC.args.cpu.native        =
+ifeq ($(HOST.machine),$(filter $(HOST.machine),i686 x86_64))
+    GCC.args.cpu.native   += -march=native
+endif
 GCC.args.D                 = -D$(1)
 GCC.args.I                 = -I$(1)
 GCC.args.muldefs           = -Wl,--allow-multiple-definition
@@ -116,6 +124,7 @@ define import.GCC
     $(1).GCC.pic     = $$(GCC.pic)
     $(1).GCC.g       = $$(GCC.g)
     $(1).GCC.O       = $$(GCC.O)
+    $(1).GCC.cpu     = $$(GCC.cpu)
     $(1).GCC.D       = $$(GCC.D)
     $(1).GCC.I       = $$(GCC.I)
     $(1).GCC.muldefs = $$(GCC.muldefs)
@@ -157,6 +166,8 @@ define import.GCC
     $(1).GCC.args.O.none    = $$(GCC.args.O.none)
     $(1).GCC.args.O.size    = $$(GCC.args.O.size)
     $(1).GCC.args.O.speed   = $$(GCC.args.O.speed)
+    $(1).GCC.args.cpu.none  = $$(GCC.args.cpu.none)
+    $(1).GCC.args.cpu.native = $$(GCC.args.cpu.native)
     $(1).GCC.args.D         = $$(GCC.args.D)
     $(1).GCC.args.I         = $$(GCC.args.I)
     $(1).GCC.args.muldefs   = $$(GCC.args.muldefs)
@@ -183,19 +194,19 @@ define import.GCC
     $(1).GCC.o = -o $$(3)
 
     # FUNCTION: C precompiled headers
-    $(1).GCC.H_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.h_o *D *I !c !o
+    $(1).GCC.H_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.h_o .cpu *D *I !c !o
     $(1).GCC.H_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.H_O.args),$$(1),$$(2))
 
     # FUNCTION: C compile source
-    $(1).GCC.C_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.c_o *D *I !c !o
+    $(1).GCC.C_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.c_o .cpu *D *I !c !o
     $(1).GCC.C_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.C_O.args),$$(1),$$(2))
 
     # FUNCTION: C++ precompile headers
-    $(1).GCC.HPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.hpp_o *D *I !c !o
+    $(1).GCC.HPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.hpp_o .cpu *D *I !c !o
     $(1).GCC.HPP_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.HPP_O.args),$$(1),$$(2))
 
     # FUNCTION: C++ compile source
-    $(1).GCC.CPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.cpp_o *D *I !c !o
+    $(1).GCC.CPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.cpp_o .cpu *D *I !c !o
     $(1).GCC.CPP_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.CPP_O.args),$$(1),$$(2))
 
     ###########################################################################

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -23,6 +23,9 @@ endif
 ifndef GCC.cpu
     GCC.cpu     = none
 endif
+ifndef GCC.lto
+    GCC.lto     = none
+endif
 GCC.D       =
 GCC.I       =
 GCC.muldefs = 0
@@ -72,6 +75,10 @@ GCC.args.cpu.native        =
 ifeq ($(HOST.machine),$(filter $(HOST.machine),i686 x86_64))
     GCC.args.cpu.native   += -march=native
 endif
+GCC.args.lto.none          =
+GCC.args.lto.off           = -fno-lto
+GCC.args.lto.on            = -flto
+GCC.args.lto.thin          = -flto=thin
 GCC.args.D                 = -D$(1)
 GCC.args.I                 = -I$(1)
 GCC.args.muldefs           = -Wl,--allow-multiple-definition
@@ -125,6 +132,7 @@ define import.GCC
     $(1).GCC.g       = $$(GCC.g)
     $(1).GCC.O       = $$(GCC.O)
     $(1).GCC.cpu     = $$(GCC.cpu)
+    $(1).GCC.lto     = $$(GCC.lto)
     $(1).GCC.D       = $$(GCC.D)
     $(1).GCC.I       = $$(GCC.I)
     $(1).GCC.muldefs = $$(GCC.muldefs)
@@ -168,6 +176,10 @@ define import.GCC
     $(1).GCC.args.O.speed   = $$(GCC.args.O.speed)
     $(1).GCC.args.cpu.none  = $$(GCC.args.cpu.none)
     $(1).GCC.args.cpu.native = $$(GCC.args.cpu.native)
+    $(1).GCC.args.lto.none  = $$(GCC.args.lto.none)
+    $(1).GCC.args.lto.off   = $$(GCC.args.lto.off)
+    $(1).GCC.args.lto.on    = $$(GCC.args.lto.on)
+    $(1).GCC.args.lto.thin  = $$(GCC.args.lto.thin)
     $(1).GCC.args.D         = $$(GCC.args.D)
     $(1).GCC.args.I         = $$(GCC.args.I)
     $(1).GCC.args.muldefs   = $$(GCC.args.muldefs)
@@ -194,19 +206,19 @@ define import.GCC
     $(1).GCC.o = -o $$(3)
 
     # FUNCTION: C precompiled headers
-    $(1).GCC.H_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.h_o .cpu *D *I !c !o
+    $(1).GCC.H_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.h_o .cpu .lto *D *I !c !o
     $(1).GCC.H_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.H_O.args),$$(1),$$(2))
 
     # FUNCTION: C compile source
-    $(1).GCC.C_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.c_o .cpu *D *I !c !o
+    $(1).GCC.C_O.args = !gcc ?c_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.c_o .cpu .lto *D *I !c !o
     $(1).GCC.C_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.C_O.args),$$(1),$$(2))
 
     # FUNCTION: C++ precompile headers
-    $(1).GCC.HPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.hpp_o .cpu *D *I !c !o
+    $(1).GCC.HPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.hpp_o .cpu .lto *D *I !c !o
     $(1).GCC.HPP_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.HPP_O.args),$$(1),$$(2))
 
     # FUNCTION: C++ compile source
-    $(1).GCC.CPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.cpp_o .cpu *D *I !c !o
+    $(1).GCC.CPP_O.args = !gxx ?cxx_std ?pipe ?ML ?H *W *archs *sysroot *minver ?vis ?pic .g .O ?extra ?extra.cpp_o .cpu .lto *D *I !c !o
     $(1).GCC.CPP_O = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.CPP_O.args),$$(1),$$(2))
 
     ###########################################################################
@@ -214,18 +226,18 @@ define import.GCC
     $(1).GCC.i = $$(4)
 
     # FUNCTION: C link dynamic-lib
-    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
     $(1).GCC.DYLIB = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB.args),$$(1),$$(2))
 
     # FUNCTION: C link executable
-    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
     $(1).GCC.EXE = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE.args),$$(1),$$(2))
 
     # FUNCTION: C++ link dynamic-lib
-    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
     $(1).GCC.DYLIB++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB++.args),$$(1),$$(2))
 
     # FUNCTION: C++ link executable
-    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
     $(1).GCC.EXE++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE++.args),$$(1),$$(2))
 endef


### PR DESCRIPTION
…s extra CFLAGS


This patch is for #3663 and does the following:

1. It adds the compiler option `--native` which passes `-march=native` to the compiler to optimize for the CPU architecture HB is build on. This might only be useful for people who build there own HB, because the build might not run on other CPUs. Actually `-march=native` does not work for arch64 (Apple M1, Max/Pro), so for now I've made this only for i686 and x86_64 architectures. I don't know how it is for Windows and Linux. On Mac this gives me, depending on the encoder, 1-2% faster encoding.

2. It adds the compiler option `--lto` which will enable ThinLTO compilation. ThinLTO compilation is a new type of LTO that is both scalable and incremental. I've tested LTO and ThinLTO and ThinLTO had the benefit of faster compile time compared to LTO. In terms of application performance ThinLTO was comparable to LTO. 
This is only tested on Mac. I don't know if ThinLTO will work on Linux or Windows. If it does not, I would need to solve this with some ifdef. This needs to be tested. I also need to say, that I am unsure if -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=TRUE -DCMAKE_LTO_THIN=TRUE is working, because cache sets it to uninitialized. 

~3. It adds the compiler option `--extra-cflags` to pass own CFLAGS to the compiler. It can be used like `--extra-cflags="-someflag"`. For some reason it does not work with more then one flag, --extra-cflags="-flag1 -flag2". I don't know why. If someone knows why, please tell my. But it works to pass several flags separately (--extra-cflags="-flag1" --extra-cflags="-flag2"). For sure, the person who uses this option needs to know what he/she is doing. Some flags might break the build.
This might fix #2934.~ Omitted; see discussion

All options will enable the features for the libhb code, for the contrib code and for the macOS code. I've only tested this on Mac. I've tested x86_64 only and universal binary. 



**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ x] macOS 11.00
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
