### PR TITLE
Expose VideoEncoderSupportsTwoPass on HandBrakeEncoderHelpers.

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -262,6 +262,20 @@ namespace HandBrake.Interop.Interop
         }
 
         /// <summary>
+        /// Returns true if the given video encoder supports two-pass mode.
+        /// </summary>
+        /// <param name="encoderId">
+        /// The encoder ID.
+        /// </param>
+        /// <returns>
+        /// True if the given video encoder supports two-pass mode.
+        /// </returns>
+        public static bool VideoEncoderSupportsTwoPass(int encoderId)
+		{
+            return HBFunctions.hb_video_twopass_is_supported((uint)encoderId) > 0;
+		}
+
+        /// <summary>
         /// Returns true if the subtitle source type can be set to forced only.
         /// </summary>
         /// <param name="source">

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -150,6 +150,12 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_video_quality_get_name", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr hb_video_quality_get_name(uint codec);
 
+        [DllImport("hb", EntryPoint = "hb_video_twopass_is_supported", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_video_twopass_is_supported(uint codec);
+
+        [DllImport("hb", EntryPoint = "hb_video_encoder_is_supported", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_video_encoder_is_supported(int encoder);
+
         [DllImport("hb", EntryPoint = "hb_audio_quality_get_limits", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_audio_quality_get_limits(uint codec, ref float low, ref float high, ref float granularity, ref int direction);
 


### PR DESCRIPTION
Added `HandBrakeEncoderHelpers.VideoEncoderSupportsTwoPass()`, to take advantage of `hb_video_twopass_is_supported`: https://github.com/HandBrake/HandBrake/commit/6e2a48d67387fb257397f7ce63fd77bd1d647e4d