### PR TITLE
WinGui: Set high DPI mode to PerMonitorV2

### DIFF
--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -23,6 +23,7 @@
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
     <LangVersion>latest</LangVersion>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/win/CS/HandBrakeWPF/app.manifest
+++ b/win/CS/HandBrakeWPF/app.manifest
@@ -59,7 +59,7 @@
       <!-- The combination of below two tags have the following effect : 
       1) Per-Monitor for >= Windows 10 Anniversary Update
       2) System < Windows 10 Anniversary Update -->
-      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitor</dpiAwareness>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
     </windowsSettings>
   </application>


### PR DESCRIPTION
Allows the UI to automatically update when the monitor DPI setting changes on Windows 10 1703+. Also restores the app.manifest which had been inadvertently removed from HandBrakeWPF.csproj.
Closes #4282 
