### PR TITLE
qsv: fix format selection, segmentation fault, proper naming

### DIFF
--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -15,10 +15,22 @@
 static const char * const hb_av1_profile_names[] = {
     "auto", "main", "high", "professional", NULL, };
 
+#if HB_PROJECT_FEATURE_QSV
+static const char * const hb_av1_qsv_profile_names[] = {
+    "auto", "main", NULL, };
+#endif
+
 static const char * const hb_av1_level_names[] = {
     "auto", "2.0", "2.1", "2.2", "2.3", "3.0", "3.1", "3.2",
     "3.3", "4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2",
     "5.3", "6.0", "6.1", "6.2", "6.3", NULL, };
+
+#if HB_PROJECT_FEATURE_QSV
+static const char * const hb_av1_qsv_level_names[] = {
+    "auto", "2.0", "2.1", "2.2", "2.3", "3.0", "3.1", "3.2",
+    "3.3", "4.0", "4.1", "4.2", "4.3", "5.0", "5.1", "5.2",
+    "5.3", "6.0", NULL, };
+#endif
 
 static const int          hb_av1_level_values[] = {
      -1,  20,  21,  22,  23,  30,  31,  32,  33,  40,  41,  42,

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -338,9 +338,9 @@ typedef struct hb_qsv_context {
 
     void *qsv_config;
 
-    int num_cpu_filters;
+    int num_sw_filters;
     int la_is_enabled;
-    int qsv_filters_are_enabled;
+    int qsv_hw_filters_are_enabled;
     int full_path_is_enabled;
     char *vpp_scale_mode;
     char *vpp_interpolation_method;

--- a/libhb/handbrake/qsv_memory.h
+++ b/libhb/handbrake/qsv_memory.h
@@ -59,7 +59,7 @@ typedef struct{
 #if !HB_QSV_ONEVPL
 int qsv_nv12_to_yuv420(struct SwsContext* sws_context,hb_buffer_t* dst, mfxFrameSurface1* src,mfxCoreInterface *core);
 #endif
-int qsv_yuv420_to_nv12(struct SwsContext* sws_context,mfxFrameSurface1* dst, hb_buffer_t* src);
-
+int qsv_convert_yuv_to_nv12(struct SwsContext *sws_context, mfxFrameSurface1 *dst, hb_buffer_t *src);
+int qsv_copy_buffer_to_surface(mfxFrameSurface1 *dst, hb_buffer_t *src);
 #endif // HB_PROJECT_FEATURE_QSV
 #endif // HANDBRAKE_QSV_MEMORY_H

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1852,7 +1852,7 @@ static int hb_d3d11va_device_check();
 
 int hb_qsv_hw_filters_are_enabled(hb_job_t *job)
 {
-    return job && job->qsv.ctx && job->qsv.ctx->qsv_filters_are_enabled;
+    return job && job->qsv.ctx && job->qsv.ctx->qsv_hw_filters_are_enabled;
 }
 
 int hb_qsv_is_enabled(hb_job_t *job)
@@ -1910,7 +1910,7 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
 
     qsv_full_path_is_enabled = (hb_qsv_decode_is_enabled(job) &&
         info && hb_qsv_implementation_is_hardware(info->implementation) &&
-        device_check_succeeded && job->qsv.ctx && !job->qsv.ctx->num_cpu_filters);
+        device_check_succeeded && job->qsv.ctx && !job->qsv.ctx->num_sw_filters);
     return qsv_full_path_is_enabled;
 }
 
@@ -4830,7 +4830,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
     if (job->vcodec & HB_VCODEC_QSV_MASK)
     {
         int i = 0;
-        int num_cpu_filters = 0;
+        int num_sw_filters = 0;
         if (job->list_filter != NULL && hb_list_count(job->list_filter) > 0)
         {
             for (i = 0; i < hb_list_count(job->list_filter); i++)
@@ -4847,17 +4847,17 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
                     case HB_FILTER_ROTATE:
                     case HB_FILTER_RENDER_SUB:
                     case HB_FILTER_AVFILTER:
-                        num_cpu_filters++;
+                        num_sw_filters++;
                         break;
                     default:
-                        num_cpu_filters++;
+                        num_sw_filters++;
                         break;
                 }
             }
         }
-        job->qsv.ctx->num_cpu_filters = num_cpu_filters;
-        job->qsv.ctx->qsv_filters_are_enabled = ((hb_list_count(job->list_filter) == 1) && hb_qsv_full_path_is_enabled(job)) ? 1 : 0;
-        if (job->qsv.ctx->qsv_filters_are_enabled)
+        job->qsv.ctx->num_sw_filters = num_sw_filters;
+        job->qsv.ctx->qsv_hw_filters_are_enabled = ((hb_list_count(job->list_filter) == 1) && hb_qsv_full_path_is_enabled(job)) ? 1 : 0;
+        if (job->qsv.ctx->qsv_hw_filters_are_enabled)
         {
             job->qsv.ctx->hb_vpp_qsv_frames_ctx = av_mallocz(sizeof(HBQSVFramesContext));
             if (!job->qsv.ctx->hb_vpp_qsv_frames_ctx)

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -209,27 +209,15 @@ static hb_triplet_t hb_qsv_av1_levels[] =
     { NULL,                            },
 };
 
-#if defined(_WIN32) || defined(__MINGW32__)
 static const enum AVPixelFormat hb_qsv_pix_fmts[] =
 {
-    AV_PIX_FMT_NV12, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+    AV_PIX_FMT_NV12, AV_PIX_FMT_NONE
 };
 
 static const enum AVPixelFormat hb_qsv_10bit_pix_fmts[] =
 {
-    AV_PIX_FMT_P010LE, AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
+    AV_PIX_FMT_P010LE, AV_PIX_FMT_NONE
 };
-#else
-static const enum AVPixelFormat hb_qsv_pix_fmts[] =
-{
-    AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
-};
-
-static const enum AVPixelFormat hb_qsv_10bit_pix_fmts[] =
-{
-    AV_PIX_FMT_YUV420P10, AV_PIX_FMT_YUV420P, AV_PIX_FMT_NONE
-};
-#endif
 
 #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
 
@@ -2781,17 +2769,17 @@ const int* hb_qsv_get_pix_fmts(int encoder)
 {
     switch (encoder)
     {
-        case HB_VCODEC_QSV_H264:
-        case HB_VCODEC_QSV_H265:
-        case HB_VCODEC_QSV_AV1:
-            return hb_qsv_pix_fmts;
-        case HB_VCODEC_QSV_H265_10BIT:
-        case HB_VCODEC_QSV_AV1_10BIT:
-            return hb_qsv_10bit_pix_fmts;
+    case HB_VCODEC_QSV_H264:
+    case HB_VCODEC_QSV_H265:
+    case HB_VCODEC_QSV_AV1:
+        return hb_qsv_pix_fmts;
+    case HB_VCODEC_QSV_H265_10BIT:
+    case HB_VCODEC_QSV_AV1_10BIT:
+        return hb_qsv_10bit_pix_fmts;
 
-         default:
-             return hb_qsv_pix_fmts;
-     }
+    default:
+        return hb_qsv_pix_fmts;
+    }
 }
 
 const char* hb_qsv_video_quality_get_name(uint32_t codec)

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2742,7 +2742,7 @@ const char* const* hb_qsv_profile_get_names(int encoder)
             return hb_h265_qsv_profile_names_10bit;
         case HB_VCODEC_QSV_AV1_10BIT:
         case HB_VCODEC_QSV_AV1:
-            return hb_av1_profile_names;
+            return hb_av1_qsv_profile_names;
         default:
             return NULL;
     }
@@ -2759,7 +2759,7 @@ const char* const* hb_qsv_level_get_names(int encoder)
             return hb_h265_level_names;
         case HB_VCODEC_QSV_AV1_10BIT:
         case HB_VCODEC_QSV_AV1:
-            return hb_av1_level_names;
+            return hb_av1_qsv_level_names;
         default:
             return NULL;
     }

--- a/libhb/qsv_filter_pp.c
+++ b/libhb/qsv_filter_pp.c
@@ -917,7 +917,7 @@ int process_filter(qsv_filter_task_t* task, void* params){
 
     if(task->pv->post.in)
     {
-    qsv_yuv420_to_nv12(task->pv->sws_context_to_nv12, task->out, task->pv->post.in);
+        qsv_convert_yuv_to_nv12(task->pv->sws_context_to_nv12, task->out, task->pv->post.in);
     }
 
     // signal: output is prepared, converted from internal buffer into pipeline

--- a/libhb/qsv_memory.c
+++ b/libhb/qsv_memory.c
@@ -104,7 +104,8 @@ int qsv_nv12_to_yuv420(struct SwsContext* sws_context,hb_buffer_t* dst, mfxFrame
 }
 #endif
 
-int qsv_yuv420_to_nv12(struct SwsContext* sws_context,mfxFrameSurface1* dst, hb_buffer_t* src){
+int qsv_convert_yuv_to_nv12(struct SwsContext *sws_context, mfxFrameSurface1 *dst, hb_buffer_t *src)
+{
     int ret = 0;
 
     int h = src->plane[0].height;
@@ -125,4 +126,15 @@ int qsv_yuv420_to_nv12(struct SwsContext* sws_context,mfxFrameSurface1* dst, hb_
     return ret;
 }
 
+int qsv_copy_buffer_to_surface(mfxFrameSurface1* dst, hb_buffer_t* src)
+{
+    uint8_t* out_luma = dst->Data.Y;
+    uint8_t* out_chroma = dst->Data.VU;
+
+    // p010 and nv12
+    memcpy(out_luma, src->plane[0].data, src->plane[0].height * src->plane[0].stride);
+    memcpy(out_chroma, src->plane[1].data, src->plane[1].height * src->plane[1].stride);
+
+    return 0;
+}
 #endif // HB_PROJECT_FEATURE_QSV


### PR DESCRIPTION
[UPD]: Remove colorspace converter from QSV encoder  
[UPD]: disabled unsupported profiles and level for AV1 encoder 

Basically it is a fix of regression only. There is no new functionality here.

* Remove colorspace converter from QSV encoder into nv12 or p010 formats in case of system memory. 
It was broken when "format filter" was introduced and no need to insert it in pipeline in case of SW decoder and QSV encoder. Otherwise double conversion happens and leads to segmentation fault. 