### PR TITLE
Replace hdr-opt with hdr10-opt

### DIFF
--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -211,7 +211,7 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
     {
         if (depth > 8)
         {
-            if (param_parse(pv, param, "hdr-opt", "1"))
+            if (param_parse(pv, param, "hdr10-opt", "1"))
             {
                 goto fail;
             }


### PR DESCRIPTION
hdr-opt is deprecated and was replaced with hdr10-opt
https://bitbucket.org/multicoreware/x265_git/commits/8758c6adaaf226733a11285be16a1c93a1eac647