### PR TITLE
libhb: replace sprintf calls with snprintf and bound checks.

### DIFF
--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -654,7 +654,7 @@ hb_title_t * hb_bd_title_scan( hb_bd_t * d, int tt, uint64_t min_duration )
         chapter = calloc( sizeof( hb_chapter_t ), 1 );
 
         chapter->index = ++jj;
-        sprintf( chapter_title, "Chapter %d", chapter->index );
+        snprintf( chapter_title, sizeof(chapter_title), "Chapter %d", chapter->index );
         hb_chapter_set_title( chapter, chapter_title );
 
         chapter->duration = ti->chapters[ii].duration;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5889,18 +5889,18 @@ void hb_hexdump( hb_debug_level_t level, const char * label, const uint8_t * dat
     {
         if( ( ii & 0x0f ) == 0x0f )
         {
-            p += sprintf( p, "%02x", data[ii] );
+            p += snprintf( p, sizeof(line), "%02x", data[ii] );
             hb_deep_log( level, "    %-50s%20s", line, ascii );
             memset(&ascii[1], '.', 16);
             p = line;
         }
         else if( ( ii & 0x07 ) == 0x07 )
         {
-            p += sprintf( p, "%02x  ", data[ii] );
+            p += snprintf( p, sizeof(line), "%02x  ", data[ii] );
         }
         else
         {
-            p += sprintf( p, "%02x ", data[ii] );
+            p += snprintf( p, sizeof(line), "%02x ", data[ii] );
         }
         if( isgraph( data[ii] ) )
             ascii[(ii & 0x0f) + 1] = data[ii];

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -162,7 +162,7 @@ static hb_buffer_t *tx3g_decode_to_ssa(hb_work_private_t *pv, hb_buffer_t *in)
     int charIndex = 0;
     int styleIndex = 0;
 
-    sprintf((char*)dst, "%d,,Default,,0,0,0,,", pv->line);
+    snprintf((char*)dst, maxOutputSize, "%d,,Default,,0,0,0,,", pv->line);
     dst += strlen((char*)dst);
     start = dst;
     for (pos = text, end = text + textLength; pos < end; pos++)

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -664,7 +664,7 @@ static hb_title_t * hb_dvdread_title_scan( hb_dvd_t * e, int t, uint64_t min_dur
 
         /* remember the on-disc chapter number */
         chapter->index = i + 1;
-        sprintf( chapter_title, "Chapter %d", chapter->index );
+        snprintf( chapter_title, sizeof(chapter_title), "Chapter %d", chapter->index );
         hb_chapter_set_title( chapter, chapter_title );
 
         pgc_id = vts->vts_ptt_srpt->title[title_ttn-1].ptt[i].pgcn;

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -803,7 +803,7 @@ static hb_title_t * hb_dvdnav_title_scan( hb_dvd_t * e, int t, uint64_t min_dura
         chapter->index    = i + 1;
         chapter->duration = dvd_chapter->duration;
 
-        sprintf(chapter_title, "Chapter %d", chapter->index);
+        snprintf(chapter_title, sizeof(chapter_title), "Chapter %d", chapter->index);
         hb_chapter_set_title(chapter, chapter_title);
 
         hb_list_add( title->list_chapter, chapter );

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1628,7 +1628,7 @@ void hb_qsv_info_print()
             {
                 char value_str[256];
                 int *value = hb_list_item(g_qsv_adapters_list, i);
-                sprintf(value_str, "%d", *value);
+                snprintf(value_str, sizeof(value_str), "%d", *value);
                 if (i > 0)
                     strcat(gpu_list_str, ", ");
                 strcat(gpu_list_str, value_str);
@@ -3558,7 +3558,7 @@ int hb_qsv_param_parse_dx_index(hb_job_t *job, const int dx_index)
                     return -1;
                 }
             }
-            sprintf(job->qsv.ctx->qsv_device, "%u", info->Number);
+            snprintf(job->qsv.ctx->qsv_device, 32, "%u", info->Number);
             job->qsv.ctx->dx_index = info->Number;
             hb_log("qsv: %s qsv adapter with index %s has been selected", hb_qsv_get_adapter_type(info), job->qsv.ctx->qsv_device);
             hb_qsv_set_adapter_index(info->Number);

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -54,9 +54,9 @@ static const char *aspect_to_string(hb_rational_t *dar)
     }
     static char arstr[32];
     if (aspect >= 1)
-        sprintf(arstr, "%.2f:1", aspect);
+        snprintf(arstr, sizeof(arstr), "%.2f:1", aspect);
     else
-        sprintf(arstr, "1:%.2f", 1. / aspect );
+        snprintf(arstr, sizeof(arstr), "1:%.2f", 1. / aspect );
     return arstr;
 }
 
@@ -1542,7 +1542,8 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_buffer_t * b)
         int channels = av_get_channel_layout_nb_channels(audio->config.in.channel_layout);
         char *desc   = audio->config.lang.description +
                         strlen(audio->config.lang.description);
-        sprintf(desc, " (%d.%d ch)", channels - lfes, lfes);
+        size_t size = sizeof(audio->config.lang.description) - strlen(audio->config.lang.description);
+        snprintf(desc, size, " (%d.%d ch)", channels - lfes, lfes);
 
         // describe the matrix encoding mode, if any
         switch (audio->config.in.matrix_encoding)

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5971,7 +5971,7 @@ static hb_title_t *ffmpeg_title_scan( hb_stream_t *stream, hb_title_t *title )
                 else
                 {
                     char chapter_title[80];
-                    sprintf( chapter_title, "Chapter %d", chapter->index );
+                    snprintf( chapter_title, sizeof(chapter_title), "Chapter %d", chapter->index );
                     hb_chapter_set_title( chapter, chapter_title );
                 }
 

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -2594,7 +2594,7 @@ static hb_buffer_t * merge_ssa(hb_buffer_t *a, hb_buffer_t *b)
         }
         // Text subtitles are SSA internally.  Use SSA newline code
         // and force style reset at beginning of new line.
-        len = sprintf((char*)buf->data, "%s\\N{\\r}%s", a->data, text);
+        len = snprintf((char*)buf->data, buf->size, "%s\\N{\\r}%s", a->data, text);
         if (len >= 0)
             buf->size = len + 1;
     }

--- a/test/test.c
+++ b/test/test.c
@@ -2483,14 +2483,15 @@ static int ParseOptions( int argc, char ** argv )
                     if( device_is_dvd( devName ))
                     {
                         free( input );
-                        input = malloc( strlen( "/dev/" ) + strlen( devName ) + 1 );
+                        size_t size = strlen( "/dev/" ) + strlen( devName ) + 1;
+                        input = malloc( size );
                         if( input == NULL )
                         {
                             fprintf( stderr, "ERROR: malloc() failed while attempting to set device path.\n" );
                             free( devName );
                             return -1;
                         }
-                        sprintf( input, "/dev/%s", devName );
+                        snprintf( input, size, "/dev/%s", devName );
                     }
                     free( devName );
                 }


### PR DESCRIPTION
Replace some sprintf calls, clang/Xcode 14 warns about them.
I think it needs another pair of eyes to check if the bounds are correct.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
