### PR TITLE
MacGui: Restore default range values when empty

### DIFF
--- a/macosx/HBRange.m
+++ b/macosx/HBRange.m
@@ -41,6 +41,16 @@ NSString *HBRangeChangedNotification = @"HBRangeChangedNotification";
     if (type != _type)
     {
         [[self.undo prepareWithInvocationTarget:self] setType:_type];
+
+        if (_type == HBRangeTypeSeconds && _secondsStart == 0 && _secondsStop == 0) {
+            [self setSecondsStart: 0];
+            [self setSecondsStop: _title.duration];
+        }
+
+        if (_type == HBRangeTypeFrames && _frameStart == 0 && _frameStop == 0) {
+            [self setFrameStart: 0];
+            [self setFrameStop: _title.frames];
+        }
     }
     _type = type;
 }


### PR DESCRIPTION
This pull request restores default range values if they have been deleted, fixing https://github.com/HandBrake/HandBrake/issues/4304.

**Test on:**
- [x] macOS 10.13+
