### PR TITLE
[Mac] Make indentation for statistics and overview equal for de

### DIFF
--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -105,12 +105,21 @@ static HBMixdownTransformer    *mixdownTransformer;
 {
     if (!detailAttr)
     {
+        
+        CGFloat indent = 100;
+        NSBundle *bundle = [NSBundle bundleForClass:[HBJob class]];
+        NSString *currentLocalization = bundle.preferredLocalizations.firstObject;
+        if ([currentLocalization hasPrefix:@"de"])
+        {
+            indent = 120;
+        }
+        
         // Attributes
         NSMutableParagraphStyle *ps = [NSParagraphStyle.defaultParagraphStyle mutableCopy];
-        ps.headIndent = 100;
+        ps.headIndent = indent;
         ps.paragraphSpacing = 1.0;
-        ps.tabStops = @[[[NSTextTab alloc] initWithType:NSRightTabStopType location:98],
-                        [[NSTextTab alloc] initWithType:NSLeftTabStopType location:100]];
+        ps.tabStops = @[[[NSTextTab alloc] initWithType:NSRightTabStopType location:indent - 2],
+                        [[NSTextTab alloc] initWithType:NSLeftTabStopType location:indent]];
 
         detailAttr = @{NSFontAttributeName: [NSFont systemFontOfSize:NSFont.smallSystemFontSize],
                        NSParagraphStyleAttributeName: ps,


### PR DESCRIPTION
https://github.com/HandBrake/HandBrake/commit/a12d73a1b0a783a9b77e31190dc191528e0c01f7 changed the indentation in the statistics panel, but not for the overview. Therefore for German language it now looks like this.


![](https://user-images.githubusercontent.com/13453351/147360642-8ae1d166-290d-4258-b1aa-2bdab2c504cb.jpg)

If we do the same change for HBJob+UIAdditions.m as well, everything look aligned again.