### PR TITLE
contrib: update to FFmpeg 4.4.1.

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -12,9 +12,9 @@ endif
 $(eval $(call import.MODULE.defs,FFMPEG,ffmpeg,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FFMPEG))
 
-FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-4.4.tar.bz2
-FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-4.4.tar.bz2
-FFMPEG.FETCH.sha256 = 42093549751b582cf0f338a21a3664f52e0a9fbe0d238d3c992005e493607d0e
+FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-4.4.1.tar.bz2
+FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-4.4.1.tar.bz2
+FFMPEG.FETCH.sha256 = 8fc9f20ac5ed95115a9e285647add0eedd5cc1a98a039ada14c132452f98ac42
 
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =


### PR DESCRIPTION
Small fixes, but it's better to not fall too behind with all the FFmpeg patches we have.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux