### PR TITLE
qsv: update onevpl v2022.1.2

### DIFF
--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
-LIBVPL.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/oneVPL-2022.0.4.tar.gz
-LIBVPL.FETCH.url      += https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2022.0.4.tar.gz
-LIBVPL.FETCH.sha256    = 7fb0965f1a22344a044840462637f23be0d019bacd011ca2ff179d72dc40064b
-LIBVPL.FETCH.basename  = oneVPL-2022.0.4.tar.gz
-LIBVPL.EXTRACT.tarbase = oneVPL-2022.0.4
+LIBVPL.FETCH.url       = https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2022.1.2.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/oneVPL-2022.1.2.tar.gz
+LIBVPL.FETCH.sha256    = 8ff93be017273eefa83dc6cd7f5d82facb168e38eafabafa2e9613a4e742016f
+LIBVPL.FETCH.basename  = oneVPL-2022.1.2.tar.gz
+LIBVPL.EXTRACT.tarbase = oneVPL-2022.1.2
 
 LIBVPL.build_dir             = build
 LIBVPL.CONFIGURE.exe         = cmake


### PR DESCRIPTION
Fixes HandBrake hangs on non-Intel systems or systems with no Intel graphics driver installed.