### PR TITLE
Fix issue 4135

### DIFF
--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1456,26 +1456,11 @@ ghb_update_all_status(signal_user_data_t *ud, int status)
 static void
 save_queue_file(signal_user_data_t *ud)
 {
-    int ii, count;
-    GhbValue *queue = ghb_value_dup(ud->queue);
-
-    count = ghb_array_len(queue);
-    for (ii = 0; ii < count; ii++)
-    {
-        GhbValue *queueDict, *uiDict;
-
-        queueDict = ghb_array_get(ud->queue, ii);
-        uiDict = ghb_dict_get(queueDict, "uiSettings");
-        if (uiDict == NULL)
-            continue;
-        ghb_dict_set_int(uiDict, "job_status", GHB_QUEUE_PENDING);
-    }
-
     GtkWidget *dialog;
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new("Queue Destination",
+    dialog = gtk_file_chooser_dialog_new("Export Queue",
                       hb_window,
                       GTK_FILE_CHOOSER_ACTION_SAVE,
                       GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
@@ -1491,6 +1476,21 @@ save_queue_file(signal_user_data_t *ud)
 
     char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER (dialog));
     gtk_widget_destroy(dialog);
+
+    int ii, count;
+    GhbValue *queue = ghb_value_dup(ud->queue);
+
+    count = ghb_array_len(queue);
+    for (ii = 0; ii < count; ii++)
+    {
+        GhbValue *queueDict, *uiDict;
+
+        queueDict = ghb_array_get(queue, ii);
+        uiDict = ghb_dict_get(queueDict, "uiSettings");
+        if (uiDict == NULL)
+            continue;
+        ghb_dict_set_int(uiDict, "job_status", GHB_QUEUE_PENDING);
+    }
 
     ghb_write_settings_file(filename, queue);
     g_free (filename);
@@ -1610,7 +1610,7 @@ open_queue_file(signal_user_data_t *ud)
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new("Queue Destination",
+    dialog = gtk_file_chooser_dialog_new("Import Queue",
                       hb_window,
                       GTK_FILE_CHOOSER_ACTION_OPEN,
                       GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1460,7 +1460,7 @@ save_queue_file(signal_user_data_t *ud)
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new("Export Queue",
+    dialog = gtk_file_chooser_dialog_new(_("Export Queue"),
                       hb_window,
                       GTK_FILE_CHOOSER_ACTION_SAVE,
                       GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
@@ -1605,7 +1605,7 @@ open_queue_file(signal_user_data_t *ud)
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new("Import Queue",
+    dialog = gtk_file_chooser_dialog_new(_("Import Queue"),
                       hb_window,
                       GTK_FILE_CHOOSER_ACTION_OPEN,
                       GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1467,34 +1467,29 @@ save_queue_file(signal_user_data_t *ud)
                       GHB_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
                       NULL);
     gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "queue.json");
-    if (gtk_dialog_run(GTK_DIALOG (dialog)) != GTK_RESPONSE_ACCEPT)
+    if (gtk_dialog_run(GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
     {
+        char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER (dialog));
+ 
+        int ii, count;
+        GhbValue *queue = ghb_value_dup(ud->queue);
+        count = ghb_array_len(queue);
+        for (ii = 0; ii < count; ii++)
+        {
+            GhbValue *queueDict, *uiDict;
+
+            queueDict = ghb_array_get(queue, ii);
+            uiDict = ghb_dict_get(queueDict, "uiSettings");
+            if (uiDict == NULL)
+                continue;
+            ghb_dict_set_int(uiDict, "job_status", GHB_QUEUE_PENDING);
+        }
+
+        ghb_write_settings_file(filename, queue);
+        g_free (filename); 
         ghb_value_free(&queue);
-        gtk_widget_destroy(dialog);
-        return;
     }
-
-    char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER (dialog));
     gtk_widget_destroy(dialog);
-
-    int ii, count;
-    GhbValue *queue = ghb_value_dup(ud->queue);
-
-    count = ghb_array_len(queue);
-    for (ii = 0; ii < count; ii++)
-    {
-        GhbValue *queueDict, *uiDict;
-
-        queueDict = ghb_array_get(queue, ii);
-        uiDict = ghb_dict_get(queueDict, "uiSettings");
-        if (uiDict == NULL)
-            continue;
-        ghb_dict_set_int(uiDict, "job_status", GHB_QUEUE_PENDING);
-    }
-
-    ghb_write_settings_file(filename, queue);
-    g_free (filename);
-    ghb_value_free(&queue);
 }
 
 static void


### PR DESCRIPTION
This change addresses issue #4135 

Originally on line number 1467 the address of the original queue was mistakenly assigned instead of the duplicate created a few lines earlier, thereby allowing the existing queue to be modified.

In function save_queue_file()
Change:
         queueDict = ghb_array_get(ud->queue, ii);

to:
        queueDict = ghb_array_get(queue, ii);

and reorder operations to avoid unnecessary work should the file selection operation be canceled by the user. 

Also change the file GTK dialog title in save_queue_file() to "Export Queue" and in open_queue_file() to "Import Queue" to better align with the naming conventions used for other dialog windows in the GUI (Both functions originally used the title "Queue Destination")


**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**





**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
