### PR TITLE
WinGUI: packaging the .NET runtime into working directory

### DIFF
--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -183,4 +183,12 @@
   <ItemGroup>
     <Folder Include="Properties\PublishProfiles\" />
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+		<ItemGroup>
+			<HostFxr Include="C:\Program Files\dotnet\host\fxr\6.0.9\hostfxr.dll" />
+			<Shared Include="C:\Program Files\dotnet\shared\**\*.*" />
+		</ItemGroup>
+		<Copy SourceFiles="@(HostFxr)" DestinationFolder="$(PublishDir)" SkipUnchangedFiles="true" />
+		<Copy SourceFiles="@(Shared)" DestinationFolder="$(PublishDir)\shared\%(RecursiveDir)" SkipUnchangedFiles="true" />
+	</Target>
 </Project>


### PR DESCRIPTION
**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

issue: #4594


As I am not an expert in C# either, the code is still a bit rough, especially the part that deals with the system .NET version number. However, I was able to package and open the software properly in a local test (version 1.5.1).

**Test on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
