### PR TITLE
libhb: high bit depth grayscale filter.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -6027,7 +6027,6 @@ static int pix_fmt_is_supported(hb_job_t * job, int pix_fmt)
             case HB_FILTER_CHROMA_SMOOTH:
             case HB_FILTER_LAPSHARP:
             case HB_FILTER_UNSHARP:
-            case HB_FILTER_GRAYSCALE:
                 if (pix_fmt != AV_PIX_FMT_YUV420P)
                 {
                     return 0;


### PR DESCRIPTION
A quick try at making it work with 10 and 12 bit and biplanar pixel formats.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux