### PR TITLE
build: Require autoconf 2.71.0 on macOS in configure.py.

### DIFF
--- a/make/configure.py
+++ b/make/configure.py
@@ -1650,7 +1650,7 @@ try:
         else:
             gmake  = ToolProbe( 'GMAKE.exe',      'make',       'gmake', 'make', abort=True )
 
-        autoconf   = ToolProbe( 'AUTOCONF.exe',   'autoconf',   'autoconf', abort=True, minversion=[2,69,0] )
+        autoconf   = ToolProbe( 'AUTOCONF.exe',   'autoconf',   'autoconf', abort=True, minversion=([2,71,0] if build_tuple.match('*-*-darwin*') else [2,69,0]) )
         automake   = ToolProbe( 'AUTOMAKE.exe',   'automake',   'automake', abort=True, minversion=[1,13,0] )
         libtool    = ToolProbe( 'LIBTOOL.exe',    'libtool',    'libtool', abort=True )
         lipo       = ToolProbe( 'LIPO.exe',       'lipo',       'lipo', abort=False )


### PR DESCRIPTION
See https://github.com/HandBrake/HandBrake/commit/89118715002f42b610fcafed78a22b39a92fedd5.

@galad87 Please test and merge if this seems correct, should prevent breakage on systems with earlier autoconf by erroring out during the configure phase. 