### PR TITLE
libhb: use the zscale (zimg) filter instead of scale (swscale). Zimg is more…

### DIFF
--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -153,8 +153,8 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     {
         hb_dict_set_int(avsettings, "width", width);
         hb_dict_set_int(avsettings, "height", height);
-        hb_dict_set_string(avsettings, "flags", "lanczos+accurate_rnd");
-        hb_dict_set(avfilter, "scale", avsettings);
+        hb_dict_set_string(avsettings, "filter", "lanczos");
+        hb_dict_set(avfilter, "zscale", avsettings);
     }
     
     hb_value_array_append(avfilters, avfilter);

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1247,16 +1247,15 @@ int reinit_video_filters(hb_work_private_t * pv)
         else
 #endif
         {
-            hb_dict_set(settings, "w", hb_value_int(orig_width));
-            hb_dict_set(settings, "h", hb_value_int(orig_height));
-            hb_dict_set(settings, "flags", hb_value_string("lanczos+accurate_rnd"));
-            hb_dict_set_string(settings, "in_range", get_range_name(pv->frame->color_range));
-            hb_dict_set_string(settings, "out_range", get_range_name(color_range));
-            hb_avfilter_append_dict(filters, "scale", settings);
-
-            settings = hb_dict_init();
             hb_dict_set(settings, "pix_fmts", hb_value_string(av_get_pix_fmt_name(pix_fmt)));
             hb_avfilter_append_dict(filters, "format", settings);
+            settings = hb_dict_init();
+
+            hb_dict_set(settings, "w", hb_value_int(orig_width));
+            hb_dict_set(settings, "h", hb_value_int(orig_height));
+            hb_dict_set_string(settings, "filter", "lanczos");
+            hb_dict_set_string(settings, "range", get_range_name(color_range));
+            hb_avfilter_append_dict(filters, "zscale", settings);
         }
     }
     if (pv->title->rotation != HB_ROTATION_0)


### PR DESCRIPTION
… optimized on arm64 than swscale.

On arm64 swscale has no asm for high depth formats. Performance on x86_64 seems comparable, I'll run some benchmarks tomorrow.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
