### PR TITLE
libhb: Add Bwdif as a deinterlace filter

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -2468,8 +2468,8 @@ ghb_update_summary_info(signal_user_data_t *ud)
     g_free(text);
 
     // Filters
-    gboolean     detel, comb_detect, deint, decomb, deblock, nlmeans, denoise;
-    gboolean     unsharp, lapsharp, hflip, rot, gray, colorspace, chroma_smooth;
+    gboolean detel, comb_detect, yadif, decomb, deblock, nlmeans, denoise, bwdif;
+    gboolean unsharp, lapsharp, hflip, rot, gray, colorspace, chroma_smooth;
     const char * sval;
 
     sval        = ghb_dict_get_string(ud->settings, "PictureDetelecine");
@@ -2477,7 +2477,8 @@ ghb_update_summary_info(signal_user_data_t *ud)
     sval        = ghb_dict_get_string(ud->settings, "PictureCombDetectPreset");
     comb_detect = sval != NULL && !!strcasecmp(sval, "off");
     sval        = ghb_dict_get_string(ud->settings, "PictureDeinterlaceFilter");
-    deint       = sval != NULL && !strcasecmp(sval, "deinterlace");
+    yadif       = sval != NULL && !strcasecmp(sval, "deinterlace");
+    bwdif       = sval != NULL && !strcasecmp(sval, "bwdif");
     decomb      = sval != NULL && !strcasecmp(sval, "decomb");
     sval        = ghb_dict_get_string(ud->settings, "PictureDeblockPreset");
     deblock     = sval != NULL && !!strcasecmp(sval, "off");
@@ -2510,9 +2511,15 @@ ghb_update_summary_info(signal_user_data_t *ud)
         g_string_append_printf(str, "%s%s", sval, filter->name);
         sval = ", ";
     }
-    if (deint)
+    if (yadif)
     {
-        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_DEINTERLACE);
+        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_YADIF);
+        g_string_append_printf(str, "%s%s", sval, filter->name);
+        sval = ", ";
+    }
+    if (bwdif)
+    {
+        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_BWDIF);
         g_string_append_printf(str, "%s%s", sval, filter->name);
         sval = ", ";
     }

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -197,9 +197,10 @@ combo_opts_t vqual_granularity_opts =
 
 static options_map_t d_deint_opts[] =
 {
-    {N_("Off"),         "off",         HB_FILTER_INVALID    },
-    {N_("Decomb"),      "decomb",      HB_FILTER_DECOMB     },
-    {N_("Yadif"),       "deinterlace", HB_FILTER_DEINTERLACE},
+    {N_("Off"),         "off",         HB_FILTER_INVALID},
+    {N_("Decomb"),      "decomb",      HB_FILTER_DECOMB },
+    {N_("Yadif"),       "deinterlace", HB_FILTER_YADIF  },
+    {N_("Bwdif"),       "bwdif",       HB_FILTER_BWDIF  },
 };
 combo_opts_t deint_opts =
 {

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -446,16 +446,17 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
     g_free(rate_str);
 
     // Append Filters to video summary
-    gboolean     detel, comb_detect, deint, decomb, deblock, nlmeans, denoise;
-    gboolean     unsharp, lapsharp, hflip, rot, gray, colorspace, chroma_smooth;
+    gboolean detel, comb_detect, yadif, decomb, deblock, nlmeans, denoise, bwdif;
+    gboolean unsharp, lapsharp, hflip, rot, gray, colorspace, chroma_smooth;
 
     ctext       = ghb_dict_get_string(uiDict, "PictureDetelecine");
     detel       = ctext != NULL && !!strcasecmp(ctext, "off");
     ctext       = ghb_dict_get_string(uiDict, "PictureCombDetectPreset");
     comb_detect = ctext != NULL && !!strcasecmp(ctext, "off");
     ctext       = ghb_dict_get_string(uiDict, "PictureDeinterlaceFilter");
-    deint       = ctext != NULL && !strcasecmp(ctext, "deinterlace");
+    yadif       = ctext != NULL && !strcasecmp(ctext, "deinterlace");
     decomb      = ctext != NULL && !strcasecmp(ctext, "decomb");
+    bwdif       = ctext != NULL && !strcasecmp(ctext, "bwdif");
     ctext       = ghb_dict_get_string(uiDict, "PictureDeblockPreset");
     deblock     = ctext != NULL && !!strcasecmp(ctext, "off");
     ctext       = ghb_dict_get_string(uiDict, "PictureDenoiseFilter");
@@ -486,9 +487,15 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         g_string_append_printf(str, "%s%s", sep, filter->name);
         sep = ", ";
     }
-    if (deint)
+    if (yadif)
     {
-        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_DEINTERLACE);
+        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_YADIF);
+        g_string_append_printf(str, "%s%s", sep, filter->name);
+        sep = ", ";
+    }
+    if (bwdif)
+    {
+        hb_filter_object_t * filter = hb_filter_get(HB_FILTER_BWDIF);
         g_string_append_printf(str, "%s%s", sep, filter->name);
         sep = ", ";
     }

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4326,8 +4326,12 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             filter = &hb_filter_decomb;
             break;
 
-        case HB_FILTER_DEINTERLACE:
-            filter = &hb_filter_deinterlace;
+        case HB_FILTER_YADIF:
+            filter = &hb_filter_yadif;
+            break;
+
+        case HB_FILTER_BWDIF:
+            filter = &hb_filter_bwdif;
             break;
 
         case HB_FILTER_COLORSPACE:

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1418,7 +1418,8 @@ enum
     HB_FILTER_DETELECINE,
     HB_FILTER_COMB_DETECT,
     HB_FILTER_DECOMB,
-    HB_FILTER_DEINTERLACE,
+    HB_FILTER_YADIF,
+    HB_FILTER_BWDIF,
     HB_FILTER_VFR,
     // Filters that must operate on the original source image are next
     HB_FILTER_DEBLOCK,

--- a/libhb/handbrake/decomb.h
+++ b/libhb/handbrake/decomb.h
@@ -19,7 +19,7 @@
 
 #define MODE_YADIF_ENABLE       1
 #define MODE_YADIF_SPATIAL      2
-#define MODE_YADIF_BOB          4
+#define MODE_XXDIF_BOB          4
 #define MODE_DEINTERLACE_QSV    8
 
 #endif // HANDBRAKE_DECOMB_H

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -462,7 +462,8 @@ enum
 extern hb_filter_object_t hb_filter_detelecine;
 extern hb_filter_object_t hb_filter_comb_detect;
 extern hb_filter_object_t hb_filter_decomb;
-extern hb_filter_object_t hb_filter_deinterlace;
+extern hb_filter_object_t hb_filter_yadif;
+extern hb_filter_object_t hb_filter_bwdif;
 extern hb_filter_object_t hb_filter_vfr;
 extern hb_filter_object_t hb_filter_deblock;
 extern hb_filter_object_t hb_filter_denoise;

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -911,7 +911,7 @@ hb_image_t * hb_get_preview3(hb_handle_t * h, int picture,
             case HB_FILTER_COLORSPACE:
             case HB_FILTER_DECOMB:
             case HB_FILTER_DETELECINE:
-            case HB_FILTER_DEINTERLACE:
+            case HB_FILTER_YADIF:
             case HB_FILTER_GRAYSCALE:
                 break;
 
@@ -925,6 +925,7 @@ hb_image_t * hb_get_preview3(hb_handle_t * h, int picture,
             case HB_FILTER_DEBLOCK:
             case HB_FILTER_COMB_DETECT:
             case HB_FILTER_HQDN3D:
+            case HB_FILTER_BWDIF:
                 // Not implemented, N/A, or requires multiple frame input
                 hb_list_rem(list_filter, filter);
                 hb_filter_close(&filter);

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -339,7 +339,8 @@ void hb_avfilter_combine( hb_list_t * list)
         switch (filter->id)
         {
             case HB_FILTER_AVFILTER:
-            case HB_FILTER_DEINTERLACE:
+            case HB_FILTER_YADIF:
+            case HB_FILTER_BWDIF:
             case HB_FILTER_DEBLOCK:
             case HB_FILTER_CROP_SCALE:
             case HB_FILTER_PAD:

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -211,7 +211,7 @@ static hb_filter_param_t decomb_presets[] =
     { 0, NULL,          NULL,         NULL              }
 };
 
-static hb_filter_param_t deinterlace_presets[] =
+static hb_filter_param_t yadif_presets[] =
 {
     { 1, "Custom",             "custom",       NULL             },
     { 3, "Default",            "default",      "mode=3"         },
@@ -225,6 +225,14 @@ static hb_filter_param_t deinterlace_presets[] =
     { 3, "Slow",               "slow",         "mode=1"         },
     { 4, "Slower",             "slower",       "mode=3"         },
     { 7, "QSV",                "qsv",          "mode=3"         }
+};
+
+static hb_filter_param_t bwdif_presets[] =
+{
+    { 1, "Custom",             "custom",       NULL             },
+    { 3, "Default",            "default",      "mode=3"         },
+    { 2, "Bob",                "bob",          "mode=7"         },
+    { 0,  NULL,                NULL,           NULL             },
 };
 
 typedef struct
@@ -269,8 +277,11 @@ static filter_param_map_t param_map[] =
     { HB_FILTER_DECOMB,      decomb_presets,      NULL,
       sizeof(decomb_presets) / sizeof(hb_filter_param_t),      0, },
 
-    { HB_FILTER_DEINTERLACE, deinterlace_presets, NULL,
-      sizeof(deinterlace_presets) / sizeof(hb_filter_param_t), 0, },
+    { HB_FILTER_YADIF, yadif_presets, NULL,
+      sizeof(yadif_presets) / sizeof(hb_filter_param_t),       0, },
+
+    { HB_FILTER_BWDIF, bwdif_presets, NULL,
+      sizeof(bwdif_presets) / sizeof(hb_filter_param_t),       0, },
 
     { HB_FILTER_DEBLOCK, deblock_presets, deblock_tunes,
       sizeof(deblock_presets) / sizeof(hb_filter_param_t),
@@ -284,7 +295,7 @@ void hb_param_configure_qsv(void)
 #if HB_PROJECT_FEATURE_QSV
     if (!hb_qsv_available())
     {
-        memset(&deinterlace_presets[4], 0, sizeof(hb_filter_param_t));
+        memset(&yadif_presets[4], 0, sizeof(hb_filter_param_t));
     }
 #endif
 }
@@ -1273,7 +1284,8 @@ hb_generate_filter_settings(int filter_id, const char *preset, const char *tune,
         case HB_FILTER_DECOMB:
         case HB_FILTER_DETELECINE:
         case HB_FILTER_HQDN3D:
-        case HB_FILTER_DEINTERLACE:
+        case HB_FILTER_YADIF:
+        case HB_FILTER_BWDIF:
         case HB_FILTER_COLORSPACE:
             settings = generate_generic_settings(filter_id, preset,
                                                  tune, custom);

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1353,7 +1353,11 @@ int hb_preset_apply_filters(const hb_dict_t *preset, hb_dict_t *job_dict)
         }
         else if (!strcasecmp(deint_filter, "deinterlace"))
         {
-            filter_id = HB_FILTER_DEINTERLACE;
+            filter_id = HB_FILTER_YADIF;
+        }
+        else if (!strcasecmp(deint_filter, "bwdif"))
+        {
+            filter_id = HB_FILTER_BWDIF;
         }
         else
         {
@@ -2895,7 +2899,7 @@ static void import_filters_11_1_0(hb_value_t *preset)
         {
             if (strcasecmp(str, "deinterlace"))
             {
-                import_custom_11_1_0(preset, HB_FILTER_DEINTERLACE,
+                import_custom_11_1_0(preset, HB_FILTER_YADIF,
                                      "PictureDeinterlaceCustom");
             }
             else if (strcasecmp(str, "decomb"))
@@ -3217,7 +3221,7 @@ static void import_deint_0_0_0(hb_value_t *preset)
     {
         const char *s;
         int index = hb_value_get_int(val);
-        s = import_indexed_filter(HB_FILTER_DEINTERLACE, index);
+        s = import_indexed_filter(HB_FILTER_YADIF, index);
         if (s != NULL)
         {
             hb_dict_set(preset, "PictureDeinterlace", hb_value_string(s));

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4338,7 +4338,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
                     case HB_FILTER_CROP_SCALE:
                         break;
 
-                    case HB_FILTER_DEINTERLACE:
+                    case HB_FILTER_YADIF:
                     case HB_FILTER_ROTATE:
                     case HB_FILTER_RENDER_SUB:
                     case HB_FILTER_AVFILTER:

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1277,7 +1277,7 @@ static void sanitize_filter_list(hb_job_t *job, hb_geometry_t src_geo)
     // Add selective deinterlacing mode if comb detection is enabled
     if (hb_filter_find(list, HB_FILTER_COMB_DETECT) != NULL)
     {
-        int selective[] = {HB_FILTER_DECOMB, HB_FILTER_DEINTERLACE};
+        int selective[] = {HB_FILTER_DECOMB, HB_FILTER_YADIF, HB_FILTER_BWDIF};
         int ii, count = sizeof(selective) / sizeof(int);
 
         for (ii = 0; ii < count; ii++)

--- a/macosx/Base.lproj/HBFiltersViewController.xib
+++ b/macosx/Base.lproj/HBFiltersViewController.xib
@@ -142,7 +142,7 @@ Default: skip-left=1:skip-right=1:skip-top=4:skip-bottom=4:plane=0</string>
                     <rect key="frame" x="118" y="234" width="138" height="22"/>
                     <string key="toolTip">Deinterlace removes comb artifacts from the picture.
 
-Yadif is a popular and fast deinterlacer.
+Bwdif and Yadif are two popular and fast deinterlacers.
 
 Decomb switches between multiple interpolation algorithms for speed and quality.</string>
                     <constraints>
@@ -172,9 +172,9 @@ Decomb switches between multiple interpolation algorithms for speed and quality.
                     <rect key="frame" x="539" y="237" width="180" height="19"/>
                     <string key="toolTip">Custom Deinterlace parameters.
 
-Yadif syntax: mode=m:parity=p
+Bwdif and Yadif syntax: mode=m:parity=p
 
-Yadif default: mode=3
+Bwdif and Yadif default: mode=3
 
 Decomb syntax: mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
 

--- a/macosx/HBFilters+UIAdditions.h
+++ b/macosx/HBFilters+UIAdditions.h
@@ -18,7 +18,8 @@
 
 + (NSDictionary *)deinterlaceTypesDict;
 + (NSDictionary *)decombPresetsDict;
-+ (NSDictionary *)deinterlacePresetsDict;
++ (NSDictionary *)yadifPresetsDict;
++ (NSDictionary *)bwdifPresetsDict;
 
 + (NSDictionary *)denoisePresetDict;
 + (NSDictionary *)nlmeansTunesDict;

--- a/macosx/HBFilters+UIAdditions.m
+++ b/macosx/HBFilters+UIAdditions.m
@@ -132,8 +132,9 @@ static NSDictionary * filterParamsToNamesDict(hb_filter_param_t * (f)(int), int 
 {
     if (self = [super init])
     {
-        NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:[HBFilters deinterlacePresetsDict]];
+        NSMutableDictionary *dict = [NSMutableDictionary dictionaryWithDictionary:[HBFilters yadifPresetsDict]];
         [dict addEntriesFromDictionary:[HBFilters decombPresetsDict]];
+        [dict addEntriesFromDictionary:[HBFilters bwdifPresetsDict]];
         self.dict = [dict copy];
     }
 
@@ -280,7 +281,8 @@ static NSDictionary *combDetectionPresetsDict = nil;
 
 static NSDictionary *deinterlaceTypesDict = nil;
 static NSDictionary *decombPresetsDict = nil;
-static NSDictionary *deinterlacePresetsDict = nil;
+static NSDictionary *yadifPresetsDict = nil; 
+static NSDictionary *bwdifPresetsDict = nil;
 
 static NSDictionary *denoisePresetDict = nil;
 static NSDictionary *nlmeansTunesDict = nil;
@@ -327,14 +329,18 @@ static NSDictionary *colorspacePresetDict = nil;
     {
         deinterlaceTypesDict = @{HBKitLocalizedString(@"Off", @"HBFilters -> filter display name"):        @"off",
                                  HBKitLocalizedString(@"Yadif", @"HBFilters -> filter display name"):      @"deinterlace",
-                                 HBKitLocalizedString(@"Decomb", @"HBFilters -> filter display name"):     @"decomb"};;
+                                 HBKitLocalizedString(@"Decomb", @"HBFilters -> filter display name"):     @"decomb",
+                                 HBKitLocalizedString(@"Bwdif", @"HBFilters -> filter display name"):      @"bwdif"};;
     }
     return deinterlaceTypesDict;
 }
 
 - (NSArray *)deinterlaceTypes
 {
-    return @[HBKitLocalizedString(@"Off", @"HBFilters -> filter display name"), HBKitLocalizedString(@"Yadif", @"HBFilters -> filter display name"), HBKitLocalizedString(@"Decomb", @"HBFilters -> filter display name")];
+    return @[HBKitLocalizedString(@"Off", @"HBFilters -> filter display name"),
+             HBKitLocalizedString(@"Yadif", @"HBFilters -> filter display name"),
+             HBKitLocalizedString(@"Decomb", @"HBFilters -> filter display name"),
+             HBKitLocalizedString(@"Bwdif", @"HBFilters -> filter display name")];
 }
 
 + (NSDictionary *)decombPresetsDict
@@ -346,13 +352,22 @@ static NSDictionary *colorspacePresetDict = nil;
     return decombPresetsDict;
 }
 
-+ (NSDictionary *)deinterlacePresetsDict
++ (NSDictionary *)yadifPresetsDict
 {
-    if (!deinterlacePresetsDict)
+    if (!yadifPresetsDict)
     {
-        deinterlacePresetsDict = filterParamsToNamesDict(hb_filter_param_get_presets, HB_FILTER_DEINTERLACE);
+        yadifPresetsDict = filterParamsToNamesDict(hb_filter_param_get_presets, HB_FILTER_YADIF);
     }
-    return deinterlacePresetsDict;
+    return yadifPresetsDict;
+}
+
++ (NSDictionary *)bwdifPresetsDict
+{
+    if (!bwdifPresetsDict)
+    {
+        bwdifPresetsDict = filterParamsToNamesDict(hb_filter_param_get_presets, HB_FILTER_BWDIF);
+    }
+    return bwdifPresetsDict;
 }
 
 + (NSDictionary *)denoisePresetDict
@@ -478,7 +493,11 @@ static NSDictionary *colorspacePresetDict = nil;
 {
     if ([self.deinterlace isEqualToString:@"deinterlace"])
     {
-        return filterParamsToNamesArray(hb_filter_param_get_presets, HB_FILTER_DEINTERLACE);
+        return filterParamsToNamesArray(hb_filter_param_get_presets, HB_FILTER_YADIF);
+    }
+    else if ([self.deinterlace isEqualToString:@"bwdif"])
+    {
+        return filterParamsToNamesArray(hb_filter_param_get_presets, HB_FILTER_BWDIF);
     }
     else
     {

--- a/macosx/HBFilters.m
+++ b/macosx/HBFilters.m
@@ -70,8 +70,9 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
 #define UNSHARP_DEFAULT_PRESET       "medium"
 #define CHROMA_SMOOTH_DEFAULT_PRESET "medium"
 #define NLMEANS_DEFAULT_PRESET       "medium"
-#define DEINTERLACE_DEFAULT_PRESET   "default"
+#define YADIF_DEFAULT_PRESET         "default"
 #define DECOMB_DEFAULT_PRESET        "default"
+#define BWDIF_DEFAULT_PRESET         "default"
 #define DETELECINE_DEFAULT_PRESET    "default"
 #define COMB_DETECT_DEFAULT_PRESET   "default"
 #define HQDN3D_DEFAULT_PRESET        "medium"
@@ -112,8 +113,11 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
         case HB_FILTER_NLMEANS:
             preset = NLMEANS_DEFAULT_PRESET;
             break;
-        case HB_FILTER_DEINTERLACE:
-            preset = DEINTERLACE_DEFAULT_PRESET;
+        case HB_FILTER_YADIF:
+            preset = YADIF_DEFAULT_PRESET;
+            break;
+        case HB_FILTER_BWDIF:
+            preset = BWDIF_DEFAULT_PRESET;
             break;
         case HB_FILTER_DECOMB:
             preset = DECOMB_DEFAULT_PRESET;
@@ -135,7 +139,8 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
     }
     switch (filter_id)
     {
-        case HB_FILTER_DEINTERLACE:
+        case HB_FILTER_YADIF:
+        case HB_FILTER_BWDIF:
         case HB_FILTER_NLMEANS:
         case HB_FILTER_CHROMA_SMOOTH:
         case HB_FILTER_COLORSPACE:
@@ -353,7 +358,11 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
     int filter_id = HB_FILTER_DECOMB;
     if ([self.deinterlace isEqualToString:@"deinterlace"])
     {
-        filter_id = HB_FILTER_DEINTERLACE;
+        filter_id = HB_FILTER_YADIF;
+    }
+    else if ([self.deinterlace isEqualToString:@"bwdif"])
+    {
+        filter_id = HB_FILTER_BWDIF;
     }
 
     if (hb_validate_filter_preset(filter_id, self.deinterlacePreset.UTF8String, NULL, NULL))
@@ -391,7 +400,11 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
         int filter_id = HB_FILTER_DECOMB;
         if ([self.deinterlace isEqualToString:@"deinterlace"])
         {
-            filter_id = HB_FILTER_DEINTERLACE;
+            filter_id = HB_FILTER_YADIF;
+        }
+        else if ([self.deinterlace isEqualToString:@"bwdif"])
+        {
+            filter_id = HB_FILTER_BWDIF;
         }
         hb_dict_t *filter_dict = hb_generate_filter_settings(filter_id,
                                                              "custom",
@@ -403,7 +416,7 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
             retval = NO;
             if (outError)
             {
-                if (filter_id == HB_FILTER_DEINTERLACE)
+                if (filter_id == HB_FILTER_YADIF)
                 {
                     NSDictionary *userInfo = @{NSLocalizedDescriptionKey: HBKitLocalizedString(@"Invalid Yadif custom settings.",
                                                                                             @"HBFilters -> invalid Yadif custom string description"),
@@ -414,6 +427,13 @@ NSString * const HBFiltersChangedNotification = @"HBFiltersChangedNotification";
                 {
                     NSDictionary *userInfo = @{NSLocalizedDescriptionKey: HBKitLocalizedString(@"Invalid Decomb custom settings.",
                                                                                             @"HBFilters -> invalid Decomb custom string description"),
+                                               NSLocalizedRecoverySuggestionErrorKey: [self filterKeysDescription:filter_id]};
+                    *outError = [NSError errorWithDomain:@"HBFilterError" code:0 userInfo:userInfo];
+                }
+                else if (filter_id == HB_FILTER_BWDIF)
+                {
+                    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: HBKitLocalizedString(@"Invalid Bwdif custom settings.",
+                                                                                            @"HBFilters -> invalid Bwdif custom string description"),
                                                NSLocalizedRecoverySuggestionErrorKey: [self filterKeysDescription:filter_id]};
                     *outError = [NSError errorWithDomain:@"HBFilterError" code:0 userInfo:userInfo];
                 }

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -458,7 +458,11 @@
         int filter_id = HB_FILTER_DECOMB;
         if ([self.filters.deinterlace isEqualToString:@"deinterlace"])
         {
-            filter_id = HB_FILTER_DEINTERLACE;
+            filter_id = HB_FILTER_YADIF;
+        }
+        else if ([self.filters.deinterlace isEqualToString:@"bwdif"])
+        {
+            filter_id = HB_FILTER_BWDIF;
         }
 
         hb_dict_t *filter_dict = hb_generate_filter_settings(filter_id,

--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -338,7 +338,7 @@ static HBMixdownTransformer    *mixdownTransformer;
     }
     else if (![filters.deinterlace isEqualToString:@"off"])
     {
-        // Deinterlace or Decomb
+        // Deinterlace filters
         NSString *type =  [[[HBFilters deinterlaceTypesDict] allKeysForObject:filters.deinterlace] firstObject];
 
         if ([filters.deinterlacePreset isEqualToString:@"custom"])
@@ -353,7 +353,11 @@ static HBMixdownTransformer    *mixdownTransformer;
             }
             else if ([filters.deinterlace isEqualToString:@"deinterlace"])
             {
-                [summary appendFormat:@", %@ (%@)", type, [[[HBFilters deinterlacePresetsDict] allKeysForObject:filters.deinterlacePreset] firstObject]];
+                [summary appendFormat:@", %@ (%@)", type, [[[HBFilters yadifPresetsDict] allKeysForObject:filters.deinterlacePreset] firstObject]];
+            }
+            else if ([filters.deinterlace isEqualToString:@"bwdif"])
+            {
+                [summary appendFormat:@", %@ (%@)", type, [[[HBFilters bwdifPresetsDict] allKeysForObject:filters.deinterlacePreset] firstObject]];
             }
         }
     }
@@ -952,7 +956,7 @@ static HBMixdownTransformer    *mixdownTransformer;
     // Deinterlace
     if (![filters.deinterlace isEqualToString:@"off"])
     {
-        // Deinterlace or Decomb
+        // Deinterlace filters
         NSString *type = [[[HBFilters deinterlaceTypesDict] allKeysForObject:filters.deinterlace] firstObject];
         if (type)
         {

--- a/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
@@ -18,7 +18,8 @@ namespace HandBrake.Interop.Interop.HbLib
         HB_FILTER_DETELECINE,
         HB_FILTER_COMB_DETECT,
         HB_FILTER_DECOMB,
-        HB_FILTER_DEINTERLACE,
+        HB_FILTER_YADIF,
+        HB_FILTER_BWDIF,
         HB_FILTER_VFR,
         // Filters that must operate on the original source image are next
         HB_FILTER_DEBLOCK,

--- a/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
@@ -23,6 +23,9 @@ namespace HandBrakeWPF.Model.Filters
         Yadif = 1,
 
         [ShortName("Decomb")]
-        Decomb = 2
+        Decomb = 2,
+
+        [ShortName("Bwdif")]
+        Bwdif = 3,
     }
 }

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
@@ -367,16 +367,16 @@ HQDN3D default: y-spatial=3:cb-spatial=2:cr-spatial=2:y-temporal=2:cb-temporal=3
   <data name="FilterView_Deinterlace" xml:space="preserve">
     <value>Deinterlace removes comb artifacts from the picture.
 
-Yadif is a popular and fast deinterlacer.
+Bwdif and Yadif are two popular and fast deinterlacers.
 
 Decomb switches between multiple interpolation algorithms for speed and quality.</value>
   </data>
   <data name="FilterView_DeinterlaceCustom" xml:space="preserve">
     <value>Custom Deinterlace parameters.
  
- Yadif syntax: mode=m:parity=p
+ Bwdif and Yadif syntax: mode=m:parity=p
  
- Yadif default: mode=3
+ Bwdif and Yadif default: mode=3
  
  Decomb syntax: mode=m:magnitude-thresh=m:variance-thresh=v:laplacian-thresh=l:dilation-thresh=d:erosion-thresh=e:noise-thresh=n:search-distance=s:postproc=p:parity=p
  

--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -364,12 +364,12 @@ namespace HandBrakeWPF.Services.Encode.Factories
             // Deinterlace
             if (job.DeinterlaceFilter == DeinterlaceFilter.Yadif)
             {
-                string unparsedJson = HandBrakeFilterHelpers.GenerateFilterSettingJson((int)hb_filter_ids.HB_FILTER_DEINTERLACE, job.DeinterlacePreset?.ShortName, null, job.CustomDeinterlaceSettings);
+                string unparsedJson = HandBrakeFilterHelpers.GenerateFilterSettingJson((int)hb_filter_ids.HB_FILTER_YADIF, job.DeinterlacePreset?.ShortName, null, job.CustomDeinterlaceSettings);
                 if (!string.IsNullOrEmpty(unparsedJson))
                 {
                     JsonDocument root = JsonDocument.Parse(unparsedJson);
 
-                    Filter filterItem = new Filter { ID = (int)hb_filter_ids.HB_FILTER_DEINTERLACE, Settings = root };
+                    Filter filterItem = new Filter { ID = (int)hb_filter_ids.HB_FILTER_YADIF, Settings = root };
                     filter.FilterList.Add(filterItem);
                 }
             }
@@ -387,7 +387,20 @@ namespace HandBrakeWPF.Services.Encode.Factories
                 }
             }
 
-            if (job.DeinterlaceFilter == DeinterlaceFilter.Decomb || job.DeinterlaceFilter == DeinterlaceFilter.Yadif)
+            // Bwdif
+            if (job.DeinterlaceFilter == DeinterlaceFilter.Bwdif)
+            {
+                string unparsedJson = HandBrakeFilterHelpers.GenerateFilterSettingJson((int)hb_filter_ids.HB_FILTER_BWDIF, job.DeinterlacePreset?.ShortName, null, job.CustomDeinterlaceSettings);
+                if (!string.IsNullOrEmpty(unparsedJson))
+                {
+                    JsonDocument settings = JsonDocument.Parse(unparsedJson);
+
+                    Filter filterItem = new Filter { ID = (int)hb_filter_ids.HB_FILTER_BWDIF, Settings = settings };
+                    filter.FilterList.Add(filterItem);
+                }
+            }
+
+            if (job.DeinterlaceFilter == DeinterlaceFilter.Decomb || job.DeinterlaceFilter == DeinterlaceFilter.Yadif || job.DeinterlaceFilter == DeinterlaceFilter.Bwdif)
             {
                 if (job.CombDetect != CombDetect.Off)
                 {

--- a/win/CS/HandBrakeWPF/Services/Presets/Factories/JsonPresetFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Presets/Factories/JsonPresetFactory.cs
@@ -174,6 +174,9 @@ namespace HandBrakeWPF.Services.Presets.Factories
                 case "yadif":
                     preset.Task.DeinterlaceFilter = DeinterlaceFilter.Yadif;
                     break;
+                case "bwdif":
+                    preset.Task.DeinterlaceFilter = DeinterlaceFilter.Bwdif;
+                    break;
                 default:
                     preset.Task.DeinterlaceFilter = DeinterlaceFilter.Off;
                     break;
@@ -189,13 +192,21 @@ namespace HandBrakeWPF.Services.Presets.Factories
 
             if (preset.Task.DeinterlaceFilter == DeinterlaceFilter.Yadif)
             {
-                List<HBPresetTune> filterPresets = HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_DEINTERLACE);
+                List<HBPresetTune> filterPresets = HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_YADIF);
                 HBPresetTune presetTune = filterPresets.FirstOrDefault(f => f.ShortName == importedPreset.PictureDeinterlacePreset);
                 preset.Task.DeinterlacePreset = presetTune ?? new HBPresetTune("Default", "default");
                 preset.Task.CustomDeinterlaceSettings = importedPreset.PictureDeinterlaceCustom;
             }
 
-            if (preset.Task.DeinterlaceFilter == DeinterlaceFilter.Yadif || preset.Task.DeinterlaceFilter == DeinterlaceFilter.Decomb)
+            if (preset.Task.DeinterlaceFilter == DeinterlaceFilter.Bwdif)
+            {
+                List<HBPresetTune> filterPresets = HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_BWDIF);
+                HBPresetTune presetTune = filterPresets.FirstOrDefault(f => f.ShortName == importedPreset.PictureDeinterlacePreset);
+                preset.Task.DeinterlacePreset = presetTune ?? new HBPresetTune("Default", "default");
+                preset.Task.CustomDeinterlaceSettings = importedPreset.PictureDeinterlaceCustom;
+            }
+
+            if (preset.Task.DeinterlaceFilter != DeinterlaceFilter.Off)
             {
                 switch (importedPreset.PictureCombDetectPreset)
                 {
@@ -646,9 +657,9 @@ namespace HandBrakeWPF.Services.Presets.Factories
             preset.PictureDeblockTune = export.Task.DeblockTune?.Key;
             preset.PictureDeblockCustom = export.Task.CustomDeblock;
 
-            preset.PictureDeinterlaceFilter = export.Task.DeinterlaceFilter == DeinterlaceFilter.Decomb
-                ? "decomb"
-                : export.Task.DeinterlaceFilter == DeinterlaceFilter.Yadif ? "yadif" : "off";
+            preset.PictureDeinterlaceFilter = export.Task.DeinterlaceFilter == DeinterlaceFilter.Decomb ? "decomb"
+                : export.Task.DeinterlaceFilter == DeinterlaceFilter.Yadif ? "yadif"
+                : export.Task.DeinterlaceFilter == DeinterlaceFilter.Bwdif ? "bwdif" : "off";
             preset.PictureDeinterlacePreset = export.Task.DeinterlacePreset?.ShortName;
             preset.PictureDeinterlaceCustom = export.Task.CustomDeinterlaceSettings;
 

--- a/win/CS/HandBrakeWPF/ViewModelItems/Filters/DeinterlaceFilterItem.cs
+++ b/win/CS/HandBrakeWPF/ViewModelItems/Filters/DeinterlaceFilterItem.cs
@@ -87,9 +87,11 @@ namespace HandBrakeWPF.ViewModelItems.Filters
                 switch (this.SelectedDeinterlaceFilter)
                 {
                     case DeinterlaceFilter.Yadif:
-                        return new BindingList<HBPresetTune>(HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_DEINTERLACE));
+                        return new BindingList<HBPresetTune>(HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_YADIF));
                     case DeinterlaceFilter.Decomb:
                         return new BindingList<HBPresetTune>(HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_DECOMB));
+                    case DeinterlaceFilter.Bwdif:
+                        return new BindingList<HBPresetTune>(HandBrakeFilterHelpers.GetFilterPresets((int)hb_filter_ids.HB_FILTER_BWDIF));
                     default:
                         return new BindingList<HBPresetTune>();
                 }


### PR DESCRIPTION
**Linked issues**
[#3193](https://github.com/HandBrake/HandBrake/issues/3193)

**Description of Change:**
Adds _Bwdif_ ("Bob Weaver Deinterlacing Filter") to the list of available deinterlace filter in HandBrake.
The implementation mostly follow the one for Yadif; it uses the FFmpeg filter internally.

It may be of interest for those who want a filter that gets close to Yadif lightning speed but offer an improvement in visual quality. I.e. a compromise between Decomb and Yadif.

**Tested on:**
- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux