### PR TITLE
Add HandBrake to video category on macOS

### DIFF
--- a/macosx/Info.plist.m4
+++ b/macosx/Info.plist.m4
@@ -55,6 +55,8 @@ dnl
 	<string>????</string>
 	<key>CFBundleVersion</key>
 	<string>__HB_build</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.video</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>


### PR DESCRIPTION
Add the LSApplicationCategoryType "Video" to Info.plist. If you arrange the applications in macOS Finder as "Application Category", HandBrake currently is located under "Others". This way, it is arranged into the "Video" category.

![image](https://user-images.githubusercontent.com/13453351/163705852-7e291fac-2758-419e-ae5c-612126a711ca.png)
