### PR TITLE
Remove --enable-muxer=av1

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -58,7 +58,6 @@ FFMPEG.CONFIGURE.extra = \
     --disable-decoder=*_crystalhd \
     --enable-demuxer=av1 \
     --enable-demuxer=obu \
-    --enable-muxer=av1 \
     --enable-decoder=av1 \
     --enable-libdav1d \
     --enable-decoder=libdav1d \


### PR DESCRIPTION
Closes #4380

According to `./configure --list-muxers` there is no muxer named av1 for ffmpeg. So remove it and get rid of the warning message in the build log.