### PR TITLE
contrib: add sse2neon.

### DIFF
--- a/contrib/sse2neon/A01-srai_epi16-fix.patch
+++ b/contrib/sse2neon/A01-srai_epi16-fix.patch
@@ -1,0 +1,36 @@
+From 7ef68928a1136a9288598d94eb27c4d6a707a51b Mon Sep 17 00:00:00 2001
+From: Developer-Ecosystem-Engineering
+ <65677710+Developer-Ecosystem-Engineering@users.noreply.github.com>
+Date: Fri, 8 Jul 2022 10:52:46 -0700
+Subject: [PATCH] Improve _mm_srai_epi32 to handle complex arguments
+
+Complex arguments are not always handled properly by _mm_srai_epi32.
+
+Arguments like below will properly evaluate
+input[i] = _mm_srai_epi32(input[i], new_sqrt2_bits - 1 + shift);
+
+This also resolves 5 failing tests
+
+[  FAILED  ] 5 tests, listed below:
+[  FAILED  ] TX_ASM/InvTxfm2dAsmTest.sqr_txfm_match_test/0, where GetParam() = (0x102c7b198, 8)
+[  FAILED  ] TX_ASM/InvTxfm2dAsmTest.sqr_txfm_match_test/1, where GetParam() = (0x102c7b198, 10)
+[  FAILED  ] TX_ASM/InvTxfm2dAsmTest.lowbd_txfm_match_test/0, where GetParam() = (0x102c7b198, 8)
+[  FAILED  ] TX_ASM/InvTxfm2dAddTest.svt_av1_inv_txfm_add/0, where GetParam() = (0x102c7d800, 8)
+[  FAILED  ] SSE4_1/AV1SelfguidedFilterTest.CorrectnessTest/0, where GetParam() = (0x102cd4f20)
+---
+ sse2neon.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/sse2neon.h b/sse2neon.h
+index 42a89195..c446f73a 100644
+--- a/sse2neon.h
++++ b/sse2neon.h
+@@ -5704,7 +5704,7 @@ FORCE_INLINE __m128i _mm_srai_epi16(__m128i a, int imm)
+             ret = a;                                                       \
+         } else if (_sse2neon_likely(0 < (imm) && (imm) < 32)) {            \
+             ret = vreinterpretq_m128i_s32(                                 \
+-                vshlq_s32(vreinterpretq_s32_m128i(a), vdupq_n_s32(-imm))); \
++                vshlq_s32(vreinterpretq_s32_m128i(a), vdupq_n_s32(-(imm)))); \
+         } else {                                                           \
+             ret = vreinterpretq_m128i_s32(                                 \
+                 vshrq_n_s32(vreinterpretq_s32_m128i(a), 31));              \

--- a/contrib/sse2neon/A02-types-fix.patch
+++ b/contrib/sse2neon/A02-types-fix.patch
@@ -1,0 +1,14 @@
+diff --git a/sse2neon.h b/sse2neon.h
+index 490c0a4..c804266 100644
+--- a/sse2neon.h
++++ b/sse2neon.h
+@@ -6003,7 +6003,7 @@ FORCE_INLINE void _mm_storeu_si32(void *p, __m128i a)
+ FORCE_INLINE void _mm_stream_pd(double *p, __m128d a)
+ {
+ #if __has_builtin(__builtin_nontemporal_store)
+-    __builtin_nontemporal_store(a, (float32x4_t *) p);
++    __builtin_nontemporal_store(a, (float64x2_t *) p);
+ #elif defined(__aarch64__)
+     vst1q_f64(p, vreinterpretq_f64_m128d(a));
+ #else
+

--- a/contrib/sse2neon/P00-mingw-fix-llvm.patch
+++ b/contrib/sse2neon/P00-mingw-fix-llvm.patch
@@ -1,0 +1,36 @@
+diff --git a/sse2neon.h b/sse2neon.h
+index 490c0a4..4f6a7c5 100644
+--- a/sse2neon.h
++++ b/sse2neon.h
+@@ -1761,12 +1761,15 @@ FORCE_INLINE __m128 _mm_div_ss(__m128 a, __m128 b)
+ #define _mm_extract_pi16(a, imm) \
+     (int32_t) vget_lane_u16(vreinterpret_u16_m64(a), (imm))
+ 
++
++#ifndef SSE2NEON_WORKAROUND_AS_LLVM_INCLUDED
+ // Free aligned memory that was allocated with _mm_malloc.
+ // https://software.intel.com/sites/landingpage/IntrinsicsGuide/#text=_mm_free
+ FORCE_INLINE void _mm_free(void *addr)
+ {
+     free(addr);
+ }
++#endif
+ 
+ // Macro: Get the flush zero bits from the MXCSR control and status register.
+ // The flush zero may contain any of the following flags: _MM_FLUSH_ZERO_ON or
+@@ -1945,6 +1948,7 @@ FORCE_INLINE __m128i _mm_loadu_si64(const void *p)
+         vcombine_s64(vld1_s64((const int64_t *) p), vdup_n_s64(0)));
+ }
+ 
++#ifndef SSE2NEON_WORKAROUND_AS_LLVM_INCLUDED
+ // Allocate aligned blocks of memory.
+ // https://software.intel.com/en-us/
+ //         cpp-compiler-developer-guide-and-reference-allocating-and-freeing-aligned-memory-blocks
+@@ -1959,6 +1963,7 @@ FORCE_INLINE void *_mm_malloc(size_t size, size_t align)
+         return ptr;
+     return NULL;
+ }
++#endif
+ 
+ // Conditionally store 8-bit integer elements from a into memory using mask
+ // (elements are not stored when the highest bit is not set in the corresponding

--- a/contrib/sse2neon/module.defs
+++ b/contrib/sse2neon/module.defs
@@ -1,0 +1,22 @@
+$(eval $(call import.MODULE.defs,SSE2NEON,sse2neon))
+$(eval $(call import.CONTRIB.defs,SSE2NEON))
+
+SSE2NEON.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/sse2neon-1.5.1.tar.gz
+SSE2NEON.FETCH.url      += https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.5.1.tar.gz
+SSE2NEON.FETCH.sha256    = 4001e2dfb14fcf3831211581ed83bcc83cf6a3a69f638dcbaa899044a351bb2a
+SSE2NEON.FETCH.basename  = sse2neon-1.5.1.tar.gz
+SSE2NEON.EXTRACT.tarbase = sse2neon-1.5.1
+
+SSE2NEON.CONFIGURE = $(TOUCH.exe) $@
+SSE2NEON.BUILD     = $(TOUCH.exe) $@
+
+define SSE2NEON.INSTALL
+    $(CP.exe) -R $(SSE2NEON.EXTRACT.dir/)sse2neon.h $(CONTRIB.build/)include
+    $(TOUCH.exe) $@
+endef
+
+define SSE2NEON.UNINSTALL
+    $(RM.exe) -rf $(CONTRIB.build/)include/sse2neon
+    $(RM.exe) -f $(SSE2NEON.INSTALL.target)
+endef
+

--- a/contrib/sse2neon/module.rules
+++ b/contrib/sse2neon/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,SSE2NEON))
+$(eval $(call import.CONTRIB.rules,SSE2NEON))

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -74,6 +74,10 @@ ifneq (,$(filter $(HOST.system),darwin))
     MODULES += contrib/xz
 endif
 
+ifneq (,$(filter $(HOST.machine),arm64 aarch64))
+    MODULES += contrib/sse2neon
+endif
+
 ifneq (,$(filter $(HOST.system),cygwin mingw))
 ifneq ($(HAS.iconv),1)
     MODULES += contrib/libiconv


### PR DESCRIPTION
Patch by Apple, it will be used later in some additional changes.
Just checking if it builds on every platform.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux