### PR TITLE
x265: include <sys/stat.h> for FreeBSD

### DIFF
--- a/contrib/x265/P00-freebsd-common-threading.patch
+++ b/contrib/x265/P00-freebsd-common-threading.patch
@@ -1,0 +1,12 @@
+--- a/source/common/threading.h	2022-02-16 10:18:38.000000000 +0900
++++ b/source/common/threading.h	2022-03-02 11:03:42.002417000 +0900
+@@ -37,6 +37,9 @@
+ #include <semaphore.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#ifdef __FreeBSD__
++#include <sys/stat.h>
++#endif
+ #endif
+ 
+ #if MACOS


### PR DESCRIPTION
This pull request fixes #4254.

**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Add a patch for contrib x265 that includes <sys/stat.h> for FreeBSD.

`mode_t` values are defined in <sys/stat.h> in FreeBSD.
They are used for calling open(2) in `source/common/ringmem.cpp`.
The prototype of open(2) is in <fctl.h>,
it's nice to put <sys/stat.h> close to it.


**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] FreeBSD

**Screenshots (If relevant):**


**Log file output (If relevant):**
