### PR TITLE
build: fix --lto=on build on GCC Linux

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -73,6 +73,9 @@ endif
 
 ifeq (on,$(GCC.lto))
     FFMPEG.CONFIGURE.extra += --enable-lto
+    ifeq (linux,$(HOST.system))
+        FFMPEG.CONFIGURE.extra += --enable-pic
+    endif
 endif
 
 ifneq (,$(filter $(FEATURE.qsv)-$(HOST.system),1-linux 1-freebsd))


### PR DESCRIPTION
fixes https://github.com/HandBrake/HandBrake/issues/4699 ffmpeg build failure with ``` --lto=on``` on GCC Linux, by using ffmpeg's ```--enable-pic``` configure flag.

<details>
  <summary>snippet of build failure logs without this PR</summary>

  ```
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h: Assembler messages:
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:202: Error: junk `(%rip)+512' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:212: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:214: Error: junk `(%rip)+1024+128' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:230: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:202: Error: junk `(%rip)+512' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:212: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:214: Error: junk `(%rip)+1024+128' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:230: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:202: Error: junk `(%rip)+512' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:212: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:214: Error: junk `(%rip)+1024+128' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:230: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:202: Error: junk `(%rip)+512' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:212: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:214: Error: junk `(%rip)+1024+128' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:230: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:202: Error: junk `(%rip)+512' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:212: Error: junk `(%rip)+0' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:214: Error: junk `(%rip)+1024+128' after expression
  : contrib/ffmpeg/ffmpeg-5.1.2/libavcodec/x86/cabac.h:230: Error: junk `(%rip)+0' after expression
  : lto-wrapper: fatal error: /usr/local/bin/g++ returned 1 exit status
  : compilation terminated.
  : /usr/bin/ld: error: lto-wrapper failed
  : collect2: error: ld returned 1 exit status
  : gmake: *** [../test/module.rules:49: HandBrakeCLI] Error 1
  ```
</details>

Discovered when I tried to build HandbrakeCLI with Docker in debian:11.5-slim using the packaged GCC 10.2.1-6. I also confirmed the same error on GCC 12.2.0 and GCC 11.3.0

---
**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

