### PR TITLE
qsv: fix BRC multiplier

### DIFF
--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -313,7 +313,7 @@ namespace HandBrakeWPF.Services
             // Video
             defaults.Add(UserSettingConstants.EnableQuickSyncEncoding, true);
             defaults.Add(UserSettingConstants.EnableQuickSyncDecoding, true);
-            defaults.Add(UserSettingConstants.EnableQuickSyncHyperEncode, true);
+            defaults.Add(UserSettingConstants.EnableQuickSyncHyperEncode, false);
             defaults.Add(UserSettingConstants.UseQSVDecodeForNonQSVEnc, false);
             defaults.Add(UserSettingConstants.EnableVceEncoder, true);
             defaults.Add(UserSettingConstants.EnableNvencEncoder, true);


### PR DESCRIPTION
- Fix for bitrates larger than 65535. 
- Also disable HyperEncode as default since for preset with filters it may cause no gain or regression in some cases. Prefer balancing multiple parallel encodes as default. HyperEncode is preferred for quality and balanced presets with no filters.