### PR TITLE
FFmpeg deprecations fixes for FFmpeg >= 5

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -41,6 +41,7 @@
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
 #include "handbrake/hbavfilter.h"
+#include "libavcodec/bsf.h"
 #include "libavfilter/avfilter.h"
 #include "libavfilter/buffersrc.h"
 #include "libavfilter/buffersink.h"

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -8,6 +8,7 @@
  */
 
 #include <ogg/ogg.h>
+#include "libavcodec/bsf.h"
 #include "libavformat/avformat.h"
 #include "libavutil/avstring.h"
 #include "libavutil/intreadwrite.h"


### PR DESCRIPTION
avcodec.h stopped including bsf.h per FFmpeg commit
57b5ec6ba7df [1]. Fixes compilation error against
FFmpeg later than the mentioned commit.
[1] https://github.com/FFmpeg/FFmpeg/commit/57b5ec6ba7df442caebc401c4a7ef3ebc066b519

**Before Posting:**

- [x] Create an issue describing the change. https://github.com/HandBrake/HandBrake/issues/4105
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

**Description of Change:**
Fix build after upstream commit https://github.com/FFmpeg/FFmpeg/commit/57b5ec6ba7df442caebc401c4a7ef3ebc066b519. In the reported bug you've stated you're not insterested in supporting FFmpeg >= 5 (yet) but since only a minor include change is required I thought I'd at least let you know in form of this pull request. Feel free to just close it if not interested or save it for later.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] Build from source

**Screenshots (If relevant):**


**Log file output (If relevant):**
