### PR TITLE
Fix minor configure typo

### DIFF
--- a/configure
+++ b/configure
@@ -22,7 +22,7 @@ if ( inpath bash ); then
             break
         fi
     done
-    if [ pp != "" ]; then
+    if [ "$pp" != "" ]; then
         exec $pp `dirname $0`/make/configure.py "$@"
         exit 0
     else


### PR DESCRIPTION
This fixes the ability of the `./configure` wrapper script to detect Python.

Before:

    ./configure: 26: exec: ./make/configure.py: Permission denied

After:

    ERROR: no suitable version of python found.