### PR TITLE
[Linux] Fix some localization issues and update the pot file

### DIFF
--- a/gtk/po/POTFILES.in
+++ b/gtk/po/POTFILES.in
@@ -1,6 +1,5 @@
 # List of source files containing translatable strings.
 src/ghb3.ui
-src/ghb4.ui
 src/fr.handbrake.ghb.metainfo.template.xml
 src/audiohandler.c
 src/callbacks.c

--- a/gtk/po/POTFILES.in
+++ b/gtk/po/POTFILES.in
@@ -1,5 +1,6 @@
 # List of source files containing translatable strings.
 src/ghb3.ui
+src/ghb4.ui
 src/fr.handbrake.ghb.metainfo.template.xml
 src/audiohandler.c
 src/callbacks.c

--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -3,13 +3,12 @@
 # This file is distributed under the same license as the ghb package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#: src/main.c:249 src/main.c:254 src/main.c:314 src/main.c:318
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-06-17 08:17-0600\n"
+"POT-Creation-Date: 2022-09-29 22:31+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,18 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/ghb3.ui:23
+#: src/ghb3.ui:23 src/ghb4.ui:23
 msgid ""
 "Render the subtitle over the video.\n"
 "\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:26
+#: src/ghb3.ui:26 src/ghb4.ui:26
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:32 src/ghb3.ui:9122
+#: src/ghb3.ui:32 src/ghb3.ui:9785 src/ghb4.ui:32 src/ghb4.ui:7601
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -40,11 +39,11 @@ msgid ""
 "in your output."
 msgstr ""
 
-#: src/ghb3.ui:39
+#: src/ghb3.ui:39 src/ghb4.ui:39
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:45 src/ghb3.ui:9084
+#: src/ghb3.ui:45 src/ghb3.ui:9747 src/ghb4.ui:45 src/ghb4.ui:7571
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -54,11 +53,11 @@ msgid ""
 "a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:51
+#: src/ghb3.ui:51 src/ghb4.ui:51
 msgid "<b>Forced Only</b>"
 msgstr ""
 
-#: src/ghb3.ui:57
+#: src/ghb3.ui:57 src/ghb4.ui:57
 msgid ""
 "Add (or subtract) an offset (in milliseconds)\n"
 "to the start of the SRT subtitle track.\n"
@@ -68,11 +67,11 @@ msgid ""
 "This setting allows you to synchronize the files."
 msgstr ""
 
-#: src/ghb3.ui:63
+#: src/ghb3.ui:63 src/ghb4.ui:63
 msgid "<b>SRT Offset</b>"
 msgstr ""
 
-#: src/ghb3.ui:69
+#: src/ghb3.ui:69 src/ghb4.ui:69
 msgid ""
 "The source subtitle track\n"
 "\n"
@@ -87,248 +86,249 @@ msgid ""
 "conjunction with the \"Forced\" option."
 msgstr ""
 
-#: src/ghb3.ui:80
+#: src/ghb3.ui:80 src/ghb4.ui:80
 msgid "<b>Track</b>"
 msgstr ""
 
-#: src/ghb3.ui:87
+#: src/ghb3.ui:87 src/ghb4.ui:87
 msgid "Open Source Directory"
 msgstr ""
 
-#: src/ghb3.ui:91
+#: src/ghb3.ui:91 src/ghb4.ui:91
 msgid "Open Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:95
+#: src/ghb3.ui:95 src/ghb4.ui:95
 msgid "Open Encode Log Directory"
 msgstr ""
 
-#: src/ghb3.ui:99
+#: src/ghb3.ui:99 src/ghb4.ui:99
 msgid "Open Encode Log"
 msgstr ""
 
-#: src/ghb3.ui:108
+#: src/ghb3.ui:108 src/ghb4.ui:108
 msgid "Reset Failed Jobs"
 msgstr ""
 
-#: src/ghb3.ui:112
+#: src/ghb3.ui:112 src/ghb4.ui:112
 msgid "Reset All Jobs"
 msgstr ""
 
-#: src/ghb3.ui:116
+#: src/ghb3.ui:116 src/ghb4.ui:116
 msgid "Clear Completed Jobs"
 msgstr ""
 
-#: src/ghb3.ui:120
+#: src/ghb3.ui:120 src/ghb4.ui:120
 msgid "Clear All Jobs"
 msgstr ""
 
-#: src/ghb3.ui:124
+#: src/ghb3.ui:124 src/ghb4.ui:124 src/queuehandler.c:1615
 msgid "Import Queue"
 msgstr ""
 
-#: src/ghb3.ui:128
+#: src/ghb3.ui:128 src/ghb4.ui:128 src/queuehandler.c:1470
 msgid "Export Queue"
 msgstr ""
 
-#: src/ghb3.ui:135
+#: src/ghb3.ui:135 src/ghb4.ui:135
 msgid "HandBrake Presets"
 msgstr ""
 
-#: src/ghb3.ui:163 src/ghb3.ui:2128
+#: src/ghb3.ui:163 src/ghb3.ui:2169 src/ghb4.ui:159 src/ghb4.ui:1853
 msgid "_Presets"
 msgstr ""
 
-#: src/ghb3.ui:171 src/ghb3.ui:2136
+#: src/ghb3.ui:171 src/ghb3.ui:2177 src/ghb4.ui:167 src/ghb4.ui:1861
 msgid "Set De_fault"
 msgstr ""
 
-#: src/ghb3.ui:185 src/ghb3.ui:2150
+#: src/ghb3.ui:185 src/ghb3.ui:2191 src/ghb4.ui:181 src/ghb4.ui:1875
 msgid "_Save"
 msgstr ""
 
-#: src/ghb3.ui:194 src/ghb3.ui:2159
+#: src/ghb3.ui:194 src/ghb3.ui:2200 src/ghb4.ui:190 src/ghb4.ui:1884
 msgid "Save _As"
 msgstr ""
 
-#: src/ghb3.ui:203 src/ghb3.ui:2168
+#: src/ghb3.ui:203 src/ghb3.ui:2209 src/ghb4.ui:199 src/ghb4.ui:1893
 msgid "_Rename"
 msgstr ""
 
-#: src/ghb3.ui:212 src/ghb3.ui:2177
+#: src/ghb3.ui:212 src/ghb3.ui:2218 src/ghb4.ui:208 src/ghb4.ui:1902
 msgid "_Delete"
 msgstr ""
 
-#: src/ghb3.ui:226 src/ghb3.ui:2191
+#: src/ghb3.ui:226 src/ghb3.ui:2232 src/ghb4.ui:222 src/ghb4.ui:1916
 msgid "_Import"
 msgstr ""
 
-#: src/ghb3.ui:235 src/ghb3.ui:2200
+#: src/ghb3.ui:235 src/ghb3.ui:2241 src/ghb4.ui:231 src/ghb4.ui:1925
 msgid "_Export"
 msgstr ""
 
-#: src/ghb3.ui:249 src/ghb3.ui:2214
+#: src/ghb3.ui:249 src/ghb3.ui:2255 src/ghb4.ui:245 src/ghb4.ui:1939
 msgid "Reset _Built-in Presets"
 msgstr ""
 
-#: src/ghb3.ui:304
+#: src/ghb3.ui:304 src/ghb4.ui:294
 msgid "<b>Presets List</b>"
 msgstr ""
 
-#: src/ghb3.ui:318
+#: src/ghb3.ui:318 src/ghb4.ui:305
 msgid "HandBrake Queue"
 msgstr ""
 
-#: src/ghb3.ui:352
+#: src/ghb3.ui:352 src/ghb4.ui:333
 msgid "<span size=\"x-large\">Queue</span>"
 msgstr ""
 
-#: src/ghb3.ui:367
+#: src/ghb3.ui:367 src/ghb4.ui:344
 msgid "0 jobs pending"
 msgstr ""
 
-#: src/ghb3.ui:404 src/ghb3.ui:2324 src/queuehandler.c:2378
-#: src/queuehandler.c:2391 src/queuehandler.c:2402
+#: src/ghb3.ui:404 src/ghb3.ui:2365 src/ghb4.ui:373 src/ghb4.ui:2039
+#: src/queuehandler.c:2400 src/queuehandler.c:2413 src/queuehandler.c:2424
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:406 src/ghb3.ui:2326 src/ghb3.ui:6432 src/queuehandler.c:2377
-#: src/queuehandler.c:2390
+#: src/ghb3.ui:406 src/ghb3.ui:2367 src/ghb3.ui:7116 src/ghb4.ui:375
+#: src/ghb4.ui:2041 src/ghb4.ui:5479 src/queuehandler.c:2399
+#: src/queuehandler.c:2412
 msgid "Start"
 msgstr ""
 
-#: src/ghb3.ui:420 src/ghb3.ui:2339 src/queuehandler.c:2416
-#: src/queuehandler.c:2429 src/queuehandler.c:2440
+#: src/ghb3.ui:420 src/ghb3.ui:2380 src/ghb4.ui:385 src/ghb4.ui:2051
+#: src/queuehandler.c:2438 src/queuehandler.c:2451 src/queuehandler.c:2462
 msgid "Pause Encoding"
 msgstr ""
 
-#: src/ghb3.ui:422 src/ghb3.ui:2341 src/queuehandler.c:2415
-#: src/queuehandler.c:2428
+#: src/ghb3.ui:422 src/ghb3.ui:2382 src/ghb4.ui:387 src/ghb4.ui:2053
+#: src/queuehandler.c:2437 src/queuehandler.c:2450
 msgid "Pause"
 msgstr ""
 
-#: src/ghb3.ui:480
+#: src/ghb3.ui:480 src/ghb4.ui:424
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:549
+#: src/ghb3.ui:549 src/ghb4.ui:476
 msgid "When Done:"
 msgstr ""
 
-#: src/ghb3.ui:630
+#: src/ghb3.ui:630 src/ghb4.ui:540
 msgid "Reset"
 msgstr ""
 
-#: src/ghb3.ui:632
+#: src/ghb3.ui:632 src/ghb4.ui:542
 msgid ""
 "Mark selected queue entry as pending.\n"
 "Resets the queue job to pending and ready to run again."
 msgstr ""
 
-#: src/ghb3.ui:647
+#: src/ghb3.ui:647 src/ghb4.ui:553
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:692
+#: src/ghb3.ui:692 src/ghb4.ui:589
 msgid "Actions"
 msgstr ""
 
-#: src/ghb3.ui:741 src/ghb3.ui:4825
+#: src/ghb3.ui:741 src/ghb3.ui:5467 src/ghb4.ui:625 src/ghb4.ui:4144
 msgid "Preset:"
 msgstr ""
 
-#: src/ghb3.ui:777
+#: src/ghb3.ui:777 src/ghb4.ui:655
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:818 src/ghb3.ui:6512
+#: src/ghb3.ui:818 src/ghb3.ui:7196 src/ghb4.ui:690 src/ghb4.ui:5541
 msgid "Title:"
 msgstr ""
 
-#: src/ghb3.ui:858
+#: src/ghb3.ui:858 src/ghb4.ui:726
 msgid "Destination:"
 msgstr ""
 
-#: src/ghb3.ui:899
+#: src/ghb3.ui:899 src/ghb4.ui:761
 msgid "Dimensions:"
 msgstr ""
 
-#: src/ghb3.ui:935
+#: src/ghb3.ui:935 src/ghb4.ui:791
 msgid "Video:"
 msgstr ""
 
-#: src/ghb3.ui:971
+#: src/ghb3.ui:971 src/ghb4.ui:821
 msgid "Audio:"
 msgstr ""
 
-#: src/ghb3.ui:1007
+#: src/ghb3.ui:1007 src/ghb4.ui:851
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1046 src/ghb3.ui:3185
+#: src/ghb3.ui:1046 src/ghb3.ui:3248 src/ghb4.ui:521 src/ghb4.ui:2475
 msgid "Summary"
 msgstr ""
 
-#: src/ghb3.ui:1084
+#: src/ghb3.ui:1084 src/ghb4.ui:917
 msgid "Pass:"
 msgstr ""
 
-#: src/ghb3.ui:1120
+#: src/ghb3.ui:1120 src/ghb4.ui:947
 msgid "Start Time:"
 msgstr ""
 
-#: src/ghb3.ui:1156
+#: src/ghb3.ui:1156 src/ghb4.ui:977
 msgid "End Time:"
 msgstr ""
 
-#: src/ghb3.ui:1196
+#: src/ghb3.ui:1196 src/ghb4.ui:1011
 msgid "Paused Duration:"
 msgstr ""
 
-#: src/ghb3.ui:1236
+#: src/ghb3.ui:1236 src/ghb4.ui:1045
 msgid "Encode Time:"
 msgstr ""
 
-#: src/ghb3.ui:1272
+#: src/ghb3.ui:1272 src/ghb4.ui:1075
 msgid "File Size:"
 msgstr ""
 
-#: src/ghb3.ui:1308
+#: src/ghb3.ui:1308 src/ghb4.ui:1105
 msgid "Status:"
 msgstr ""
 
-#: src/ghb3.ui:1347
+#: src/ghb3.ui:1347 src/ghb4.ui:884
 msgid "Statistics"
 msgstr ""
 
-#: src/ghb3.ui:1412
+#: src/ghb3.ui:1412 src/ghb4.ui:1138
 msgid "Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1435
+#: src/ghb3.ui:1435 src/ghb4.ui:1202
 msgid "HandBrake Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1710
+#: src/ghb3.ui:1751 src/ghb4.ui:1459
 msgid "About HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1716
+#: src/ghb3.ui:1757 src/ghb4.ui:1463
 msgid ""
 "Copyright © 2008 -  John Stebbins\n"
 "Copyright © 2004 - , HandBrake Devs"
 msgstr ""
 
-#: src/ghb3.ui:1718
+#: src/ghb3.ui:1759 src/ghb4.ui:1465
 msgid ""
 "HandBrake is a GPL-licensed, multiplatform, multithreaded video transcoder."
 msgstr ""
 
-#: src/ghb3.ui:1720
+#: src/ghb3.ui:1761 src/ghb4.ui:1467
 msgid "https://handbrake.fr"
 msgstr ""
 
-#: src/ghb3.ui:1721
+#: src/ghb3.ui:1762 src/ghb4.ui:1469
 msgid ""
 "HandBrake is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License version 2, as published by the "
@@ -344,463 +344,525 @@ msgid ""
 "Street, Fifth Floor, Boston, MA 02110-1301, USA."
 msgstr ""
 
-#: src/ghb3.ui:1907
+#: src/ghb3.ui:1948 src/ghb4.ui:1633
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1930
+#: src/ghb3.ui:1971 src/ghb4.ui:1655
 msgid "_File"
 msgstr ""
 
-#: src/ghb3.ui:1938
+#: src/ghb3.ui:1979 src/ghb4.ui:1663
 msgid "Open _Source"
 msgstr ""
 
-#: src/ghb3.ui:1947
+#: src/ghb3.ui:1988 src/ghb4.ui:1672
 msgid "Open Single _Title"
 msgstr ""
 
-#: src/ghb3.ui:1956
+#: src/ghb3.ui:1997 src/ghb4.ui:1681
 msgid "Set _Destination"
 msgstr ""
 
-#: src/ghb3.ui:1971
+#: src/ghb3.ui:2012 src/ghb4.ui:1696
 msgid "_Preferences"
 msgstr ""
 
-#: src/ghb3.ui:1986
+#: src/ghb3.ui:2027 src/ghb4.ui:1711
 msgid "_Quit"
 msgstr ""
 
-#: src/ghb3.ui:2001 src/ghb3.ui:2095
+#: src/ghb3.ui:2042 src/ghb3.ui:2136 src/ghb4.ui:1726 src/ghb4.ui:1820
 msgid "_Queue"
 msgstr ""
 
-#: src/ghb3.ui:2009
+#: src/ghb3.ui:2050 src/ghb4.ui:1734
 msgid "_Add"
 msgstr ""
 
-#: src/ghb3.ui:2018
+#: src/ghb3.ui:2059 src/ghb4.ui:1743
 msgid "Add _Multiple"
 msgstr ""
 
-#: src/ghb3.ui:2027 src/queuehandler.c:2401
+#: src/ghb3.ui:2068 src/ghb4.ui:1752 src/queuehandler.c:2423
 msgid "_Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:2036 src/queuehandler.c:2439
+#: src/ghb3.ui:2077 src/ghb4.ui:1761 src/queuehandler.c:2461
 msgid "_Pause Encoding"
 msgstr ""
 
-#: src/ghb3.ui:2045
+#: src/ghb3.ui:2086 src/ghb4.ui:1770
 msgid "S_ave Queue"
 msgstr ""
 
-#: src/ghb3.ui:2054
+#: src/ghb3.ui:2095 src/ghb4.ui:1779
 msgid "_Load Queue File"
 msgstr ""
 
-#: src/ghb3.ui:2069
+#: src/ghb3.ui:2110 src/ghb4.ui:1794
 msgid "_View"
 msgstr ""
 
-#: src/ghb3.ui:2077
-msgid "HandBrake For _Dumbies"
+#: src/ghb3.ui:2118 src/ghb4.ui:1802
+msgid "HandBrake For _Dummies"
 msgstr ""
 
-#: src/ghb3.ui:2086
+#: src/ghb3.ui:2127 src/ghb4.ui:1811
 msgid "Presets _List"
 msgstr ""
 
-#: src/ghb3.ui:2104
+#: src/ghb3.ui:2145 src/ghb4.ui:1829
 msgid "_Preview"
 msgstr ""
 
-#: src/ghb3.ui:2113
+#: src/ghb3.ui:2154 src/ghb4.ui:1838
 msgid "_Activity Window"
 msgstr ""
 
-#: src/ghb3.ui:2229
+#: src/ghb3.ui:2270 src/ghb4.ui:1954
 msgid "_Help"
 msgstr ""
 
-#: src/ghb3.ui:2237
+#: src/ghb3.ui:2278 src/ghb4.ui:1962
 msgid "_About"
 msgstr ""
 
-#: src/ghb3.ui:2246
+#: src/ghb3.ui:2287 src/ghb4.ui:1971
 msgid "_Guide"
 msgstr ""
 
-#: src/ghb3.ui:2284 src/callbacks.c:4123
+#: src/ghb3.ui:2325 src/ghb4.ui:2003 src/callbacks.c:4338
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2286 src/callbacks.c:4122
+#: src/ghb3.ui:2327 src/ghb4.ui:2005 src/callbacks.c:4337
 msgid "Open Source"
 msgstr ""
 
-#: src/ghb3.ui:2309
+#: src/ghb3.ui:2350 src/ghb4.ui:2027
 msgid "Add to Queue"
 msgstr ""
 
-#: src/ghb3.ui:2311
+#: src/ghb3.ui:2352 src/ghb4.ui:2029
 msgid "Add To Queue"
 msgstr ""
 
-#: src/ghb3.ui:2366
+#: src/ghb3.ui:2407 src/ghb4.ui:2072
 msgid "Show Presets Window"
 msgstr ""
 
-#: src/ghb3.ui:2368
+#: src/ghb3.ui:2409 src/ghb4.ui:2074
 msgid "Presets"
 msgstr ""
 
-#: src/ghb3.ui:2381
+#: src/ghb3.ui:2422 src/ghb4.ui:2084
 msgid "Show Preview Window"
 msgstr ""
 
-#: src/ghb3.ui:2383
+#: src/ghb3.ui:2424 src/ghb4.ui:2086
 msgid "Preview"
 msgstr ""
 
-#: src/ghb3.ui:2396
+#: src/ghb3.ui:2437 src/ghb4.ui:2096
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2398 src/callbacks.c:4567
+#: src/ghb3.ui:2439 src/ghb4.ui:2098 src/callbacks.c:4783
 msgid "Queue"
 msgstr ""
 
-#: src/ghb3.ui:2411
+#: src/ghb3.ui:2452 src/ghb4.ui:2108
 msgid "Show Activity Window"
 msgstr ""
 
-#: src/ghb3.ui:2413
+#: src/ghb3.ui:2454 src/ghb4.ui:2110
 msgid "Activity"
 msgstr ""
 
-#: src/ghb3.ui:2443
+#: src/ghb3.ui:2484 src/ghb4.ui:2135
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2469 src/hb-backend.c:59 src/hb-backend.c:71 src/hb-backend.c:84
-#: src/hb-backend.c:249 src/hb-backend.c:334 src/hb-backend.c:2421
-#: src/hb-backend.c:2647 src/subtitlehandler.c:1365
+#: src/ghb3.ui:2510 src/ghb4.ui:2161 src/hb-backend.c:60 src/hb-backend.c:72
+#: src/hb-backend.c:85 src/hb-backend.c:124 src/hb-backend.c:238
+#: src/hb-backend.c:269 src/hb-backend.c:280 src/hb-backend.c:307
+#: src/hb-backend.c:392 src/hb-backend.c:2592 src/hb-backend.c:2818
+#: src/subtitlehandler.c:1365
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2514 src/callbacks.c:4095
+#: src/ghb3.ui:2555 src/ghb4.ui:2195 src/callbacks.c:4310
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2548
+#: src/ghb3.ui:2589 src/ghb4.ui:2216
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2576
+#: src/ghb3.ui:2617 src/ghb4.ui:2242
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2639 src/ghb4.ui:2263
 msgid "<small>No Titles</small>"
 msgstr ""
 
-#: src/ghb3.ui:2616
+#: src/ghb3.ui:2657 src/ghb4.ui:2278
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2628
+#: src/ghb3.ui:2669 src/ghb4.ui:2286
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2644
+#: src/ghb3.ui:2685 src/ghb4.ui:2299
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2655
+#: src/ghb3.ui:2696 src/ghb4.ui:2307
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2668
+#: src/ghb3.ui:2709 src/ghb4.ui:2316
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2683
+#: src/ghb3.ui:2725 src/ghb4.ui:2328
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2695
+#: src/ghb3.ui:2737 src/ghb4.ui:2336
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2720
+#: src/ghb3.ui:2763 src/ghb4.ui:2352
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2756
+#: src/ghb3.ui:2799 src/ghb4.ui:2389
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2787
+#: src/ghb3.ui:2830 src/ghb4.ui:2411
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2796 src/ghb3.ui:5169 src/ghb3.ui:5913
+#: src/ghb3.ui:2839 src/ghb3.ui:5811 src/ghb3.ui:6597 src/ghb4.ui:2417
+#: src/ghb4.ui:4442 src/ghb4.ui:5058
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2799
+#: src/ghb3.ui:2842 src/ghb4.ui:2420
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2811
+#: src/ghb3.ui:2854 src/ghb4.ui:2429
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2814
+#: src/ghb3.ui:2857 src/ghb4.ui:2432
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2939 src/ghb4.ui:2496
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2914
+#: src/ghb3.ui:2957 src/ghb4.ui:2510
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2926 src/queuehandler.c:290
+#: src/ghb3.ui:2969 src/ghb4.ui:2520 src/queuehandler.c:290
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2931
+#: src/ghb3.ui:2974 src/ghb4.ui:2524
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2947
+#: src/ghb3.ui:2990 src/ghb4.ui:2537
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2952
+#: src/ghb3.ui:2995 src/ghb4.ui:2541
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2969
+#: src/ghb3.ui:3012 src/ghb4.ui:2555
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2974
+#: src/ghb3.ui:3017 src/ghb4.ui:2559
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2996
+#: src/ghb3.ui:3032
+msgid "Passthru Common Metadata"
+msgstr ""
+
+#: src/ghb3.ui:3037
+msgid "Copy metadata from source to output."
+msgstr ""
+
+#: src/ghb3.ui:3059 src/ghb4.ui:2578
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3014
+#: src/ghb3.ui:3077 src/ghb4.ui:2592
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3029
+#: src/ghb3.ui:3092 src/ghb4.ui:2605
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3069
+#: src/ghb3.ui:3132 src/ghb4.ui:2639
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3109
+#: src/ghb3.ui:3172 src/ghb4.ui:2674
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3134 src/ghb3.ui:3355
+#: src/ghb3.ui:3197 src/ghb3.ui:3296 src/ghb3.ui:3334 src/ghb3.ui:3372
+#: src/ghb3.ui:4208 src/ghb3.ui:4346 src/ghb4.ui:2695 src/ghb4.ui:2889
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3227
-msgid "Auto Crop"
+#: src/ghb3.ui:3284 src/ghb3.ui:4196
+msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3232
-msgid "Automatically crop black borders around edges of the video."
+#: src/ghb3.ui:3322 src/ghb3.ui:4240
+msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3246
-msgid "Loose Crop"
+#: src/ghb3.ui:3360 src/ghb3.ui:4334
+msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3250
-msgid ""
-"When picture settings require that the image\n"
-"dimensions be rounded to some multiple number\n"
-"of pixels, this setting will crop a few extra pixels\n"
-"instead of doing exact cropping and then scaling to\n"
-"the required multiple."
+#: src/ghb3.ui:3397
+msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3272
+#: src/ghb3.ui:3444
+msgid "Flipping:"
+msgstr ""
+
+#: src/ghb3.ui:3455
+msgid "Horizontal ⇌"
+msgstr ""
+
+#: src/ghb3.ui:3460
+msgid "Flip video horizontally."
+msgstr ""
+
+#: src/ghb3.ui:3477
+msgid "Rotation:"
+msgstr ""
+
+#: src/ghb3.ui:3493 src/ghb4.ui:3813
+msgid "Rotate the video clockwise in 90 degree increments."
+msgstr ""
+
+#: src/ghb3.ui:3508
+msgid "Cropping:"
+msgstr ""
+
+#: src/ghb3.ui:3524
+msgid "How to apply crop settings."
+msgstr ""
+
+#: src/ghb3.ui:3540 src/ghb4.ui:2816
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3289
+#: src/ghb3.ui:3557 src/ghb4.ui:2831
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3306
+#: src/ghb3.ui:3574 src/ghb4.ui:2846
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3323
+#: src/ghb3.ui:3591 src/ghb4.ui:2861
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3340
-msgid "Crop Dimensions:"
+#: src/ghb3.ui:3627
+msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3376
-msgid "<b>Cropping</b>"
+#: src/ghb3.ui:3666
+msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3411
-msgid "Optimal for source"
+#: src/ghb3.ui:3681
+msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3415
+#: src/ghb3.ui:3697
+msgid "Maximum Size:"
+msgstr ""
+
+#: src/ghb3.ui:3712
+msgid "This is the maximum width that the video will be stored at."
+msgstr ""
+
+#: src/ghb3.ui:3729 src/ghb3.ui:3898 src/ghb3.ui:4272
+msgid "x"
+msgstr ""
+
+#: src/ghb3.ui:3744
+msgid "This is the maximum height that the video will be stored at."
+msgstr ""
+
+#: src/ghb3.ui:3760 src/ghb4.ui:3019
+msgid "Anamorphic:"
+msgstr ""
+
+#: src/ghb3.ui:3775
 msgid ""
-"If enabled, select the 'optimal' storage resolution.\n"
-"This will be the resolution that most closely matches the source resolution "
-"after cropping."
+"<b>Anamorphic Modes:</b><small><tt>\n"
+"    Automatic - Use a pixel aspect ratio that maximizes\n"
+"        storage resolution while preserving the original\n"
+"        display aspect ratio.\n"
+"    None      - Force pixel aspect ratio to 1:1.\n"
+"    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3433 src/ghb3.ui:3648
-msgid "Width:"
+#: src/ghb3.ui:3796 src/ghb4.ui:3195
+msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3448
+#: src/ghb3.ui:3811 src/ghb4.ui:3207
+msgid ""
+"Pixel aspect defines the shape of the pixels.\n"
+"\n"
+"A 1:1 ratio defines a square pixel.  Other values define rectangular "
+"shapes.\n"
+"Players will scale the image in order to achieve the specified aspect."
+msgstr ""
+
+#: src/ghb3.ui:3831 src/ghb4.ui:3224
+msgid ":"
+msgstr ""
+
+#: src/ghb3.ui:3846 src/ghb4.ui:3236
+msgid ""
+"Pixel aspect defines the shape of the pixels.\n"
+"A 1:1 ratio defines a square pixel.  Other values define rectangular "
+"shapes.\n"
+"Players will scale the image in order to achieve the specified aspect."
+msgstr ""
+
+#: src/ghb3.ui:3865
+msgid "Scaled Size:"
+msgstr ""
+
+#: src/ghb3.ui:3880 src/ghb4.ui:2967
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3466 src/ghb3.ui:3680
-msgid "Height:"
-msgstr ""
-
-#: src/ghb3.ui:3481
+#: src/ghb3.ui:3913 src/ghb4.ui:2994
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3511
-msgid "Anamorphic:"
+#: src/ghb3.ui:3927
+msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3526
-msgid ""
-"<b>Anamorphic Modes:</b>\n"
-"<small><tt>\n"
-"None      - Force pixel aspect ratio to 1:1.\n"
-"Loose     - Use a pixel aspect ratio that is as\n"
-"        close as possible to the source video pixel\n"
-"        aspect ratio while preserving the original\n"
-"        display aspect ratio\n"
-"Automatic - Use a pixel aspect ratio that maximizes\n"
-"        storage resolution while preserving the original\n"
-"        display aspect ratio</tt></small>"
+#: src/ghb3.ui:3932
+msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3550
-msgid "Alignment:"
+#: src/ghb3.ui:3947
+msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3565
-msgid ""
-"Align storage dimensions to multiples of this value.\n"
-"\n"
-"This setting is only necessary for compatibility with some devices.\n"
-"You should use 2 unless you experience compatibility issues."
+#: src/ghb3.ui:3952
+msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3590
-msgid "<b>Storage Geometry</b>"
+#: src/ghb3.ui:3977
+msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3625
-msgid "Keep Aspect"
+#: src/ghb3.ui:4017
+msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3630
-msgid ""
-"If enabled, the original display aspect of the source will be maintained."
+#: src/ghb3.ui:4034
+msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3663
-msgid ""
-"This is the display width. It is the result of scaling the storage "
-"dimensions by the pixel aspect."
+#: src/ghb3.ui:4051
+msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:3724
-msgid "Pixel Aspect:"
+#: src/ghb3.ui:4068
+msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:3739
-msgid ""
-"Pixel aspect defines the shape of the pixels.\n"
-"\n"
-"A 1:1 ratio defines a square pixel.  Other values define rectangular "
-"shapes.\n"
-"Players will scale the image in order to achieve the specified aspect."
+#: src/ghb3.ui:4085
+msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:3759
-msgid ":"
+#: src/ghb3.ui:4102
+msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:3774
-msgid ""
-"Pixel aspect defines the shape of the pixels.\n"
-"A 1:1 ratio defines a square pixel.  Other values define rectangular "
-"shapes.\n"
-"Players will scale the image in order to achieve the specified aspect."
+#: src/ghb3.ui:4118
+msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:3794
-msgid "Display Aspect:"
+#: src/ghb3.ui:4135
+msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:3809
-msgid "--:--"
+#: src/ghb3.ui:4157
+msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:3830
-msgid "<b>Display Geometry</b>"
+#: src/ghb3.ui:4255 src/ghb3.ui:4287 src/ghb3.ui:4305
+msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:3848
+#: src/ghb3.ui:4300 src/hb-backend.c:123 src/hb-backend.c:237
+#: src/hb-backend.c:310
+msgid "Automatic"
+msgstr ""
+
+#: src/ghb3.ui:4371
+msgid "<b>Final Dimensions</b>"
+msgstr ""
+
+#: src/ghb3.ui:4384 src/ghb4.ui:2738
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:3876
+#: src/ghb3.ui:4412 src/ghb4.ui:3321
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:3892
+#: src/ghb3.ui:4428 src/ghb4.ui:3334
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -808,18 +870,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:3907
+#: src/ghb3.ui:4443 src/ghb3.ui:5096 src/ghb4.ui:3347
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:3935
+#: src/ghb3.ui:4471 src/ghb4.ui:3373
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:3951
+#: src/ghb3.ui:4487 src/ghb4.ui:3386
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -827,7 +889,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:3967
+#: src/ghb3.ui:4503 src/ghb4.ui:3400
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -835,11 +897,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:3996
+#: src/ghb3.ui:4532 src/ghb4.ui:3427
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4012
+#: src/ghb3.ui:4548 src/ghb4.ui:3440
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -847,11 +909,11 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4031
+#: src/ghb3.ui:4567 src/ghb4.ui:3457
 msgid "Deinterlace Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4047
+#: src/ghb3.ui:4583 src/ghb4.ui:3470
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -859,32 +921,33 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4090
+#: src/ghb3.ui:4626 src/ghb4.ui:3509
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4106 src/ghb3.ui:4138
+#: src/ghb3.ui:4642 src/ghb3.ui:4674 src/ghb4.ui:3522 src/ghb4.ui:3549
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4122
+#: src/ghb3.ui:4658 src/ghb4.ui:3536
 msgid "Deblock Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4152
+#: src/ghb3.ui:4688 src/ghb3.ui:4903 src/ghb4.ui:3561
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4180
+#: src/ghb3.ui:4716 src/ghb4.ui:3587
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4196 src/ghb3.ui:4229 src/ghb3.ui:4262
+#: src/ghb3.ui:4732 src/ghb3.ui:4765 src/ghb3.ui:4798 src/ghb4.ui:3600
+#: src/ghb4.ui:3628 src/ghb4.ui:3656
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -892,72 +955,87 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4213
+#: src/ghb3.ui:4749 src/ghb4.ui:3615
 msgid "Denoise Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4246
+#: src/ghb3.ui:4782 src/ghb4.ui:3643
 msgid "Denoise Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4277 src/ghb3.ui:4399
+#: src/ghb3.ui:4813 src/ghb3.ui:5025 src/ghb4.ui:3669 src/ghb4.ui:3774
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4305
+#: src/ghb3.ui:4841
+msgid "Chroma Smooth Filter:"
+msgstr ""
+
+#: src/ghb3.ui:4857 src/ghb3.ui:4889
+msgid ""
+"The chroma smooth filter removes common color artifacts.\n"
+"Lower resolution analog source content may benefit from this filter."
+msgstr ""
+
+#: src/ghb3.ui:4873
+msgid "Chroma Smooth Tune:"
+msgstr ""
+
+#: src/ghb3.ui:4931 src/ghb4.ui:3695
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4321 src/ghb3.ui:4353 src/ghb3.ui:4385
+#: src/ghb3.ui:4947 src/ghb3.ui:4979 src/ghb3.ui:5011 src/ghb4.ui:3708
+#: src/ghb4.ui:3735 src/ghb4.ui:3762
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4337
+#: src/ghb3.ui:4963 src/ghb4.ui:3722
 msgid "Sharpen Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4369
+#: src/ghb3.ui:4995 src/ghb4.ui:3749
 msgid "Sharpen Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4427
-msgid "Rotate Filter:"
-msgstr ""
-
-#: src/ghb3.ui:4443
-msgid "Rotate the video clockwise in 90 degree increments."
-msgstr ""
-
-#: src/ghb3.ui:4457
+#: src/ghb3.ui:5042 src/ghb4.ui:3825
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4462
+#: src/ghb3.ui:5047 src/ghb4.ui:3829
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4473
+#: src/ghb3.ui:5067
+msgid "Colorspace:"
+msgstr ""
+
+#: src/ghb3.ui:5083
+msgid "Translate the colorspace of the source."
+msgstr ""
+
+#: src/ghb3.ui:5115 src/ghb4.ui:3295
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4504
+#: src/ghb3.ui:5146 src/ghb4.ui:3869
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:4518
+#: src/ghb3.ui:5160 src/ghb4.ui:3881
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:4534
+#: src/ghb3.ui:5176 src/ghb4.ui:3894
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:4549
+#: src/ghb3.ui:5191 src/ghb4.ui:3906
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -965,19 +1043,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:4564
+#: src/ghb3.ui:5206 src/ghb4.ui:3919
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:4569
+#: src/ghb3.ui:5211 src/ghb4.ui:3923
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:4583
+#: src/ghb3.ui:5225 src/ghb4.ui:3936
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:4588
+#: src/ghb3.ui:5230 src/ghb4.ui:3940
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -985,18 +1063,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:4606
+#: src/ghb3.ui:5248 src/ghb4.ui:3957
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:4611
+#: src/ghb3.ui:5253 src/ghb4.ui:3961
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:4647 src/ghb3.ui:4679
+#: src/ghb3.ui:5289 src/ghb3.ui:5321 src/ghb4.ui:3991 src/ghb4.ui:4021
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1012,15 +1090,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:4674
+#: src/ghb3.ui:5316 src/ghb4.ui:4017
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:4705
+#: src/ghb3.ui:5347 src/ghb4.ui:4045
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:4710 src/ghb3.ui:4732
+#: src/ghb3.ui:5352 src/ghb3.ui:5374 src/ghb4.ui:4049 src/ghb4.ui:4068
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1031,11 +1109,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:4749
+#: src/ghb3.ui:5391 src/ghb4.ui:4083
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:4754
+#: src/ghb3.ui:5396 src/ghb4.ui:4087
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1045,16 +1123,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:4772
+#: src/ghb3.ui:5414 src/ghb4.ui:4103
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:4777
+#: src/ghb3.ui:5419 src/ghb4.ui:4107
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:4839
+#: src/ghb3.ui:5481 src/ghb4.ui:4155
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1066,11 +1144,11 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:4865
+#: src/ghb3.ui:5507 src/ghb4.ui:4179
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4882
+#: src/ghb3.ui:5524 src/ghb4.ui:4193
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1079,22 +1157,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:4898
+#: src/ghb3.ui:5540 src/ghb4.ui:4207
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:4903
+#: src/ghb3.ui:5545 src/ghb4.ui:4211
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:4921
+#: src/ghb3.ui:5563 src/ghb4.ui:4227
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:4925
+#: src/ghb3.ui:5567 src/ghb4.ui:4230
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1104,278 +1182,302 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:4949
+#: src/ghb3.ui:5591 src/ghb4.ui:4251
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:4966
+#: src/ghb3.ui:5608 src/ghb4.ui:4265
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:4984
+#: src/ghb3.ui:5626 src/ghb4.ui:4280
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5643 src/ghb4.ui:4294
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5026
+#: src/ghb3.ui:5668 src/ghb4.ui:4321
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5044
+#: src/ghb3.ui:5686 src/ghb4.ui:4336
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5078 src/main.c:1155
+#: src/ghb3.ui:5720 src/ghb4.ui:3843 src/main.c:1172
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5144 src/ghb3.ui:5337 src/ghb3.ui:5874 src/ghb3.ui:6094
-#: src/audiohandler.c:1744
+#: src/ghb3.ui:5786 src/ghb3.ui:5979 src/ghb3.ui:6558 src/ghb3.ui:6778
+#: src/ghb4.ui:4418 src/ghb4.ui:4589 src/ghb4.ui:5020 src/ghb4.ui:5218
+#: src/audiohandler.c:1752
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5146
+#: src/ghb3.ui:5788 src/ghb4.ui:4420
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5156 src/ghb3.ui:5886
+#: src/ghb3.ui:5798 src/ghb3.ui:6570 src/ghb4.ui:4430 src/ghb4.ui:5032
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5158
+#: src/ghb3.ui:5800 src/ghb4.ui:4432
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5171
+#: src/ghb3.ui:5813 src/ghb4.ui:4444
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5215 src/ghb3.ui:5959
+#: src/ghb3.ui:5857 src/ghb3.ui:6643 src/ghb4.ui:4395 src/ghb4.ui:4997
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5246 src/ghb3.ui:5994
+#: src/ghb3.ui:5888 src/ghb3.ui:6678 src/ghb4.ui:4509 src/ghb4.ui:5129
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5261
+#: src/ghb3.ui:5903 src/ghb4.ui:4522
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5964 src/ghb4.ui:4580
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5353 src/ghb3.ui:6110
+#: src/ghb3.ui:5995 src/ghb3.ui:6794 src/ghb4.ui:4603 src/ghb4.ui:5232
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5371 src/ghb3.ui:6128
+#: src/ghb3.ui:6013 src/ghb3.ui:6812 src/ghb4.ui:4619 src/ghb4.ui:5248
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5384 src/ghb3.ui:6141
+#: src/ghb3.ui:6026 src/ghb3.ui:6825 src/ghb4.ui:4630 src/ghb4.ui:5259
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5400
+#: src/ghb3.ui:6042 src/ghb4.ui:4641
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5405
+#: src/ghb3.ui:6047 src/ghb4.ui:4645
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5441
+#: src/ghb3.ui:6083 src/ghb4.ui:4674
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5452
+#: src/ghb3.ui:6094
+msgid "MP2"
+msgstr ""
+
+#: src/ghb3.ui:6099
+msgid ""
+"Enable this if your playback device supports MP2.\n"
+"This permits MP2 passthru to be selected when automatic passthru selection "
+"is enabled."
+msgstr ""
+
+#: src/ghb3.ui:6115 src/ghb4.ui:4683
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5457
+#: src/ghb3.ui:6120 src/ghb4.ui:4687
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5473
-msgid "AAC"
-msgstr ""
-
-#: src/ghb3.ui:5478
-msgid ""
-"Enable this if your playback device supports AAC.\n"
-"This permits AAC passthru to be selected when automatic passthru selection "
-"is enabled."
-msgstr ""
-
-#: src/ghb3.ui:5494
+#: src/ghb3.ui:6136 src/ghb4.ui:4719
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5499
+#: src/ghb3.ui:6141 src/ghb4.ui:4723
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5515
-msgid "DTS"
-msgstr ""
-
-#: src/ghb3.ui:5520
-msgid ""
-"Enable this if your playback device supports DTS.\n"
-"This permits DTS passthru to be selected when automatic passthru selection "
-"is enabled."
-msgstr ""
-
-#: src/ghb3.ui:5536
-msgid "DTS-HD"
-msgstr ""
-
-#: src/ghb3.ui:5541
-msgid ""
-"Enable this if your playback device supports DTS-HD.\n"
-"This permits DTS-HD passthru to be selected when automatic passthru "
-"selection is enabled."
-msgstr ""
-
-#: src/ghb3.ui:5557
+#: src/ghb3.ui:6157 src/ghb4.ui:4773
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:5562
+#: src/ghb3.ui:6162 src/ghb4.ui:4777
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5578
+#: src/ghb3.ui:6178 src/ghb4.ui:4737
+msgid "DTS"
+msgstr ""
+
+#: src/ghb3.ui:6183 src/ghb4.ui:4741
+msgid ""
+"Enable this if your playback device supports DTS.\n"
+"This permits DTS passthru to be selected when automatic passthru selection "
+"is enabled."
+msgstr ""
+
+#: src/ghb3.ui:6199 src/ghb4.ui:4755
+msgid "DTS-HD"
+msgstr ""
+
+#: src/ghb3.ui:6204 src/ghb4.ui:4759
+msgid ""
+"Enable this if your playback device supports DTS-HD.\n"
+"This permits DTS-HD passthru to be selected when automatic passthru "
+"selection is enabled."
+msgstr ""
+
+#: src/ghb3.ui:6220 src/ghb4.ui:4791
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:5583
+#: src/ghb3.ui:6225 src/ghb4.ui:4795
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5599
+#: src/ghb3.ui:6241 src/ghb4.ui:4809
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:5604
+#: src/ghb3.ui:6246 src/ghb4.ui:4813
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5637
+#: src/ghb3.ui:6262 src/ghb4.ui:4701
+msgid "AAC"
+msgstr ""
+
+#: src/ghb3.ui:6267 src/ghb4.ui:4705
+msgid ""
+"Enable this if your playback device supports AAC.\n"
+"This permits AAC passthru to be selected when automatic passthru selection "
+"is enabled."
+msgstr ""
+
+#: src/ghb3.ui:6283
+msgid "Opus"
+msgstr ""
+
+#: src/ghb3.ui:6288
+msgid ""
+"Enable this if your playback device supports Opus.\n"
+"This permits Opus passthru to be selected when automatic passthru selection "
+"is enabled."
+msgstr ""
+
+#: src/ghb3.ui:6321 src/ghb4.ui:4840
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:5649
+#: src/ghb3.ui:6333 src/ghb4.ui:4848
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:5678
+#: src/ghb3.ui:6362 src/ghb4.ui:4865
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:5679
+#: src/ghb3.ui:6363 src/ghb4.ui:4866
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:5704 src/ghb3.ui:9279
+#: src/ghb3.ui:6388 src/ghb3.ui:9942 src/ghb4.ui:4884 src/ghb4.ui:7733
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:5715 src/ghb3.ui:9292
+#: src/ghb3.ui:6399 src/ghb3.ui:9955 src/ghb4.ui:4892 src/ghb4.ui:7744
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:5726
+#: src/ghb3.ui:6410 src/ghb4.ui:4900
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:5737
+#: src/ghb3.ui:6421 src/ghb4.ui:4908
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:5748 src/ghb3.ui:9336
+#: src/ghb3.ui:6432 src/ghb3.ui:9999 src/ghb4.ui:4916 src/ghb4.ui:7781
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:5759 src/ghb3.ui:9355
+#: src/ghb3.ui:6443 src/ghb3.ui:10018 src/ghb4.ui:4924 src/ghb4.ui:7798
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:5796 src/ghb3.ui:6354
+#: src/ghb3.ui:6480 src/ghb3.ui:7038 src/ghb4.ui:4480 src/ghb4.ui:5096
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:5808
+#: src/ghb3.ui:6492 src/ghb4.ui:4358
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:5876
+#: src/ghb3.ui:6560 src/ghb4.ui:5022
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5888
+#: src/ghb3.ui:6572 src/ghb4.ui:5034
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5898 src/queuehandler.c:607 src/queuehandler.c:1038
-#: src/subtitlehandler.c:413
+#: src/ghb3.ui:6582 src/ghb4.ui:5044 src/queuehandler.c:631
+#: src/queuehandler.c:1062 src/subtitlehandler.c:413
+#, c-format
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:5900
+#: src/ghb3.ui:6584 src/ghb4.ui:5046
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:5915
+#: src/ghb3.ui:6599 src/ghb4.ui:5060
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6009
+#: src/ghb3.ui:6693 src/ghb4.ui:5142
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6074
+#: src/ghb3.ui:6758 src/ghb4.ui:5204
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1386,15 +1488,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6155
+#: src/ghb3.ui:6839 src/ghb4.ui:5271
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6182
+#: src/ghb3.ui:6866 src/ghb4.ui:5287
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6187
+#: src/ghb3.ui:6871 src/ghb4.ui:5291
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1404,11 +1506,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6886 src/ghb4.ui:5303
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6207
+#: src/ghb3.ui:6891 src/ghb4.ui:5307
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1416,21 +1518,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6221
+#: src/ghb3.ui:6905 src/ghb4.ui:5318
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6226
+#: src/ghb3.ui:6910 src/ghb4.ui:5322
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6247
+#: src/ghb3.ui:6931 src/ghb4.ui:5339
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6259
+#: src/ghb3.ui:6943 src/ghb4.ui:5348
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1440,15 +1542,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6286
+#: src/ghb3.ui:6970 src/ghb4.ui:5368
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6295
+#: src/ghb3.ui:6979 src/ghb4.ui:5374
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6300
+#: src/ghb3.ui:6984 src/ghb4.ui:5378
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1459,11 +1561,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6314
+#: src/ghb3.ui:6998 src/ghb4.ui:5389
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6319
+#: src/ghb3.ui:7003 src/ghb4.ui:5393
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1474,244 +1576,268 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6341
+#: src/ghb3.ui:7025 src/ghb4.ui:5409
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6342
+#: src/ghb3.ui:7026 src/ghb4.ui:5410
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6366
+#: src/ghb3.ui:7050 src/ghb4.ui:4960
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6381 src/queuehandler.c:280
+#: src/ghb3.ui:7065 src/ghb4.ui:5441 src/queuehandler.c:280
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6386
+#: src/ghb3.ui:7070 src/ghb4.ui:5445
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6420
+#: src/ghb3.ui:7104 src/ghb4.ui:5470
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6444
+#: src/ghb3.ui:7128 src/ghb4.ui:5488
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:6455
+#: src/ghb3.ui:7139 src/ghb4.ui:5496
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:6492
+#: src/ghb3.ui:7176 src/ghb4.ui:5428
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6547
+#: src/ghb3.ui:7231 src/ghb4.ui:5570
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:6582
+#: src/ghb3.ui:7266 src/ghb4.ui:5599
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:6617
+#: src/ghb3.ui:7301 src/ghb4.ui:5628
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:6652
+#: src/ghb3.ui:7336 src/ghb4.ui:5657
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:6687
+#: src/ghb3.ui:7371 src/ghb4.ui:5686
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:6722
+#: src/ghb3.ui:7406 src/ghb4.ui:5715
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:6757
+#: src/ghb3.ui:7441 src/ghb4.ui:5744
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:6795
+#: src/ghb3.ui:7479 src/ghb4.ui:5525
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:6824
+#: src/ghb3.ui:7508 src/ghb4.ui:5798
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6838
+#: src/ghb3.ui:7522 src/ghb4.ui:5810
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:6858
+#: src/ghb3.ui:7542 src/ghb4.ui:5826
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6871
+#: src/ghb3.ui:7555 src/ghb4.ui:5837
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:6874 src/queuehandler.c:2225
+#: src/ghb3.ui:7558 src/ghb4.ui:5840 src/queuehandler.c:2247
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:6967 src/ghb3.ui:7875 src/ghb3.ui:8027 src/ghb3.ui:8753
-#: src/ghb3.ui:9158 src/callbacks.c:5463 src/callbacks.c:5473
-#: src/callbacks.c:5481 src/hb-backend.c:4181 src/hb-backend.c:4214
-#: src/hb-backend.c:4253 src/hb-backend.c:4284 src/hb-backend.c:4312
-#: src/hb-backend.c:4358 src/hb-backend.c:4415 src/hb-backend.c:4435
-#: src/hb-backend.c:4455 src/hb-backend.c:4516 src/hb-backend.c:4571
-#: src/queuehandler.c:1835 src/queuehandler.c:1852 src/queuehandler.c:1866
-#: src/queuehandler.c:1881
+#: src/ghb3.ui:7651 src/ghb3.ui:8617 src/ghb3.ui:8769 src/ghb3.ui:9416
+#: src/ghb3.ui:9821 src/ghb4.ui:5913 src/ghb4.ui:6618 src/ghb4.ui:6732
+#: src/ghb4.ui:7298 src/ghb4.ui:7629 src/callbacks.c:5713 src/callbacks.c:5723
+#: src/callbacks.c:5731 src/hb-backend.c:4307 src/hb-backend.c:4340
+#: src/hb-backend.c:4379 src/hb-backend.c:4410 src/hb-backend.c:4438
+#: src/hb-backend.c:4484 src/hb-backend.c:4541 src/hb-backend.c:4561
+#: src/hb-backend.c:4581 src/hb-backend.c:4642 src/hb-backend.c:4697
+#: src/queuehandler.c:1854 src/queuehandler.c:1871 src/queuehandler.c:1885
+#: src/queuehandler.c:1900
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:6976 src/ghb3.ui:7120 src/ghb3.ui:7884 src/ghb3.ui:8036
-#: src/ghb3.ui:8762 src/ghb3.ui:9167
+#: src/ghb3.ui:7660 src/ghb3.ui:7804 src/ghb3.ui:8626 src/ghb3.ui:8778
+#: src/ghb3.ui:9425 src/ghb3.ui:9830 src/ghb4.ui:5921 src/ghb4.ui:6035
+#: src/ghb4.ui:6626 src/ghb4.ui:6740 src/ghb4.ui:7306 src/ghb4.ui:7637
 msgid "OK"
 msgstr ""
 
-#: src/ghb3.ui:7005
+#: src/ghb3.ui:7689 src/ghb4.ui:5949
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7693 src/ghb4.ui:5953
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7022
+#: src/ghb3.ui:7706 src/ghb4.ui:5963
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7026
+#: src/ghb3.ui:7710 src/ghb4.ui:5967
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7087
+#: src/ghb3.ui:7771 src/ghb4.ui:6013
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7109
+#: src/ghb3.ui:7793 src/ghb4.ui:6026
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7215
+#: src/ghb3.ui:7899 src/ghb4.ui:6113
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7252
+#: src/ghb3.ui:7936 src/ghb4.ui:6141
 msgid "When all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7274
+#: src/ghb3.ui:7958 src/ghb4.ui:6157
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7275
+#: src/ghb3.ui:7959 src/ghb4.ui:6158
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7299
+#: src/ghb3.ui:7983 src/ghb4.ui:6179
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7310
+#: src/ghb3.ui:7994 src/ghb4.ui:6187
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {quality} {bitrate}"
 msgstr ""
 
-#: src/ghb3.ui:7330
+#: src/ghb3.ui:8014 src/ghb4.ui:6200
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7373
+#: src/ghb3.ui:8057 src/ghb4.ui:6234
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7411
+#: src/ghb3.ui:8095 src/ghb4.ui:6263
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:7425
+#: src/ghb3.ui:8109 src/ghb4.ui:6271
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:8113
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:7446
+#: src/ghb3.ui:8130 src/ghb4.ui:6086
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:7489
+#: src/ghb3.ui:8158
+msgid "Set a custom directory for Handbrake temporary files"
+msgstr ""
+
+#: src/ghb3.ui:8162 src/ghb3.ui:8182
+msgid ""
+"Temporary files that HandBrake creates will be placed under this directory.\n"
+"\n"
+"Changing this setting will require restarting HandBrake.\n"
+"\n"
+"This setting overrides the TEMP environment variable that is normally used "
+"to define this directory.\n"
+"\n"
+"Flatpak users may need to set this for certain workflows to work properly. "
+"The default size of the TEMP directory in a flatpak sandbox is 1/2 physical "
+"memory size and may be too small for things like the 2-pass stats file."
+msgstr ""
+
+#: src/ghb3.ui:8192
+msgid "Temp Directory"
+msgstr ""
+
+#: src/ghb3.ui:8232 src/ghb4.ui:6327
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:7506
+#: src/ghb3.ui:8249 src/ghb4.ui:6335
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:7529
+#: src/ghb3.ui:8272 src/ghb4.ui:6360
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:7533 src/ghb3.ui:7555 src/ghb3.ui:7736
+#: src/ghb3.ui:8276 src/ghb3.ui:8298 src/ghb4.ui:6364 src/ghb4.ui:6382
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:7570
+#: src/ghb3.ui:8313 src/ghb4.ui:6394
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:7598
+#: src/ghb3.ui:8341 src/ghb4.ui:6414
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:7634
+#: src/ghb3.ui:8377 src/ghb4.ui:6444
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:7669
+#: src/ghb3.ui:8412 src/ghb4.ui:6470
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:7690
+#: src/ghb3.ui:8433 src/ghb4.ui:6479
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:7707
+#: src/ghb3.ui:8450 src/ghb4.ui:6494
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:7711
+#: src/ghb3.ui:8454 src/ghb4.ui:6498
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:7750
+#: src/ghb3.ui:8492 src/ghb4.ui:6534
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:7767
+#: src/ghb3.ui:8509 src/ghb4.ui:6542
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:7771
+#: src/ghb3.ui:8513
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1720,212 +1846,178 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:7799
+#: src/ghb3.ui:8541 src/ghb4.ui:6569
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:7815
+#: src/ghb3.ui:8557 src/ghb4.ui:6584
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:7843
+#: src/ghb3.ui:8585 src/ghb4.ui:6289
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:7921
+#: src/ghb3.ui:8663 src/ghb4.ui:6653
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:7941
+#: src/ghb3.ui:8683 src/ghb4.ui:6668
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:7998 src/ghb3.ui:8345
+#: src/ghb3.ui:8740 src/ghb3.ui:9008 src/ghb4.ui:6712 src/ghb4.ui:6988
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8821 src/ghb4.ui:6773
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8094
+#: src/ghb3.ui:8836 src/ghb4.ui:6785
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8110
+#: src/ghb3.ui:8852 src/ghb4.ui:6798
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8143
+#: src/ghb3.ui:8885 src/ghb4.ui:6825
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8177
+#: src/ghb3.ui:8919 src/ghb4.ui:6851
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8182
+#: src/ghb3.ui:8924 src/ghb4.ui:6855
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8208
+#: src/ghb3.ui:8950 src/ghb4.ui:6873
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:8234
-msgid "Maximum Width:"
-msgstr ""
-
-#: src/ghb3.ui:8239
-msgid "Enable maximum width limit."
-msgstr ""
-
-#: src/ghb3.ui:8257
-msgid ""
-"This is the maximum width that the video will be stored at.\n"
-"\n"
-"Whenever a new source is loaded, this value will be applied if the source "
-"width is greater.\n"
-"Setting this to 0 means there is no maximum width."
-msgstr ""
-
-#: src/ghb3.ui:8274
-msgid "Maximum Height:"
-msgstr ""
-
-#: src/ghb3.ui:8279
-msgid "Enable maximum height limit."
-msgstr ""
-
-#: src/ghb3.ui:8297
-msgid ""
-"This is the maximum height that the video will be stored at.\n"
-"\n"
-"Whenever a new source is loaded, this value will be applied if the source "
-"height is greater.\n"
-"Setting this to 0 means there is no maximum height."
-msgstr ""
-
-#: src/ghb3.ui:8368
+#: src/ghb3.ui:9031 src/ghb4.ui:7003
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:8427
+#: src/ghb3.ui:9090 src/ghb4.ui:7052
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:8449
+#: src/ghb3.ui:9112 src/ghb4.ui:7071
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:8520
+#: src/ghb3.ui:9183 src/ghb4.ui:7126
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:8532
+#: src/ghb3.ui:9195 src/ghb4.ui:7135
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:8548
+#: src/ghb3.ui:9211 src/ghb4.ui:7145
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:8552
+#: src/ghb3.ui:9215 src/ghb4.ui:7149
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:8563
+#: src/ghb3.ui:9226 src/ghb4.ui:7157
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:8567
+#: src/ghb3.ui:9230 src/ghb4.ui:7161
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:8599
+#: src/ghb3.ui:9262 src/ghb4.ui:7185
 msgid "_Cancel"
 msgstr ""
 
-#: src/ghb3.ui:8611
+#: src/ghb3.ui:9274 src/ghb4.ui:7194
 msgid "_Open"
 msgstr ""
 
-#: src/ghb3.ui:8645
+#: src/ghb3.ui:9308 src/ghb4.ui:7224
 msgid "Title Number:"
 msgstr ""
 
-#: src/ghb3.ui:8681
+#: src/ghb3.ui:9344 src/ghb4.ui:7250
 msgid "Detected DVD devices:"
 msgstr ""
 
-#: src/ghb3.ui:8791
+#: src/ghb3.ui:9454 src/ghb4.ui:7334
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:8796
+#: src/ghb3.ui:9459 src/ghb4.ui:7338
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:8807
+#: src/ghb3.ui:9470 src/ghb4.ui:7346
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:8812
+#: src/ghb3.ui:9475 src/ghb4.ui:7350
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:8824
+#: src/ghb3.ui:9487 src/ghb4.ui:7359
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:8829
+#: src/ghb3.ui:9492 src/ghb4.ui:7363
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:8856 src/ghb3.ui:9199
+#: src/ghb3.ui:9519 src/ghb3.ui:9862 src/ghb4.ui:7383 src/ghb4.ui:7668
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:8871
+#: src/ghb3.ui:9534 src/ghb4.ui:7395
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:8885 src/ghb3.ui:9229
+#: src/ghb3.ui:9548 src/ghb3.ui:9892 src/ghb4.ui:7407 src/ghb4.ui:7693
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:8901
+#: src/ghb3.ui:9564 src/ghb4.ui:7420
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:8934
+#: src/ghb3.ui:9597 src/ghb4.ui:7446
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:8948
+#: src/ghb3.ui:9611 src/ghb4.ui:7457
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:8962
+#: src/ghb3.ui:9625 src/ghb4.ui:7468
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:8977
+#: src/ghb3.ui:9640 src/ghb4.ui:7480
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:8992
+#: src/ghb3.ui:9655 src/ghb4.ui:7492
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9010
+#: src/ghb3.ui:9673 src/ghb4.ui:7507
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -1934,56 +2026,57 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9034
+#: src/ghb3.ui:9697 src/ghb4.ui:7529
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9037
+#: src/ghb3.ui:9700 src/ghb4.ui:7532
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9055
+#: src/ghb3.ui:9718 src/ghb4.ui:7548
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9079
+#: src/ghb3.ui:9742 src/ghb4.ui:7567
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9100
+#: src/ghb3.ui:9763 src/ghb4.ui:7584
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9105
+#: src/ghb3.ui:9768 src/ghb4.ui:7588
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9117
+#: src/ghb3.ui:9780 src/ghb4.ui:7597
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9215
+#: src/ghb3.ui:9878 src/ghb4.ui:7681
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9245
+#: src/ghb3.ui:9908 src/ghb4.ui:7706
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9308
+#: src/ghb3.ui:9971 src/ghb4.ui:7757
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9321
+#: src/ghb3.ui:9984 src/ghb4.ui:7768
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9351 src/ghb3.ui:9590 src/audiohandler.c:1917
+#: src/ghb3.ui:10014 src/ghb3.ui:10253 src/ghb4.ui:7794 src/ghb4.ui:7986
+#: src/audiohandler.c:1925
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -1994,122 +2087,283 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9372 src/audiohandler.c:1768
+#: src/ghb3.ui:10035 src/ghb4.ui:7812 src/audiohandler.c:1776
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9394 src/audiohandler.c:1782
+#: src/ghb3.ui:10057 src/ghb4.ui:7836 src/audiohandler.c:1790
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9399
+#: src/ghb3.ui:10062 src/ghb4.ui:7840
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9409 src/audiohandler.c:1787
+#: src/ghb3.ui:10072 src/ghb4.ui:7847 src/audiohandler.c:1795
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9414
+#: src/ghb3.ui:10077 src/ghb4.ui:7851
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:9435 src/audiohandler.c:1801
+#: src/ghb3.ui:10098 src/ghb4.ui:7865 src/audiohandler.c:1809
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9455
+#: src/ghb3.ui:10118 src/ghb4.ui:7880
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:9477
+#: src/ghb3.ui:10140 src/ghb4.ui:7899
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:9504 src/audiohandler.c:1853
+#: src/ghb3.ui:10167 src/ghb4.ui:7913 src/audiohandler.c:1861
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:9520 src/audiohandler.c:1866
+#: src/ghb3.ui:10183 src/ghb4.ui:7926 src/audiohandler.c:1874
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:9543 src/audiohandler.c:1887
+#: src/ghb3.ui:10206 src/ghb4.ui:7949 src/audiohandler.c:1895
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:9561 src/audiohandler.c:1897
+#: src/ghb3.ui:10224 src/ghb4.ui:7964 src/audiohandler.c:1905
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:9608 src/audiohandler.c:416 src/audiohandler.c:754
-#: src/audiohandler.c:1157 src/audiohandler.c:1931 src/callbacks.c:5232
-#: src/hb-backend.c:122 src/hb-backend.c:200 src/hb-backend.c:212
-#: src/hb-backend.c:224 src/hb-backend.c:236 src/hb-backend.c:262
-#: src/hb-backend.c:274 src/hb-backend.c:286 src/hb-backend.c:347
+#: src/ghb3.ui:10271 src/ghb4.ui:8001 src/audiohandler.c:424
+#: src/audiohandler.c:762 src/audiohandler.c:1165 src/audiohandler.c:1939
+#: src/callbacks.c:5482 src/hb-backend.c:200 src/hb-backend.c:213
+#: src/hb-backend.c:225 src/hb-backend.c:249 src/hb-backend.c:320
+#: src/hb-backend.c:332 src/hb-backend.c:344 src/hb-backend.c:405
+#, c-format
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:9644
+#: src/ghb3.ui:10307 src/ghb4.ui:8023
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:9652
+#: src/ghb3.ui:10315 src/ghb4.ui:8031
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:9721
+#: src/ghb3.ui:10384 src/ghb4.ui:8084
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:9737
+#: src/ghb3.ui:10400 src/ghb4.ui:8097
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:9765
+#: src/ghb3.ui:10428 src/ghb4.ui:8119
 msgid "<b>Release Notes</b>"
 msgstr ""
 
-#: src/audiohandler.c:428 src/audiohandler.c:750 src/audiohandler.c:1225
+#: src/ghb4.ui:2775
+msgid "Auto Crop"
+msgstr ""
+
+#: src/ghb4.ui:2779
+msgid "Automatically crop black borders around edges of the video."
+msgstr ""
+
+#: src/ghb4.ui:2792
+msgid "Loose Crop"
+msgstr ""
+
+#: src/ghb4.ui:2796
+msgid ""
+"When picture settings require that the image\n"
+"dimensions be rounded to some multiple number\n"
+"of pixels, this setting will crop a few extra pixels\n"
+"instead of doing exact cropping and then scaling to\n"
+"the required multiple."
+msgstr ""
+
+#: src/ghb4.ui:2876
+msgid "Crop Dimensions:"
+msgstr ""
+
+#: src/ghb4.ui:2905
+msgid "<b>Cropping</b>"
+msgstr ""
+
+#: src/ghb4.ui:2935
+msgid "Optimal for source"
+msgstr ""
+
+#: src/ghb4.ui:2939
+msgid ""
+"If enabled, select the 'optimal' storage resolution.\n"
+"This will be the resolution that most closely matches the source resolution "
+"after cropping."
+msgstr ""
+
+#: src/ghb4.ui:2955 src/ghb4.ui:3134
+msgid "Width:"
+msgstr ""
+
+#: src/ghb4.ui:2982 src/ghb4.ui:3160
+msgid "Height:"
+msgstr ""
+
+#: src/ghb4.ui:3031
+msgid ""
+"<b>Anamorphic Modes:</b>\n"
+"<small><tt>\n"
+"None      - Force pixel aspect ratio to 1:1.\n"
+"Loose     - Use a pixel aspect ratio that is as\n"
+"            close as possible to the source video pixel\n"
+"            aspect ratio while preserving the original\n"
+"            display aspect ratio\n"
+"Automatic - Use a pixel aspect ratio that maximizes\n"
+"            storage resolution while preserving the original\n"
+"            display aspect ratio</tt></small>"
+msgstr ""
+
+#: src/ghb4.ui:3053
+msgid "Alignment:"
+msgstr ""
+
+#: src/ghb4.ui:3065
+msgid ""
+"Align storage dimensions to multiples of this value.\n"
+"\n"
+"This setting is only necessary for compatibility with some devices.\n"
+"You should use 2 unless you experience compatibility issues."
+msgstr ""
+
+#: src/ghb4.ui:3084
+msgid "<b>Storage Geometry</b>"
+msgstr ""
+
+#: src/ghb4.ui:3114
+msgid "Keep Aspect"
+msgstr ""
+
+#: src/ghb4.ui:3118
+msgid ""
+"If enabled, the original display aspect of the source will be maintained."
+msgstr ""
+
+#: src/ghb4.ui:3146
+msgid ""
+"This is the display width. It is the result of scaling the storage "
+"dimensions by the pixel aspect."
+msgstr ""
+
+#: src/ghb4.ui:3253
+msgid "Display Aspect:"
+msgstr ""
+
+#: src/ghb4.ui:3265
+msgid "--:--"
+msgstr ""
+
+#: src/ghb4.ui:3280
+msgid "<b>Display Geometry</b>"
+msgstr ""
+
+#: src/ghb4.ui:3800
+msgid "Rotate Filter:"
+msgstr ""
+
+#: src/ghb4.ui:6275
+msgid ""
+"By default, completed jobs remain in the queue and are marked as complete.\n"
+"    Check this if you want the queue to clean itself up by deleting "
+"completed jobs."
+msgstr ""
+
+#: src/ghb4.ui:6546
+msgid ""
+"When checked, every title will use the same settings when adding a\n"
+"    batch of titles to the queue.\n"
+"\n"
+"    Uncheck this if you want to allow changing each title's settings "
+"independently."
+msgstr ""
+
+#: src/ghb4.ui:6895
+msgid "Maximum Width:"
+msgstr ""
+
+#: src/ghb4.ui:6899
+msgid "Enable maximum width limit."
+msgstr ""
+
+#: src/ghb4.ui:6914
+msgid ""
+"This is the maximum width that the video will be stored at.\n"
+"\n"
+"Whenever a new source is loaded, this value will be applied if the source "
+"width is greater.\n"
+"Setting this to 0 means there is no maximum width."
+msgstr ""
+
+#: src/ghb4.ui:6929
+msgid "Maximum Height:"
+msgstr ""
+
+#: src/ghb4.ui:6933
+msgid "Enable maximum height limit."
+msgstr ""
+
+#: src/ghb4.ui:6948
+msgid ""
+"This is the maximum height that the video will be stored at.\n"
+"\n"
+"Whenever a new source is loaded, this value will be applied if the source "
+"height is greater.\n"
+"Setting this to 0 means there is no maximum height."
+msgstr ""
+
+#: src/audiohandler.c:436 src/audiohandler.c:758 src/audiohandler.c:1233
 #, c-format
 msgid "%ddB"
 msgstr ""
 
-#: src/audiohandler.c:726
+#: src/audiohandler.c:734
 msgid "Quality: "
 msgstr ""
 
-#: src/audiohandler.c:733
+#: src/audiohandler.c:741
 #, c-format
 msgid "Bitrate: %dkbps\n"
 msgstr ""
 
-#: src/audiohandler.c:745
+#: src/audiohandler.c:753
 #, c-format
 msgid "%.4gkHz"
 msgstr ""
 
-#: src/audiohandler.c:760
+#: src/audiohandler.c:768
 #, c-format
 msgid "<small>%d - %s (%.4gkHz)</small>"
 msgstr ""
 
-#: src/audiohandler.c:765
+#: src/audiohandler.c:773
 #, c-format
 msgid "Bitrate: %.4gkbps"
 msgstr ""
 
-#: src/audiohandler.c:771
+#: src/audiohandler.c:779
+#, c-format
 msgid "<small>Passthrough</small>"
 msgstr ""
 
-#: src/audiohandler.c:780
+#: src/audiohandler.c:788
 #, c-format
 msgid ""
 "%sGain: %s\n"
@@ -2117,26 +2371,26 @@ msgid ""
 "Track Name: %s"
 msgstr ""
 
-#: src/audiohandler.c:785
+#: src/audiohandler.c:793
 #, c-format
 msgid ""
 "%sGain: %s\n"
 "DRC: %s"
 msgstr ""
 
-#: src/audiohandler.c:1746
+#: src/audiohandler.c:1754
 msgid ""
 "Add an audio encoder.\n"
 "Each selected source track will be encoded with all selected encoders."
 msgstr ""
 
-#: src/audiohandler.c:1826
+#: src/audiohandler.c:1834
 msgid ""
 "<b>Audio Quality:</b>\n"
 "For encoders that support it, adjust the quality of the output."
 msgstr ""
 
-#: src/audiohandler.c:1946
+#: src/audiohandler.c:1954
 msgid "Remove this audio encoder"
 msgstr ""
 
@@ -2150,7 +2404,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1711 src/callbacks.c:4182
+#: src/callbacks.c:1711 src/callbacks.c:4397
 msgid "Scanning ..."
 msgstr ""
 
@@ -2158,17 +2412,17 @@ msgstr ""
 msgid "Stop Scan"
 msgstr ""
 
-#: src/callbacks.c:2735 src/hb-backend.c:2085 src/hb-backend.c:2205
-#: src/hb-backend.c:2217
+#: src/callbacks.c:2748 src/hb-backend.c:2256 src/hb-backend.c:2376
+#: src/hb-backend.c:2388
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2736
+#: src/callbacks.c:2749
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3522 src/callbacks.c:3544 src/callbacks.c:3563
-#: src/callbacks.c:3595
+#: src/callbacks.c:3737 src/callbacks.c:3759 src/callbacks.c:3778
+#: src/callbacks.c:3810
 #, c-format
 msgid ""
 "%s\n"
@@ -2176,195 +2430,189 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3666 src/callbacks.c:3708
+#: src/callbacks.c:3881 src/callbacks.c:3923
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3669 src/callbacks.c:3711 src/queuehandler.c:1777
+#: src/callbacks.c:3884 src/callbacks.c:3926 src/queuehandler.c:1796
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3670
+#: src/callbacks.c:3885
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3671
+#: src/callbacks.c:3886
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3672 src/callbacks.c:3712
+#: src/callbacks.c:3887 src/callbacks.c:3927
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:3890
+#: src/callbacks.c:4105
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:3894
+#: src/callbacks.c:4109
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:3951 src/callbacks.c:4019
+#: src/callbacks.c:4166 src/callbacks.c:4234
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:3961
+#: src/callbacks.c:4176
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:3966
+#: src/callbacks.c:4181
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:3979
+#: src/callbacks.c:4194
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:3989 src/callbacks.c:4029
+#: src/callbacks.c:4204 src/callbacks.c:4244
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:3999 src/callbacks.c:4038
+#: src/callbacks.c:4214 src/callbacks.c:4253
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4025
+#: src/callbacks.c:4240
+#, c-format
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4100
+#: src/callbacks.c:4315
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4104
+#: src/callbacks.c:4319
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4193
+#: src/callbacks.c:4408
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4224
+#: src/callbacks.c:4439
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4228
+#: src/callbacks.c:4443
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4233
+#: src/callbacks.c:4448
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4275
+#: src/callbacks.c:4490
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:4877
+#: src/callbacks.c:5127
 msgid "Scan this DVD source"
 msgstr ""
 
-#: src/callbacks.c:5265
+#: src/callbacks.c:5515
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5446
+#: src/callbacks.c:5696
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5448
+#: src/callbacks.c:5698
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5461 src/callbacks.c:5471 src/callbacks.c:5479
+#: src/callbacks.c:5711 src/callbacks.c:5721 src/callbacks.c:5729
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5462
+#: src/callbacks.c:5712
 msgid "Shutting down the computer"
 msgstr ""
 
-#: src/callbacks.c:5472
+#: src/callbacks.c:5722
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5480
+#: src/callbacks.c:5730
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/hb-backend.c:60 src/hb-backend.c:85
+#: src/hb-backend.c:61 src/hb-backend.c:86
 msgid "First Track Matching Selected Languages"
 msgstr ""
 
-#: src/hb-backend.c:61 src/hb-backend.c:86
+#: src/hb-backend.c:62 src/hb-backend.c:87
 msgid "All Tracks Matching Selected Languages"
 msgstr ""
 
-#: src/hb-backend.c:72
+#: src/hb-backend.c:73
 msgid "Foreign Audio Subtitle Track"
 msgstr ""
 
-#: src/hb-backend.c:73
+#: src/hb-backend.c:74
 msgid "First Selected Track"
 msgstr ""
 
-#: src/hb-backend.c:74
+#: src/hb-backend.c:75
 msgid "Foreign Audio, then First Selected Track"
 msgstr ""
 
-#: src/hb-backend.c:96
+#: src/hb-backend.c:97
 msgid "Chapters:"
 msgstr ""
 
-#: src/hb-backend.c:97
+#: src/hb-backend.c:98
 msgid "Seconds:"
 msgstr ""
 
-#: src/hb-backend.c:98
+#: src/hb-backend.c:99
 msgid "Frames:"
 msgstr ""
 
-#: src/hb-backend.c:108
+#: src/hb-backend.c:109
 msgid "Do Nothing"
 msgstr ""
 
-#: src/hb-backend.c:109
+#: src/hb-backend.c:110
 msgid "Show Notification"
 msgstr ""
 
-#: src/hb-backend.c:110
+#: src/hb-backend.c:111
 msgid "Quit Handbrake"
 msgstr ""
 
-#: src/hb-backend.c:111
+#: src/hb-backend.c:112
 msgid "Put Computer To Sleep"
 msgstr ""
 
-#: src/hb-backend.c:112
+#: src/hb-backend.c:113
 msgid "Shutdown Computer"
 msgstr ""
 
-#: src/hb-backend.c:123 src/hb-backend.c:252
-msgid "Automatic"
-msgstr ""
-
-#: src/hb-backend.c:124
-msgid "Loose"
-msgstr ""
-
-#: src/hb-backend.c:125 src/hb-backend.c:337
+#: src/hb-backend.c:125 src/hb-backend.c:239 src/hb-backend.c:270
+#: src/hb-backend.c:284 src/hb-backend.c:395
 msgid "Custom"
 msgstr ""
 
@@ -2408,205 +2656,265 @@ msgstr ""
 msgid "Yadif"
 msgstr ""
 
-#: src/hb-backend.c:213
-msgid "NLMeans"
+#: src/hb-backend.c:203
+msgid "Bwdif"
 msgstr ""
 
 #: src/hb-backend.c:214
+msgid "NLMeans"
+msgstr ""
+
+#: src/hb-backend.c:215
 msgid "HQDN3D"
 msgstr ""
 
-#: src/hb-backend.c:225
+#: src/hb-backend.c:226
 msgid "Unsharp"
 msgstr ""
 
-#: src/hb-backend.c:226
+#: src/hb-backend.c:227
 msgid "Lapsharp"
 msgstr ""
 
-#: src/hb-backend.c:237
-msgid "90 Degrees"
-msgstr ""
-
-#: src/hb-backend.c:238
-msgid "180 Degrees"
-msgstr ""
-
-#: src/hb-backend.c:239
-msgid "270 Degrees"
-msgstr ""
-
 #: src/hb-backend.c:250
-msgid "Spatial"
+msgid "90°"
 msgstr ""
 
 #: src/hb-backend.c:251
-msgid "Temporal"
+msgid "180°"
+msgstr ""
+
+#: src/hb-backend.c:252
+msgid "270°"
+msgstr ""
+
+#: src/hb-backend.c:262
+msgid "4320p 8K Ultra HD"
 msgstr ""
 
 #: src/hb-backend.c:263
-msgid "Fast"
+msgid "2160p 4K Ultra HD"
 msgstr ""
 
 #: src/hb-backend.c:264
-msgid "Optimal"
+msgid "1440p 2.5K Quad HD"
 msgstr ""
 
-#: src/hb-backend.c:275
-msgid "Strict"
+#: src/hb-backend.c:265
+msgid "1080p Full HD"
 msgstr ""
 
-#: src/hb-backend.c:276
-msgid "Normal"
+#: src/hb-backend.c:266
+msgid "720p HD"
 msgstr ""
 
-#: src/hb-backend.c:287
-msgid "Simple"
+#: src/hb-backend.c:267
+msgid "576p PAL"
 msgstr ""
 
-#: src/hb-backend.c:288
-msgid "Smart"
+#: src/hb-backend.c:268
+msgid "480p NTSC"
 msgstr ""
 
-#: src/hb-backend.c:298
-msgid "Diamond"
+#: src/hb-backend.c:281
+msgid "Height (Letterbox)"
 msgstr ""
 
-#: src/hb-backend.c:299
-msgid "Hexagon"
+#: src/hb-backend.c:282
+msgid "Width (Pillarbox)"
 msgstr ""
 
-#: src/hb-backend.c:300
-msgid "Uneven Multi-Hexagon"
+#: src/hb-backend.c:283
+msgid "Width &amp; Height"
 msgstr ""
 
-#: src/hb-backend.c:301
-msgid "Exhaustive"
+#: src/hb-backend.c:294
+msgid "Black"
 msgstr ""
 
-#: src/hb-backend.c:302
-msgid "Hadamard Exhaustive"
+#: src/hb-backend.c:295
+msgid "Dark Gray"
 msgstr ""
 
-#: src/hb-backend.c:312
-msgid "0: SAD, no subpel"
+#: src/hb-backend.c:296
+msgid "Gray"
 msgstr ""
 
-#: src/hb-backend.c:313
-msgid "1: SAD, qpel"
+#: src/hb-backend.c:297
+msgid "White"
 msgstr ""
 
-#: src/hb-backend.c:314
-msgid "2: SATD, qpel"
+#: src/hb-backend.c:308
+msgid "Spatial"
 msgstr ""
 
-#: src/hb-backend.c:315
-msgid "3: SATD: multi-qpel"
-msgstr ""
-
-#: src/hb-backend.c:316
-msgid "4: SATD, qpel on all"
-msgstr ""
-
-#: src/hb-backend.c:317
-msgid "5: SATD, multi-qpel on all"
-msgstr ""
-
-#: src/hb-backend.c:318
-msgid "6: RD in I/P-frames"
-msgstr ""
-
-#: src/hb-backend.c:319
-msgid "7: RD in all frames"
-msgstr ""
-
-#: src/hb-backend.c:320
-msgid "8: RD refine in I/P-frames"
+#: src/hb-backend.c:309
+msgid "Temporal"
 msgstr ""
 
 #: src/hb-backend.c:321
-msgid "9: RD refine in all frames"
+msgid "Fast"
 msgstr ""
 
 #: src/hb-backend.c:322
-msgid "10: QPRD in all frames"
-msgstr ""
-
-#: src/hb-backend.c:323
-msgid "11: No early terminations in analysis"
+msgid "Optimal"
 msgstr ""
 
 #: src/hb-backend.c:333
+msgid "Strict"
+msgstr ""
+
+#: src/hb-backend.c:334
+msgid "Normal"
+msgstr ""
+
+#: src/hb-backend.c:345
+msgid "Simple"
+msgstr ""
+
+#: src/hb-backend.c:346
+msgid "Smart"
+msgstr ""
+
+#: src/hb-backend.c:356
+msgid "Diamond"
+msgstr ""
+
+#: src/hb-backend.c:357
+msgid "Hexagon"
+msgstr ""
+
+#: src/hb-backend.c:358
+msgid "Uneven Multi-Hexagon"
+msgstr ""
+
+#: src/hb-backend.c:359
+msgid "Exhaustive"
+msgstr ""
+
+#: src/hb-backend.c:360
+msgid "Hadamard Exhaustive"
+msgstr ""
+
+#: src/hb-backend.c:370
+msgid "0: SAD, no subpel"
+msgstr ""
+
+#: src/hb-backend.c:371
+msgid "1: SAD, qpel"
+msgstr ""
+
+#: src/hb-backend.c:372
+msgid "2: SATD, qpel"
+msgstr ""
+
+#: src/hb-backend.c:373
+msgid "3: SATD: multi-qpel"
+msgstr ""
+
+#: src/hb-backend.c:374
+msgid "4: SATD, qpel on all"
+msgstr ""
+
+#: src/hb-backend.c:375
+msgid "5: SATD, multi-qpel on all"
+msgstr ""
+
+#: src/hb-backend.c:376
+msgid "6: RD in I/P-frames"
+msgstr ""
+
+#: src/hb-backend.c:377
+msgid "7: RD in all frames"
+msgstr ""
+
+#: src/hb-backend.c:378
+msgid "8: RD refine in I/P-frames"
+msgstr ""
+
+#: src/hb-backend.c:379
+msgid "9: RD refine in all frames"
+msgstr ""
+
+#: src/hb-backend.c:380
+msgid "10: QPRD in all frames"
+msgstr ""
+
+#: src/hb-backend.c:381
+msgid "11: No early terminations in analysis"
+msgstr ""
+
+#: src/hb-backend.c:391
 msgid "Most"
 msgstr ""
 
-#: src/hb-backend.c:335
+#: src/hb-backend.c:393
 msgid "Some"
 msgstr ""
 
-#: src/hb-backend.c:336 src/main.c:1151 src/queuehandler.c:1607
+#: src/hb-backend.c:394 src/main.c:1168 src/queuehandler.c:1626
 msgid "All"
 msgstr ""
 
-#: src/hb-backend.c:348
+#: src/hb-backend.c:406
 msgid "Encode only"
 msgstr ""
 
-#: src/hb-backend.c:349
+#: src/hb-backend.c:407
 msgid "Always"
 msgstr ""
 
-#: src/hb-backend.c:1346 src/hb-backend.c:1406 src/hb-backend.c:1485
+#: src/hb-backend.c:1517 src/hb-backend.c:1577 src/hb-backend.c:1656
 msgid "Same as source"
 msgstr ""
 
-#: src/hb-backend.c:1499
+#: src/hb-backend.c:1670
 msgid "(NTSC Film)"
 msgstr ""
 
-#: src/hb-backend.c:1503
+#: src/hb-backend.c:1674
 msgid "(PAL Film/Video)"
 msgstr ""
 
-#: src/hb-backend.c:1507
+#: src/hb-backend.c:1678
 msgid "(NTSC Video)"
 msgstr ""
 
-#: src/hb-backend.c:2074
+#: src/hb-backend.c:2245
 #, c-format
 msgid "%s - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2224
+#: src/hb-backend.c:2395
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - %s"
 msgstr ""
 
-#: src/hb-backend.c:2243
+#: src/hb-backend.c:2414
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2249
+#: src/hb-backend.c:2420
 #, c-format
 msgid "%3d - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2255
+#: src/hb-backend.c:2426
 #, c-format
 msgid "%3d - %02dh%02dm%02ds"
 msgstr ""
 
-#: src/hb-backend.c:2289
+#: src/hb-backend.c:2460
 msgid "No Titles"
 msgstr ""
 
 #. No audio. set some default
-#: src/hb-backend.c:2574
+#: src/hb-backend.c:2745
 msgid "No Audio"
 msgstr ""
 
-#: src/hb-backend.c:4170
+#: src/hb-backend.c:4296
 #, c-format
 msgid ""
 "Invalid Detelecine Settings:\n"
@@ -2615,7 +2923,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4177
+#: src/hb-backend.c:4303
 #, c-format
 msgid ""
 "Invalid Detelecine Settings:\n"
@@ -2623,7 +2931,7 @@ msgid ""
 "Preset:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4203
+#: src/hb-backend.c:4329
 #, c-format
 msgid ""
 "Invalid Comb Detect Settings:\n"
@@ -2632,7 +2940,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4210
+#: src/hb-backend.c:4336
 #, c-format
 msgid ""
 "Invalid Comb Detect Settings:\n"
@@ -2640,7 +2948,7 @@ msgid ""
 "Preset:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4239
+#: src/hb-backend.c:4365
 #, c-format
 msgid ""
 "Invalid Deinterlace Settings:\n"
@@ -2650,7 +2958,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4248
+#: src/hb-backend.c:4374
 #, c-format
 msgid ""
 "Invalid Deinterlace Settings:\n"
@@ -2659,7 +2967,7 @@ msgid ""
 "Preset:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4277
+#: src/hb-backend.c:4403
 #, c-format
 msgid ""
 "Invalid Denoise Settings:\n"
@@ -2670,7 +2978,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4305
+#: src/hb-backend.c:4431
 #, c-format
 msgid ""
 "Invalid Sharpen Settings:\n"
@@ -2681,7 +2989,8 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4339
+#: src/hb-backend.c:4465
+#, c-format
 msgid ""
 "Theora is not supported in the MP4 container.\n"
 "\n"
@@ -2689,25 +2998,27 @@ msgid ""
 "If you continue, FFMPEG will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4349
+#: src/hb-backend.c:4475
+#, c-format
 msgid ""
-"Only VP8 or VP9 is supported in the WebM container.\n"
+"Only VP8, VP9 and AV1 is supported in the WebM container.\n"
 "\n"
 "You should choose a different video codec or container.\n"
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4358 src/hb-backend.c:4415 src/hb-backend.c:4435
-#: src/hb-backend.c:4455 src/hb-backend.c:4516 src/hb-backend.c:4571
+#: src/hb-backend.c:4484 src/hb-backend.c:4541 src/hb-backend.c:4561
+#: src/hb-backend.c:4581 src/hb-backend.c:4642 src/hb-backend.c:4697
 msgid "Continue"
 msgstr ""
 
 #. No valid title, stop right there
-#: src/hb-backend.c:4384 src/hb-backend.c:4480
+#: src/hb-backend.c:4510 src/hb-backend.c:4606
 msgid "No title found.\n"
 msgstr ""
 
-#: src/hb-backend.c:4411
+#: src/hb-backend.c:4537
+#, c-format
 msgid ""
 "Only one subtitle may be burned into the video.\n"
 "\n"
@@ -2715,7 +3026,8 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4431
+#: src/hb-backend.c:4557
+#, c-format
 msgid ""
 "WebM in HandBrake only supports burned subtitles.\n"
 "\n"
@@ -2723,7 +3035,8 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4451
+#: src/hb-backend.c:4577
+#, c-format
 msgid ""
 "SRT file does not exist or not a regular file.\n"
 "\n"
@@ -2731,7 +3044,8 @@ msgid ""
 "If you continue, this subtitle will be ignored."
 msgstr ""
 
-#: src/hb-backend.c:4512
+#: src/hb-backend.c:4638
+#, c-format
 msgid ""
 "The source does not support Pass-Thru.\n"
 "\n"
@@ -2739,7 +3053,7 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4567
+#: src/hb-backend.c:4693
 #, c-format
 msgid ""
 "%s is not supported in the %s container.\n"
@@ -2761,39 +3075,44 @@ msgstr ""
 msgid "Track Information"
 msgstr ""
 
+#: src/main.c:249 src/main.c:254 src/main.c:314 src/main.c:318
+msgid " "
+msgstr ""
+
 #: src/main.c:362
 msgid "Preset Name"
 msgstr ""
 
-#: src/main.c:580
+#: src/main.c:579
 msgid "The device or file to encode"
 msgstr ""
 
-#: src/main.c:581
+#: src/main.c:580
 msgid "The preset values to use for encoding"
 msgstr ""
 
-#: src/main.c:582
+#: src/main.c:581
 msgid "Spam a lot"
 msgstr ""
 
-#: src/main.c:583
+#: src/main.c:582
 msgid "The path to override user config dir"
 msgstr ""
 
-#: src/main.c:585
+#: src/main.c:584
 msgid "Open a console for debug output"
 msgstr ""
 
-#: src/presets.c:1232
+#: src/presets.c:1249
 msgid "ghb_presets_menu_init: Failed to find presets folder."
 msgstr ""
 
-#: src/presets.c:1388
+#: src/presets.c:1405
 msgid "Failed to find parent folder when adding child."
 msgstr ""
 
-#: src/presets.c:1848
+#: src/presets.c:1868
+#, c-format
 msgid ""
 "Presets found are newer than what is supported by this version of "
 "HandBrake!\n"
@@ -2801,31 +3120,31 @@ msgid ""
 "Would you like to continue?"
 msgstr ""
 
-#: src/presets.c:1851
+#: src/presets.c:1871
 msgid "Get me out of here!"
 msgstr ""
 
-#: src/presets.c:1851
+#: src/presets.c:1871
 msgid "Load backup presets"
 msgstr ""
 
-#: src/presets.c:1997
+#: src/presets.c:2017
 msgid "All (*)"
 msgstr ""
 
-#: src/presets.c:2002
+#: src/presets.c:2022
 msgid "Presets (*.json)"
 msgstr ""
 
-#: src/presets.c:2008
+#: src/presets.c:2028
 msgid "Legacy Presets (*.plist)"
 msgstr ""
 
-#: src/presets.c:2104
+#: src/presets.c:2124
 msgid "Export Preset"
 msgstr ""
 
-#: src/presets.c:2445
+#: src/presets.c:2448
 #, c-format
 msgid ""
 "Confirm deletion of %s:\n"
@@ -2833,15 +3152,15 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/presets.c:2446
+#: src/presets.c:2449
 msgid "folder"
 msgstr ""
 
-#: src/presets.c:2446
+#: src/presets.c:2449
 msgid "preset"
 msgstr ""
 
-#: src/preview.c:487
+#: src/preview.c:522
 #, c-format
 msgid ""
 "Missing GStreamer plugin\n"
@@ -2928,112 +3247,115 @@ msgid ""
 "Variable Framerate %s fps"
 msgstr ""
 
-#: src/queuehandler.c:610 src/queuehandler.c:641
+#: src/queuehandler.c:634 src/queuehandler.c:665
+#, c-format
 msgid ", Forced Only"
 msgstr ""
 
-#: src/queuehandler.c:614 src/queuehandler.c:645
+#: src/queuehandler.c:638 src/queuehandler.c:669
+#, c-format
 msgid ", Burned"
 msgstr ""
 
-#: src/queuehandler.c:618 src/queuehandler.c:649
+#: src/queuehandler.c:642 src/queuehandler.c:673
+#, c-format
 msgid ", Default"
 msgstr ""
 
-#: src/queuehandler.c:705 src/queuehandler.c:1204
+#: src/queuehandler.c:729 src/queuehandler.c:1228
 msgid "Completed"
 msgstr ""
 
-#: src/queuehandler.c:709 src/queuehandler.c:1208
+#: src/queuehandler.c:733 src/queuehandler.c:1232
 msgid "Canceled"
 msgstr ""
 
-#: src/queuehandler.c:713 src/queuehandler.c:1212
+#: src/queuehandler.c:737 src/queuehandler.c:1236
 msgid "Failed"
 msgstr ""
 
-#: src/queuehandler.c:718
+#: src/queuehandler.c:742
 msgid "Pending"
 msgstr ""
 
-#: src/queuehandler.c:754 src/queuehandler.c:782 src/queuehandler.c:1252
-#: src/queuehandler.c:1280
+#: src/queuehandler.c:778 src/queuehandler.c:806 src/queuehandler.c:1276
+#: src/queuehandler.c:1304
 #, c-format
 msgid "%d Day %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:757 src/queuehandler.c:785 src/queuehandler.c:1255
-#: src/queuehandler.c:1283
+#: src/queuehandler.c:781 src/queuehandler.c:809 src/queuehandler.c:1279
+#: src/queuehandler.c:1307
 #, c-format
 msgid "%d Days %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:798 src/queuehandler.c:1296
+#: src/queuehandler.c:822 src/queuehandler.c:1320
 msgid "B"
 msgstr ""
 
-#: src/queuehandler.c:802 src/queuehandler.c:1300
+#: src/queuehandler.c:826 src/queuehandler.c:1324
 msgid "KB"
 msgstr ""
 
-#: src/queuehandler.c:807 src/queuehandler.c:1305
+#: src/queuehandler.c:831 src/queuehandler.c:1329
 msgid "MB"
 msgstr ""
 
-#: src/queuehandler.c:812 src/queuehandler.c:1310
+#: src/queuehandler.c:836 src/queuehandler.c:1334
 msgid "GB"
 msgstr ""
 
-#: src/queuehandler.c:823 src/queuehandler.c:1321
+#: src/queuehandler.c:847 src/queuehandler.c:1345
 msgid "Not Available"
 msgstr ""
 
-#: src/queuehandler.c:1156
+#: src/queuehandler.c:1180
 msgid "Foreign Audio Search"
 msgstr ""
 
-#: src/queuehandler.c:1160
+#: src/queuehandler.c:1184
 msgid "Encode"
 msgstr ""
 
-#: src/queuehandler.c:1164
+#: src/queuehandler.c:1188
 msgid "Encode First Pass (Analysis)"
 msgstr ""
 
-#: src/queuehandler.c:1168
+#: src/queuehandler.c:1192
 msgid "Encode Second Pass (Final)"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1173
+#: src/queuehandler.c:1197
 msgid "Error"
 msgstr ""
 
-#: src/queuehandler.c:1177
+#: src/queuehandler.c:1201
 #, c-format
 msgid ""
 "pass %d of %d\n"
 "%s"
 msgstr ""
 
-#: src/queuehandler.c:1189
+#: src/queuehandler.c:1213
 msgid "Scanning Title"
 msgstr ""
 
-#: src/queuehandler.c:1193
+#: src/queuehandler.c:1217
 msgid "Encoding Paused"
 msgstr ""
 
-#: src/queuehandler.c:1197
+#: src/queuehandler.c:1221
 msgid "Encoding In Progress"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1217
+#: src/queuehandler.c:1241
 msgid "Unknown"
 msgstr ""
 
-#: src/queuehandler.c:1770
+#: src/queuehandler.c:1789
 #, c-format
 msgid ""
 "%sThe destination filesystem is almost full: %<PRId64> MB free.\n"
@@ -3041,15 +3363,15 @@ msgid ""
 "Encode may be incomplete if you proceed.\n"
 msgstr ""
 
-#: src/queuehandler.c:1775
+#: src/queuehandler.c:1794
 msgid "Resume, I've fixed the problem"
 msgstr ""
 
-#: src/queuehandler.c:1776
+#: src/queuehandler.c:1795
 msgid "Resume, Don't tell me again"
 msgstr ""
 
-#: src/queuehandler.c:1830
+#: src/queuehandler.c:1849
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3058,11 +3380,11 @@ msgid ""
 "Do you want to overwrite?"
 msgstr ""
 
-#: src/queuehandler.c:1835 src/queuehandler.c:1881
+#: src/queuehandler.c:1854 src/queuehandler.c:1900
 msgid "Overwrite"
 msgstr ""
 
-#: src/queuehandler.c:1848
+#: src/queuehandler.c:1867
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3070,7 +3392,7 @@ msgid ""
 "This is not a valid directory."
 msgstr ""
 
-#: src/queuehandler.c:1862
+#: src/queuehandler.c:1881
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3078,7 +3400,7 @@ msgid ""
 "Can not read or write the directory."
 msgstr ""
 
-#: src/queuehandler.c:1876
+#: src/queuehandler.c:1895
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3087,47 +3409,47 @@ msgid ""
 "Do you want to overwrite?"
 msgstr ""
 
-#: src/queuehandler.c:2189
+#: src/queuehandler.c:2211
 msgid "Select this title for adding to the queue.\n"
 msgstr ""
 
 #. Title label
-#: src/queuehandler.c:2197
+#: src/queuehandler.c:2219
 msgid "No Title"
 msgstr ""
 
-#: src/queuehandler.c:2207
+#: src/queuehandler.c:2229
 msgid ""
 "There is another title with the same destination file name.\n"
 "This title will not be added to the queue unless you change\n"
 "the output file name.\n"
 msgstr ""
 
-#: src/queuehandler.c:2371 src/queuehandler.c:2384
+#: src/queuehandler.c:2393 src/queuehandler.c:2406
 msgid "Stop"
 msgstr ""
 
-#: src/queuehandler.c:2372 src/queuehandler.c:2385 src/queuehandler.c:2397
+#: src/queuehandler.c:2394 src/queuehandler.c:2407 src/queuehandler.c:2419
 msgid "Stop Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2396
+#: src/queuehandler.c:2418
 msgid "S_top Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2409 src/queuehandler.c:2422
+#: src/queuehandler.c:2431 src/queuehandler.c:2444
 msgid "Resume"
 msgstr ""
 
-#: src/queuehandler.c:2410 src/queuehandler.c:2423 src/queuehandler.c:2435
+#: src/queuehandler.c:2432 src/queuehandler.c:2445 src/queuehandler.c:2457
 msgid "Resume Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2434
+#: src/queuehandler.c:2456
 msgid "_Resume Encoding"
 msgstr ""
 
-#: src/queuehandler.c:3065
+#: src/queuehandler.c:3087
 msgid ""
 "You are currently encoding.  What would you like to do?\n"
 "\n"
@@ -3144,6 +3466,7 @@ msgid "Add %s subtitle track if default audio is not %s"
 msgstr ""
 
 #: src/subtitlehandler.c:1398
+#, c-format
 msgid "Add subtitle track if default audio is not your preferred language"
 msgstr ""
 
@@ -3165,7 +3488,7 @@ msgid ""
 "\"\""
 msgstr ""
 
-#: src/videohandler.c:349
+#: src/videohandler.c:350
 #, c-format
 msgid "%s: %.4g (Warning: lossless)"
 msgstr ""

--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -17,18 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/ghb3.ui:23 src/ghb4.ui:23
+#: src/ghb3.ui:23
 msgid ""
 "Render the subtitle over the video.\n"
 "\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:26 src/ghb4.ui:26
+#: src/ghb3.ui:26
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:32 src/ghb3.ui:9785 src/ghb4.ui:32 src/ghb4.ui:7601
+#: src/ghb3.ui:32 src/ghb3.ui:9785
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -39,11 +39,11 @@ msgid ""
 "in your output."
 msgstr ""
 
-#: src/ghb3.ui:39 src/ghb4.ui:39
+#: src/ghb3.ui:39
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:45 src/ghb3.ui:9747 src/ghb4.ui:45 src/ghb4.ui:7571
+#: src/ghb3.ui:45 src/ghb3.ui:9747
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -53,11 +53,11 @@ msgid ""
 "a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:51 src/ghb4.ui:51
+#: src/ghb3.ui:51
 msgid "<b>Forced Only</b>"
 msgstr ""
 
-#: src/ghb3.ui:57 src/ghb4.ui:57
+#: src/ghb3.ui:57
 msgid ""
 "Add (or subtract) an offset (in milliseconds)\n"
 "to the start of the SRT subtitle track.\n"
@@ -67,11 +67,11 @@ msgid ""
 "This setting allows you to synchronize the files."
 msgstr ""
 
-#: src/ghb3.ui:63 src/ghb4.ui:63
+#: src/ghb3.ui:63
 msgid "<b>SRT Offset</b>"
 msgstr ""
 
-#: src/ghb3.ui:69 src/ghb4.ui:69
+#: src/ghb3.ui:69
 msgid ""
 "The source subtitle track\n"
 "\n"
@@ -86,249 +86,248 @@ msgid ""
 "conjunction with the \"Forced\" option."
 msgstr ""
 
-#: src/ghb3.ui:80 src/ghb4.ui:80
+#: src/ghb3.ui:80
 msgid "<b>Track</b>"
 msgstr ""
 
-#: src/ghb3.ui:87 src/ghb4.ui:87
+#: src/ghb3.ui:87
 msgid "Open Source Directory"
 msgstr ""
 
-#: src/ghb3.ui:91 src/ghb4.ui:91
+#: src/ghb3.ui:91
 msgid "Open Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:95 src/ghb4.ui:95
+#: src/ghb3.ui:95
 msgid "Open Encode Log Directory"
 msgstr ""
 
-#: src/ghb3.ui:99 src/ghb4.ui:99
+#: src/ghb3.ui:99
 msgid "Open Encode Log"
 msgstr ""
 
-#: src/ghb3.ui:108 src/ghb4.ui:108
+#: src/ghb3.ui:108
 msgid "Reset Failed Jobs"
 msgstr ""
 
-#: src/ghb3.ui:112 src/ghb4.ui:112
+#: src/ghb3.ui:112
 msgid "Reset All Jobs"
 msgstr ""
 
-#: src/ghb3.ui:116 src/ghb4.ui:116
+#: src/ghb3.ui:116
 msgid "Clear Completed Jobs"
 msgstr ""
 
-#: src/ghb3.ui:120 src/ghb4.ui:120
+#: src/ghb3.ui:120
 msgid "Clear All Jobs"
 msgstr ""
 
-#: src/ghb3.ui:124 src/ghb4.ui:124 src/queuehandler.c:1615
+#: src/ghb3.ui:124 src/queuehandler.c:1615
 msgid "Import Queue"
 msgstr ""
 
-#: src/ghb3.ui:128 src/ghb4.ui:128 src/queuehandler.c:1470
+#: src/ghb3.ui:128 src/queuehandler.c:1470
 msgid "Export Queue"
 msgstr ""
 
-#: src/ghb3.ui:135 src/ghb4.ui:135
+#: src/ghb3.ui:135
 msgid "HandBrake Presets"
 msgstr ""
 
-#: src/ghb3.ui:163 src/ghb3.ui:2169 src/ghb4.ui:159 src/ghb4.ui:1853
+#: src/ghb3.ui:163 src/ghb3.ui:2169
 msgid "_Presets"
 msgstr ""
 
-#: src/ghb3.ui:171 src/ghb3.ui:2177 src/ghb4.ui:167 src/ghb4.ui:1861
+#: src/ghb3.ui:171 src/ghb3.ui:2177
 msgid "Set De_fault"
 msgstr ""
 
-#: src/ghb3.ui:185 src/ghb3.ui:2191 src/ghb4.ui:181 src/ghb4.ui:1875
+#: src/ghb3.ui:185 src/ghb3.ui:2191
 msgid "_Save"
 msgstr ""
 
-#: src/ghb3.ui:194 src/ghb3.ui:2200 src/ghb4.ui:190 src/ghb4.ui:1884
+#: src/ghb3.ui:194 src/ghb3.ui:2200
 msgid "Save _As"
 msgstr ""
 
-#: src/ghb3.ui:203 src/ghb3.ui:2209 src/ghb4.ui:199 src/ghb4.ui:1893
+#: src/ghb3.ui:203 src/ghb3.ui:2209
 msgid "_Rename"
 msgstr ""
 
-#: src/ghb3.ui:212 src/ghb3.ui:2218 src/ghb4.ui:208 src/ghb4.ui:1902
+#: src/ghb3.ui:212 src/ghb3.ui:2218
 msgid "_Delete"
 msgstr ""
 
-#: src/ghb3.ui:226 src/ghb3.ui:2232 src/ghb4.ui:222 src/ghb4.ui:1916
+#: src/ghb3.ui:226 src/ghb3.ui:2232
 msgid "_Import"
 msgstr ""
 
-#: src/ghb3.ui:235 src/ghb3.ui:2241 src/ghb4.ui:231 src/ghb4.ui:1925
+#: src/ghb3.ui:235 src/ghb3.ui:2241
 msgid "_Export"
 msgstr ""
 
-#: src/ghb3.ui:249 src/ghb3.ui:2255 src/ghb4.ui:245 src/ghb4.ui:1939
+#: src/ghb3.ui:249 src/ghb3.ui:2255
 msgid "Reset _Built-in Presets"
 msgstr ""
 
-#: src/ghb3.ui:304 src/ghb4.ui:294
+#: src/ghb3.ui:304
 msgid "<b>Presets List</b>"
 msgstr ""
 
-#: src/ghb3.ui:318 src/ghb4.ui:305
+#: src/ghb3.ui:318
 msgid "HandBrake Queue"
 msgstr ""
 
-#: src/ghb3.ui:352 src/ghb4.ui:333
+#: src/ghb3.ui:352
 msgid "<span size=\"x-large\">Queue</span>"
 msgstr ""
 
-#: src/ghb3.ui:367 src/ghb4.ui:344
+#: src/ghb3.ui:367
 msgid "0 jobs pending"
 msgstr ""
 
-#: src/ghb3.ui:404 src/ghb3.ui:2365 src/ghb4.ui:373 src/ghb4.ui:2039
-#: src/queuehandler.c:2400 src/queuehandler.c:2413 src/queuehandler.c:2424
+#: src/ghb3.ui:404 src/ghb3.ui:2365 src/queuehandler.c:2400
+#: src/queuehandler.c:2413 src/queuehandler.c:2424
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:406 src/ghb3.ui:2367 src/ghb3.ui:7116 src/ghb4.ui:375
-#: src/ghb4.ui:2041 src/ghb4.ui:5479 src/queuehandler.c:2399
+#: src/ghb3.ui:406 src/ghb3.ui:2367 src/ghb3.ui:7116 src/queuehandler.c:2399
 #: src/queuehandler.c:2412
 msgid "Start"
 msgstr ""
 
-#: src/ghb3.ui:420 src/ghb3.ui:2380 src/ghb4.ui:385 src/ghb4.ui:2051
-#: src/queuehandler.c:2438 src/queuehandler.c:2451 src/queuehandler.c:2462
+#: src/ghb3.ui:420 src/ghb3.ui:2380 src/queuehandler.c:2438
+#: src/queuehandler.c:2451 src/queuehandler.c:2462
 msgid "Pause Encoding"
 msgstr ""
 
-#: src/ghb3.ui:422 src/ghb3.ui:2382 src/ghb4.ui:387 src/ghb4.ui:2053
-#: src/queuehandler.c:2437 src/queuehandler.c:2450
+#: src/ghb3.ui:422 src/ghb3.ui:2382 src/queuehandler.c:2437
+#: src/queuehandler.c:2450
 msgid "Pause"
 msgstr ""
 
-#: src/ghb3.ui:480 src/ghb4.ui:424
+#: src/ghb3.ui:480
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:549 src/ghb4.ui:476
+#: src/ghb3.ui:549
 msgid "When Done:"
 msgstr ""
 
-#: src/ghb3.ui:630 src/ghb4.ui:540
+#: src/ghb3.ui:630
 msgid "Reset"
 msgstr ""
 
-#: src/ghb3.ui:632 src/ghb4.ui:542
+#: src/ghb3.ui:632
 msgid ""
 "Mark selected queue entry as pending.\n"
 "Resets the queue job to pending and ready to run again."
 msgstr ""
 
-#: src/ghb3.ui:647 src/ghb4.ui:553
+#: src/ghb3.ui:647
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:692 src/ghb4.ui:589
+#: src/ghb3.ui:692
 msgid "Actions"
 msgstr ""
 
-#: src/ghb3.ui:741 src/ghb3.ui:5467 src/ghb4.ui:625 src/ghb4.ui:4144
+#: src/ghb3.ui:741 src/ghb3.ui:5467
 msgid "Preset:"
 msgstr ""
 
-#: src/ghb3.ui:777 src/ghb4.ui:655
+#: src/ghb3.ui:777
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:818 src/ghb3.ui:7196 src/ghb4.ui:690 src/ghb4.ui:5541
+#: src/ghb3.ui:818 src/ghb3.ui:7196
 msgid "Title:"
 msgstr ""
 
-#: src/ghb3.ui:858 src/ghb4.ui:726
+#: src/ghb3.ui:858
 msgid "Destination:"
 msgstr ""
 
-#: src/ghb3.ui:899 src/ghb4.ui:761
+#: src/ghb3.ui:899
 msgid "Dimensions:"
 msgstr ""
 
-#: src/ghb3.ui:935 src/ghb4.ui:791
+#: src/ghb3.ui:935
 msgid "Video:"
 msgstr ""
 
-#: src/ghb3.ui:971 src/ghb4.ui:821
+#: src/ghb3.ui:971
 msgid "Audio:"
 msgstr ""
 
-#: src/ghb3.ui:1007 src/ghb4.ui:851
+#: src/ghb3.ui:1007
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1046 src/ghb3.ui:3248 src/ghb4.ui:521 src/ghb4.ui:2475
+#: src/ghb3.ui:1046 src/ghb3.ui:3248
 msgid "Summary"
 msgstr ""
 
-#: src/ghb3.ui:1084 src/ghb4.ui:917
+#: src/ghb3.ui:1084
 msgid "Pass:"
 msgstr ""
 
-#: src/ghb3.ui:1120 src/ghb4.ui:947
+#: src/ghb3.ui:1120
 msgid "Start Time:"
 msgstr ""
 
-#: src/ghb3.ui:1156 src/ghb4.ui:977
+#: src/ghb3.ui:1156
 msgid "End Time:"
 msgstr ""
 
-#: src/ghb3.ui:1196 src/ghb4.ui:1011
+#: src/ghb3.ui:1196
 msgid "Paused Duration:"
 msgstr ""
 
-#: src/ghb3.ui:1236 src/ghb4.ui:1045
+#: src/ghb3.ui:1236
 msgid "Encode Time:"
 msgstr ""
 
-#: src/ghb3.ui:1272 src/ghb4.ui:1075
+#: src/ghb3.ui:1272
 msgid "File Size:"
 msgstr ""
 
-#: src/ghb3.ui:1308 src/ghb4.ui:1105
+#: src/ghb3.ui:1308
 msgid "Status:"
 msgstr ""
 
-#: src/ghb3.ui:1347 src/ghb4.ui:884
+#: src/ghb3.ui:1347
 msgid "Statistics"
 msgstr ""
 
-#: src/ghb3.ui:1412 src/ghb4.ui:1138
+#: src/ghb3.ui:1412
 msgid "Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1435 src/ghb4.ui:1202
+#: src/ghb3.ui:1435
 msgid "HandBrake Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1751 src/ghb4.ui:1459
+#: src/ghb3.ui:1751
 msgid "About HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1757 src/ghb4.ui:1463
+#: src/ghb3.ui:1757
 msgid ""
 "Copyright © 2008 -  John Stebbins\n"
 "Copyright © 2004 - , HandBrake Devs"
 msgstr ""
 
-#: src/ghb3.ui:1759 src/ghb4.ui:1465
+#: src/ghb3.ui:1759
 msgid ""
 "HandBrake is a GPL-licensed, multiplatform, multithreaded video transcoder."
 msgstr ""
 
-#: src/ghb3.ui:1761 src/ghb4.ui:1467
+#: src/ghb3.ui:1761
 msgid "https://handbrake.fr"
 msgstr ""
 
-#: src/ghb3.ui:1762 src/ghb4.ui:1469
+#: src/ghb3.ui:1762
 msgid ""
 "HandBrake is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License version 2, as published by the "
@@ -344,266 +343,264 @@ msgid ""
 "Street, Fifth Floor, Boston, MA 02110-1301, USA."
 msgstr ""
 
-#: src/ghb3.ui:1948 src/ghb4.ui:1633
+#: src/ghb3.ui:1948
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1971 src/ghb4.ui:1655
+#: src/ghb3.ui:1971
 msgid "_File"
 msgstr ""
 
-#: src/ghb3.ui:1979 src/ghb4.ui:1663
+#: src/ghb3.ui:1979
 msgid "Open _Source"
 msgstr ""
 
-#: src/ghb3.ui:1988 src/ghb4.ui:1672
+#: src/ghb3.ui:1988
 msgid "Open Single _Title"
 msgstr ""
 
-#: src/ghb3.ui:1997 src/ghb4.ui:1681
+#: src/ghb3.ui:1997
 msgid "Set _Destination"
 msgstr ""
 
-#: src/ghb3.ui:2012 src/ghb4.ui:1696
+#: src/ghb3.ui:2012
 msgid "_Preferences"
 msgstr ""
 
-#: src/ghb3.ui:2027 src/ghb4.ui:1711
+#: src/ghb3.ui:2027
 msgid "_Quit"
 msgstr ""
 
-#: src/ghb3.ui:2042 src/ghb3.ui:2136 src/ghb4.ui:1726 src/ghb4.ui:1820
+#: src/ghb3.ui:2042 src/ghb3.ui:2136
 msgid "_Queue"
 msgstr ""
 
-#: src/ghb3.ui:2050 src/ghb4.ui:1734
+#: src/ghb3.ui:2050
 msgid "_Add"
 msgstr ""
 
-#: src/ghb3.ui:2059 src/ghb4.ui:1743
+#: src/ghb3.ui:2059
 msgid "Add _Multiple"
 msgstr ""
 
-#: src/ghb3.ui:2068 src/ghb4.ui:1752 src/queuehandler.c:2423
+#: src/ghb3.ui:2068 src/queuehandler.c:2423
 msgid "_Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:2077 src/ghb4.ui:1761 src/queuehandler.c:2461
+#: src/ghb3.ui:2077 src/queuehandler.c:2461
 msgid "_Pause Encoding"
 msgstr ""
 
-#: src/ghb3.ui:2086 src/ghb4.ui:1770
+#: src/ghb3.ui:2086
 msgid "S_ave Queue"
 msgstr ""
 
-#: src/ghb3.ui:2095 src/ghb4.ui:1779
+#: src/ghb3.ui:2095
 msgid "_Load Queue File"
 msgstr ""
 
-#: src/ghb3.ui:2110 src/ghb4.ui:1794
+#: src/ghb3.ui:2110
 msgid "_View"
 msgstr ""
 
-#: src/ghb3.ui:2118 src/ghb4.ui:1802
+#: src/ghb3.ui:2118
 msgid "HandBrake For _Dummies"
 msgstr ""
 
-#: src/ghb3.ui:2127 src/ghb4.ui:1811
+#: src/ghb3.ui:2127
 msgid "Presets _List"
 msgstr ""
 
-#: src/ghb3.ui:2145 src/ghb4.ui:1829
+#: src/ghb3.ui:2145
 msgid "_Preview"
 msgstr ""
 
-#: src/ghb3.ui:2154 src/ghb4.ui:1838
+#: src/ghb3.ui:2154
 msgid "_Activity Window"
 msgstr ""
 
-#: src/ghb3.ui:2270 src/ghb4.ui:1954
+#: src/ghb3.ui:2270
 msgid "_Help"
 msgstr ""
 
-#: src/ghb3.ui:2278 src/ghb4.ui:1962
+#: src/ghb3.ui:2278
 msgid "_About"
 msgstr ""
 
-#: src/ghb3.ui:2287 src/ghb4.ui:1971
+#: src/ghb3.ui:2287
 msgid "_Guide"
 msgstr ""
 
-#: src/ghb3.ui:2325 src/ghb4.ui:2003 src/callbacks.c:4338
+#: src/ghb3.ui:2325 src/callbacks.c:4338
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2327 src/ghb4.ui:2005 src/callbacks.c:4337
+#: src/ghb3.ui:2327 src/callbacks.c:4337
 msgid "Open Source"
 msgstr ""
 
-#: src/ghb3.ui:2350 src/ghb4.ui:2027
+#: src/ghb3.ui:2350
 msgid "Add to Queue"
 msgstr ""
 
-#: src/ghb3.ui:2352 src/ghb4.ui:2029
+#: src/ghb3.ui:2352
 msgid "Add To Queue"
 msgstr ""
 
-#: src/ghb3.ui:2407 src/ghb4.ui:2072
+#: src/ghb3.ui:2407
 msgid "Show Presets Window"
 msgstr ""
 
-#: src/ghb3.ui:2409 src/ghb4.ui:2074
+#: src/ghb3.ui:2409
 msgid "Presets"
 msgstr ""
 
-#: src/ghb3.ui:2422 src/ghb4.ui:2084
+#: src/ghb3.ui:2422
 msgid "Show Preview Window"
 msgstr ""
 
-#: src/ghb3.ui:2424 src/ghb4.ui:2086
+#: src/ghb3.ui:2424
 msgid "Preview"
 msgstr ""
 
-#: src/ghb3.ui:2437 src/ghb4.ui:2096
+#: src/ghb3.ui:2437
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2439 src/ghb4.ui:2098 src/callbacks.c:4783
+#: src/ghb3.ui:2439 src/callbacks.c:4783
 msgid "Queue"
 msgstr ""
 
-#: src/ghb3.ui:2452 src/ghb4.ui:2108
+#: src/ghb3.ui:2452
 msgid "Show Activity Window"
 msgstr ""
 
-#: src/ghb3.ui:2454 src/ghb4.ui:2110
+#: src/ghb3.ui:2454
 msgid "Activity"
 msgstr ""
 
-#: src/ghb3.ui:2484 src/ghb4.ui:2135
+#: src/ghb3.ui:2484
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2510 src/ghb4.ui:2161 src/hb-backend.c:60 src/hb-backend.c:72
-#: src/hb-backend.c:85 src/hb-backend.c:124 src/hb-backend.c:238
-#: src/hb-backend.c:269 src/hb-backend.c:280 src/hb-backend.c:307
-#: src/hb-backend.c:392 src/hb-backend.c:2592 src/hb-backend.c:2818
-#: src/subtitlehandler.c:1365
+#: src/ghb3.ui:2510 src/hb-backend.c:60 src/hb-backend.c:72 src/hb-backend.c:85
+#: src/hb-backend.c:124 src/hb-backend.c:238 src/hb-backend.c:269
+#: src/hb-backend.c:280 src/hb-backend.c:307 src/hb-backend.c:392
+#: src/hb-backend.c:2592 src/hb-backend.c:2818 src/subtitlehandler.c:1365
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2555 src/ghb4.ui:2195 src/callbacks.c:4310
+#: src/ghb3.ui:2555 src/callbacks.c:4310
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2589 src/ghb4.ui:2216
+#: src/ghb3.ui:2589
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2617 src/ghb4.ui:2242
+#: src/ghb3.ui:2617
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2639 src/ghb4.ui:2263
+#: src/ghb3.ui:2639
 msgid "<small>No Titles</small>"
 msgstr ""
 
-#: src/ghb3.ui:2657 src/ghb4.ui:2278
+#: src/ghb3.ui:2657
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2669 src/ghb4.ui:2286
+#: src/ghb3.ui:2669
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2685 src/ghb4.ui:2299
+#: src/ghb3.ui:2685
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2696 src/ghb4.ui:2307
+#: src/ghb3.ui:2696
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2709 src/ghb4.ui:2316
+#: src/ghb3.ui:2709
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2725 src/ghb4.ui:2328
+#: src/ghb3.ui:2725
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2737 src/ghb4.ui:2336
+#: src/ghb3.ui:2737
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2763 src/ghb4.ui:2352
+#: src/ghb3.ui:2763
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2799 src/ghb4.ui:2389
+#: src/ghb3.ui:2799
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2830 src/ghb4.ui:2411
+#: src/ghb3.ui:2830
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2839 src/ghb3.ui:5811 src/ghb3.ui:6597 src/ghb4.ui:2417
-#: src/ghb4.ui:4442 src/ghb4.ui:5058
+#: src/ghb3.ui:2839 src/ghb3.ui:5811 src/ghb3.ui:6597
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2842 src/ghb4.ui:2420
+#: src/ghb3.ui:2842
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2854 src/ghb4.ui:2429
+#: src/ghb3.ui:2854
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2857 src/ghb4.ui:2432
+#: src/ghb3.ui:2857
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2939 src/ghb4.ui:2496
+#: src/ghb3.ui:2939
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2957 src/ghb4.ui:2510
+#: src/ghb3.ui:2957
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2969 src/ghb4.ui:2520 src/queuehandler.c:290
+#: src/ghb3.ui:2969 src/queuehandler.c:290
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2974 src/ghb4.ui:2524
+#: src/ghb3.ui:2974
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2990 src/ghb4.ui:2537
+#: src/ghb3.ui:2990
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2995 src/ghb4.ui:2541
+#: src/ghb3.ui:2995
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:3012 src/ghb4.ui:2555
+#: src/ghb3.ui:3012
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:3017 src/ghb4.ui:2559
+#: src/ghb3.ui:3017
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
@@ -615,28 +612,28 @@ msgstr ""
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:3059 src/ghb4.ui:2578
+#: src/ghb3.ui:3059
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3077 src/ghb4.ui:2592
+#: src/ghb3.ui:3077
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3092 src/ghb4.ui:2605
+#: src/ghb3.ui:3092
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3132 src/ghb4.ui:2639
+#: src/ghb3.ui:3132
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3172 src/ghb4.ui:2674
+#: src/ghb3.ui:3172
 msgid "Size:"
 msgstr ""
 
 #: src/ghb3.ui:3197 src/ghb3.ui:3296 src/ghb3.ui:3334 src/ghb3.ui:3372
-#: src/ghb3.ui:4208 src/ghb3.ui:4346 src/ghb4.ui:2695 src/ghb4.ui:2889
+#: src/ghb3.ui:4208 src/ghb3.ui:4346
 msgid "--"
 msgstr ""
 
@@ -672,7 +669,7 @@ msgstr ""
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3493 src/ghb4.ui:3813
+#: src/ghb3.ui:3493
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
@@ -684,19 +681,19 @@ msgstr ""
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3540 src/ghb4.ui:2816
+#: src/ghb3.ui:3540
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3557 src/ghb4.ui:2831
+#: src/ghb3.ui:3557
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3574 src/ghb4.ui:2846
+#: src/ghb3.ui:3574
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3591 src/ghb4.ui:2861
+#: src/ghb3.ui:3591
 msgid "Right Crop"
 msgstr ""
 
@@ -728,7 +725,7 @@ msgstr ""
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3760 src/ghb4.ui:3019
+#: src/ghb3.ui:3760
 msgid "Anamorphic:"
 msgstr ""
 
@@ -742,11 +739,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3796 src/ghb4.ui:3195
+#: src/ghb3.ui:3796
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3811 src/ghb4.ui:3207
+#: src/ghb3.ui:3811
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -755,11 +752,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3831 src/ghb4.ui:3224
+#: src/ghb3.ui:3831
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3846 src/ghb4.ui:3236
+#: src/ghb3.ui:3846
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -771,14 +768,14 @@ msgstr ""
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3880 src/ghb4.ui:2967
+#: src/ghb3.ui:3880
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3913 src/ghb4.ui:2994
+#: src/ghb3.ui:3913
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -854,15 +851,15 @@ msgstr ""
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4384 src/ghb4.ui:2738
+#: src/ghb3.ui:4384
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4412 src/ghb4.ui:3321
+#: src/ghb3.ui:4412
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4428 src/ghb4.ui:3334
+#: src/ghb3.ui:4428
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -870,18 +867,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4443 src/ghb3.ui:5096 src/ghb4.ui:3347
+#: src/ghb3.ui:4443 src/ghb3.ui:5096
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4471 src/ghb4.ui:3373
+#: src/ghb3.ui:4471
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4487 src/ghb4.ui:3386
+#: src/ghb3.ui:4487
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -889,7 +886,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4503 src/ghb4.ui:3400
+#: src/ghb3.ui:4503
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -897,11 +894,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4532 src/ghb4.ui:3427
+#: src/ghb3.ui:4532
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4548 src/ghb4.ui:3440
+#: src/ghb3.ui:4548
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -909,11 +906,11 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4567 src/ghb4.ui:3457
+#: src/ghb3.ui:4567
 msgid "Deinterlace Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4583 src/ghb4.ui:3470
+#: src/ghb3.ui:4583
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -921,33 +918,32 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4626 src/ghb4.ui:3509
+#: src/ghb3.ui:4626
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4642 src/ghb3.ui:4674 src/ghb4.ui:3522 src/ghb4.ui:3549
+#: src/ghb3.ui:4642 src/ghb3.ui:4674
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4658 src/ghb4.ui:3536
+#: src/ghb3.ui:4658
 msgid "Deblock Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4903 src/ghb4.ui:3561
+#: src/ghb3.ui:4688 src/ghb3.ui:4903
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4716 src/ghb4.ui:3587
+#: src/ghb3.ui:4716
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4732 src/ghb3.ui:4765 src/ghb3.ui:4798 src/ghb4.ui:3600
-#: src/ghb4.ui:3628 src/ghb4.ui:3656
+#: src/ghb3.ui:4732 src/ghb3.ui:4765 src/ghb3.ui:4798
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -955,15 +951,15 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4749 src/ghb4.ui:3615
+#: src/ghb3.ui:4749
 msgid "Denoise Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4782 src/ghb4.ui:3643
+#: src/ghb3.ui:4782
 msgid "Denoise Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4813 src/ghb3.ui:5025 src/ghb4.ui:3669 src/ghb4.ui:3774
+#: src/ghb3.ui:4813 src/ghb3.ui:5025
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
@@ -984,30 +980,29 @@ msgstr ""
 msgid "Chroma Smooth Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4931 src/ghb4.ui:3695
+#: src/ghb3.ui:4931
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4947 src/ghb3.ui:4979 src/ghb3.ui:5011 src/ghb4.ui:3708
-#: src/ghb4.ui:3735 src/ghb4.ui:3762
+#: src/ghb3.ui:4947 src/ghb3.ui:4979 src/ghb3.ui:5011
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4963 src/ghb4.ui:3722
+#: src/ghb3.ui:4963
 msgid "Sharpen Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4995 src/ghb4.ui:3749
+#: src/ghb3.ui:4995
 msgid "Sharpen Tune:"
 msgstr ""
 
-#: src/ghb3.ui:5042 src/ghb4.ui:3825
+#: src/ghb3.ui:5042
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:5047 src/ghb4.ui:3829
+#: src/ghb3.ui:5047
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
@@ -1019,23 +1014,23 @@ msgstr ""
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:5115 src/ghb4.ui:3295
+#: src/ghb3.ui:5115
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:5146 src/ghb4.ui:3869
+#: src/ghb3.ui:5146
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5160 src/ghb4.ui:3881
+#: src/ghb3.ui:5160
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5176 src/ghb4.ui:3894
+#: src/ghb3.ui:5176
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5191 src/ghb4.ui:3906
+#: src/ghb3.ui:5191
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1043,19 +1038,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5206 src/ghb4.ui:3919
+#: src/ghb3.ui:5206
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5211 src/ghb4.ui:3923
+#: src/ghb3.ui:5211
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5225 src/ghb4.ui:3936
+#: src/ghb3.ui:5225
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5230 src/ghb4.ui:3940
+#: src/ghb3.ui:5230
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1063,18 +1058,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5248 src/ghb4.ui:3957
+#: src/ghb3.ui:5248
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5253 src/ghb4.ui:3961
+#: src/ghb3.ui:5253
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5289 src/ghb3.ui:5321 src/ghb4.ui:3991 src/ghb4.ui:4021
+#: src/ghb3.ui:5289 src/ghb3.ui:5321
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1090,15 +1085,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5316 src/ghb4.ui:4017
+#: src/ghb3.ui:5316
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5347 src/ghb4.ui:4045
+#: src/ghb3.ui:5347
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5352 src/ghb3.ui:5374 src/ghb4.ui:4049 src/ghb4.ui:4068
+#: src/ghb3.ui:5352 src/ghb3.ui:5374
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1109,11 +1104,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5391 src/ghb4.ui:4083
+#: src/ghb3.ui:5391
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5396 src/ghb4.ui:4087
+#: src/ghb3.ui:5396
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1123,16 +1118,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5414 src/ghb4.ui:4103
+#: src/ghb3.ui:5414
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5419 src/ghb4.ui:4107
+#: src/ghb3.ui:5419
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5481 src/ghb4.ui:4155
+#: src/ghb3.ui:5481
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1144,11 +1139,11 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5507 src/ghb4.ui:4179
+#: src/ghb3.ui:5507
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:5524 src/ghb4.ui:4193
+#: src/ghb3.ui:5524
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1157,22 +1152,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5540 src/ghb4.ui:4207
+#: src/ghb3.ui:5540
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5545 src/ghb4.ui:4211
+#: src/ghb3.ui:5545
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5563 src/ghb4.ui:4227
+#: src/ghb3.ui:5563
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5567 src/ghb4.ui:4230
+#: src/ghb3.ui:5567
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1182,109 +1177,108 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5591 src/ghb4.ui:4251
+#: src/ghb3.ui:5591
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5608 src/ghb4.ui:4265
+#: src/ghb3.ui:5608
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5626 src/ghb4.ui:4280
+#: src/ghb3.ui:5626
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5643 src/ghb4.ui:4294
+#: src/ghb3.ui:5643
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5668 src/ghb4.ui:4321
+#: src/ghb3.ui:5668
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5686 src/ghb4.ui:4336
+#: src/ghb3.ui:5686
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5720 src/ghb4.ui:3843 src/main.c:1172
+#: src/ghb3.ui:5720 src/main.c:1172
 msgid "Video"
 msgstr ""
 
 #. Add Button
 #: src/ghb3.ui:5786 src/ghb3.ui:5979 src/ghb3.ui:6558 src/ghb3.ui:6778
-#: src/ghb4.ui:4418 src/ghb4.ui:4589 src/ghb4.ui:5020 src/ghb4.ui:5218
 #: src/audiohandler.c:1752
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5788 src/ghb4.ui:4420
+#: src/ghb3.ui:5788
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5798 src/ghb3.ui:6570 src/ghb4.ui:4430 src/ghb4.ui:5032
+#: src/ghb3.ui:5798 src/ghb3.ui:6570
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5800 src/ghb4.ui:4432
+#: src/ghb3.ui:5800
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5813 src/ghb4.ui:4444
+#: src/ghb3.ui:5813
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5857 src/ghb3.ui:6643 src/ghb4.ui:4395 src/ghb4.ui:4997
+#: src/ghb3.ui:5857 src/ghb3.ui:6643
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5888 src/ghb3.ui:6678 src/ghb4.ui:4509 src/ghb4.ui:5129
+#: src/ghb3.ui:5888 src/ghb3.ui:6678
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5903 src/ghb4.ui:4522
+#: src/ghb3.ui:5903
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5964 src/ghb4.ui:4580
+#: src/ghb3.ui:5964
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5995 src/ghb3.ui:6794 src/ghb4.ui:4603 src/ghb4.ui:5232
+#: src/ghb3.ui:5995 src/ghb3.ui:6794
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:6013 src/ghb3.ui:6812 src/ghb4.ui:4619 src/ghb4.ui:5248
+#: src/ghb3.ui:6013 src/ghb3.ui:6812
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:6026 src/ghb3.ui:6825 src/ghb4.ui:4630 src/ghb4.ui:5259
+#: src/ghb3.ui:6026 src/ghb3.ui:6825
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:6042 src/ghb4.ui:4641
+#: src/ghb3.ui:6042
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:6047 src/ghb4.ui:4645
+#: src/ghb3.ui:6047
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:6083 src/ghb4.ui:4674
+#: src/ghb3.ui:6083
 msgid "Auto Passthru:"
 msgstr ""
 
@@ -1299,88 +1293,88 @@ msgid ""
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6115 src/ghb4.ui:4683
+#: src/ghb3.ui:6115
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:6120 src/ghb4.ui:4687
+#: src/ghb3.ui:6120
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6136 src/ghb4.ui:4719
+#: src/ghb3.ui:6136
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:6141 src/ghb4.ui:4723
+#: src/ghb3.ui:6141
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6157 src/ghb4.ui:4773
+#: src/ghb3.ui:6157
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6162 src/ghb4.ui:4777
+#: src/ghb3.ui:6162
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6178 src/ghb4.ui:4737
+#: src/ghb3.ui:6178
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6183 src/ghb4.ui:4741
+#: src/ghb3.ui:6183
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6199 src/ghb4.ui:4755
+#: src/ghb3.ui:6199
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6204 src/ghb4.ui:4759
+#: src/ghb3.ui:6204
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6220 src/ghb4.ui:4791
+#: src/ghb3.ui:6220
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6225 src/ghb4.ui:4795
+#: src/ghb3.ui:6225
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6241 src/ghb4.ui:4809
+#: src/ghb3.ui:6241
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6246 src/ghb4.ui:4813
+#: src/ghb3.ui:6246
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6262 src/ghb4.ui:4701
+#: src/ghb3.ui:6262
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6267 src/ghb4.ui:4705
+#: src/ghb3.ui:6267
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1398,86 +1392,86 @@ msgid ""
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6321 src/ghb4.ui:4840
+#: src/ghb3.ui:6321
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6333 src/ghb4.ui:4848
+#: src/ghb3.ui:6333
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6362 src/ghb4.ui:4865
+#: src/ghb3.ui:6362
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6363 src/ghb4.ui:4866
+#: src/ghb3.ui:6363
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6388 src/ghb3.ui:9942 src/ghb4.ui:4884 src/ghb4.ui:7733
+#: src/ghb3.ui:6388 src/ghb3.ui:9942
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6399 src/ghb3.ui:9955 src/ghb4.ui:4892 src/ghb4.ui:7744
+#: src/ghb3.ui:6399 src/ghb3.ui:9955
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6410 src/ghb4.ui:4900
+#: src/ghb3.ui:6410
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6421 src/ghb4.ui:4908
+#: src/ghb3.ui:6421
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6432 src/ghb3.ui:9999 src/ghb4.ui:4916 src/ghb4.ui:7781
+#: src/ghb3.ui:6432 src/ghb3.ui:9999
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6443 src/ghb3.ui:10018 src/ghb4.ui:4924 src/ghb4.ui:7798
+#: src/ghb3.ui:6443 src/ghb3.ui:10018
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6480 src/ghb3.ui:7038 src/ghb4.ui:4480 src/ghb4.ui:5096
+#: src/ghb3.ui:6480 src/ghb3.ui:7038
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6492 src/ghb4.ui:4358
+#: src/ghb3.ui:6492
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6560 src/ghb4.ui:5022
+#: src/ghb3.ui:6560
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6572 src/ghb4.ui:5034
+#: src/ghb3.ui:6572
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6582 src/ghb4.ui:5044 src/queuehandler.c:631
-#: src/queuehandler.c:1062 src/subtitlehandler.c:413
+#: src/ghb3.ui:6582 src/queuehandler.c:631 src/queuehandler.c:1062
+#: src/subtitlehandler.c:413
 #, c-format
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6584 src/ghb4.ui:5046
+#: src/ghb3.ui:6584
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6599 src/ghb4.ui:5060
+#: src/ghb3.ui:6599
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6693 src/ghb4.ui:5142
+#: src/ghb3.ui:6693
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6758 src/ghb4.ui:5204
+#: src/ghb3.ui:6758
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1488,15 +1482,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6839 src/ghb4.ui:5271
+#: src/ghb3.ui:6839
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6866 src/ghb4.ui:5287
+#: src/ghb3.ui:6866
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6871 src/ghb4.ui:5291
+#: src/ghb3.ui:6871
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1506,11 +1500,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6886 src/ghb4.ui:5303
+#: src/ghb3.ui:6886
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6891 src/ghb4.ui:5307
+#: src/ghb3.ui:6891
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1518,21 +1512,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6905 src/ghb4.ui:5318
+#: src/ghb3.ui:6905
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6910 src/ghb4.ui:5322
+#: src/ghb3.ui:6910
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6931 src/ghb4.ui:5339
+#: src/ghb3.ui:6931
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6943 src/ghb4.ui:5348
+#: src/ghb3.ui:6943
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1542,15 +1536,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6970 src/ghb4.ui:5368
+#: src/ghb3.ui:6970
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6979 src/ghb4.ui:5374
+#: src/ghb3.ui:6979
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6984 src/ghb4.ui:5378
+#: src/ghb3.ui:6984
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1561,11 +1555,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6998 src/ghb4.ui:5389
+#: src/ghb3.ui:6998
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:7003 src/ghb4.ui:5393
+#: src/ghb3.ui:7003
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1576,101 +1570,100 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:7025 src/ghb4.ui:5409
+#: src/ghb3.ui:7025
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:7026 src/ghb4.ui:5410
+#: src/ghb3.ui:7026
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:7050 src/ghb4.ui:4960
+#: src/ghb3.ui:7050
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:7065 src/ghb4.ui:5441 src/queuehandler.c:280
+#: src/ghb3.ui:7065 src/queuehandler.c:280
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:7070 src/ghb4.ui:5445
+#: src/ghb3.ui:7070
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:7104 src/ghb4.ui:5470
+#: src/ghb3.ui:7104
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:7128 src/ghb4.ui:5488
+#: src/ghb3.ui:7128
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7139 src/ghb4.ui:5496
+#: src/ghb3.ui:7139
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7176 src/ghb4.ui:5428
+#: src/ghb3.ui:7176
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7231 src/ghb4.ui:5570
+#: src/ghb3.ui:7231
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7266 src/ghb4.ui:5599
+#: src/ghb3.ui:7266
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7301 src/ghb4.ui:5628
+#: src/ghb3.ui:7301
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7336 src/ghb4.ui:5657
+#: src/ghb3.ui:7336
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7371 src/ghb4.ui:5686
+#: src/ghb3.ui:7371
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7406 src/ghb4.ui:5715
+#: src/ghb3.ui:7406
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7441 src/ghb4.ui:5744
+#: src/ghb3.ui:7441
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7479 src/ghb4.ui:5525
+#: src/ghb3.ui:7479
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7508 src/ghb4.ui:5798
+#: src/ghb3.ui:7508
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7522 src/ghb4.ui:5810
+#: src/ghb3.ui:7522
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7542 src/ghb4.ui:5826
+#: src/ghb3.ui:7542
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7555 src/ghb4.ui:5837
+#: src/ghb3.ui:7555
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7558 src/ghb4.ui:5840 src/queuehandler.c:2247
+#: src/ghb3.ui:7558 src/queuehandler.c:2247
 msgid "Destination Directory"
 msgstr ""
 
 #: src/ghb3.ui:7651 src/ghb3.ui:8617 src/ghb3.ui:8769 src/ghb3.ui:9416
-#: src/ghb3.ui:9821 src/ghb4.ui:5913 src/ghb4.ui:6618 src/ghb4.ui:6732
-#: src/ghb4.ui:7298 src/ghb4.ui:7629 src/callbacks.c:5713 src/callbacks.c:5723
+#: src/ghb3.ui:9821 src/callbacks.c:5713 src/callbacks.c:5723
 #: src/callbacks.c:5731 src/hb-backend.c:4307 src/hb-backend.c:4340
 #: src/hb-backend.c:4379 src/hb-backend.c:4410 src/hb-backend.c:4438
 #: src/hb-backend.c:4484 src/hb-backend.c:4541 src/hb-backend.c:4561
@@ -1681,74 +1674,73 @@ msgid "Cancel"
 msgstr ""
 
 #: src/ghb3.ui:7660 src/ghb3.ui:7804 src/ghb3.ui:8626 src/ghb3.ui:8778
-#: src/ghb3.ui:9425 src/ghb3.ui:9830 src/ghb4.ui:5921 src/ghb4.ui:6035
-#: src/ghb4.ui:6626 src/ghb4.ui:6740 src/ghb4.ui:7306 src/ghb4.ui:7637
+#: src/ghb3.ui:9425 src/ghb3.ui:9830
 msgid "OK"
 msgstr ""
 
-#: src/ghb3.ui:7689 src/ghb4.ui:5949
+#: src/ghb3.ui:7689
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7693 src/ghb4.ui:5953
+#: src/ghb3.ui:7693
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7706 src/ghb4.ui:5963
+#: src/ghb3.ui:7706
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7710 src/ghb4.ui:5967
+#: src/ghb3.ui:7710
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7771 src/ghb4.ui:6013
+#: src/ghb3.ui:7771
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7793 src/ghb4.ui:6026
+#: src/ghb3.ui:7793
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7899 src/ghb4.ui:6113
+#: src/ghb3.ui:7899
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7936 src/ghb4.ui:6141
+#: src/ghb3.ui:7936
 msgid "When all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7958 src/ghb4.ui:6157
+#: src/ghb3.ui:7958
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7959 src/ghb4.ui:6158
+#: src/ghb3.ui:7959
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7983 src/ghb4.ui:6179
+#: src/ghb3.ui:7983
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7994 src/ghb4.ui:6187
+#: src/ghb3.ui:7994
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {quality} {bitrate}"
 msgstr ""
 
-#: src/ghb3.ui:8014 src/ghb4.ui:6200
+#: src/ghb3.ui:8014
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:8057 src/ghb4.ui:6234
+#: src/ghb3.ui:8057
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:8095 src/ghb4.ui:6263
+#: src/ghb3.ui:8095
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8109 src/ghb4.ui:6271
+#: src/ghb3.ui:8109
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
@@ -1759,7 +1751,7 @@ msgid ""
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8130 src/ghb4.ui:6086
+#: src/ghb3.ui:8130
 msgid "General"
 msgstr ""
 
@@ -1785,55 +1777,55 @@ msgstr ""
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8232 src/ghb4.ui:6327
+#: src/ghb3.ui:8232
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8249 src/ghb4.ui:6335
+#: src/ghb3.ui:8249
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8272 src/ghb4.ui:6360
+#: src/ghb3.ui:8272
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8276 src/ghb3.ui:8298 src/ghb4.ui:6364 src/ghb4.ui:6382
+#: src/ghb3.ui:8276 src/ghb3.ui:8298
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8313 src/ghb4.ui:6394
+#: src/ghb3.ui:8313
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8341 src/ghb4.ui:6414
+#: src/ghb3.ui:8341
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8377 src/ghb4.ui:6444
+#: src/ghb3.ui:8377
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8412 src/ghb4.ui:6470
+#: src/ghb3.ui:8412
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8433 src/ghb4.ui:6479
+#: src/ghb3.ui:8433
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8450 src/ghb4.ui:6494
+#: src/ghb3.ui:8450
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8454 src/ghb4.ui:6498
+#: src/ghb3.ui:8454
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8492 src/ghb4.ui:6534
+#: src/ghb3.ui:8492
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8509 src/ghb4.ui:6542
+#: src/ghb3.ui:8509
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
@@ -1846,178 +1838,178 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8541 src/ghb4.ui:6569
+#: src/ghb3.ui:8541
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8557 src/ghb4.ui:6584
+#: src/ghb3.ui:8557
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8585 src/ghb4.ui:6289
+#: src/ghb3.ui:8585
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8663 src/ghb4.ui:6653
+#: src/ghb3.ui:8663
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8683 src/ghb4.ui:6668
+#: src/ghb3.ui:8683
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8740 src/ghb3.ui:9008 src/ghb4.ui:6712 src/ghb4.ui:6988
+#: src/ghb3.ui:8740 src/ghb3.ui:9008
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8821 src/ghb4.ui:6773
+#: src/ghb3.ui:8821
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8836 src/ghb4.ui:6785
+#: src/ghb3.ui:8836
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8852 src/ghb4.ui:6798
+#: src/ghb3.ui:8852
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8885 src/ghb4.ui:6825
+#: src/ghb3.ui:8885
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8919 src/ghb4.ui:6851
+#: src/ghb3.ui:8919
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8924 src/ghb4.ui:6855
+#: src/ghb3.ui:8924
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8950 src/ghb4.ui:6873
+#: src/ghb3.ui:8950
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9031 src/ghb4.ui:7003
+#: src/ghb3.ui:9031
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9090 src/ghb4.ui:7052
+#: src/ghb3.ui:9090
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9112 src/ghb4.ui:7071
+#: src/ghb3.ui:9112
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9183 src/ghb4.ui:7126
+#: src/ghb3.ui:9183
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9195 src/ghb4.ui:7135
+#: src/ghb3.ui:9195
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9211 src/ghb4.ui:7145
+#: src/ghb3.ui:9211
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9215 src/ghb4.ui:7149
+#: src/ghb3.ui:9215
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9226 src/ghb4.ui:7157
+#: src/ghb3.ui:9226
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9230 src/ghb4.ui:7161
+#: src/ghb3.ui:9230
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9262 src/ghb4.ui:7185
+#: src/ghb3.ui:9262
 msgid "_Cancel"
 msgstr ""
 
-#: src/ghb3.ui:9274 src/ghb4.ui:7194
+#: src/ghb3.ui:9274
 msgid "_Open"
 msgstr ""
 
-#: src/ghb3.ui:9308 src/ghb4.ui:7224
+#: src/ghb3.ui:9308
 msgid "Title Number:"
 msgstr ""
 
-#: src/ghb3.ui:9344 src/ghb4.ui:7250
+#: src/ghb3.ui:9344
 msgid "Detected DVD devices:"
 msgstr ""
 
-#: src/ghb3.ui:9454 src/ghb4.ui:7334
+#: src/ghb3.ui:9454
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9459 src/ghb4.ui:7338
+#: src/ghb3.ui:9459
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9470 src/ghb4.ui:7346
+#: src/ghb3.ui:9470
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9475 src/ghb4.ui:7350
+#: src/ghb3.ui:9475
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9487 src/ghb4.ui:7359
+#: src/ghb3.ui:9487
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9492 src/ghb4.ui:7363
+#: src/ghb3.ui:9492
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9519 src/ghb3.ui:9862 src/ghb4.ui:7383 src/ghb4.ui:7668
+#: src/ghb3.ui:9519 src/ghb3.ui:9862
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9534 src/ghb4.ui:7395
+#: src/ghb3.ui:9534
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9548 src/ghb3.ui:9892 src/ghb4.ui:7407 src/ghb4.ui:7693
+#: src/ghb3.ui:9548 src/ghb3.ui:9892
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9564 src/ghb4.ui:7420
+#: src/ghb3.ui:9564
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9597 src/ghb4.ui:7446
+#: src/ghb3.ui:9597
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9611 src/ghb4.ui:7457
+#: src/ghb3.ui:9611
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9625 src/ghb4.ui:7468
+#: src/ghb3.ui:9625
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9640 src/ghb4.ui:7480
+#: src/ghb3.ui:9640
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9655 src/ghb4.ui:7492
+#: src/ghb3.ui:9655
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9673 src/ghb4.ui:7507
+#: src/ghb3.ui:9673
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2026,57 +2018,56 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9697 src/ghb4.ui:7529
+#: src/ghb3.ui:9697
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9700 src/ghb4.ui:7532
+#: src/ghb3.ui:9700
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9718 src/ghb4.ui:7548
+#: src/ghb3.ui:9718
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9742 src/ghb4.ui:7567
+#: src/ghb3.ui:9742
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9763 src/ghb4.ui:7584
+#: src/ghb3.ui:9763
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9768 src/ghb4.ui:7588
+#: src/ghb3.ui:9768
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9780 src/ghb4.ui:7597
+#: src/ghb3.ui:9780
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9878 src/ghb4.ui:7681
+#: src/ghb3.ui:9878
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9908 src/ghb4.ui:7706
+#: src/ghb3.ui:9908
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9971 src/ghb4.ui:7757
+#: src/ghb3.ui:9971
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9984 src/ghb4.ui:7768
+#: src/ghb3.ui:9984
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:10014 src/ghb3.ui:10253 src/ghb4.ui:7794 src/ghb4.ui:7986
-#: src/audiohandler.c:1925
+#: src/ghb3.ui:10014 src/ghb3.ui:10253 src/audiohandler.c:1925
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2087,246 +2078,87 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:10035 src/ghb4.ui:7812 src/audiohandler.c:1776
+#: src/ghb3.ui:10035 src/audiohandler.c:1776
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10057 src/ghb4.ui:7836 src/audiohandler.c:1790
+#: src/ghb3.ui:10057 src/audiohandler.c:1790
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:10062 src/ghb4.ui:7840
+#: src/ghb3.ui:10062
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/ghb4.ui:7847 src/audiohandler.c:1795
+#: src/ghb3.ui:10072 src/audiohandler.c:1795
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:10077 src/ghb4.ui:7851
+#: src/ghb3.ui:10077
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10098 src/ghb4.ui:7865 src/audiohandler.c:1809
+#: src/ghb3.ui:10098 src/audiohandler.c:1809
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10118 src/ghb4.ui:7880
+#: src/ghb3.ui:10118
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10140 src/ghb4.ui:7899
+#: src/ghb3.ui:10140
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10167 src/ghb4.ui:7913 src/audiohandler.c:1861
+#: src/ghb3.ui:10167 src/audiohandler.c:1861
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10183 src/ghb4.ui:7926 src/audiohandler.c:1874
+#: src/ghb3.ui:10183 src/audiohandler.c:1874
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10206 src/ghb4.ui:7949 src/audiohandler.c:1895
+#: src/ghb3.ui:10206 src/audiohandler.c:1895
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10224 src/ghb4.ui:7964 src/audiohandler.c:1905
+#: src/ghb3.ui:10224 src/audiohandler.c:1905
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10271 src/ghb4.ui:8001 src/audiohandler.c:424
-#: src/audiohandler.c:762 src/audiohandler.c:1165 src/audiohandler.c:1939
-#: src/callbacks.c:5482 src/hb-backend.c:200 src/hb-backend.c:213
-#: src/hb-backend.c:225 src/hb-backend.c:249 src/hb-backend.c:320
-#: src/hb-backend.c:332 src/hb-backend.c:344 src/hb-backend.c:405
+#: src/ghb3.ui:10271 src/audiohandler.c:424 src/audiohandler.c:762
+#: src/audiohandler.c:1165 src/audiohandler.c:1939 src/callbacks.c:5482
+#: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
+#: src/hb-backend.c:249 src/hb-backend.c:320 src/hb-backend.c:332
+#: src/hb-backend.c:344 src/hb-backend.c:405
 #, c-format
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10307 src/ghb4.ui:8023
+#: src/ghb3.ui:10307
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10315 src/ghb4.ui:8031
+#: src/ghb3.ui:10315
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10384 src/ghb4.ui:8084
+#: src/ghb3.ui:10384
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10400 src/ghb4.ui:8097
+#: src/ghb3.ui:10400
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10428 src/ghb4.ui:8119
+#: src/ghb3.ui:10428
 msgid "<b>Release Notes</b>"
-msgstr ""
-
-#: src/ghb4.ui:2775
-msgid "Auto Crop"
-msgstr ""
-
-#: src/ghb4.ui:2779
-msgid "Automatically crop black borders around edges of the video."
-msgstr ""
-
-#: src/ghb4.ui:2792
-msgid "Loose Crop"
-msgstr ""
-
-#: src/ghb4.ui:2796
-msgid ""
-"When picture settings require that the image\n"
-"dimensions be rounded to some multiple number\n"
-"of pixels, this setting will crop a few extra pixels\n"
-"instead of doing exact cropping and then scaling to\n"
-"the required multiple."
-msgstr ""
-
-#: src/ghb4.ui:2876
-msgid "Crop Dimensions:"
-msgstr ""
-
-#: src/ghb4.ui:2905
-msgid "<b>Cropping</b>"
-msgstr ""
-
-#: src/ghb4.ui:2935
-msgid "Optimal for source"
-msgstr ""
-
-#: src/ghb4.ui:2939
-msgid ""
-"If enabled, select the 'optimal' storage resolution.\n"
-"This will be the resolution that most closely matches the source resolution "
-"after cropping."
-msgstr ""
-
-#: src/ghb4.ui:2955 src/ghb4.ui:3134
-msgid "Width:"
-msgstr ""
-
-#: src/ghb4.ui:2982 src/ghb4.ui:3160
-msgid "Height:"
-msgstr ""
-
-#: src/ghb4.ui:3031
-msgid ""
-"<b>Anamorphic Modes:</b>\n"
-"<small><tt>\n"
-"None      - Force pixel aspect ratio to 1:1.\n"
-"Loose     - Use a pixel aspect ratio that is as\n"
-"            close as possible to the source video pixel\n"
-"            aspect ratio while preserving the original\n"
-"            display aspect ratio\n"
-"Automatic - Use a pixel aspect ratio that maximizes\n"
-"            storage resolution while preserving the original\n"
-"            display aspect ratio</tt></small>"
-msgstr ""
-
-#: src/ghb4.ui:3053
-msgid "Alignment:"
-msgstr ""
-
-#: src/ghb4.ui:3065
-msgid ""
-"Align storage dimensions to multiples of this value.\n"
-"\n"
-"This setting is only necessary for compatibility with some devices.\n"
-"You should use 2 unless you experience compatibility issues."
-msgstr ""
-
-#: src/ghb4.ui:3084
-msgid "<b>Storage Geometry</b>"
-msgstr ""
-
-#: src/ghb4.ui:3114
-msgid "Keep Aspect"
-msgstr ""
-
-#: src/ghb4.ui:3118
-msgid ""
-"If enabled, the original display aspect of the source will be maintained."
-msgstr ""
-
-#: src/ghb4.ui:3146
-msgid ""
-"This is the display width. It is the result of scaling the storage "
-"dimensions by the pixel aspect."
-msgstr ""
-
-#: src/ghb4.ui:3253
-msgid "Display Aspect:"
-msgstr ""
-
-#: src/ghb4.ui:3265
-msgid "--:--"
-msgstr ""
-
-#: src/ghb4.ui:3280
-msgid "<b>Display Geometry</b>"
-msgstr ""
-
-#: src/ghb4.ui:3800
-msgid "Rotate Filter:"
-msgstr ""
-
-#: src/ghb4.ui:6275
-msgid ""
-"By default, completed jobs remain in the queue and are marked as complete.\n"
-"    Check this if you want the queue to clean itself up by deleting "
-"completed jobs."
-msgstr ""
-
-#: src/ghb4.ui:6546
-msgid ""
-"When checked, every title will use the same settings when adding a\n"
-"    batch of titles to the queue.\n"
-"\n"
-"    Uncheck this if you want to allow changing each title's settings "
-"independently."
-msgstr ""
-
-#: src/ghb4.ui:6895
-msgid "Maximum Width:"
-msgstr ""
-
-#: src/ghb4.ui:6899
-msgid "Enable maximum width limit."
-msgstr ""
-
-#: src/ghb4.ui:6914
-msgid ""
-"This is the maximum width that the video will be stored at.\n"
-"\n"
-"Whenever a new source is loaded, this value will be applied if the source "
-"width is greater.\n"
-"Setting this to 0 means there is no maximum width."
-msgstr ""
-
-#: src/ghb4.ui:6929
-msgid "Maximum Height:"
-msgstr ""
-
-#: src/ghb4.ui:6933
-msgid "Enable maximum height limit."
-msgstr ""
-
-#: src/ghb4.ui:6948
-msgid ""
-"This is the maximum height that the video will be stored at.\n"
-"\n"
-"Whenever a new source is loaded, this value will be applied if the source "
-"height is greater.\n"
-"Setting this to 0 means there is no maximum height."
 msgstr ""
 
 #: src/audiohandler.c:436 src/audiohandler.c:758 src/audiohandler.c:1233

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -246,12 +246,12 @@ bind_audio_tree_model(signal_user_data_t *ud)
     gtk_tree_view_column_set_max_width(column, 400);
 
     column = gtk_tree_view_column_new_with_attributes(
-                                    _(""), edit_cell, "icon-name", 3, NULL);
+                                    _(" "), edit_cell, "icon-name", 3, NULL);
     //gtk_tree_view_column_set_min_width(column, 24);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
     column = gtk_tree_view_column_new_with_attributes(
-                                    _(""), delete_cell, "icon-name", 4, NULL);
+                                    _(" "), delete_cell, "icon-name", 4, NULL);
     //gtk_tree_view_column_set_min_width(column, 24);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
@@ -311,11 +311,11 @@ bind_subtitle_tree_model(signal_user_data_t *ud)
     gtk_tree_view_column_set_max_width(column, 400);
 
     column = gtk_tree_view_column_new_with_attributes(
-                                    _(""), edit_cell, "icon-name", 3, NULL);
+                                    _(" "), edit_cell, "icon-name", 3, NULL);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
     column = gtk_tree_view_column_new_with_attributes(
-                                    _(""), delete_cell, "icon-name", 4, NULL);
+                                    _(" "), delete_cell, "icon-name", 4, NULL);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
     g_signal_connect(selection, "changed", subtitle_list_selection_changed_cb, ud);


### PR DESCRIPTION
This should fix #4572.

The change for `POTFILES.in` is, because `intltool-update --maintain` told me `src/ghb4.ui `was missing.
The change for `main.c` is, because it fixes the following warning:

> src/main.c:249: warning: Empty msgid.  It is reserved by GNU gettext:
>                          gettext("") returns the header entry with
>                          meta information, not the empty string.
> src/main.c:254: warning: Empty msgid.  It is reserved by GNU gettext:
>                          gettext("") returns the header entry with
>                          meta information, not the empty string.
> src/main.c:314: warning: Empty msgid.  It is reserved by GNU gettext:
>                          gettext("") returns the header entry with
>                          meta information, not the empty string.
> src/main.c:318: warning: Empty msgid.  It is reserved by GNU gettext:
>                          gettext("") returns the header entry with
>                          meta information, not the empty string.

The updated `ghb.pot` has been generated with:
`xgettext --files-from=POTFILES.in --copyright-holder='Free Software Foundation, Inc.' --directory=.. --add-comments --keyword=_ --keyword=N_ --keyword=C_:1c,2 --keyword=NC_:1c,2 --keyword=g_dcgettext:2 --keyword=g_dngettext:2,3 --keyword=g_dpgettext2:2c,3 --flag=N_:1:pass-c-format --flag=_:1:pass-c-format --flag=C_:2:pass-c-format --flag=NC_:2:pass-c-format --flag=g_dngettext:2:pass-c-format --flag=g_strdup_printf:1:c-format --flag=g_string_printf:2:c-format --flag=g_string_append_printf:2:c-format --flag=g_error_new:3:c-format --flag=g_set_error:4:c-format --from-code=UTF-8 --output=ghb.pot`