### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,9 @@ name: Linux Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build on Ubuntu

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,6 +2,9 @@ name: macOS build
 
 on: [push, pull_request, workflow_dispatch]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build on macOS

--- a/.github/workflows/windows-arm.yml
+++ b/.github/workflows/windows-arm.yml
@@ -2,6 +2,9 @@ name: Windows Build (ARM)
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_mingw:
     name: CLI / LibHB (ARM)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,6 +2,9 @@ name: Windows Build
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build_mingw:
     name: CLI / LibHB


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: neilnaveen <42328488+neilnaveen@users.noreply.github.com>
