### PR TITLE
Nvdec: fix bluray decode crash

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1772,6 +1772,10 @@ static int decodePacket( hb_work_object_t * w )
             return HB_WORK_OK;
         }
 
+#if HB_PROJECT_FEATURE_NVENC
+        int use_hw_dec = (NULL != pv->context->hw_device_ctx);
+#endif
+
         hb_avcodec_free_context(&pv->context);
         pv->context = context;
 
@@ -1779,6 +1783,12 @@ static int decodePacket( hb_work_object_t * w )
         pv->context->err_recognition   = AV_EF_CRCCHECK;
         pv->context->error_concealment = FF_EC_GUESS_MVS|FF_EC_DEBLOCK;
 
+#if HB_PROJECT_FEATURE_NVENC
+        if (use_hw_dec)
+        {
+            hb_nvdec_hw_ctx_init(pv->context, pv->job);
+        }
+#endif
 
 #if HB_PROJECT_FEATURE_QSV
         if (pv->qsv.decode &&

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -768,7 +768,7 @@ void hb_buffer_close( hb_buffer_t ** _b )
 
 #if HB_PROJECT_FEATURE_NVENC
         if (b->hw_ctx.frame)
-            av_frame_free(&b->hw_ctx.frame);
+            av_frame_free((AVFrame**)&b->hw_ctx.frame);
 #endif
 
         hb_buffer_t * next = b->next;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -174,7 +174,7 @@ int hb_nvdec_hwframes_ctx_init(AVCodecContext *ctx, hb_job_t *job)
     ctx->pix_fmt = AV_PIX_FMT_CUDA;
     ctx->hw_frames_ctx = av_hwframe_ctx_alloc(ctx->hw_device_ctx);
 
-    AVHWFramesContext *frames_ctx = ctx->hw_frames_ctx->data;
+    AVHWFramesContext *frames_ctx = (AVHWFramesContext*)ctx->hw_frames_ctx->data;
     frames_ctx->format = AV_PIX_FMT_CUDA;
     frames_ctx->sw_format = job->output_pix_fmt;
     frames_ctx->width = ctx->width;
@@ -195,7 +195,7 @@ static AVBufferRef *init_hw_frames_ctx(AVBufferRef *hw_device_ctx,
                                        int height)
 {
     AVBufferRef *hw_frames_ctx = av_hwframe_ctx_alloc(hw_device_ctx);
-    AVHWFramesContext *frames_ctx = hw_frames_ctx->data;
+    AVHWFramesContext *frames_ctx = (AVHWFramesContext*)hw_frames_ctx->data;
     frames_ctx->format = AV_PIX_FMT_CUDA;
     frames_ctx->sw_format = sw_fmt;
     frames_ctx->width = width;
@@ -283,7 +283,7 @@ int hb_nvdec_is_usable(hb_job_t *job)
      ** When video filters aren't opted-in (vRAM > RAM memcpy will occur).
      ** When Nvenc is used to encode (otherwise vRAM > RAM memcpy will occur).
      */
-     
+
     const int main_dec_loop = (NULL != job);
     const int supported_filters = main_dec_loop && hb_nvdec_are_filters_supported(job->list_filter);
     const int nvenc_is_used = main_dec_loop && is_nvenc_used(job->vcodec);

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -430,7 +430,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
 
             if (!buf->hw_ctx.frame)
             {
-                hb_nvdec_hwframe_init(stream->common->job, &buf->hw_ctx.frame);
+                hb_nvdec_hwframe_init(stream->common->job, (AVFrame**)&buf->hw_ctx.frame);
             }
 
             av_frame_copy_props(buf->hw_ctx.frame, &frame);


### PR DESCRIPTION
**Before Posting:**

Fixes issue #4568 


`AVCodecContext` structure is reinitialized in `decodePacket` function in some cases. This happens during blu-ray transcoding as well. Proposed patch adds HW device context re-initialization in such case.

Also couple compiler warnings were fixed which are caused by implicit pointer conversions.

**Test on:**

- [ ] Ubuntu Linux 20.04
- [ ] Windows 10
