### PR TITLE
libhb: fix some warnings caused by the usage of deprecated functions.…

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -713,7 +713,7 @@ AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref)
     if (!hw_frames_ref1)
         return NULL;
 
-    mids = av_mallocz_array(nb_surfaces, sizeof(*mids));
+    mids = av_calloc(nb_surfaces, sizeof(*mids));
     if (!mids) {
         av_buffer_unref(&hw_frames_ref1);
         return NULL;
@@ -748,7 +748,7 @@ static int qsv_setup_mids(mfxFrameAllocResponse *resp, AVBufferRef *hw_frames_re
     // the allocated size of the array is two larger than the number of
     // surfaces, we store the references to the frames context and the
     // QSVMid array there
-    resp->mids = av_mallocz_array(nb_surfaces + 2, sizeof(*resp->mids));
+    resp->mids = av_calloc(nb_surfaces + 2, sizeof(*resp->mids));
     if (!resp->mids)
         return AVERROR(ENOMEM);
 

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -8,6 +8,7 @@
  */
 
 #include "handbrake/hbffmpeg.h"
+#include "handbrake/nvenc_common.h"
 #include "handbrake/handbrake.h"
 
 #if HB_PROJECT_FEATURE_NVENC


### PR DESCRIPTION
Fixed a couple of warnings and deprecated functions in qsv code. It shouldn't cause any issue, but if someone can do a quick test.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux