### PR TITLE
libhb: enable 4:2:2 and 4:4:4 profiles for x264, x265, and HEVC 1…

### DIFF
--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -375,6 +375,21 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     param->sourceWidth    = job->width;
     param->sourceHeight   = job->height;
 
+    switch (job->output_pix_fmt)
+    {
+        case AV_PIX_FMT_YUV422P:
+        case AV_PIX_FMT_YUV422P10:
+        case AV_PIX_FMT_YUV422P12:
+        case AV_PIX_FMT_YUV422P16:
+            param->internalCsp = X265_CSP_I422;
+            break;
+        case AV_PIX_FMT_YUV444P:
+        case AV_PIX_FMT_YUV444P10:
+        case AV_PIX_FMT_YUV444P12:
+        case AV_PIX_FMT_YUV444P16:
+            param->internalCsp = X265_CSP_I444;
+    }
+
     /*
      * Let x265 determine whether to use an aspect ratio
      * index vs. the extended SAR index + SAR width/height.

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -411,13 +411,13 @@ int         hb_video_quality_is_supported(uint32_t codec);
 int         hb_video_twopass_is_supported(uint32_t codec);
 
 int                hb_video_encoder_is_supported(int encoder);
-int                hb_video_encoder_pix_fmt_is_supported(int encoder, int pix_fmt);
+int                hb_video_encoder_pix_fmt_is_supported(int encoder, int pix_fmt, const char *profile);
 int                hb_video_encoder_get_depth   (int encoder);
 const char* const* hb_video_encoder_get_presets (int encoder);
 const char* const* hb_video_encoder_get_tunes   (int encoder);
 const char* const* hb_video_encoder_get_profiles(int encoder);
 const char* const* hb_video_encoder_get_levels  (int encoder);
-const int*         hb_video_encoder_get_pix_fmts(int encoder);
+const int*         hb_video_encoder_get_pix_fmts(int encoder, const char *profile);
 
 void  hb_audio_quality_get_limits(uint32_t codec, float *low, float *high, float *granularity, int *direction);
 float hb_audio_quality_get_best(uint32_t codec, float quality);

--- a/libhb/handbrake/h264_common.h
+++ b/libhb/handbrake/h264_common.h
@@ -11,9 +11,13 @@
 #define HANDBRAKE_H264_COMMON_H
 
 static const char * const hb_h264_profile_names_8bit[]  = {
-    "auto", "high", "main", "baseline", NULL, };
+    "auto", "baseline", "main", "high", NULL, };
+static const char * const hb_x264_profile_names_8bit[] = {
+    "auto", "baseline", "main", "high", "high422", "high444", NULL, };
 static const char * const hb_h264_profile_names_10bit[] = {
     "auto", "high10", NULL, };
+static const char * const hb_x264_profile_names_10bit[] = {
+    "auto", "high10", "high422", "high444", NULL, };
 static const char * const hb_h264_level_names[]         = {
     "auto", "1.0", "1b", "1.1", "1.2", "1.3", "2.0", "2.1", "2.2", "3.0",
     "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2",  NULL, };

--- a/libhb/handbrake/h265_common.h
+++ b/libhb/handbrake/h265_common.h
@@ -20,14 +20,20 @@ static const char * const hb_h265_tier_names[]              = {
     "auto", "main", "high", NULL, };
 static const char * const hb_h265_profile_names_8bit[]      = {
     "auto", "main", "mainstillpicture", NULL, };
+static const char * const hb_x265_profile_names_8bit[]      = {
+    "auto", "main", "mainstillpicture", "main444-8", "main444-intra", NULL, };
 static const char * const hb_h265_profile_names_10bit[]     = {
     "auto", "main10", "main10-intra", NULL, };
+static const char * const hb_x265_profile_names_10bit[]     = {
+    "auto", "main10", "main10-intra", "main422-10", "main422-10-intra", "main444-10", "main444-10-intra", NULL, };
 #if HB_PROJECT_FEATURE_QSV
 static const char * const hb_h265_qsv_profile_names_10bit[] = {
     "auto", "main10", NULL, };
 #endif
 static const char * const hb_h265_profile_names_12bit[]     = {
     "auto", "main12", "main12-intra", NULL, };
+static const char * const hb_x265_profile_names_12bit[]     = {
+    "auto", "main12", "main12-intra", "main422-12", "main422-12-intra", "main444-12", "main444-12-intra", NULL, };
 static const char * const hb_h265_profile_names_16bit[]     = {
     "auto", "main16", "main16-intra", NULL, };
 static const char * const hb_h265_level_names[]             = {

--- a/libhb/platform/macosx/encvt.c
+++ b/libhb/platform/macosx/encvt.c
@@ -173,6 +173,7 @@ enum
 {
     HB_VT_H265_PROFILE_MAIN = 0,
     HB_VT_H265_PROFILE_MAIN_10,
+    HB_VT_H265_PROFILE_MAIN_422_10,
     HB_VT_H265_PROFILE_NB,
 };
 
@@ -183,7 +184,7 @@ static struct
 }
 hb_vt_h265_levels[] =
 {
-    { "auto", { CFSTR("HEVC_Main_AutoLevel"), CFSTR("HEVC_Main10_AutoLevel") }, }
+    { "auto", { CFSTR("HEVC_Main_AutoLevel"), CFSTR("HEVC_Main10_AutoLevel"), CFSTR("HEVC_Main42210_AutoLevel") } }
 };
 
 /*
@@ -427,7 +428,9 @@ static OSType hb_vt_get_cv_pixel_format(hb_job_t* job)
     }
     else if (job->output_pix_fmt == AV_PIX_FMT_P210)
     {
-        return kCVPixelFormatType_422YpCbCr16BiPlanarVideoRange;
+        return job->color_range == AVCOL_RANGE_JPEG ?
+                                        kCVPixelFormatType_422YpCbCr10BiPlanarFullRange :
+                                        kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange;
     }
     else if (job->output_pix_fmt == AV_PIX_FMT_NV24)
     {
@@ -508,10 +511,14 @@ static int hb_vt_settings_xlat(hb_work_private_t *pv, hb_job_t *job)
         }
         else if (job->vcodec == HB_VCODEC_VT_H265_10BIT)
         {
-            if (!strcasecmp(job->encoder_profile, "main") ||
+            if (!strcasecmp(job->encoder_profile, "main10") ||
                 !strcasecmp(job->encoder_profile, "auto"))
             {
                 pv->settings.profile = HB_VT_H265_PROFILE_MAIN_10;
+            }
+            else if (!strcasecmp(job->encoder_profile, "main422-10"))
+            {
+                pv->settings.profile = HB_VT_H265_PROFILE_MAIN_422_10;
             }
             else
             {

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -66,6 +66,7 @@ static int is_hardware_encoder_available(CMVideoCodecType codecType, CFStringRef
 static int vt_h264_available;
 static int vt_h265_available;
 static int vt_h265_10bit_available;
+static int vt_h265_422_10bit_available;
 
 int hb_vt_is_encoder_available(int encoder)
 {
@@ -94,6 +95,7 @@ int hb_vt_is_encoder_available(int encoder)
                 if (__builtin_available (macOS 11, *))
                 {
                     vt_h265_10bit_available = is_hardware_encoder_available(kCMVideoCodecType_HEVC, kVTProfileLevel_HEVC_Main10_AutoLevel);
+                    vt_h265_422_10bit_available = is_hardware_encoder_available(kCMVideoCodecType_HEVC, CFSTR("HEVC_Main42210_AutoLevel"));
                 }
                 else
                 {
@@ -206,7 +208,17 @@ static const char * const vt_h264_profile_name[] =
 
 static const char * const vt_h265_profile_name[] =
 {
-    "auto", NULL
+    "auto", "main", NULL
+};
+
+static const char * const vt_h265_10_profile_name[] =
+{
+    "auto", "main10", NULL
+};
+
+static const char * const vt_h265_422_10_profile_name[] =
+{
+    "auto", "main10", "main422-10", NULL
 };
 
 static const char * vt_h264_level_names[] =
@@ -226,7 +238,7 @@ static const enum AVPixelFormat vt_h26x_pix_fmts[] =
 
 static const enum AVPixelFormat vt_h265_10bit_pix_fmts[] =
 {
-    AV_PIX_FMT_P010LE, AV_PIX_FMT_NONE
+    AV_PIX_FMT_P210, AV_PIX_FMT_P010LE, AV_PIX_FMT_NONE
 };
 
 const int* hb_vt_get_pix_fmts(int encoder)
@@ -254,8 +266,18 @@ const char* const* hb_vt_profile_get_names(int encoder)
         case HB_VCODEC_VT_H264:
             return vt_h264_profile_name;
         case HB_VCODEC_VT_H265:
-        case HB_VCODEC_VT_H265_10BIT:
             return vt_h265_profile_name;
+        case HB_VCODEC_VT_H265_10BIT:
+        {
+            if (vt_h265_422_10bit_available)
+            {
+                return vt_h265_422_10_profile_name;
+            }
+            else
+            {
+                return vt_h265_10_profile_name;
+            }
+        }
     }
     return NULL;
 }

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -16,6 +16,10 @@
 struct hb_filter_private_s
 {
     // Common
+    int                 pix_fmt_alpha;
+    int                 depth;
+    int                 hshift;
+    int                 wshift;
     int                 crop[4];
     int                 type;
     struct SwsContext * sws;
@@ -104,9 +108,8 @@ hb_filter_object_t hb_filter_render_sub =
     .close         = hb_rendersub_close,
 };
 
-// blends src YUVA420P buffer into dst
-// dst is currently YUV420P, but in future will be other formats as well
-static void blend( hb_buffer_t *dst, hb_buffer_t *src, int left, int top )
+// blends src YUVA4**P buffer into dst
+static void blend(hb_buffer_t *dst, const hb_buffer_t *src, const int left, const int top)
 {
     int xx, yy;
     int ww, hh;
@@ -175,7 +178,7 @@ static void blend( hb_buffer_t *dst, hb_buffer_t *src, int left, int top )
         {
             alpha = a_in[xx << wshift];
 
-            // Blend averge U and alpha
+            // Blend U and alpha
             u_out[(left >> wshift) + xx] =
                 ( (uint16_t)u_out[(left >> wshift) + xx] * ( 255 - alpha ) +
                   (uint16_t)u_in[xx] * alpha ) / 255;
@@ -188,7 +191,7 @@ static void blend( hb_buffer_t *dst, hb_buffer_t *src, int left, int top )
     }
 }
 
-static void blend8on1x( hb_buffer_t *dst, hb_buffer_t *src, int left, int top, int shift )
+static void blend8on1x(hb_buffer_t *dst, const hb_buffer_t *src, const int left, const int top, const int shift)
 {
     int xx, yy;
     int ww, hh;
@@ -266,7 +269,7 @@ static void blend8on1x( hb_buffer_t *dst, hb_buffer_t *src, int left, int top, i
         {
             alpha = a_in[xx << wshift] << shift;
 
-            // Blend averge U and alpha
+            // Blend U and alpha
             u_out[(left >> wshift) + xx] =
                 ( (uint32_t)u_out[(left >> wshift) + xx] * ( max - alpha ) +
                   ((uint32_t)u_in[xx] << shift) * alpha ) / max;
@@ -281,17 +284,15 @@ static void blend8on1x( hb_buffer_t *dst, hb_buffer_t *src, int left, int top, i
 
 // Assumes that the input destination buffer has the same dimensions
 // as the original title dimensions
-static void ApplySub( hb_filter_private_t * pv, hb_buffer_t * buf, hb_buffer_t * sub )
+static void ApplySub(const hb_filter_private_t *pv, hb_buffer_t *buf, const hb_buffer_t *sub)
 {
-    switch (pv->output.pix_fmt) {
-        case AV_PIX_FMT_YUV420P10:
-            blend8on1x(buf, sub, sub->f.x, sub->f.y, 2);
-            break;
-        case AV_PIX_FMT_YUV420P12:
-            blend8on1x(buf, sub, sub->f.x, sub->f.y, 4);
+    switch (pv->output.pix_fmt)
+    {
+        case AV_PIX_FMT_YUV420P:
+            blend(buf, sub, sub->f.x, sub->f.y);
             break;
         default:
-            blend(buf, sub, sub->f.x, sub->f.y);
+            blend8on1x(buf, sub, sub->f.x, sub->f.y, pv->depth - 8);
             break;
     }
 }
@@ -541,38 +542,37 @@ static int vobsub_work( hb_filter_object_t * filter,
     return HB_FILTER_OK;
 }
 
-static uint8_t ssaAlpha( ASS_Image *frame, int x, int y )
+static uint8_t ssaAlpha(const ASS_Image *frame, const int x, const int y)
 {
-    unsigned frameA = ( frame->color ) & 0xff;
-    unsigned gliphA = frame->bitmap[y*frame->stride + x];
+    const unsigned frameA = (frame->color) & 0xff;
+    const unsigned gliphA = frame->bitmap[y*frame->stride + x];
 
     // Alpha for this pixel is the frame opacity (255 - frameA)
-    // multiplied by the gliph alfa (gliphA) for this pixel
+    // multiplied by the gliph alpha (gliphA) for this pixel
     unsigned alpha = (255 - frameA) * gliphA >> 8;
 
     return (uint8_t)alpha;
 }
 
-// Returns a subtitle rendered to a YUVA420P frame
-static hb_buffer_t * RenderSSAFrame( hb_filter_private_t * pv, ASS_Image * frame )
+// Returns a subtitle rendered to a YUVA4**P frame
+static hb_buffer_t * RenderSSAFrame(const hb_filter_private_t *pv, const ASS_Image *frame)
 {
-    hb_buffer_t *sub;
-    int xx, yy;
+    const unsigned r = (frame->color >> 24) & 0xff;
+    const unsigned g = (frame->color >> 16) & 0xff;
+    const unsigned b = (frame->color >>  8) & 0xff;
 
-    unsigned r = ( frame->color >> 24 ) & 0xff;
-    unsigned g = ( frame->color >> 16 ) & 0xff;
-    unsigned b = ( frame->color >>  8 ) & 0xff;
+    const int yuv = hb_rgb2yuv_bt709((r << 16) | (g << 8) | b);
 
-    int yuv = hb_rgb2yuv_bt709((r << 16) | (g << 8) | b );
+    const unsigned frameY = (yuv >> 16) & 0xff;
+    const unsigned frameV = (yuv >> 8 ) & 0xff;
+    const unsigned frameU = (yuv >> 0 ) & 0xff;
 
-    unsigned frameY = (yuv >> 16) & 0xff;
-    unsigned frameV = (yuv >> 8 ) & 0xff;
-    unsigned frameU = (yuv >> 0 ) & 0xff;
-
-    // Note that subtitle frame buffer is YUVA420P, not YUV420P, it has alpha
-    sub = hb_frame_buffer_init(AV_PIX_FMT_YUVA420P, frame->w, frame->h);
+    // Note that subtitle frame buffer has alpha
+    hb_buffer_t *sub = hb_frame_buffer_init(pv->pix_fmt_alpha, frame->w, frame->h);
     if (sub == NULL)
+    {
         return NULL;
+    }
 
     uint8_t *y_out, *u_out, *v_out, *a_out;
     y_out = sub->plane[0].data;
@@ -580,26 +580,28 @@ static hb_buffer_t * RenderSSAFrame( hb_filter_private_t * pv, ASS_Image * frame
     v_out = sub->plane[2].data;
     a_out = sub->plane[3].data;
 
-    for( yy = 0; yy < frame->h; yy++ )
+    for (int yy = 0; yy < frame->h; yy++)
     {
-        for( xx = 0; xx < frame->w; xx++ )
+        for (int xx = 0; xx < frame->w; xx++)
         {
             y_out[xx] = frameY;
-            if( ( yy & 1 ) == 0 )
-            {
-                u_out[xx>>1] = frameU;
-                v_out[xx>>1] = frameV;
-            }
-            a_out[xx] = ssaAlpha( frame, xx, yy );;
+            a_out[xx] = ssaAlpha(frame, xx, yy);
         }
         y_out += sub->plane[0].stride;
-        if( ( yy & 1 ) == 0 )
-        {
-            u_out += sub->plane[1].stride;
-            v_out += sub->plane[2].stride;
-        }
         a_out += sub->plane[3].stride;
     }
+
+    for (int yy = 0; yy < frame->h >> pv->hshift; yy++)
+    {
+        for (int xx = 0; xx < frame->w >> pv->wshift; xx++)
+        {
+            u_out[xx] = frameU;
+            v_out[xx] = frameV;
+        }
+        u_out += sub->plane[1].stride;
+        v_out += sub->plane[2].stride;
+    }
+
     sub->f.width = frame->w;
     sub->f.height = frame->h;
     sub->f.x = frame->dst_x + pv->crop[2];
@@ -1065,6 +1067,34 @@ static int hb_rendersub_init( hb_filter_object_t * filter,
     int ii;
 
     pv->input = *init;
+
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(init->pix_fmt);
+    pv->depth      = desc->comp[0].depth;
+    pv->wshift     = desc->log2_chroma_w;
+    pv->hshift     = desc->log2_chroma_h;
+
+    switch (init->pix_fmt)
+    {
+        case AV_PIX_FMT_YUV420P:
+        case AV_PIX_FMT_YUV420P10:
+        case AV_PIX_FMT_YUV420P12:
+        case AV_PIX_FMT_YUV420P16:
+            pv->pix_fmt_alpha = AV_PIX_FMT_YUVA420P;
+            break;
+        case AV_PIX_FMT_YUV422P:
+        case AV_PIX_FMT_YUV422P10:
+        case AV_PIX_FMT_YUV422P12:
+        case AV_PIX_FMT_YUV422P16:
+            pv->pix_fmt_alpha = AV_PIX_FMT_YUVA422P;
+            break;
+        case AV_PIX_FMT_YUV444P:
+        case AV_PIX_FMT_YUV444P10:
+        case AV_PIX_FMT_YUV444P12:
+        case AV_PIX_FMT_YUV444P16:
+        default:
+            pv->pix_fmt_alpha = AV_PIX_FMT_YUVA444P;
+            break;
+    }
 
     // Find the subtitle we need
     for( ii = 0; ii < hb_list_count(init->job->list_subtitle); ii++ )


### PR DESCRIPTION
…-bit VideoToolbox encoders.

**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux