### PR TITLE
libhb: Fix vpl header path for FreeBSD

### DIFF
--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -46,7 +46,11 @@ LIBHB.GCC.D += __LIBHB__ USE_PTHREAD
 LIBHB.GCC.I += $(LIBHB.build/) $(CONTRIB.build/)include
 
 ifeq (1,$(FEATURE.qsv))
-    LIBHB.GCC.I += $(CONTRIB.build/)include/vpl
+    ifeq ($(HOST.system),freebsd))
+        LIBHB.GCC.I += $(LOCALBASE)/include/vpl
+    else
+        LIBHB.GCC.I += $(CONTRIB.build/)include/vpl
+    endif
 endif
 
 ifneq (,$(filter $(HOST.system),freebsd netbsd))


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Fix vpl header path to `${LOCALBASE}/include/vpl` for FreeBSD.
Because system libvpl is used on FreeBSD environment.
This fixes #4386.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] FreeBSD

**Screenshots (If relevant):**


**Log file output (If relevant):**
