### PR TITLE
contrib: remove set thread priority for x264 for better performance

### DIFF
--- a/contrib/x264/A01-threads-priority.patch
+++ b/contrib/x264/A01-threads-priority.patch
@@ -1,0 +1,13 @@
+diff --git a/encoder/encoder.c b/encoder/encoder.c
+index d4ddfa0c..3c827412 100644
+--- a/encoder/encoder.c
++++ b/encoder/encoder.c
+@@ -415,8 +415,6 @@ static int bitstream_check_buffer_filler( x264_t *h, int filler )
+ #if HAVE_THREAD
+ static void encoder_thread_init( x264_t *h )
+ {
+-    if( h->param.i_sync_lookahead )
+-        x264_lower_thread_priority( 10 );
+ }
+ #endif
+ 


### PR DESCRIPTION
Improve performance for Intel 12th-gen hybrid architecture on Windows 10.
No regressions were observed for older platforms.

Could be smoothly added for 1.4.x