### PR TITLE
Respect build type for SVT-AV1

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -18,7 +18,7 @@ SVT-AV1.CONFIGURE.extra       = -DBUILD_DEC=OFF
 ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
     SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
 else
-    ifneq (none,$(X265_8.GCC.g))
+    ifneq (none,$(SVT-AV1.GCC.g))
         SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
     else
         SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -15,6 +15,16 @@ SVT-AV1.CONFIGURE.static      =
 SVT-AV1.CONFIGURE.shared      = -DBUILD_SHARED_LIBS=OFF
 SVT-AV1.CONFIGURE.extra       = -DBUILD_DEC=OFF
 
+ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
+    SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
+else
+    ifneq (none,$(X265_8.GCC.g))
+        SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+    else
+        SVT-AV1.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+    endif
+endif
+
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))
         SVT-AV1.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON


### PR DESCRIPTION
Respect build type `size-aggressive` and `debug` also for SVT-AV1.

This is just a carbon copy of the thing we are doing for 
libjpeg-turbo https://github.com/HandBrake/HandBrake/blob/eb343f298ae43d2164404cad08c4686ed0137e5e/contrib/libjpeg-turbo/module.defs#L19
x265 https://github.com/HandBrake/HandBrake/blob/f90f8cbcba14b41f1b49abe35020f01335abfed1/contrib/x265_10bit/module.defs#L31
libvpl https://github.com/HandBrake/HandBrake/blob/b549bd5e4c3a182fe421c8b28df334eacf975f95/contrib/libvpl/module.defs#L18
