### PR TITLE
[x265] correctly define 64-bit for aarch64

### DIFF
--- a/contrib/x265/A04-64-bit_for_aarch64.patch
+++ b/contrib/x265/A04-64-bit_for_aarch64.patch
@@ -1,0 +1,25 @@
+From 1a8e353e4e4d0120c85df6c3505738d0f1ba03cd Mon Sep 17 00:00:00 2001
+From: Nomis101 <Nomis101@web.de>
+Date: Fri, 10 Jun 2022 23:11:25 +0200
+Subject: [x265] [PATCH] correctly define 64-bit for aarch64
+
+Signed-off-by: Nomis101 <Nomis101@web.de>
+---
+ source/common/version.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/source/common/version.cpp b/source/common/version.cpp
+index 42a6b1d86..618ff4276 100644
+--- a/source/common/version.cpp
++++ b/source/common/version.cpp
+@@ -71,7 +71,7 @@
+ #define ONOS    "[Unk-OS]"
+ #endif
+ 
+-#if X86_64
++#if X86_64 || defined(__aarch64__)
+ #define BITS    "[64 bit]"
+ #else
+ #define BITS    "[32 bit]"
+-- 
+2.32.0 (Apple Git-132)


### PR DESCRIPTION
At the moment on a Mac with Apple Silicon x265 outputs e.g.
> x265 [info]: build info [Mac OS X][clang 13.0.0][32 bit] 10bit

After this patch, it correctly outputs an Apple Silicon as 64-bit.
> x265 [info]: build info [Mac OS X][clang 13.0.0][64 bit] 10bit

I also submitted this patch (and another one) upstream some time ago, but no response so far.