### PR TITLE
qsv: update Plugin.IntelMediaSDK flatpak

### DIFF
--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
-LIBVPL.FETCH.url       = https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2022.1.2.tar.gz
-LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/oneVPL-2022.1.2.tar.gz
-LIBVPL.FETCH.sha256    = 8ff93be017273eefa83dc6cd7f5d82facb168e38eafabafa2e9613a4e742016f
-LIBVPL.FETCH.basename  = oneVPL-2022.1.2.tar.gz
-LIBVPL.EXTRACT.tarbase = oneVPL-2022.1.2
+LIBVPL.FETCH.url       = https://github.com/oneapi-src/oneVPL/archive/refs/tags/v2023.1.0.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/oneVPL-2023.1.0.tar.gz
+LIBVPL.FETCH.sha256    = 0a1991278c64849f471e4b307a7c01f465a308674f359054886c32352e887b60
+LIBVPL.FETCH.basename  = oneVPL-2023.1.0.tar.gz
+LIBVPL.EXTRACT.tarbase = oneVPL-2023.1.0
 
 LIBVPL.build_dir             = build
 LIBVPL.CONFIGURE.exe         = cmake

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -579,6 +579,15 @@ static int hb_qsv_make_adapters_list(hb_list_t **qsv_adapters_list, hb_list_t **
             hb_list_add(list, (void*)adapter_index);
             hb_list_add(list2, (void*)adapter_details);
 
+            // On linux, the handle to the VA display must be set.
+            // This code is essentially a NOP other platforms.
+            hb_display_t * display = hb_qsv_display_init();
+            if (display != NULL)
+            {
+                MFXVideoCORE_SetHandle(session, display->mfxType,
+                                    (mfxHDL)display->handle);
+            }
+
             mfxPlatform platform = { 0 };
             err = MFXVideoCORE_QueryPlatform(session, &platform);
             if (MFX_ERR_NONE == err)
@@ -596,6 +605,8 @@ static int hb_qsv_make_adapters_list(hb_list_t **qsv_adapters_list, hb_list_t **
             {
                 hb_error("hb_qsv_make_adapters_list: MFXVideoCORE_QueryPlatform failed impl=%d err=%d", i, err);
             }
+            MFXClose(session);
+            hb_display_close(&display);
         }
         else
         {

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1662,8 +1662,8 @@ static int hb_qsv_collect_adapters_details(hb_list_t *hb_qsv_adapter_details_lis
                     // available, we can set the preferred implementation
                     qsv_impl_set_preferred(details, "hardware");
                 }
-                hb_display_close(&display);
                 MFXClose(session);
+                hb_display_close(&display);
                 hw_preference = 0;
             }
             else

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -650,6 +650,7 @@ int hb_qsv_available()
         qsv_init_result = 0;
         return qsv_init_result;
     }
+    hb_log("qsv: is available on this system");
 
     qsv_init_result = ((hb_qsv_video_encoder_is_enabled(hb_qsv_get_adapter_index(), HB_VCODEC_QSV_H264) ? HB_VCODEC_QSV_H264 : 0) |
                       (hb_qsv_video_encoder_is_enabled(hb_qsv_get_adapter_index(), HB_VCODEC_QSV_H265) ? HB_VCODEC_QSV_H265 : 0) |

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -13,8 +13,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-21.3.1.tar.gz",
-                    "sha256": "d26a6512a1b3ca604dabe035ddaf47b4b445bd503eac69a59e4acb2d1f54634b"
+                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.2.0.tar.gz",
+                    "sha256": "0b2253894c6fc8455b6d7c5e87e6504a76d6f60ea192e1445c2f93164bf529c0"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -37,11 +37,11 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva/releases/download/2.13.0/libva-2.13.0.tar.bz2",
-                    "sha256": "fad383f39f36115814bd0eda1496a4cc01761643bd962635400df2d4470ad460"
+                    "url": "https://github.com/intel/libva/archive/refs/tags/2.16.0.tar.gz",
+                    "sha256": "766edf51fd86efe9e836a4467d4ec7c3af690a3c601b3c717237cee856302279"
                 }
             ],
-            "no-autogen": true,
+            "no-autogen": false,
             "config-opts": ["--with-drivers-path=/app/extensions/IntelMediaSDK/lib/dri"],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK"
@@ -52,11 +52,11 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva-utils/releases/download/2.12.0/libva-utils-2.12.0.tar.bz2",
-                    "sha256": "bbe49e68fbdf379acc769e4c1680a76be3e2b48020ca320edafaf7235b62cc44"
+                    "url": "https://github.com/intel/libva-utils/archive/refs/tags/2.16.0.tar.gz",
+                    "sha256": "646c9bfff6a83504c48de2c786c9514ca30c5e916127faf00f143ef8147ee950"
                 }
             ],
-            "no-autogen": true,
+            "no-autogen": false,
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
                 "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
@@ -67,8 +67,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-21.3.4.tar.gz",
-                    "sha256": "4a8233c6a39d7ef7ccd22e43d3d3b890df71501844705783a6c364167a69cae2"
+                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-22.5.4.tar.gz",
+                    "sha256": "08d8d041f94b094a2dd5c4739c413b75185521c7f788a02411395ff374ee4ead"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -105,8 +105,31 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/Intel-Media-SDK/MediaSDK/archive/refs/tags/intel-mediasdk-21.3.5.tar.gz",
-                    "sha256": "3f13869298d3946d7d91e58846e274ef62cd5af2473f59f36b57b2c27ebfd87c"
+                    "url": "https://github.com/Intel-Media-SDK/MediaSDK/archive/refs/tags/intel-mediasdk-22.5.4.tar.gz",
+                    "sha256": "0eb04409a226da6e752576d60c46a3ec969ddfe03042897088367392207c7ab3"
+                },
+                {
+                    "type": "file",
+                    "path": "fr.handbrake.ghb.Plugin.IntelMediaSDK.metainfo.xml"
+                }
+            ]
+        },
+        {
+            "name": "onevpl-intel-gpu",
+            "buildsystem": "cmake-ninja",
+            "builddir": true,
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=Release"
+            ],
+            "build-options": {
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+            },
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/refs/tags/intel-onevpl-22.5.4.tar.gz",
+                    "sha256": "7e42e86a79460b95f17660716b797536479ce91c1804e55f8032711ce1cb9a65"
                 },
                 {
                     "type": "file",
@@ -116,4 +139,3 @@
         }
     ]
 }
-

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -3,7 +3,7 @@
     "branch": "1",
     "runtime": "fr.handbrake.ghb",
     "runtime-version": "development",
-    "sdk": "org.gnome.Sdk//41",
+    "sdk": "org.gnome.Sdk//43",
     "build-extension": true,
     "separate-locales": false,
     "appstream-compose": false,

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -15,7 +15,9 @@
         "--filesystem=xdg-config/gtk-3.0",
         "--talk-name=org.gtk.vfs.*",
         "--system-talk-name=org.freedesktop.login1",
-        "--env=PATH=/app/bin:/usr/bin:/app/extensions/bin",
+        "--env=PATH=/app/bin:/app/extensions/bin:/usr/bin",
+        "--env=LIBVA_DRIVERS_PATH=/app/extensions/lib/dri",
+        "--env=LD_LIBRARY_PATH=/app/extensions/lib",
         "--env=JAVA_HOME=/app/extensions/jre",
         "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules"
     ],


### PR DESCRIPTION
Since TigerLake oneVPL runtime must be used on Linux based on https://github.com/oneapi-src/oneVPL#onevpl-dispatcher-behavior-when-targeting-intel-gpus

![image](https://user-images.githubusercontent.com/25517145/203182333-a681cc79-71d8-455b-9b28-068f42e6ac85.png)

Prioritize the flatpak package libraries to prevent conflict with system ones.

Used the following releases:

oneVPL GPU Runtime 2022Q3 Release - 22.5.4 (for platforms TGL and above)
https://github.com/oneapi-src/oneVPL-intel-gpu/releases/tag/intel-onevpl-22.5.4
`Impl mfx-gen library path: /app/extensions/IntelMediaSDK/lib/libmfx-gen.so.1.2.7`

Intel MediaSDK 2022Q3 Release - 22.5.4 (for platforms before TGL)
https://github.com/Intel-Media-SDK/MediaSDK/releases/tag/intel-mediasdk-22.5.4
`Impl mfxhw64 library path: /app/extensions/IntelMediaSDK/lib/libmfxhw64.so.1.35`

Potential fix for the following issues:
https://github.com/HandBrake/HandBrake/issues/4108
https://github.com/HandBrake/HandBrake/issues/3986