### PR TITLE
flatpak: Use HandBrake's make rules for building libass

### DIFF
--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -12,18 +12,22 @@ LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.16.0
 LIBASS.FETCH.sha256  = fea8019b1887cab9ab00c1e58614b4ec2b1cee339b3f7e446f5fab01b032d430
 
 # Tell configure where to find our versions of these libs
+ifneq (1,$(FEATURE.flatpak))
 LIBASS.CONFIGURE.extra = \
     HARFBUZZ_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lharfbuzz" \
     HARFBUZZ_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/harfbuzz" \
     FREETYPE_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfreetype" \
     FREETYPE_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include/freetype2"
+endif
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     # Tell configure where to find our version of fontconfig
+    LIBASS.CONFIGURE.extra += --enable-fontconfig
+ifneq (1,$(FEATURE.flatpak))
     LIBASS.CONFIGURE.extra += \
-        --enable-fontconfig \
         FONTCONFIG_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfontconfig" \
         FONTCONFIG_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include"
+endif
 else
     LIBASS.CONFIGURE.extra += --disable-fontconfig
 endif

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -32,6 +32,7 @@ ifneq (,$(filter $(HOST.system),darwin cygwin mingw))
 endif
 
 ifeq (1,$(FEATURE.flatpak))
+    MODULES += contrib/libass
     MODULES += contrib/jansson
     MODULES += contrib/x264
 endif

--- a/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
+++ b/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
@@ -20,18 +20,6 @@
             ]
         },
         {
-            "name": "libass-cli",
-            "config-opts": ["--enable-asm", "--enable-harfbuzz",
-                            "--enable-fontconfig"],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libass/libass/releases/download/0.14.0/libass-0.14.0.tar.gz",
-                    "sha256": "8d5a5c920b90b70a108007ffcd2289ac652c0e03fc88e6eecefa37df0f2e7fdf"
-                }
-            ]
-        },
-        {
             "name": "handbrake-cli",
             "no-autogen": true,
             "config-opts": ["--flatpak", "--disable-gtk"],

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -45,18 +45,6 @@
             ]
         },
         {
-            "name": "libass",
-            "config-opts": ["--enable-asm", "--enable-harfbuzz",
-                            "--enable-fontconfig"],
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://github.com/libass/libass/releases/download/0.15.2/libass-0.15.2.tar.gz",
-                    "sha256": "1b2a54dda819ef84fa2dee3069cf99748a886363d2adb630fde87fe046e2d1d5"
-                }
-            ]
-        },
-        {
             "name": "handbrake",
             "no-autogen": true,
             "config-opts": [


### PR DESCRIPTION
I took a shortcut when adding libass for flatpaks by putting the build
instructions in the flatpak manifest. It's been a maintenance problem
ever since keeping them in sync. This puts everything back into the
hands of HandBrake's build system.

**Test on:**

Just need to be certain that I didn't break the build on other platforms

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Fedora Linux
- [x] Flatpak Linux
