### PR TITLE
Improve Presets audio track selection logic

### DIFF
--- a/contrib/ffmpeg/A29-avformat-mov-add-support-audio-fallback-track-ref.patch
+++ b/contrib/ffmpeg/A29-avformat-mov-add-support-audio-fallback-track-ref.patch
@@ -1,0 +1,87 @@
+From 3cde454927b259cab4e6377bba9b0412f85936a0 Mon Sep 17 00:00:00 2001
+From: John Stebbins <jstebbins@jetheaddev.com>
+Date: Fri, 12 Apr 2024 10:06:24 -0600
+Subject: [PATCH] avformat/mov: add support audio fallback track ref
+
+---
+ libavformat/isom.h |  3 +++
+ libavformat/mov.c  | 35 +++++++++++++++++++++++++++++++++++
+ 2 files changed, 38 insertions(+)
+
+diff --git a/libavformat/isom.h b/libavformat/isom.h
+index 07f09d6eff..131aedaef5 100644
+--- a/libavformat/isom.h
++++ b/libavformat/isom.h
+@@ -266,6 +266,9 @@ typedef struct MOVStreamContext {
+         MOVEncryptionIndex *encryption_index;
+     } cenc;
+ 
++    int has_fallback;   // Audio fallback track
++    int fallback;
++
+     struct IAMFDemuxContext *iamf;
+ } MOVStreamContext;
+ 
+diff --git a/libavformat/mov.c b/libavformat/mov.c
+index 0c892b56c8..a490e78b83 100644
+--- a/libavformat/mov.c
++++ b/libavformat/mov.c
+@@ -8465,6 +8465,23 @@ fail:
+     return ret;
+ }
+ 
++static int mov_read_fall(MOVContext *c, AVIOContext *pb, MOVAtom atom)
++{
++    AVStream *st;
++    MOVStreamContext *sc;
++
++    if (c->fc->nb_streams < 1)
++        return 0;
++    st = c->fc->streams[c->fc->nb_streams-1];
++    sc = st->priv_data;
++
++    sc->fallback = avio_rb32(pb);
++    sc->has_fallback = 1;
++
++    return 0;
++}
++
++
+ static const MOVParseTableEntry mov_default_parse_table[] = {
+ { MKTAG('A','C','L','R'), mov_read_aclr },
+ { MKTAG('A','P','R','G'), mov_read_avid },
+@@ -8563,6 +8580,7 @@ static const MOVParseTableEntry mov_default_parse_table[] = {
+ { MKTAG('v','p','c','C'), mov_read_vpcc },
+ { MKTAG('m','d','c','v'), mov_read_mdcv },
+ { MKTAG('c','l','l','i'), mov_read_clli },
++{ MKTAG('f','a','l','l'), mov_read_fall },
+ { MKTAG('d','v','c','C'), mov_read_dvcc_dvvc },
+ { MKTAG('d','v','v','C'), mov_read_dvcc_dvvc },
+ { MKTAG('d','v','w','C'), mov_read_dvcc_dvvc },
+@@ -9675,6 +9693,23 @@ static int mov_read_header(AVFormatContext *s)
+             err = ff_replaygain_export(st, s->metadata);
+             if (err < 0)
+                 return err;
++            if (sc->has_fallback) {
++                for (j = 0; j < s->nb_streams; j++) {
++                    if (s->streams[j]->id == sc->fallback) {
++                        AVPacketSideData *sd;
++                        int *fallback;
++                        sd = av_packet_side_data_new(&st->codecpar->coded_side_data,
++                                 &st->codecpar->nb_coded_side_data,
++                                 AV_PKT_DATA_FALLBACK_TRACK,
++                                 sizeof(int), 0);
++                        if (!sd)
++                            return AVERROR(ENOMEM);
++                        fallback = (int*)sd->data;
++                        *fallback = j;
++                        break;
++                    }
++                }
++            }
+             break;
+         case AVMEDIA_TYPE_VIDEO:
+             if (sc->display_matrix) {
+-- 
+2.44.0
+

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -141,7 +141,12 @@ static void add_audio(int index, int linked_index, int track, hb_list_t *list_au
 
     audio->id = (substream_type << 16) | bdaudio->pid;
     audio->config.index = index;
-    audio->config.linked_index = linked_index;
+    if (linked_index >= 0)
+    {
+        audio->config.list_linked_index = hb_list_init();
+        hb_list_add_dup(audio->config.list_linked_index,
+                        &linked_index, sizeof(linked_index));
+    }
     audio->config.in.reg_desc = STR4_TO_UINT32("HDMV");
     audio->config.in.stream_type = bdaudio->coding_type;
     audio->config.in.substream_type = substream_type;

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -131,7 +131,7 @@ static void add_subtitle(int track, hb_list_t *list_subtitle, BLURAY_STREAM_INFO
     return;
 }
 
-static void add_audio(int index, int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdaudio, int substream_type, uint32_t codec, uint32_t codec_param, int attributes)
+static void add_audio(int index, int linked_index, int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdaudio, int substream_type, uint32_t codec, uint32_t codec_param, int attributes)
 {
     const char * codec_name;
     hb_audio_t * audio;
@@ -141,6 +141,7 @@ static void add_audio(int index, int track, hb_list_t *list_audio, BLURAY_STREAM
 
     audio->id = (substream_type << 16) | bdaudio->pid;
     audio->config.index = index;
+    audio->config.linked_index = linked_index;
     audio->config.in.reg_desc = STR4_TO_UINT32("HDMV");
     audio->config.in.stream_type = bdaudio->coding_type;
     audio->config.in.substream_type = substream_type;
@@ -470,57 +471,57 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
         {
             case BLURAY_STREAM_TYPE_AUDIO_TRUHD:
                 // Add 2 audio tracks.  One for TrueHD and one for AC-3
-                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
+                add_audio(index, index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3, HB_AUDIO_ATTR_NONE);
-                add_audio(index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
+                add_audio(index + 1, index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
                           HB_ACODEC_FFTRUEHD, AV_CODEC_ID_TRUEHD,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTS:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS, HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_MPEG2:
             case BLURAY_STREAM_TYPE_AUDIO_MPEG1:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_MP2,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS_SECONDARY:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_LPCM:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_PCM_BLURAY,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3, HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_MASTER:
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD:
                 // Add 2 audio tracks.  One for DTS-HD and one for DTS
-                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
+                add_audio(index, index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS, HB_AUDIO_ATTR_NONE);
                 // DTS-HD is special.  The substreams must be concatenated
                 // DTS-core followed by DTS-hd-extensions.  Setting
                 // a substream id of 0 says use all substreams.
-                add_audio(index + 1, ii, title->list_audio, bdaudio, 0,
+                add_audio(index + 1, index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_NONE);
                 break;
@@ -528,7 +529,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_SECONDARY:
                 // BD "DTSHD_SECONDARY" is DTS Express which has no
                 // DTS core
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_NONE);
                 break;
@@ -553,42 +554,42 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
         {
             case BLURAY_STREAM_TYPE_AUDIO_TRUHD:
                 // Add 2 audio tracks.  One for TrueHD and one for AC-3
-                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
+                add_audio(index, index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3,
                           HB_AUDIO_ATTR_SECONDARY);
-                add_audio(index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
+                add_audio(index + 1, index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
                           HB_ACODEC_FFTRUEHD, AV_CODEC_ID_TRUEHD,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTS:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_MPEG2:
             case BLURAY_STREAM_TYPE_AUDIO_MPEG1:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_MP2,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS:
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS_SECONDARY:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_LPCM:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_PCM_BLURAY,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3:
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
@@ -596,13 +597,13 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_MASTER:
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD:
                 // Add 2 audio tracks.  One for DTS-HD and one for DTS
-                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
+                add_audio(index, index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 // DTS-HD is special.  The substreams must be concatenated
                 // DTS-core followed by DTS-hd-extensions.  Setting
                 // a substream id of 0 says use all substreams.
-                add_audio(index + 1, ii, title->list_audio, bdaudio, 0,
+                add_audio(index + 1, index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
@@ -610,7 +611,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_SECONDARY:
                 // BD "DTSHD_SECONDARY" is DTS Express which has no
                 // DTS core
-                add_audio(index, ii, title->list_audio, bdaudio, 0,
+                add_audio(index, -1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -131,7 +131,7 @@ static void add_subtitle(int track, hb_list_t *list_subtitle, BLURAY_STREAM_INFO
     return;
 }
 
-static void add_audio(int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdaudio, int substream_type, uint32_t codec, uint32_t codec_param, int attributes)
+static void add_audio(int index, int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdaudio, int substream_type, uint32_t codec, uint32_t codec_param, int attributes)
 {
     const char * codec_name;
     hb_audio_t * audio;
@@ -140,6 +140,7 @@ static void add_audio(int track, hb_list_t *list_audio, BLURAY_STREAM_INFO *bdau
     audio = calloc( sizeof( hb_audio_t ), 1 );
 
     audio->id = (substream_type << 16) | bdaudio->pid;
+    audio->config.index = index;
     audio->config.in.reg_desc = STR4_TO_UINT32("HDMV");
     audio->config.in.stream_type = bdaudio->coding_type;
     audio->config.in.substream_type = substream_type;
@@ -460,64 +461,66 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
     for (ii = 0; ii < ti->clips[audio_clip_index].audio_stream_count; ii++)
     {
         BLURAY_STREAM_INFO * bdaudio;
+        int                  index;
 
         bdaudio = &ti->clips[audio_clip_index].audio_streams[ii];
+        index   = hb_list_count(title->list_audio);
 
         switch (bdaudio->coding_type)
         {
             case BLURAY_STREAM_TYPE_AUDIO_TRUHD:
                 // Add 2 audio tracks.  One for TrueHD and one for AC-3
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
+                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3, HB_AUDIO_ATTR_NONE);
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
+                add_audio(index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
                           HB_ACODEC_FFTRUEHD, AV_CODEC_ID_TRUEHD,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTS:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS, HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_MPEG2:
             case BLURAY_STREAM_TYPE_AUDIO_MPEG1:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_MP2,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS_SECONDARY:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_LPCM:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_PCM_BLURAY,
                           HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3, HB_AUDIO_ATTR_NONE);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_MASTER:
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD:
                 // Add 2 audio tracks.  One for DTS-HD and one for DTS
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
+                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS, HB_AUDIO_ATTR_NONE);
                 // DTS-HD is special.  The substreams must be concatenated
                 // DTS-core followed by DTS-hd-extensions.  Setting
                 // a substream id of 0 says use all substreams.
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index + 1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_NONE);
                 break;
@@ -525,7 +528,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_SECONDARY:
                 // BD "DTSHD_SECONDARY" is DTS Express which has no
                 // DTS core
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_NONE);
                 break;
@@ -541,49 +544,51 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
     for (jj = 0; jj < ti->clips[audio_clip_index].sec_audio_stream_count; jj++, ii++)
     {
         BLURAY_STREAM_INFO * bdaudio;
+        int                  index;
 
         bdaudio = &ti->clips[audio_clip_index].sec_audio_streams[jj];
+        index   = hb_list_count(title->list_audio);
 
         switch (bdaudio->coding_type)
         {
             case BLURAY_STREAM_TYPE_AUDIO_TRUHD:
                 // Add 2 audio tracks.  One for TrueHD and one for AC-3
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
+                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_AC3,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3,
                           HB_AUDIO_ATTR_SECONDARY);
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
+                add_audio(index + 1, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_TRUEHD,
                           HB_ACODEC_FFTRUEHD, AV_CODEC_ID_TRUEHD,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_DTS:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_MPEG2:
             case BLURAY_STREAM_TYPE_AUDIO_MPEG1:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_MP2,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS:
             case BLURAY_STREAM_TYPE_AUDIO_AC3PLUS_SECONDARY:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFEAC3, AV_CODEC_ID_EAC3,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_LPCM:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_FFMPEG, AV_CODEC_ID_PCM_BLURAY,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
 
             case BLURAY_STREAM_TYPE_AUDIO_AC3:
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_AC3, AV_CODEC_ID_AC3,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
@@ -591,13 +596,13 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_MASTER:
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD:
                 // Add 2 audio tracks.  One for DTS-HD and one for DTS
-                add_audio(ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
+                add_audio(index, ii, title->list_audio, bdaudio, HB_SUBSTREAM_BD_DTS,
                           HB_ACODEC_DCA, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 // DTS-HD is special.  The substreams must be concatenated
                 // DTS-core followed by DTS-hd-extensions.  Setting
                 // a substream id of 0 says use all substreams.
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index + 1, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;
@@ -605,7 +610,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
             case BLURAY_STREAM_TYPE_AUDIO_DTSHD_SECONDARY:
                 // BD "DTSHD_SECONDARY" is DTS Express which has no
                 // DTS core
-                add_audio(ii, title->list_audio, bdaudio, 0,
+                add_audio(index, ii, title->list_audio, bdaudio, 0,
                           HB_ACODEC_DCA_HD, AV_CODEC_ID_DTS,
                           HB_AUDIO_ATTR_SECONDARY);
                 break;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5367,6 +5367,8 @@ void hb_audio_close( hb_audio_t **audio )
  *********************************************************************/
 void hb_audio_config_init(hb_audio_config_t * audiocfg)
 {
+    audiocfg->index = 0;
+
     /* Set read-only parameters to invalid values */
     audiocfg->in.codec = 0;
     audiocfg->in.codec_param = 0;
@@ -5413,7 +5415,7 @@ int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg)
     hb_title_t *title = job->title;
     hb_audio_t *audio;
 
-    audio = hb_audio_copy( hb_list_item( title->list_audio, audiocfg->in.track ) );
+    audio = hb_audio_copy( hb_list_item( title->list_audio, audiocfg->index ) );
     if( audio == NULL )
     {
         /* We fail! */
@@ -5427,14 +5429,6 @@ int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg)
         hb_audio_close(&audio);
         return 0;
     }
-
-    /* Set the job's "in track" to the value passed in audiocfg.
-     * HandBrakeCLI assumes this value is preserved in the jobs
-     * audio list, but in.track in the title's audio list is not
-     * required to be the same. */
-    // "track" in title->list_audio is an index into the source's tracks.
-    // "track" in job->list_audio is an index into title->list_audio
-    audio->config.in.track = audiocfg->in.track;
 
     /* Really shouldn't ignore the passed out track, but there is currently no
      * way to handle duplicates or out-of-order track numbers. */

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5368,6 +5368,7 @@ void hb_audio_close( hb_audio_t **audio )
 void hb_audio_config_init(hb_audio_config_t * audiocfg)
 {
     audiocfg->index = 0;
+    audiocfg->linked_index = -1;
 
     /* Set read-only parameters to invalid values */
     audiocfg->in.codec = 0;

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -568,6 +568,7 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
                audio->config.lang.simple, codec_name,
                audio->config.lang.iso639_2, lang_extension);
 
+        audio->config.index           = hb_list_count(title->list_audio);
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -569,7 +569,6 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
                audio->config.lang.iso639_2, lang_extension);
 
         audio->config.index           = hb_list_count(title->list_audio);
-        audio->config.linked_index    = -1;
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -569,6 +569,7 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
                audio->config.lang.iso639_2, lang_extension);
 
         audio->config.index           = hb_list_count(title->list_audio);
+        audio->config.linked_index    = -1;
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -703,6 +703,7 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
                audio->config.lang.simple, codec_name,
                audio->config.lang.iso639_2, lang_extension);
 
+        audio->config.index           = hb_list_count(title->list_audio);
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -704,7 +704,6 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
                audio->config.lang.iso639_2, lang_extension);
 
         audio->config.index           = hb_list_count(title->list_audio);
-        audio->config.linked_index    = -1;
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -704,6 +704,7 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
                audio->config.lang.iso639_2, lang_extension);
 
         audio->config.index           = hb_list_count(title->list_audio);
+        audio->config.linked_index    = -1;
         audio->config.in.track        = i;
         audio->config.in.timebase.num = 1;
         audio->config.in.timebase.den = 90000;

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -928,6 +928,14 @@ struct hb_audio_config_s
     // index of this item in title.list_audio
     int index;
 
+    // index of a "linked" audio item in title.list_audio
+    // a linked audio is *exactly* the same audio encoded differently
+    //
+    // e.g. TrueHD tracks that have embedded AC3 and DTSHD that have
+    // embedded DTS are split into distinct "tracks" by HandBrake but
+    // are actually the exact same source track.
+    int linked_index;
+
     /* Output */
     struct
     {

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -133,6 +133,7 @@ int hb_buffer_list_size(hb_buffer_list_t *list);
 hb_list_t * hb_list_init(void);
 int         hb_list_count( const hb_list_t * );
 void        hb_list_add( hb_list_t *, void * );
+void        hb_list_add_dup( hb_list_t *, void *, int );
 void        hb_list_insert( hb_list_t * l, int pos, void * p );
 void        hb_list_rem( hb_list_t *, void * );
 void      * hb_list_item( const hb_list_t *, int );
@@ -934,7 +935,7 @@ struct hb_audio_config_s
     // e.g. TrueHD tracks that have embedded AC3 and DTSHD that have
     // embedded DTS are split into distinct "tracks" by HandBrake but
     // are actually the exact same source track.
-    int linked_index;
+    hb_list_t * list_linked_index;
 
     /* Output */
     struct

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -925,6 +925,9 @@ struct hb_job_s
 // Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/hb_audio_config_s.cs when changing this struct
 struct hb_audio_config_s
 {
+    // index of this item in title.list_audio
+    int index;
+
     /* Output */
     struct
     {
@@ -961,7 +964,7 @@ struct hb_audio_config_s
     /* Input */
     struct
     {
-        int track; /* Input track number */
+        PRIVATE int track; /* Input track number */
         PRIVATE uint32_t codec; /* Input audio codec */
         PRIVATE uint32_t codec_param; /* Per-codec config info */
         PRIVATE uint32_t reg_desc; /* Registration descriptor of source */

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -910,7 +910,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
 
         audio_dict = json_pack_ex(&error, 0,
             "{s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
-            "Track",                hb_value_int(audio->config.in.track),
+            "Track",                hb_value_int(audio->config.index),
             "Encoder",              hb_value_int(audio->config.out.codec),
             "Gain",                 hb_value_double(audio->config.out.gain),
             "DRC",                  hb_value_double(audio->config.out.dynamic_range_compression),
@@ -1535,7 +1535,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             hb_audio_config_init(&audio);
             result = json_unpack_ex(audio_dict, &error, 0,
                 "{s:i, s?s, s?o, s?F, s?F, s?o, s?b, s?o, s?o, s?i, s?F, s?F}",
-                "Track",                unpack_i(&audio.in.track),
+                "Track",                unpack_i(&audio.index),
                 "Name",                 unpack_s(&name),
                 "Encoder",              unpack_o(&acodec),
                 "Gain",                 unpack_f(&audio.out.gain),
@@ -1607,7 +1607,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             {
                 audio.out.name = name;
             }
-            if (audio.in.track >= 0)
+            if (audio.index >= 0)
             {
                 audio.out.track = ii;
                 hb_audio_add(job, &audio);

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -719,7 +719,7 @@ static int avformatInit( hb_mux_object_t * m )
 
                     fallback = hb_list_item( job->list_audio, jj );
                     codec = fallback->config.out.codec & HB_ACODEC_MASK;
-                    if (fallback->config.in.track == audio->config.in.track &&
+                    if (fallback->config.index == audio->config.index &&
                         (codec == HB_ACODEC_FFAAC ||
                          codec == HB_ACODEC_CA_AAC ||
                          codec == HB_ACODEC_CA_HAAC ||

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -2100,7 +2100,7 @@ static void pes_add_subtitle_to_title(
 // out of order in pes_add_audio_to_title
 static void pes_set_audio_indices(hb_title_t * title)
 {
-    int ii, count;
+    int ii, jj, count;
 
     count = hb_list_count( title->list_audio );
 
@@ -2110,6 +2110,18 @@ static void pes_set_audio_indices(hb_title_t * title)
 
         audio_ii = hb_list_item( title->list_audio, ii );
         audio_ii->config.index        = ii;
+        audio_ii->config.linked_index = -1;
+        for ( jj = ii + 1; jj < count; jj++ )
+        {
+            hb_audio_t *audio_jj;
+
+            audio_jj = hb_list_item( title->list_audio, jj );
+            if ((audio_ii->id & 0xffff) == (audio_jj->id & 0xffff))
+            {
+                audio_ii->config.linked_index = jj;
+                audio_jj->config.linked_index = ii;
+            }
+        }
     }
 }
 
@@ -5391,6 +5403,7 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
     hb_audio_t *audio              = calloc(1, sizeof(*audio));
     audio->id                      = id;
     audio->config.index            = hb_list_count(title->list_audio);
+    audio->config.linked_index     = -1;
     audio->config.in.track         = id;
     audio->config.in.codec         = HB_ACODEC_FFMPEG;
     audio->config.in.codec_param   = codecpar->codec_id;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -801,7 +801,7 @@ void hb_display_job_info(hb_job_t *job)
             if( audio->config.out.name )
                 hb_log( "   + name: %s", audio->config.out.name );
 
-            hb_log( "   + decoder: %s (track %d, id 0x%x)", audio->config.lang.description, audio->config.in.track + 1, audio->id );
+            hb_log( "   + decoder: %s (track %d, id 0x%x)", audio->config.lang.description, audio->config.index + 1, audio->id );
 
             if (audio->config.in.bitrate >= 1000)
                 hb_log("     + bitrate: %d kbps, samplerate: %d Hz",

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -395,7 +395,7 @@
                                    inputTrack.sampleRate :
                                    audioTrack.sampleRate);
 
-            audio->in.track = (int)audioTrack.sourceTrackIdx - 1;
+            audio->index = (int)audioTrack.sourceTrackIdx - 1;
 
             // We go ahead and assign values to our audio->out.<properties>
             audio->out.track                     = audio->in.track;


### PR DESCRIPTION
For some types of audio tracks, there can be "linked" tracks that are
exactly the same audio encoded differently. For these linked tracks,
choose the best one given the output encoder settings specified.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Fedora Linux

