### PR TITLE
qsv: fix gpu device number for decoding

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1553,9 +1553,19 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
         }
 
 #if HB_PROJECT_FEATURE_QSV
-        if (pv->qsv.decode && pv->context->codec_id == AV_CODEC_ID_HEVC)
+        if (pv->qsv.decode)
         {
-            av_dict_set( &av_opts, "load_plugin", "hevc_hw", 0 );
+            if (pv->context->codec_id == AV_CODEC_ID_HEVC)
+                av_dict_set( &av_opts, "load_plugin", "hevc_hw", 0 );
+#if defined(_WIN32) || defined(__MINGW32__)
+            if (!hb_qsv_full_path_is_enabled(job))
+            {
+                hb_qsv_device_init(job);
+                pv->context->hw_device_ctx = av_buffer_ref(job->qsv.ctx->hb_hw_device_ctx);
+                pv->context->get_format = hb_qsv_get_format;
+                pv->context->opaque = pv->job;
+            }
+#endif
         }
 #endif
 

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -292,6 +292,7 @@ int hb_qsv_decode_h265_is_supported(int adapter_index);
 int hb_qsv_decode_h265_10_bit_is_supported(int adapter_index);
 int hb_qsv_decode_av1_is_supported(int adapter_index);
 int hb_qsv_decode_codec_supported_codec(int adapter_index, int video_codec_param, int pix_fmt, int width, int height);
+int hb_qsv_device_init(hb_job_t *job);
 
 #endif // __LIBHB__
 #endif // HB_PROJECT_FEATURE_QSV


### PR DESCRIPTION
Fixed the case where both GPUs are lighting up https://github.com/HandBrake/HandBrake/pull/4190

Co-authored-by: Vladyslav Sosunovych <vladyslav.sosunovych@intel.com>