### PR TITLE
contribs: Update AMF to 1.4.24 

### DIFF
--- a/contrib/amf/module.defs
+++ b/contrib/amf/module.defs
@@ -1,10 +1,11 @@
 $(eval $(call import.MODULE.defs,AMF,amf))
 $(eval $(call import.CONTRIB.defs,AMF))
 
-AMF.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/AMF-1.4.18.tar.gz
-AMF.FETCH.url     += https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/refs/tags/v1.4.18.zip
-AMF.FETCH.sha256   = 4f21ee07c8bb9b73ff48dbce7cb0917cdcd4d81d33333da391d97ce7f00642fe
-AMF.FETCH.basename = AMF-1.4.18.tar.gz
+AMF.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/AMF-1.4.24.tar.gz
+# Commented out official source for now. The official tar includes ffmpeg binaries which seriously bloats the file. Our version is cut down.
+# AMF.FETCH.url     += https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/refs/tags/v1.4.24.zip
+AMF.FETCH.sha256   = 07d325da97a5a3cb58d83c54b2ce1148dc84dc9bb3971b0c30ff4cc16e159194
+AMF.FETCH.basename = AMF-1.4.24.tar.gz
 
 AMF.CONFIGURE = $(TOUCH.exe) $@
 AMF.BUILD     = $(TOUCH.exe) $@


### PR DESCRIPTION
**Description of Change:**

It doesn't seem to cause any regressions. No noticeable improvements. 

I have a feeling the presets are still not doing an awful lot of anything. I'll look into that separately as it's not a behaviour change. 

I've created a custom tar package as their own repo has a full multi-hundred-mb set of ffmpeg binaries which massively bloats the tar file.  I've got it down to around 3.2MB from 176MB 



**Test on:**

- [x] Windows 10+  (via MinGW)

