### PR TITLE
Enable TrueHD Passthru muxing into MP4

### DIFF
--- a/contrib/ffmpeg/A25-enable-truehd-pass.patch
+++ b/contrib/ffmpeg/A25-enable-truehd-pass.patch
@@ -1,0 +1,25 @@
+From 703e4a5cea1a75d384cb7b29cca398767312c08a Mon Sep 17 00:00:00 2001
+From: Nomis101 <Nomis101@web.de>
+Date: Sun, 3 Jul 2022 19:39:44 +0200
+Subject: [PATCH] enable TrueHD for MP4
+
+Signed-off-by: Nomis101 <Nomis101@web.de>
+---
+ libavformat/movenc.c | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index 4c868919ae..f811f9a927 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -6848,7 +6848,6 @@ static int mov_init(AVFormatContext *s)
+                 }
+             }
+             if (track->par->codec_id == AV_CODEC_ID_FLAC ||
+-                track->par->codec_id == AV_CODEC_ID_TRUEHD ||
+                 track->par->codec_id == AV_CODEC_ID_OPUS) {
+                 if (track->mode != MODE_MP4) {
+                     av_log(s, AV_LOG_ERROR, "%s only supported in MP4.\n", avcodec_get_name(track->par->codec_id));
+-- 
+2.32.0 (Apple Git-132)
+

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -408,7 +408,7 @@ hb_encoder_internal_t hb_audio_encoders[]  =
     { { "AC3 Passthru",       "copy:ac3",   "AC3 Passthru",                HB_ACODEC_AC3_PASS,    HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_ACODEC_AC3_PASS,   },
     { { "E-AC3",              "eac3",       "E-AC3 (libavcodec)",          HB_ACODEC_FFEAC3,      HB_MUX_MASK_MP4|HB_MUX_AV_MKV,   }, NULL, 0, 1, HB_GID_ACODEC_EAC3,       },
     { { "E-AC3 Passthru",     "copy:eac3",  "E-AC3 Passthru",              HB_ACODEC_EAC3_PASS,   HB_MUX_MASK_MP4|HB_MUX_AV_MKV,   }, NULL, 0, 1, HB_GID_ACODEC_EAC3_PASS,  },
-    { { "TrueHD Passthru",    "copy:truehd","TrueHD Passthru",             HB_ACODEC_TRUEHD_PASS,                 HB_MUX_AV_MKV,   }, NULL, 0, 1, HB_GID_ACODEC_TRUEHD_PASS,},
+    { { "TrueHD Passthru",    "copy:truehd","TrueHD Passthru",             HB_ACODEC_TRUEHD_PASS, HB_MUX_MASK_MP4|HB_MUX_AV_MKV,   }, NULL, 0, 1, HB_GID_ACODEC_TRUEHD_PASS,},
     { { "DTS Passthru",       "copy:dts",   "DTS Passthru",                HB_ACODEC_DCA_PASS,    HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_ACODEC_DTS_PASS,   },
     { { "DTS-HD Passthru",    "copy:dtshd", "DTS-HD Passthru",             HB_ACODEC_DCA_HD_PASS, HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_ACODEC_DTSHD_PASS, },
     { { "MP2 Passthru",       "copy:mp2",   "MP2 Passthru",                HB_ACODEC_MP2_PASS,                    HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_ACODEC_MP2_PASS,   },


### PR DESCRIPTION
**Description of Change:**
See #4327. Enables mixing of TrueHD audio into MP4 files. As mentioned, it is the user's responsibility to choose this only if the user's software/hardware supports it.
For a short sample file see #4327.




**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux