### PR TITLE
Native desktop file dialogs on Linux

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -141,15 +141,15 @@ esac
 PKG_PROG_PKG_CONFIG
 
 HAVE_GTK_400=0
-HAVE_GTK_316=0
+HAVE_GTK_3_22=0
 if test "x$use_gtk4" = "xyes" ; then
 	PKG_CHECK_MODULES([gtk], [gtk4 >= 3.92], [HAVE_GTK_400=1], [HAVE_GTK_400=0])
 else
-	PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.16], [HAVE_GTK_316=1], [HAVE_GTK_316=0])
+	PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.22], [HAVE_GTK_3_22=1], [HAVE_GTK_3_22=0])
 fi
 
-if test "$HAVE_GTK_316" -eq 0 -a "$HAVE_GTK_400" -eq 0 ; then
-	AC_MSG_ERROR("GTK 3.16 or above is required)
+if test "$HAVE_GTK_3_22" -eq 0 -a "$HAVE_GTK_400" -eq 0 ; then
+	AC_MSG_ERROR("GTK 3.22 or above is required)
 fi
 HB_LIBS="$HB_LIBS $gtk_LIBS"
 HB_CPPFLAGS="$HB_CPPFLAGS $gtk_CFLAGS"
@@ -199,7 +199,7 @@ else
 fi
 
 AM_CONDITIONAL([GHB_GTK_4_00], [test "$HAVE_GTK_400" -eq 1])
-AM_CONDITIONAL([GHB_GTK_3_16], [test "$HAVE_GTK_316" -eq 1])
+AM_CONDITIONAL([GHB_GTK_3_22], [test "$HAVE_GTK_3_22" -eq 1])
 
 AM_CONDITIONAL([MINGW], [test "x$mingw_flag" = "xyes"])
 

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -140,15 +140,15 @@ esac
 
 PKG_PROG_PKG_CONFIG
 
-HAVE_GTK_400=0
+HAVE_GTK_4_4=0
 HAVE_GTK_3_22=0
 if test "x$use_gtk4" = "xyes" ; then
-	PKG_CHECK_MODULES([gtk], [gtk4 >= 3.92], [HAVE_GTK_400=1], [HAVE_GTK_400=0])
+	PKG_CHECK_MODULES([gtk], [gtk4 >= 4.4], [HAVE_GTK_4_4=1], [HAVE_GTK_4_4=0])
 else
 	PKG_CHECK_MODULES([gtk], [gtk+-3.0 >= 3.22], [HAVE_GTK_3_22=1], [HAVE_GTK_3_22=0])
 fi
 
-if test "$HAVE_GTK_3_22" -eq 0 -a "$HAVE_GTK_400" -eq 0 ; then
+if test "$HAVE_GTK_3_22" -eq 0 -a "$HAVE_GTK_4_4" -eq 0 ; then
 	AC_MSG_ERROR("GTK 3.22 or above is required)
 fi
 HB_LIBS="$HB_LIBS $gtk_LIBS"
@@ -198,7 +198,7 @@ else
 	CFLAGS="$CFLAGS -D_NO_UPDATE_CHECK"
 fi
 
-AM_CONDITIONAL([GHB_GTK_4_00], [test "$HAVE_GTK_400" -eq 1])
+AM_CONDITIONAL([GHB_GTK_4_4], [test "$HAVE_GTK_4_4" -eq 1])
 AM_CONDITIONAL([GHB_GTK_3_22], [test "$HAVE_GTK_3_22" -eq 1])
 
 AM_CONDITIONAL([MINGW], [test "x$mingw_flag" = "xyes"])

--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -152,11 +152,8 @@ if GHB_GTK_4_00
 UI=400
 UI_FILE=ghb4.ui
 else
-if GHB_GTK_3_16
-UI=316
-UI_FILE=ghb3.ui
-else
-UI=300
+if GHB_GTK_3_22
+UI=322
 UI_FILE=ghb3.ui
 endif
 endif

--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -148,8 +148,8 @@ data_res.c : data_res.gresource.xml internal_defaults.json widget.deps widget_re
 data_res.h : data_res.gresource.xml internal_defaults.json widget.deps widget_reverse.deps
 	glib-compile-resources --generate --target=$@ --c-name ghb_data --manual-register $<
 
-if GHB_GTK_4_00
-UI=400
+if GHB_GTK_4_4
+UI=404
 UI_FILE=ghb4.ui
 else
 if GHB_GTK_3_22

--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -1385,6 +1385,7 @@ audio_add_clicked_cb(GtkWidget *xwidget, signal_user_data_t *ud)
         // Pop up the edit dialog
         GtkResponseType response;
         GtkWidget *dialog = GHB_WIDGET(ud->builder, "audio_dialog");
+        gtk_window_set_title(GTK_WINDOW(dialog), _("Add Audio Track"));
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_hide(dialog);
         if (response != GTK_RESPONSE_OK)
@@ -1466,6 +1467,7 @@ audio_edit(GtkTreeView *tv, GtkTreePath *tp, signal_user_data_t *ud)
         // Pop up the edit dialog
         GtkResponseType response;
         GtkWidget *dialog = GHB_WIDGET(ud->builder, "audio_dialog");
+        gtk_window_set_title(GTK_WINDOW(dialog), _("Edit Audio Track"));
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_hide(dialog);
         if (response != GTK_RESPONSE_OK)

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -5761,7 +5761,7 @@ gboolean on_presets_list_press_cb (GtkWidget *widget,
                GdkEvent  *event,
                signal_user_data_t *ud)
 {
-    if((event->type == GDK_BUTTON_PRESS) && (event->button.button == 3))
+    if (gdk_event_triggers_context_menu(event) && (event->type == GDK_BUTTON_PRESS))
     {
         GtkMenu *context_menu = GTK_MENU(GHB_WIDGET(ud->builder, "presets_window_submenu"));
         gtk_menu_popup_at_pointer(context_menu, event);

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1304,8 +1304,7 @@ source_dialog_extra_widgets(
 {
     GtkComboBoxText *combo;
     GList *drives, *link;
-    GtkWidget *source_extra, *ok_button;
-    GtkStyleContext *ok_style;
+    GtkWidget *source_extra;
 
     g_debug("source_dialog_extra_widgets ()");
     combo = GTK_COMBO_BOX_TEXT(GHB_WIDGET(ud->builder, "source_device"));
@@ -1325,9 +1324,6 @@ source_dialog_extra_widgets(
     g_list_free(drives);
     gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
 
-    ok_button = gtk_dialog_get_widget_for_response(GTK_DIALOG(dialog), GTK_RESPONSE_OK);
-    ok_style = gtk_widget_get_style_context(ok_button);
-    gtk_style_context_add_class(ok_style, "suggested-action");
     source_extra = GHB_WIDGET(ud->builder, "source_extra");
     gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(dialog), source_extra);
 }
@@ -4890,7 +4886,7 @@ activity_font_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
         {                                   \n\
             font-family: monospace;         \n\
             font-size: %dpt;                \n\
-            font-weight: lighter;           \n\
+            font-weight: 300;               \n\
         }                                   \n\
         ";
     char           * css      = g_strdup_printf(css_template, size);

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1782,7 +1782,7 @@ do_source_dialog(gboolean single, signal_user_data_t *ud)
 
     response = gtk_dialog_run(GTK_DIALOG (dialog));
     gtk_widget_hide(dialog);
-    if (response == GTK_RESPONSE_OK)
+    if (response == GTK_RESPONSE_NO)
     {
         gchar *filename;
 

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1878,7 +1878,7 @@ destination_action_cb(GSimpleAction *action, GVariant *param,
 G_MODULE_EXPORT gboolean
 window_destroy_event_cb(
     GtkWidget *widget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -1892,7 +1892,7 @@ window_destroy_event_cb(
 G_MODULE_EXPORT gboolean
 window_delete_event_cb(
     GtkWidget *widget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -4474,7 +4474,7 @@ show_activity_action_cb(GSimpleAction *action, GVariant *value,
 G_MODULE_EXPORT gboolean
 activity_window_delete_cb(
     GtkWidget *xwidget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -4613,7 +4613,7 @@ presets_window_set_visible(signal_user_data_t *ud, gboolean visible)
     }
     gtk_widget_set_visible(presets_window, visible);
 
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     // TODO: Is this possible in GTK4?
     int             x, y;
 
@@ -4716,7 +4716,7 @@ activity_font_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
 
     ghb_css_provider_load_from_data(provider, css, -1);
     GtkWidget * win = GHB_WIDGET(ud->builder, "hb_window");
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkDisplay *dd = gtk_widget_get_display(win);
     gtk_style_context_add_provider_for_display(dd,
                                 GTK_STYLE_PROVIDER(provider),
@@ -5473,7 +5473,7 @@ ghb_notify_done(signal_user_data_t *ud)
 G_MODULE_EXPORT gboolean
 window_map_cb(
     GtkWidget *widget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEventAny *event,
 #endif
     signal_user_data_t *ud)
@@ -5484,7 +5484,7 @@ window_map_cb(
 G_MODULE_EXPORT void
 hb_win_sz_alloc_cb(
     GtkWidget *widget,
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     int width,
     int height,
     int baseline,
@@ -5589,7 +5589,7 @@ GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
     return filter;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT gboolean
 combo_search_key_press_cb(
     GtkEventControllerKey * keycon,

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -87,6 +87,8 @@
 #include "ghb-dvd.h"
 #include "libavutil/parseutils.h"
 
+
+static void ghb_add_video_file_filters(GtkFileChooser *chooser, signal_user_data_t *ud);
 static void update_queue_labels(signal_user_data_t *ud);
 static void load_all_titles(signal_user_data_t *ud, int titleindex);
 static GList* dvd_device_list();
@@ -96,6 +98,7 @@ gpointer ghb_check_update(signal_user_data_t *ud);
 static gboolean ghb_can_suspend_logind();
 static void ghb_suspend_logind();
 static gboolean appcast_busy = FALSE;
+static gboolean has_drive = FALSE;
 
 #if !defined(_WIN32)
 #define DBUS_LOGIND_SERVICE         "org.freedesktop.login1"
@@ -1058,97 +1061,38 @@ set_destination(signal_user_data_t *ud)
         ghb_dict_get_value(ud->settings, "dest_file"));
 }
 
-G_MODULE_EXPORT void
-chooser_file_selected_cb(GtkFileChooser *dialog, signal_user_data_t *ud)
-{
-    gchar *name = gtk_file_chooser_get_filename (dialog);
-    GtkTreeModel *store;
-    GtkTreeIter iter;
-    const gchar *device;
-    gboolean foundit = FALSE;
-    GtkComboBox *combo;
-
-    g_debug("chooser_file_selected_cb ()");
-
-    if (name == NULL) return;
-    combo = GTK_COMBO_BOX(GHB_WIDGET(ud->builder, "source_device"));
-    store = gtk_combo_box_get_model(combo);
-    if (gtk_tree_model_get_iter_first(store, &iter))
-    {
-        do
-        {
-            gtk_tree_model_get(store, &iter, 0, &device, -1);
-            if (strcmp(name, device) == 0)
-            {
-                foundit = TRUE;
-                break;
-            }
-        } while (gtk_tree_model_iter_next(GTK_TREE_MODEL(store), &iter));
-    }
-    if (foundit)
-        gtk_combo_box_set_active_iter (combo, &iter);
-    else
-        gtk_combo_box_set_active (combo, 0);
-
-    g_free(name);
-}
-
-G_MODULE_EXPORT void
-dvd_device_changed_cb(GtkComboBoxText *combo, signal_user_data_t *ud)
-{
-    GtkWidget *dialog;
-    gint ii;
-
-    g_debug("dvd_device_changed_cb ()");
-    ii = gtk_combo_box_get_active (GTK_COMBO_BOX(combo));
-    if (ii > 0)
-    {
-        const gchar *device;
-        gchar *name;
-
-        dialog = GHB_WIDGET(ud->builder, "source_dialog");
-        device = gtk_combo_box_text_get_active_text(combo);
-        // Protects against unexpected NULL return value
-        if (device != NULL)
-        {
-            name = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER(dialog));
-            if (name == NULL || strcmp(name, device) != 0)
-                gtk_file_chooser_select_filename (GTK_FILE_CHOOSER(dialog), device);
-            if (name != NULL)
-                g_free(name);
-        }
-    }
-}
-
 static void
 source_dialog_extra_widgets(
     signal_user_data_t *ud,
-    GtkWidget *dialog)
+    GtkFileChooser *dialog)
 {
-    GtkComboBoxText *combo;
     GList *drives, *link;
-    GtkWidget *source_extra;
+    GStrvBuilder *builder;
+    const gchar** entries;
 
     g_debug("source_dialog_extra_widgets ()");
-    combo = GTK_COMBO_BOX_TEXT(GHB_WIDGET(ud->builder, "source_device"));
-    gtk_list_store_clear(GTK_LIST_STORE(
-                gtk_combo_box_get_model(GTK_COMBO_BOX(combo))));
-
     link = drives = dvd_device_list();
-    gtk_combo_box_text_append_text (combo, _("Not Selected"));
+    if (!link)
+    {
+        has_drive = FALSE;
+        return;
+    }
+    has_drive = TRUE;
+
+    builder = g_strv_builder_new();
+    g_strv_builder_add(builder, _("Not Selected"));
     while (link != NULL)
     {
         gchar *name = get_dvd_device_name(link->data);
-        gtk_combo_box_text_append_text(combo, name);
-        g_free(name);
+        g_strv_builder_add(builder, name);
         free_drive(link->data);
         link = link->next;
     }
     g_list_free(drives);
-    gtk_combo_box_set_active(GTK_COMBO_BOX(combo), 0);
-
-    source_extra = GHB_WIDGET(ud->builder, "source_extra");
-    gtk_file_chooser_set_extra_widget(GTK_FILE_CHOOSER(dialog), source_extra);
+    entries = (const gchar**) g_strv_builder_end(builder);
+    g_strv_builder_unref(builder);
+    gtk_file_chooser_add_choice(dialog, "drive", _("Detected DVD devices:"), entries, entries);
+    gtk_file_chooser_set_choice(GTK_FILE_CHOOSER(dialog), "drive", _("Not Selected"));
 }
 
 void ghb_break_pts_duration(gint64 ptsDuration, gint *hh, gint *mm, gdouble *ss)
@@ -1581,43 +1525,54 @@ ghb_do_scan(
     }
 }
 
-static void
-do_source_dialog(gboolean single, signal_user_data_t *ud)
+static gint
+single_title_dialog (signal_user_data_t *ud)
 {
-    GtkWidget *dialog;
+    GtkWidget *dialog, *spin, *msg;
+    GtkAdjustment *adj;
+
+    dialog = gtk_message_dialog_new(GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window")),
+                                    GTK_DIALOG_MODAL | GTK_DIALOG_DESTROY_WITH_PARENT,
+                                    GTK_MESSAGE_QUESTION,
+                                    GTK_BUTTONS_OK,
+                                    "Title Number:");
+
+    adj = gtk_adjustment_new(1, 0, 100, 1, 10, 10);
+    spin = gtk_spin_button_new(adj, 1, 0);
+    gtk_widget_show(spin);
+    msg = gtk_message_dialog_get_message_area(GTK_MESSAGE_DIALOG(dialog));
+    gtk_box_pack_end(GTK_BOX(msg), spin, FALSE, FALSE, 0);
+    gtk_dialog_run(GTK_DIALOG(dialog));
+    gtk_widget_destroy(dialog);
+    return gtk_spin_button_get_value_as_int(GTK_SPIN_BUTTON(spin));
+}
+
+static void
+source_dialog_response_cb(GtkFileChooser *dialog,
+                          GtkResponseType response, signal_user_data_t *ud)
+{
     const gchar *sourcename;
-    gint response;
+    const gchar *drivename;
+    gchar *filename;
 
-    g_debug("source_browse_clicked_cb ()");
-    sourcename = ghb_dict_get_string(ud->globals, "scan_source");
-    GtkWidget *widget;
-    widget = GHB_WIDGET(ud->builder, "single_title_box");
-    if (single)
-        gtk_widget_show(widget);
-    else
-        gtk_widget_hide(widget);
-
-    dialog = GHB_WIDGET(ud->builder, "source_dialog");
-    source_dialog_extra_widgets(ud, dialog);
-
-    gtk_widget_show(dialog);
-    gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(dialog), sourcename);
-
-    response = gtk_dialog_run(GTK_DIALOG (dialog));
-    gtk_widget_hide(dialog);
-    if (response == GTK_RESPONSE_NO)
+    if (response == GTK_RESPONSE_ACCEPT)
     {
-        gchar *filename;
+        if (has_drive)
+            drivename = gtk_file_chooser_get_choice(dialog, "drive");
 
-        filename = gtk_file_chooser_get_filename (GTK_FILE_CHOOSER (dialog));
+        if (drivename && g_strcmp0(drivename, _("Not Selected")))
+            filename = g_strdup(drivename);
+        else
+            filename = gtk_file_chooser_get_filename(dialog);
+
         if (filename != NULL)
         {
-            gint title_id;
+            gint title_id = 0;
 
-            if (single)
-                title_id = ghb_dict_get_int(ud->settings, "single_title");
-            else
-                title_id = 0;
+            if (g_strcmp0(gtk_file_chooser_get_choice(dialog, "single"), "true") == 0)
+                title_id = single_title_dialog(ud);
+            sourcename = ghb_dict_get_string(ud->globals, "scan_source");
+
             // ghb_do_scan replaces "scan_source" key in dict, so we must
             // be finished with sourcename before calling ghb_do_scan
             // since the memory it references will be freed
@@ -1631,6 +1586,44 @@ do_source_dialog(gboolean single, signal_user_data_t *ud)
             g_free(filename);
         }
     }
+    ud->source_dialog = NULL;
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+}
+
+static void
+do_source_dialog(gboolean dir, signal_user_data_t *ud)
+{
+    GtkFileChooserNative *dialog;
+    GtkWindow *hb_window;
+    const gchar *sourcename;
+
+    if (ud->source_dialog)
+    return;
+
+    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
+    dialog = ud->source_dialog = gtk_file_chooser_native_new(
+                dir ? _("Open Source Directory") : _("Open Source"),
+                hb_window,
+                dir ? GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER : GTK_FILE_CHOOSER_ACTION_OPEN,
+                GHB_STOCK_OPEN,
+                GHB_STOCK_CANCEL);
+
+    g_debug("do_source_dialog ()");
+    sourcename = ghb_dict_get_string(ud->globals, "scan_source");
+
+    if (!dir)
+        ghb_add_video_file_filters(GTK_FILE_CHOOSER(dialog), ud);
+
+    source_dialog_extra_widgets(ud, GTK_FILE_CHOOSER(dialog));
+
+    gtk_file_chooser_add_choice(GTK_FILE_CHOOSER(dialog), "single",
+                                _("Single Title"), NULL, NULL);
+
+    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
+    gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(dialog), hb_window);
+    g_signal_connect(dialog, "response", G_CALLBACK(source_dialog_response_cb), ud);
+    gtk_file_chooser_select_filename(GTK_FILE_CHOOSER(dialog), sourcename);
+    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
 }
 
 #if 0
@@ -1667,7 +1660,7 @@ source_action_cb(GSimpleAction *action, GVariant *param,
 #endif
 
 G_MODULE_EXPORT void
-single_title_action_cb(GSimpleAction *action, GVariant * param,
+source_dir_action_cb(GSimpleAction *action, GVariant * param,
                        signal_user_data_t *ud)
 {
     do_source_dialog(TRUE, ud);
@@ -1834,29 +1827,14 @@ dest_file_changed_cb(GtkEntry *entry, signal_user_data_t *ud)
     g_free(dest);
 }
 
-G_MODULE_EXPORT void
-destination_action_cb(GSimpleAction *action, GVariant *param,
-                      signal_user_data_t *ud)
+static void
+destination_response_cb(GtkFileChooserNative *dialog,
+                        GtkResponseType response, signal_user_data_t *ud)
 {
-    GtkWidget *dialog;
     GtkEntry *entry;
-    const gchar *destname;
     gchar *basename;
-    GtkWindow *hb_window;
 
-    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    destname = ghb_dict_get_string(ud->settings, "destination");
-    dialog = gtk_file_chooser_dialog_new("Choose Destination",
-                      hb_window,
-                      GTK_FILE_CHOOSER_ACTION_SAVE,
-                      GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                      GHB_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-                      NULL);
-    gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), destname);
-    basename = g_path_get_basename(destname);
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), basename);
-    g_free(basename);
-    if (gtk_dialog_run(GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
+    if (response == GTK_RESPONSE_ACCEPT)
     {
         char *filename, *dirname;
         GtkFileChooser *dest_chooser;
@@ -1872,7 +1850,33 @@ destination_action_cb(GSimpleAction *action, GVariant *param,
         g_free (basename);
         g_free (filename);
     }
-    gtk_widget_destroy(dialog);
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+}
+
+G_MODULE_EXPORT void
+destination_action_cb(GSimpleAction *action, GVariant *param,
+                      signal_user_data_t *ud)
+{
+    GtkFileChooserNative *dialog;
+    GtkWindow *hb_window;
+    const gchar *destname;
+    gchar *basename;
+
+    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
+    destname = ghb_dict_get_string(ud->settings, "destination");
+    dialog = gtk_file_chooser_native_new("Choose Destination",
+                                         hb_window,
+                                         GTK_FILE_CHOOSER_ACTION_SAVE,
+                                         GHB_STOCK_SAVE,
+                                         GHB_STOCK_CANCEL);
+    gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(dialog), destname);
+    basename = g_path_get_basename(destname);
+    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), basename);
+    g_free(basename);
+
+    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
+    g_signal_connect(dialog, "response", G_CALLBACK(destination_response_cb), ud);
+    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
 }
 
 G_MODULE_EXPORT gboolean
@@ -5442,7 +5446,7 @@ ghb_notify_done(signal_user_data_t *ud)
     g_object_unref(G_OBJECT(icon));
 
     switch (ud->when_complete)    {
-	    case 2:
+        case 2:
             ghb_countdown_dialog(GTK_MESSAGE_INFO,
                                 _("Your encode is complete."),
                                 _("Quitting Handbrake"),
@@ -5457,7 +5461,7 @@ ghb_notify_done(signal_user_data_t *ud)
                     _("Cancel"), (GSourceFunc)suspend_cb, ud, 60);
             }
             break;
-	    case 4:
+        case 4:
             if (ghb_can_shutdown_logind())
             {
                 ghb_countdown_dialog(GTK_MESSAGE_INFO,
@@ -5579,16 +5583,35 @@ gboolean on_presets_list_press_cb (GtkWidget *widget,
     return FALSE;
 }
 
+
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    signal_user_data_t *ud,
                                    const char *name, const char *id)
 {
-    GtkFileFilter *filter = GTK_FILE_FILTER(GHB_OBJECT(ud->builder, id));
+    g_autoptr(GtkFileFilter) filter = GTK_FILE_FILTER(GHB_OBJECT(ud->builder, id));
     gtk_file_filter_set_name(filter, name);
     gtk_file_chooser_add_filter(chooser, filter);
     return filter;
 }
 
+static void ghb_add_video_file_filters(GtkFileChooser *chooser,
+                                       signal_user_data_t *ud)
+{
+    ghb_add_file_filter(chooser, ud, _("All Files"), "SourceFilterAll");
+    ghb_add_file_filter(chooser, ud, _("Video"), "SourceFilterVideo");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/mp4"), "SourceFilterMP4");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/mp2t"), "SourceFilterTS");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/mpeg"), "SourceFilterMPG");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/x-matroska"), "SourceFilterMKV");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/webm"), "SourceFilterWebM");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/ogg"), "SourceFilterOGG");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/x-msvideo"), "SourceFilterAVI");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/x-flv"), "SourceFilterFLV");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/quicktime"), "SourceFilterMOV");
+    ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/x-ms-wmv"), "SourceFilterWMV");
+    ghb_add_file_filter(chooser, ud, "EVO", "SourceFilterEVO");
+    ghb_add_file_filter(chooser, ud, "VOB", "SourceFilterVOB");
+}
 #if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT gboolean
 combo_search_key_press_cb(

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -61,10 +61,6 @@
 #define NOTIFY_CHECK_VERSION(x,y,z) 0
 #endif
 
-#if !GTK_CHECK_VERSION(3, 4, 0)
-#include <gdk/gdkx.h>
-#endif
-
 #ifndef NOTIFY_CHECK_VERSION
 #define NOTIFY_CHECK_VERSION(x,y,z) 0
 #endif
@@ -300,159 +296,11 @@ ghb_shutdown_logind(void)
 }
 #endif
 
-#if !GTK_CHECK_VERSION(3, 4, 0)
-guint
-ghb_inhibit_gpm()
-{
-    guint cookie = -1;
-
-#if !defined(_WIN32)
-    GDBusProxy  *proxy;
-    GError *error = NULL;
-    GVariant *res;
-
-    g_debug("ghb_inhibit_gpm()");
-    proxy = ghb_get_dbus_proxy(G_BUS_TYPE_SESSION, GPM_DBUS_PM_SERVICE,
-                            GPM_DBUS_INHIBIT_PATH, GPM_DBUS_INHIBIT_INTERFACE);
-    if (proxy == NULL)
-        return 0;
-
-    res = g_dbus_proxy_call_sync(proxy, "Inhibit",
-                                 g_variant_new("(ss)", "ghb", "Encoding"),
-                                 G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-    if (!res)
-    {
-        if (error != NULL)
-        {
-            g_error_free(error);
-        }
-    }
-    else
-    {
-        g_variant_get(res, "(u)", &cookie);
-        g_variant_unref(res);
-    }
-    g_object_unref(G_OBJECT(proxy));
-#endif
-
-    return cookie;
-}
-
-void
-ghb_uninhibit_gpm(guint cookie)
-{
-#if !defined(_WIN32)
-    GDBusProxy  *proxy;
-    GError *error = NULL;
-    GVariant *res;
-
-    g_debug("ghb_uninhibit_gpm() cookie %u", cookie);
-
-    proxy = ghb_get_dbus_proxy(G_BUS_TYPE_SESSION, GPM_DBUS_PM_SERVICE,
-                            GPM_DBUS_INHIBIT_PATH, GPM_DBUS_INHIBIT_INTERFACE);
-    if (proxy == NULL)
-        return;
-
-    res = g_dbus_proxy_call_sync(proxy, "UnInhibit",
-                                 g_variant_new("(u)", cookie),
-                                 G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-    if (!res)
-    {
-        if (error != NULL)
-        {
-            g_error_free(error);
-        }
-    }
-    else
-    {
-        g_variant_unref(res);
-    }
-    g_object_unref(G_OBJECT(proxy));
-#endif
-}
-#endif
-
 #if !defined(_WIN32)
 // For inhibit and shutdown
 #define GPM_DBUS_SM_SERVICE         "org.gnome.SessionManager"
 #define GPM_DBUS_SM_PATH            "/org/gnome/SessionManager"
 #define GPM_DBUS_SM_INTERFACE       "org.gnome.SessionManager"
-#endif
-
-#if !GTK_CHECK_VERSION(3, 4, 0)
-guint
-ghb_inhibit_gsm(signal_user_data_t *ud)
-{
-    guint cookie = -1;
-
-#if !defined(_WIN32)
-    GDBusProxy  *proxy;
-    GError *error = NULL;
-    GVariant *res;
-    guint xid;
-    GtkWidget *widget;
-
-    g_debug("ghb_inhibit_gsm()");
-    proxy = ghb_get_dbus_proxy(G_BUS_TYPE_SESSION, GPM_DBUS_SM_SERVICE,
-                            GPM_DBUS_SM_PATH, GPM_DBUS_SM_INTERFACE);
-    if (proxy == NULL)
-        return -1;
-
-    widget = GHB_WIDGET(ud->builder, "hb_window");
-    xid = GDK_WINDOW_XID(gtk_widget_get_window(widget));
-    res = g_dbus_proxy_call_sync(proxy, "Inhibit",
-                                 g_variant_new("(susu)", "ghb", xid, "Encoding", 1 | 4),
-                                 G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-    g_object_unref(G_OBJECT(proxy));
-    if (!res)
-    {
-        if (error != NULL)
-        {
-            g_error_free(error);
-        }
-    }
-    else
-    {
-        g_variant_get(res, "(u)", &cookie);
-        g_variant_unref(res);
-    }
-#endif
-
-    return cookie;
-}
-
-void
-ghb_uninhibit_gsm(guint cookie)
-{
-#if !defined(_WIN32)
-    GDBusProxy  *proxy;
-    GError *error = NULL;
-    GVariant *res;
-
-    g_debug("ghb_uninhibit_gsm() cookie %u", cookie);
-
-    proxy = ghb_get_dbus_proxy(G_BUS_TYPE_SESSION, GPM_DBUS_SM_SERVICE,
-                            GPM_DBUS_SM_PATH, GPM_DBUS_SM_INTERFACE);
-    if (proxy == NULL)
-        return;
-
-    res = g_dbus_proxy_call_sync(proxy, "Uninhibit",
-                                 g_variant_new("(u)", cookie),
-                                 G_DBUS_CALL_FLAGS_NONE, -1, NULL, &error);
-    if (!res)
-    {
-        if (error != NULL)
-        {
-            g_error_free(error);
-        }
-    }
-    else
-    {
-        g_variant_unref(res);
-    }
-    g_object_unref(G_OBJECT(proxy));
-#endif
-}
 #endif
 
 enum {
@@ -472,7 +320,6 @@ ghb_inhibit_suspend(signal_user_data_t *ud)
         // Already inhibited
         return;
     }
-#if GTK_CHECK_VERSION(3, 4, 0)
     suspend_cookie = gtk_application_inhibit(ud->app, NULL,
                             GTK_APPLICATION_INHIBIT_SUSPEND, "Encoding");
     if (suspend_cookie != 0)
@@ -480,20 +327,6 @@ ghb_inhibit_suspend(signal_user_data_t *ud)
         suspend_inhibited = GHB_SUSPEND_INHIBITED_GTK;
         return;
     }
-#else
-    suspend_cookie = ghb_inhibit_gsm(ud);
-    if (suspend_cookie != -1)
-    {
-        suspend_inhibited = GHB_SUSPEND_INHIBITED_GSM;
-        return;
-    }
-    suspend_cookie = ghb_inhibit_gpm(ud);
-    if (suspend_cookie != -1)
-    {
-        suspend_inhibited = GHB_SUSPEND_INHIBITED_GPM;
-        return;
-    }
-#endif
 }
 
 void
@@ -501,19 +334,9 @@ ghb_uninhibit_suspend(signal_user_data_t *ud)
 {
     switch (suspend_inhibited)
     {
-#if GTK_CHECK_VERSION(3, 4, 0)
         case GHB_SUSPEND_INHIBITED_GTK:
             gtk_application_uninhibit(ud->app, suspend_cookie);
             break;
-#else
-        case GHB_SUSPEND_INHIBITED_GPM:
-            ghb_uninhibit_gpm(suspend_cookie);
-            break;
-
-        case GHB_SUSPEND_INHIBITED_GSM:
-            ghb_uninhibit_gsm(suspend_cookie);
-            break;
-#endif
         default:
             break;
     }
@@ -4879,7 +4702,6 @@ activity_font_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
 
     int size = ghb_dict_get_int(ud->prefs, "ActivityFontSize");
 
-#if GTK_CHECK_VERSION(3, 16, 0)
     const gchar *css_template =
         "                                   \n\
         #activity_view                      \n\
@@ -4907,18 +4729,6 @@ activity_font_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
 #endif
     g_object_unref(provider);
     g_free(css);
-#else
-    const gchar          * font_template = "monospace %d";
-    char                 * font          = g_strdup_printf(font_template, size);
-    PangoFontDescription * font_desc;
-    GtkTextView          * textview;
-
-    font_desc = pango_font_description_from_string(font);
-    textview = GTK_TEXT_VIEW(GHB_WIDGET(ud->builder, "activity_view"));
-    gtk_widget_override_font(GTK_WIDGET(textview), font_desc);
-    pango_font_description_free(font_desc);
-    g_free(font);
-#endif
 }
 
 // Changes the setting for the current session

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -2212,6 +2212,26 @@ static void update_meta(GhbValue *settings, const char *name, const char *val)
         ghb_dict_set_string(metadata, name, val);
 }
 
+void ghb_update_mini_preview(gboolean has_preview, signal_user_data_t *ud)
+{
+    GtkWidget *widget;
+
+    if (ghb_dict_get_bool(ud->prefs, "ShowMiniPreview") && has_preview)
+    {
+        widget = GHB_WIDGET(ud->builder, "summary_image");
+        gtk_widget_hide(widget);
+        widget = GHB_WIDGET(ud->builder, "preview_button_image");
+        gtk_widget_show(widget);
+    }
+    else
+    {
+        widget = GHB_WIDGET(ud->builder, "summary_image");
+        gtk_widget_show(widget);
+        widget = GHB_WIDGET(ud->builder, "preview_button_image");
+        gtk_widget_hide(widget);
+    }
+}
+
 void
 ghb_update_summary_info(signal_user_data_t *ud)
 {
@@ -2232,17 +2252,10 @@ ghb_update_summary_info(signal_user_data_t *ud)
         gtk_label_set_text(GTK_LABEL(widget), "");
         widget = GHB_WIDGET(ud->builder, "dimensions_summary");
         gtk_label_set_text(GTK_LABEL(widget), "--");
-        widget = GHB_WIDGET(ud->builder, "summary_image");
-        gtk_widget_show(widget);
-        widget = GHB_WIDGET(ud->builder, "preview_button_image");
-        gtk_widget_hide(widget);
+        ghb_update_mini_preview(FALSE, ud);
         return;
     }
-
-    widget = GHB_WIDGET(ud->builder, "summary_image");
-    gtk_widget_hide(widget);
-    widget = GHB_WIDGET(ud->builder, "preview_button_image");
-    gtk_widget_show(widget);
+    ghb_update_mini_preview(TRUE, ud);
 
     // Video Track
     const hb_encoder_t * video_encoder;
@@ -5031,6 +5044,16 @@ tweaks_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_widget_to_setting (ud->prefs, widget);
     const gchar *name = ghb_get_setting_key(widget);
     ghb_pref_set(ud->prefs, name);
+}
+
+G_MODULE_EXPORT void
+show_preview_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
+{
+    g_debug("show_preview_changed_cb");
+    ghb_widget_to_setting (ud->prefs, widget);
+    const gchar *name = ghb_get_setting_key(widget);
+    ghb_pref_set(ud->prefs, name);
+    ghb_update_mini_preview(TRUE, ud);
 }
 
 G_MODULE_EXPORT void

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -5367,28 +5367,6 @@ drive_changed_cb(GVolumeMonitor *gvm, GDrive *gd, signal_user_data_t *ud)
 }
 #endif
 
-typedef struct
-{
-    gint count;
-    signal_user_data_t *ud;
-} button_click_t;
-
-static gboolean
-easter_egg_timeout_cb(button_click_t *bc)
-{
-    if (bc->count == 1)
-    {
-        GtkWidget *widget;
-        widget = GHB_WIDGET(bc->ud->builder, "allow_tweaks");
-        gtk_widget_hide(widget);
-        widget = GHB_WIDGET(bc->ud->builder, "hbfd_feature");
-        gtk_widget_hide(widget);
-    }
-    bc->count = 0;
-
-    return FALSE;
-}
-
 G_MODULE_EXPORT void
 easter_egg_multi_cb(
     GtkGestureMultiPress * gest,
@@ -5415,33 +5393,16 @@ easter_egg_cb(
 {
     GdkEventType type = ghb_event_get_event_type(event);
     guint        button;
-    static button_click_t bc = { .count = 0 };
 
-    bc.ud = ud;
     ghb_event_get_button(event, &button);
-    if (type == GDK_BUTTON_PRESS && button == 1)
+    if (type == GDK_3BUTTON_PRESS && button == 1)
     {
-        bc.count++;
-        switch (bc.count)
-        {
-            case 1:
-            {
-                g_timeout_add(500, (GSourceFunc)easter_egg_timeout_cb, &bc);
-            } break;
-
-            case 3:
-            {
-                // It's a triple left mouse button click
-                GtkWidget *widget;
-                widget = GHB_WIDGET(ud->builder, "allow_tweaks");
-                gtk_widget_show(widget);
-                widget = GHB_WIDGET(ud->builder, "hbfd_feature");
-                gtk_widget_show(widget);
-            } break;
-
-            default:
-                break;
-        }
+        // It's a triple left mouse button click
+        GtkWidget *widget;
+        widget = GHB_WIDGET(ud->builder, "allow_tweaks");
+        gtk_widget_set_visible(widget, !gtk_widget_get_visible(widget));
+        widget = GHB_WIDGET(ud->builder, "hbfd_feature");
+        gtk_widget_set_visible(widget, !gtk_widget_get_visible(widget));
     }
     return FALSE;
 }

--- a/gtk/src/chapters.c
+++ b/gtk/src/chapters.c
@@ -29,7 +29,7 @@
 static void
 chapter_changed_cb(GtkEditable * edit, signal_user_data_t *ud);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static gboolean
 chapter_keypress_cb(
     GtkEventController * keycon,
@@ -121,7 +121,7 @@ create_chapter_row(int index, int64_t start, int64_t duration,
     gtk_label_set_xalign(GTK_LABEL(label), 1);
     ghb_box_append_child(hbox, label);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     entry = gtk_text_new();
 #else
     entry = gtk_entry_new();
@@ -132,7 +132,7 @@ create_chapter_row(int index, int64_t start, int64_t duration,
     ghb_editable_set_text(entry, name);
     ghb_box_append_child(hbox, entry);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GtkEventController * econ;
 
     econ = gtk_event_controller_key_new();
@@ -145,7 +145,7 @@ create_chapter_row(int index, int64_t start, int64_t duration,
     g_signal_connect(entry, "changed", G_CALLBACK(chapter_changed_cb), ud);
 
     gtk_container_add(GTK_CONTAINER(row), GTK_WIDGET(hbox));
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     gtk_widget_show_all(row);
 #endif
 
@@ -247,7 +247,7 @@ chapter_keypress(
     return FALSE;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static gboolean
 chapter_keypress_cb(
     GtkEventController * keycon,

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -217,6 +217,10 @@ conjunction with the "Forced" option.</property>
   <menu id="queue_actions_menu">
     <section>
       <item>
+        <attribute name="label" translatable="yes">Play File</attribute>
+        <attribute name="action">app.queue-play-file</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">Open Source Directory</attribute>
         <attribute name="action">app.queue-open-source</attribute>
       </item>
@@ -224,6 +228,8 @@ conjunction with the "Forced" option.</property>
         <attribute name="label" translatable="yes">Open Destination Directory</attribute>
         <attribute name="action">app.queue-open-dest</attribute>
       </item>
+    </section>
+    <section>
       <item>
         <attribute name="label" translatable="yes">Open Encode Log Directory</attribute>
         <attribute name="action">app.queue-open-log-dir</attribute>
@@ -236,16 +242,6 @@ conjunction with the "Forced" option.</property>
   </menu>
 
   <menu id="queue_options_menu">
-    <section>
-      <item>
-        <attribute name="label" translatable="yes">Move to Top</attribute>
-        <attribute name="action">app.queue-move-top</attribute>
-      </item>
-      <item>
-        <attribute name="label" translatable="yes">Move to Bottom</attribute>
-        <attribute name="action">app.queue-move-bottom</attribute>
-      </item>
-    </section>
     <section>
       <item>
         <attribute name="label" translatable="yes">Reset Failed Jobs</attribute>
@@ -541,6 +537,109 @@ conjunction with the "Forced" option.</property>
         <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
+          <object class="GtkMenuBar">
+            <property name="visible">False</property>
+            <child>
+              <object class="GtkMenuItem">
+                <property name="visible">True</property>
+                <child type="submenu">
+                  <object class="GtkMenu" id="queue_list_menu">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_play">
+                        <property name="label" translatable="yes">_Play File</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-play-file</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_source">
+                        <property name="label" translatable="yes">Open _Source Directory</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-open-source</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_dest">
+                        <property name="label" translatable="yes">Open _Destination Directory</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-open-dest</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_move_top">
+                        <property name="label" translatable="yes">Move to _Top</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-move-top</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_move_bottom">
+                        <property name="label" translatable="yes">Move to _Bottom</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-move-bottom</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_edit">
+                        <property name="label" translatable="yes">_Edit</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-edit</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_reset">
+                        <property name="label" translatable="yes">_Reset</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-reset</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkSeparatorMenuItem">
+                        <property name="visible">True</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuItem" id="queue_item_remove">
+                        <property name="label" translatable="yes">Re_move</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
+                        <property name="action-name">app.queue-delete</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="GtkBox" id="queue_box0">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
@@ -723,9 +822,10 @@ conjunction with the "Forced" option.</property>
                         <property name="can-focus">True</property>
                         <property name="vexpand">True</property>
                         <property name="hexpand">True</property>
-                        <property name="selection-mode">single</property>
+                        <property name="selection-mode">multiple</property>
                         <property name="activate-on-single-click">False</property>
                         <signal name="row-selected" handler="queue_list_selection_changed_cb" swapped="no"/>
+                        <signal name="button-press-event" handler="queue_button_press_cb" swapped="no"/>
                         <signal name="key-press-event" handler="queue_key_press_cb" swapped="no"/>
                         <signal name="drag-motion" handler="queue_drag_motion_cb" swapped="no"/>
                         <signal name="drag-leave" handler="queue_drag_leave_cb" swapped="no"/>

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -8929,6 +8929,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <property name="halign">fill</property>
             <property name="valign">fill</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK</property>
+            <signal name="button-press-event" handler="preview_click_cb" swapped="no"/>
             <signal name="leave-notify-event" handler="preview_leave_cb" swapped="no"/>
             <signal name="motion-notify-event" handler="preview_motion_cb" swapped="no"/>
             <signal name="size-allocate" handler="preview_resize_cb" swapped="no"/>
@@ -8945,6 +8946,10 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK | GDK_ENTER_NOTIFY_MASK | GDK_LEAVE_NOTIFY_MASK</property>
             <signal name="enter-notify-event" handler="hud_enter_cb" swapped="no"/>
             <signal name="leave-notify-event" handler="hud_leave_cb" swapped="no"/>
+            <style>
+              <class name="osd"/>
+              <class name="app-notification"/>
+            </style>
             <child>
               <object class="GtkBox" id="vbox35">
                 <property name="orientation">vertical</property>
@@ -8989,7 +8994,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
                           <object class="GtkImage" id="live_preview_play_image">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="icon_name">gtk-media-play</property>
+                            <property name="icon_name">media-playbck-start</property>
                           </object>
                         </child>
                       </object>
@@ -9030,6 +9035,27 @@ Uncheck this if you want to allow changing each title's settings independently.<
                       </object>
                       <packing>
                         <property name="position">2</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkToggleButton" id="live_preview_fullscreen">
+                        <property name="height_request">30</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Click to toggle full screen mode</property>
+                        <property name="relief">none</property>
+                        <property name="action-name">app.preview-fullscreen</property>
+                        <child>
+                          <object class="GtkImage" id="live_preview_fullscreen_image">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">view-fullscreen</property>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="position">3</property>
                       </packing>
                     </child>
                   </object>

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -3072,7 +3072,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                     </child>
                     <child>
                       <object class="GtkImage" id="preview_button_image">
-                        <property name="visible">True</property>
+                        <property name="visible">False</property>
                         <property name="can_focus">False</property>
                         <property name="margin-bottom">4</property>
                         <property name="margin-start">4</property>
@@ -8385,6 +8385,24 @@ Uncheck this if you want to allow changing each title's settings independently.<
                           </object>
                           <packing>
                             <property name="top_attach">8</property>
+                            <property name="left_attach">0</property>
+                            <property name="width">1</property>
+                            <property name="height">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="ShowMiniPreview">
+                            <property name="label" translatable="yes">Show preview image in Summary tab</property>
+                            <property name="can_focus">True</property>
+                            <property name="visible">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="tooltip-text" translatable="yes">Uncheck this if you want to hide the video preview image on the Summary tab for privacy reasons.</property>
+                            <signal name="toggled" handler="show_preview_changed_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="top_attach">9</property>
                             <property name="left_attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -9306,7 +9306,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
     <action-widgets>
       <action-widget response="cancel">source_cancel</action-widget>
-      <action-widget response="ok">source_ok</action-widget>
+      <action-widget response="no">source_ok</action-widget>
     </action-widgets>
   </object>
   <object class="GtkBox" id="source_extra">

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -8,70 +8,50 @@
     </patterns>
   </object>
   <object class="GtkFileFilter" id="SourceFilterFLV">
-    <patterns>
-      <pattern>*.flv</pattern>
-      <pattern>*.FLV</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/x-flv</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterMKV">
-    <patterns>
-      <pattern>*.mkv</pattern>
-      <pattern>*.MKV</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/x-matroska</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterWebM">
-    <patterns>
-      <pattern>*.webm</pattern>
-      <pattern>*.WEBM</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/webm</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterMOV">
-    <patterns>
-      <pattern>*.mov</pattern>
-      <pattern>*.MOV</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/quicktime</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterAVI">
-    <patterns>
-      <pattern>*.avi</pattern>
-      <pattern>*.AVI</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/x-ms-video</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterMP4">
-    <patterns>
-      <pattern>*.mp4</pattern>
-      <pattern>*.m4v</pattern>
-      <pattern>*.MP4</pattern>
-      <pattern>*.M4V</pattern>
-      <pattern>*.EVO</pattern>
-      <pattern>*.m4v</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/mp4</mime-type>
+      <mime-type>video/3gpp</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterMPG">
-    <patterns>
-      <pattern>*.mpeg</pattern>
-      <pattern>*.MPEG</pattern>
-      <pattern>*.mpg</pattern>
-      <pattern>*.MPG</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/mpeg</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterOGG">
-    <patterns>
-      <pattern>*.ogg</pattern>
-      <pattern>*.OGG</pattern>
-      <pattern>*.ogv</pattern>
-      <pattern>*.OGV</pattern>
-      <pattern>*.ogm</pattern>
-      <pattern>*.OGM</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/ogg</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterTS">
-    <patterns>
-      <pattern>*.m2ts</pattern>
-      <pattern>*.M2TS</pattern>
-      <pattern>*.ts</pattern>
-      <pattern>*.TS</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/mp2t</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterVOB">
     <patterns>
@@ -85,10 +65,14 @@
     </mime-types>
   </object>
   <object class="GtkFileFilter" id="SourceFilterWMV">
-    <patterns>
-      <pattern>*.wmv</pattern>
-      <pattern>*.WMV</pattern>
-    </patterns>
+    <mime-types>
+      <mime-type>video/x-ms-wmv</mime-type>
+    </mime-types>
+  </object>
+  <object class="GtkFileFilter" id="SourceFilterAll">
+    <mime-types>
+      <mime-type>application/octet-stream</mime-type>
+    </mime-types>
   </object>
   <object class="GtkFileFilter" id="FilterAll">
     <patterns>
@@ -9268,121 +9252,6 @@ Uncheck this if you want to allow changing each title's settings independently.<
           </object>
         </child>
       </object>
-    </child>
-  </object>
-  <object class="GtkFileChooserDialog" id="source_dialog">
-    <property name="can-focus">False</property>
-    <property name="modal">True</property>
-    <property name="title" translatable="yes">Open Source</property>
-    <property name="type-hint">dialog</property>
-    <property name="skip-taskbar-hint">True</property>
-    <property name="skip-pager-hint">True</property>
-    <property name="create-folders">False</property>
-    <property name="local-only">False</property>
-    <property name="transient-for">hb_window</property>
-    <signal name="selection-changed" handler="chooser_file_selected_cb" swapped="no"/>
-    <child type="action">
-      <object class="GtkButton" id="source_cancel">
-        <property name="label" translatable="yes">_Cancel</property>
-        <property name="use-underline">True</property>
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">False</property>
-      </object>
-    </child>
-    <child type="action">
-      <object class="GtkButton" id="source_ok">
-        <property name="label" translatable="yes">_Open</property>
-        <property name="use-underline">True</property>
-        <property name="visible">True</property>
-        <property name="can-focus">True</property>
-        <property name="receives-default">True</property>
-        <property name="can-default">True</property>
-        <property name="has-default">True</property>
-        <style>
-          <class name="default"/>
-        </style>
-      </object>
-    </child>
-    <action-widgets>
-      <action-widget response="cancel">source_cancel</action-widget>
-      <action-widget response="no">source_ok</action-widget>
-    </action-widgets>
-  </object>
-  <object class="GtkBox" id="source_extra">
-    <property name="orientation">horizontal</property>
-    <property name="visible">True</property>
-    <property name="spacing">10</property>
-    <property name="expand">False</property>
-    <property name="can-focus">False</property>
-    <child>
-      <object class="GtkBox" id="single_title_box">
-        <property name="orientation">horizontal</property>
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="spacing">4</property>
-        <child>
-          <object class="GtkLabel" id="label89">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Title Number:</property>
-          </object>
-          <packing>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSpinButton" id="single_title">
-            <property name="width-chars">5</property>
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="halign">start</property>
-            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="adjustment">adjustment24</property>
-            <property name="hexpand">True</property>
-            <signal name="value-changed" handler="nonsetting_widget_changed_cb" swapped="no"/>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="position">1</property>
-      </packing>
-    </child>
-    <child>
-      <object class="GtkBox" id="hbox74">
-        <property name="orientation">horizontal</property>
-        <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="spacing">4</property>
-        <child>
-          <object class="GtkLabel" id="label90">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="label" translatable="yes">Detected DVD devices:</property>
-          </object>
-          <packing>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkComboBoxText" id="source_device">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="halign">start</property>
-            <property name="hexpand">True</property>
-            <signal name="changed" handler="dvd_device_changed_cb" swapped="no"/>
-          </object>
-          <packing>
-            <property name="position">1</property>
-          </packing>
-        </child>
-      </object>
-      <packing>
-        <property name="position">0</property>
-      </packing>
     </child>
   </object>
   <object class="GtkImage" id="gtk-cancel">

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -109,17 +109,17 @@
   </object>
   <object class="GtkLabel" id="SubBurnedLabel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
+    <property name="can-focus">False</property>
+    <property name="tooltip-text" translatable="yes">Render the subtitle over the video.
 
 The subtitle will be part of the video and can not be disabled.</property>
     <property name="label" translatable="yes">&lt;b&gt;Burned In&lt;/b&gt;</property>
-    <property name="use_markup">True</property>
+    <property name="use-markup">True</property>
   </object>
   <object class="GtkLabel" id="SubDefaultLabel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
+    <property name="can-focus">False</property>
+    <property name="tooltip-text" translatable="yes">Set the default output subtitle track.
 
 Most players will automatically display this
 subtitle track whenever the video is played.
@@ -127,36 +127,36 @@ subtitle track whenever the video is played.
 This is useful for creating a "forced" track
 in your output.</property>
     <property name="label" translatable="yes">&lt;b&gt;Default&lt;/b&gt;</property>
-    <property name="use_markup">True</property>
+    <property name="use-markup">True</property>
   </object>
   <object class="GtkLabel" id="SubForcedLabel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
+    <property name="can-focus">False</property>
+    <property name="tooltip-text" translatable="yes">Use only subtitles that have been flagged
 as forced in the source subtitle track
 
 "Forced" subtitles are usually used to show
 subtitles during scenes where someone is speaking
 a foreign language.</property>
     <property name="label" translatable="yes">&lt;b&gt;Forced Only&lt;/b&gt;</property>
-    <property name="use_markup">True</property>
+    <property name="use-markup">True</property>
   </object>
   <object class="GtkLabel" id="SubSRTOffsetLabel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="tooltip_text" translatable="yes">Add (or subtract) an offset (in milliseconds)
+    <property name="can-focus">False</property>
+    <property name="tooltip-text" translatable="yes">Add (or subtract) an offset (in milliseconds)
 to the start of the SRT subtitle track.
 
 Often, the start of an external SRT file
 does not coincide with the start of the video.
 This setting allows you to synchronize the files.</property>
     <property name="label" translatable="yes">&lt;b&gt;SRT Offset&lt;/b&gt;</property>
-    <property name="use_markup">True</property>
+    <property name="use-markup">True</property>
   </object>
   <object class="GtkLabel" id="SubTrackLabel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="tooltip_text" translatable="yes">The source subtitle track
+    <property name="can-focus">False</property>
+    <property name="tooltip-text" translatable="yes">The source subtitle track
 
 You can choose any of the subtitles
 recognized in your source file.
@@ -168,7 +168,7 @@ subtitles that may correspond to a foreign
 language scene.  This option is best used in
 conjunction with the "Forced" option.</property>
     <property name="label" translatable="yes">&lt;b&gt;Track&lt;/b&gt;</property>
-    <property name="use_markup">True</property>
+    <property name="use-markup">True</property>
   </object>
 
   <menu id="preset_actions_menu">
@@ -267,38 +267,38 @@ conjunction with the "Forced" option.</property>
   <object class="GtkWindow" id="presets_window">
     <property name="title" translatable="yes">HandBrake Presets</property>
     <property name="visible">False</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="type_hint">utility</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="transient_for">hb_window</property>
-    <property name="default_width">300</property>
-    <property name="default_height">600</property>
+    <property name="type-hint">utility</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <property name="transient-for">hb_window</property>
+    <property name="default-width">300</property>
+    <property name="default-height">600</property>
     <signal name="delete-event" handler="presets_window_delete_cb" swapped="no"/>
     <signal name="size-allocate" handler="presets_sz_alloc_cb" swapped="no"/>
     <child>
       <object class="GtkBox" id="presets_window_box">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
           <object class="GtkToolbar" id="presets_window_toolbar">
             <property name="hexpand">True</property>
             <property name="halign">fill</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="icon-size">GTK_ICON_SIZE_SMALL_TOOLBAR</property>
             <child>
               <object class="GtkToolButton" id="preset_save_as_button">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="is_important">True</property>
+                <property name="is-important">True</property>
                 <property name="label" translatable="yes">Save As</property>
-                <property name="icon_name">document-save-as</property>
+                <property name="icon-name">document-save-as</property>
                 <property name="action-name">app.preset-save-as</property>
               </object>
               <packing>
@@ -323,15 +323,15 @@ conjunction with the "Forced" option.</property>
             <child>
               <object class="GtkToolItem" id="preset_actions">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="is_important">True</property>
+                <property name="is-important">True</property>
                 <property name="hexpand">False</property>
                 <property name="halign">end</property>
                 <child>
                   <object class="GtkMenuButton" id="preset_actions_menu_button">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="direction">down</property>
                     <property name="relief">GTK_RELIEF_NONE</property>
                     <property name="menu-model">preset_actions_menu</property>
@@ -341,14 +341,14 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkBox" id="preset_actions_menu_button_box">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">False</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkImage" id="preset_actions_menu_button_image">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">hb-advanced</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">hb-advanced</property>
                           </object>
                           <packing>
                             <property name="position">0</property>
@@ -357,10 +357,10 @@ conjunction with the "Forced" option.</property>
                         <child>
                           <object class="GtkLabel" id="preset_actions_menu_button_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="xalign">0</property>
                             <property name="label" translatable="yes">Actions</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="hexpand">False</property>
                           </object>
                           <packing>
@@ -385,25 +385,25 @@ conjunction with the "Forced" option.</property>
         <child>
           <object class="GtkMenuBar" id="presets_menu_bar">
             <property name="visible">False</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="vexpand">False</property>
             <property name="valign">GTK_ALIGN_FILL</property>
             <child>
               <object class="GtkMenuItem" id="presets_window_menu">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">_Presets</property>
-                <property name="use_underline">True</property>
+                <property name="use-underline">True</property>
                 <child type="submenu">
                   <object class="GtkMenu" id="presets_window_submenu">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkMenuItem" id="presets_window_default">
                         <property name="label" translatable="yes">Set De_fault</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-default</property>
                       </object>
                     </child>
@@ -416,8 +416,8 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkMenuItem" id="presets_window_save">
                         <property name="label" translatable="yes">_Save</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-save</property>
                       </object>
                     </child>
@@ -425,8 +425,8 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkMenuItem" id="presets_window_save_as">
                         <property name="label" translatable="yes">Save _As</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-save-as</property>
                       </object>
                     </child>
@@ -434,8 +434,8 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkMenuItem" id="presets_window_rename">
                         <property name="label" translatable="yes">_Rename</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-rename</property>
                       </object>
                     </child>
@@ -443,8 +443,8 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkMenuItem" id="presets_window_remove">
                         <property name="label" translatable="yes">_Delete</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-remove</property>
                       </object>
                     </child>
@@ -457,8 +457,8 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkMenuItem" id="presets_window_export">
                         <property name="label" translatable="yes">_Export</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="use-underline">True</property>
                         <property name="action-name">app.preset-export</property>
                       </object>
                     </child>
@@ -474,25 +474,25 @@ conjunction with the "Forced" option.</property>
         <child>
           <object class="GtkFrame" id="presets_frame">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="label_xalign">0</property>
-            <property name="shadow_type">none</property>
+            <property name="label-xalign">0</property>
+            <property name="shadow-type">none</property>
             <property name="vexpand">True</property>
             <property name="valign">GTK_ALIGN_FILL</property>
             <child>
               <object class="GtkScrolledWindow" id="presets_scroll">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="shadow_type">none</property>
-                <property name="min_content_width">200</property>
+                <property name="can-focus">False</property>
+                <property name="shadow-type">none</property>
+                <property name="min-content-width">200</property>
                 <child>
                   <object class="GtkTreeView" id="presets_list">
-                    <property name="width_request">206</property>
+                    <property name="width-request">206</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="headers_visible">False</property>
+                    <property name="headers-visible">False</property>
                     <signal name="button-press-event" handler="on_presets_list_press_cb"/>
                     <child internal-child="selection">
                       <object class="GtkTreeSelection" id="treeview-selection4"/>
@@ -512,27 +512,27 @@ conjunction with the "Forced" option.</property>
 
   <object class="GtkWindow" id="queue_window">
     <property name="title" translatable="yes">HandBrake Queue</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="resizable">True</property>
-    <property name="window_position">center</property>
-    <property name="type_hint">utility</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="transient_for">hb_window</property>
-    <property name="default_width">1024</property>
+    <property name="window-position">center</property>
+    <property name="type-hint">utility</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <property name="transient-for">hb_window</property>
+    <property name="default-width">1024</property>
     <signal name="delete-event" handler="queue_window_delete_cb" swapped="no"/>
     <child>
       <object class="GtkBox" id="queue_tab">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
           <object class="GtkBox" id="queue_box0">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="margin-top">12</property>
             <property name="margin-bottom">12</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -540,10 +540,10 @@ conjunction with the "Forced" option.</property>
               <object class="GtkLabel" id="queue_label">
                 <property name="visible">True</property>
                 <property name="hexpand">False</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">baseline</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="margin-start">12</property>
                 <property name="label" translatable="yes">&lt;span size="x-large"&gt;Queue&lt;/span&gt;</property>
               </object>
@@ -555,10 +555,10 @@ conjunction with the "Forced" option.</property>
               <object class="GtkLabel" id="queue_status_label">
                 <property name="visible">True</property>
                 <property name="hexpand">False</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">start</property>
                 <property name="valign">baseline</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="margin-start">12</property>
                 <property name="label" translatable="yes">0 jobs pending</property>
               </object>
@@ -576,13 +576,13 @@ conjunction with the "Forced" option.</property>
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="position">500</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <child>
               <object class="GtkBox" id="queue_box2">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <child>
@@ -590,17 +590,17 @@ conjunction with the "Forced" option.</property>
                     <property name="hexpand">True</property>
                     <property name="halign">fill</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <child>
                       <object class="GtkToolButton" id="queue_list_start">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Start Encoding</property>
-                        <property name="is_important">True</property>
+                        <property name="tooltip-text" translatable="yes">Start Encoding</property>
+                        <property name="is-important">True</property>
                         <property name="label" translatable="yes">Start</property>
-                        <property name="icon_name">hb-start</property>
+                        <property name="icon-name">hb-start</property>
                         <property name="action-name">app.queue-start</property>
                       </object>
                       <packing>
@@ -611,12 +611,12 @@ conjunction with the "Forced" option.</property>
                     <child>
                       <object class="GtkToolButton" id="queue_list_pause">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Pause Encoding</property>
-                        <property name="is_important">True</property>
+                        <property name="tooltip-text" translatable="yes">Pause Encoding</property>
+                        <property name="is-important">True</property>
                         <property name="label" translatable="yes">Pause</property>
-                        <property name="icon_name">hb-pause</property>
+                        <property name="icon-name">hb-pause</property>
                         <property name="action-name">app.queue-pause</property>
                       </object>
                       <packing>
@@ -641,15 +641,15 @@ conjunction with the "Forced" option.</property>
                     <child>
                       <object class="GtkToolItem" id="queue_list_options">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="is_important">True</property>
+                        <property name="is-important">True</property>
                         <property name="hexpand">False</property>
                         <property name="halign">end</property>
                         <child>
                           <object class="GtkMenuButton" id="queue_options_menu_button">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="direction">down</property>
                             <property name="menu-model">queue_options_menu</property>
                             <property name="relief">GTK_RELIEF_NONE</property>
@@ -657,13 +657,13 @@ conjunction with the "Forced" option.</property>
                               <object class="GtkBox" id="queue_options_menu_button_box">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkImage" id="queue_options_menu_button_image">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="icon_name">hb-advanced</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="icon-name">hb-advanced</property>
                                   </object>
                                   <packing>
                                     <property name="position">0</property>
@@ -672,10 +672,10 @@ conjunction with the "Forced" option.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_options_menu_button_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="label" translatable="yes">Options</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="hexpand">True</property>
                                   </object>
                                   <packing>
@@ -701,18 +701,18 @@ conjunction with the "Forced" option.</property>
                   <object class="GtkScrolledWindow" id="queue_list_window">
                     <property name="hexpand">True</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                    <property name="can-focus">False</property>
+                    <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="min_content_height">400</property>
+                    <property name="min-content-height">400</property>
                     <child>
                       <object class="GtkListBox" id="queue_list">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="vexpand">True</property>
                         <property name="hexpand">True</property>
-                        <property name="selection_mode">single</property>
-                        <property name="activate_on_single_click">False</property>
+                        <property name="selection-mode">single</property>
+                        <property name="activate-on-single-click">False</property>
                         <signal name="row-selected" handler="queue_list_selection_changed_cb" swapped="no"/>
                         <signal name="key-press-event" handler="queue_key_press_cb" swapped="no"/>
                         <signal name="drag-motion" handler="queue_drag_motion_cb" swapped="no"/>
@@ -729,7 +729,7 @@ conjunction with the "Forced" option.</property>
                   <object class="GtkBox" id="queue_box4">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="margin-top">6</property>
                     <property name="margin-bottom">6</property>
                     <property name="halign">center</property>
@@ -740,9 +740,9 @@ conjunction with the "Forced" option.</property>
                       <object class="GtkLabel" id="queue_done_label">
                         <property name="visible">True</property>
                         <property name="hexpand">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                         <property name="label" translatable="yes">When Done:</property>
                       </object>
                       <packing>
@@ -752,7 +752,7 @@ conjunction with the "Forced" option.</property>
                     <child>
                       <object class="GtkComboBox" id="QueueWhenComplete">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <signal name="changed" handler="temp_when_complete_changed_cb" swapped="no"/>
                       </object>
                       <packing>
@@ -773,13 +773,13 @@ conjunction with the "Forced" option.</property>
               <object class="GtkBox" id="queue_box5">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="margin-top">4</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <child>
                   <object class="GtkStackSwitcher" id="QueueStackSwitcher">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="stack">QueueStack</property>
                     <property name="hexpand">True</property>
@@ -798,7 +798,7 @@ conjunction with the "Forced" option.</property>
                     <property name="transition-type">GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT_RIGHT</property>
                     <property name="transition-duration">400</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="margin-start">12</property>
                     <property name="margin-end">12</property>
                     <property name="vexpand">True</property>
@@ -808,7 +808,7 @@ conjunction with the "Forced" option.</property>
                         <property name="visible">True</property>
                         <property name="expand">True</property>
                         <property name="margin-top">12</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="spacing">3</property>
                         <child>
@@ -816,17 +816,17 @@ conjunction with the "Forced" option.</property>
                             <property name="hexpand">False</property>
                             <property name="halign">start</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkToolButton" id="queue_reload">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="is_important">True</property>
+                                <property name="is-important">True</property>
                                 <property name="label" translatable="yes">Reset</property>
-                                <property name="icon_name">view-refresh</property>
-                                <property name="tooltip_text" translatable="yes">Mark selected queue entry as pending.
+                                <property name="icon-name">view-refresh</property>
+                                <property name="tooltip-text" translatable="yes">Mark selected queue entry as pending.
 Resets the queue job to pending and ready to run again.</property>
                                 <property name="action-name">app.queue-reset</property>
                               </object>
@@ -838,11 +838,11 @@ Resets the queue job to pending and ready to run again.</property>
                             <child>
                               <object class="GtkToolButton" id="queue_edit">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="is_important">True</property>
+                                <property name="is-important">True</property>
                                 <property name="label" translatable="yes">Edit</property>
-                                <property name="icon_name">document-edit</property>
+                                <property name="icon-name">document-edit</property>
                                 <property name="action-name">app.queue-edit</property>
                               </object>
                               <packing>
@@ -853,14 +853,14 @@ Resets the queue job to pending and ready to run again.</property>
                             <child>
                               <object class="GtkToolItem" id="queue_actions">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="is_important">True</property>
+                                <property name="is-important">True</property>
                                 <property name="hexpand">False</property>
                                 <child>
                                   <object class="GtkMenuButton" id="queue_actions_menu_button">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="direction">down</property>
                                     <property name="relief">GTK_RELIEF_NONE</property>
                                     <property name="menu-model">queue_actions_menu</property>
@@ -869,14 +869,14 @@ Resets the queue job to pending and ready to run again.</property>
                                       <object class="GtkBox" id="queue_actions_menu_button_box">
                                         <property name="orientation">horizontal</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="hexpand">False</property>
                                         <property name="spacing">6</property>
                                         <child>
                                           <object class="GtkImage" id="queue_actions_menu_button_image">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="icon_name">hb-advanced</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="icon-name">hb-advanced</property>
                                           </object>
                                           <packing>
                                             <property name="position">0</property>
@@ -885,10 +885,10 @@ Resets the queue job to pending and ready to run again.</property>
                                         <child>
                                           <object class="GtkLabel" id="queue_actions_menu_button_label">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="xalign">0</property>
                                             <property name="label" translatable="yes">Actions</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="use-markup">True</property>
                                             <property name="hexpand">False</property>
                                           </object>
                                           <packing>
@@ -925,22 +925,22 @@ Resets the queue job to pending and ready to run again.</property>
                                 <property name="visible">True</property>
                                 <property name="vexpand">True</property>
                                 <property name="hexpand">False</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="column-spacing">12</property>
                                 <property name="row-spacing">12</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_preset_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Preset:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -948,7 +948,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_preset">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -958,8 +958,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -967,16 +967,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_source_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Source:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -984,7 +984,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_source">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -993,14 +993,14 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="label" translatable="yes"></property>
                                     <property name="width-chars">50</property>
                                     <property name="lines">2</property>
-                                    <property name="wrap_mode">word-char</property>
+                                    <property name="wrap-mode">word-char</property>
                                     <property name="ellipsize">middle</property>
                                     <property name="selectable">True</property>
                                     <property name="margin-bottom">12</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1008,16 +1008,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_title_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Title:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1025,7 +1025,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_title">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1034,13 +1034,13 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="label" translatable="yes"></property>
                                     <property name="width-chars">50</property>
                                     <property name="lines">2</property>
-                                    <property name="wrap_mode">word-char</property>
+                                    <property name="wrap-mode">word-char</property>
                                     <property name="ellipsize">middle</property>
                                     <property name="selectable">True</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1048,16 +1048,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_dest_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Destination:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1065,7 +1065,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_dest">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1074,14 +1074,14 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="label" translatable="yes"></property>
                                     <property name="width-chars">50</property>
                                     <property name="lines">2</property>
-                                    <property name="wrap_mode">word-char</property>
+                                    <property name="wrap-mode">word-char</property>
                                     <property name="ellipsize">middle</property>
                                     <property name="selectable">True</property>
                                     <property name="margin-bottom">12</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1089,16 +1089,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_dimensions_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Dimensions:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">4</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1106,7 +1106,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_dimensions">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1116,8 +1116,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">4</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1125,16 +1125,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_video_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Video:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">5</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1142,7 +1142,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_video">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1152,8 +1152,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">5</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1161,16 +1161,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_audio_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Audio:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">6</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">6</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1178,7 +1178,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_audio">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1188,8 +1188,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">6</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">6</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1197,16 +1197,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_subtitle_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Subtitles:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">7</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">7</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1214,7 +1214,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_summary_subtitle">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1224,8 +1224,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">7</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">7</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1250,7 +1250,7 @@ Resets the queue job to pending and ready to run again.</property>
                         <property name="visible">True</property>
                         <property name="expand">True</property>
                         <property name="margin-top">12</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="spacing">3</property>
                         <child>
@@ -1268,22 +1268,22 @@ Resets the queue job to pending and ready to run again.</property>
                                 <property name="visible">True</property>
                                 <property name="vexpand">True</property>
                                 <property name="hexpand">False</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="column-spacing">12</property>
                                 <property name="row-spacing">12</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_pass_label">
                                     <property name="visible">False</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Pass:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1291,7 +1291,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_pass">
                                     <property name="visible">False</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1301,8 +1301,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1310,16 +1310,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_start_time_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Start Time:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1327,7 +1327,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_start_time">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1337,8 +1337,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">1</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1346,16 +1346,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_finish_time_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">End Time:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1363,7 +1363,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_finish_time">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1372,13 +1372,13 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="label" translatable="yes"></property>
                                     <property name="width-chars">50</property>
                                     <property name="lines">2</property>
-                                    <property name="wrap_mode">word-char</property>
+                                    <property name="wrap-mode">word-char</property>
                                     <property name="ellipsize">middle</property>
                                     <property name="selectable">True</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">2</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1386,16 +1386,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_paused_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Paused Duration:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1403,7 +1403,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_paused">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1412,13 +1412,13 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="label" translatable="yes"></property>
                                     <property name="width-chars">50</property>
                                     <property name="lines">2</property>
-                                    <property name="wrap_mode">word-char</property>
+                                    <property name="wrap-mode">word-char</property>
                                     <property name="ellipsize">middle</property>
                                     <property name="selectable">True</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">3</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1426,16 +1426,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_encode_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Encode Time:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">4</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1443,7 +1443,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_encode">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1453,8 +1453,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">4</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">4</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1462,16 +1462,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_file_size_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">File Size:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">5</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1479,7 +1479,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_file_size">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1489,8 +1489,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">5</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">5</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1498,16 +1498,16 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_result_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="yalign">0</property>
                                     <property name="halign">start</property>
-                                    <property name="use_markup">True</property>
+                                    <property name="use-markup">True</property>
                                     <property name="label" translatable="yes">Status:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">6</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">6</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1515,7 +1515,7 @@ Resets the queue job to pending and ready to run again.</property>
                                 <child>
                                   <object class="GtkLabel" id="queue_stats_result">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="xalign">0</property>
@@ -1525,8 +1525,8 @@ Resets the queue job to pending and ready to run again.</property>
                                     <property name="width-chars">50</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">6</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">6</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -1551,19 +1551,19 @@ Resets the queue job to pending and ready to run again.</property>
                         <property name="visible">True</property>
                         <property name="expand">True</property>
                         <property name="margin-top">12</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="spacing">3</property>
                         <child>
                           <object class="GtkBox" id="queue_box6">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkLabel" id="queue_activity_location">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="vexpand">False</property>
                                 <property name="valign">GTK_ALIGN_FILL</property>
                                 <property name="margin-top">5</property>
@@ -1578,22 +1578,22 @@ Resets the queue job to pending and ready to run again.</property>
                             <child>
                               <object class="GtkScrolledWindow" id="queue_activity_scroll">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="shadow_type">in</property>
+                                <property name="shadow-type">in</property>
                                 <property name="vexpand">True</property>
                                 <property name="margin-bottom">6</property>
                                 <property name="valign">GTK_ALIGN_FILL</property>
                                 <child>
                                   <object class="GtkTextView" id="queue_activity_view">
-                                    <property name="width_request">600</property>
-                                    <property name="height_request">600</property>
+                                    <property name="width-request">600</property>
+                                    <property name="height-request">600</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="editable">False</property>
-                                    <property name="wrap_mode">char</property>
-                                    <property name="cursor_visible">False</property>
+                                    <property name="wrap-mode">char</property>
+                                    <property name="cursor-visible">False</property>
                                   </object>
                                 </child>
                               </object>
@@ -1631,20 +1631,20 @@ Resets the queue job to pending and ready to run again.</property>
 
   <object class="GtkWindow" id="activity_window">
     <property name="title" translatable="yes">HandBrake Activity Log</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="default_width">800</property>
-    <property name="default_height">600</property>
-    <property name="type_hint">utility</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="transient_for">hb_window</property>
+    <property name="default-width">800</property>
+    <property name="default-height">600</property>
+    <property name="type-hint">utility</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <property name="transient-for">hb_window</property>
     <signal name="delete-event" handler="activity_window_delete_cb" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox37">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
           <placeholder/>
@@ -1652,7 +1652,7 @@ Resets the queue job to pending and ready to run again.</property>
         <child>
           <object class="GtkLabel" id="activity_location">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="vexpand">False</property>
             <property name="valign">GTK_ALIGN_FILL</property>
             <property name="margin-top">5</property>
@@ -1666,21 +1666,21 @@ Resets the queue job to pending and ready to run again.</property>
         <child>
           <object class="GtkScrolledWindow" id="activity_scroll">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="shadow_type">in</property>
+            <property name="shadow-type">in</property>
             <property name="vexpand">True</property>
             <property name="valign">GTK_ALIGN_FILL</property>
             <child>
               <object class="GtkTextView" id="activity_view">
-                <property name="width_request">600</property>
-                <property name="height_request">600</property>
+                <property name="width-request">600</property>
+                <property name="height-request">600</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="editable">False</property>
-                <property name="wrap_mode">char</property>
-                <property name="cursor_visible">False</property>
+                <property name="wrap-mode">char</property>
+                <property name="cursor-visible">False</property>
               </object>
             </child>
           </object>
@@ -1696,267 +1696,267 @@ Resets the queue job to pending and ready to run again.</property>
   </object>
   <object class="GtkImage" id="display_size_lock_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">emblem-readonly</property>
+    <property name="can-focus">False</property>
+    <property name="icon-name">emblem-readonly</property>
   </object>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment10">
     <property name="lower">4</property>
     <property name="upper">64</property>
     <property name="value">16</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment11">
     <property name="lower">-6</property>
     <property name="upper">6</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment12">
     <property name="lower">-6</property>
     <property name="upper">6</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="TopPadAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="BottomPadAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="LeftPadAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="RightPadAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="LeftCropAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="TopCropAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="BottomCropAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="RightCropAdjustment">
     <property name="upper">8192</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="scale_width_adjustment">
     <property name="lower">32</property>
     <property name="upper">20480</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="scale_height_adjustment">
     <property name="lower">32</property>
     <property name="upper">20480</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment19">
     <property name="lower">1</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment2">
     <property name="lower">1</property>
     <property name="upper">100</property>
     <property name="value">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment20">
     <property name="lower">4</property>
     <property name="upper">15</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment21">
     <property name="lower">15</property>
     <property name="upper">240</property>
     <property name="value">15</property>
-    <property name="step_increment">15</property>
-    <property name="page_increment">15</property>
+    <property name="step-increment">15</property>
+    <property name="page-increment">15</property>
   </object>
   <object class="GtkAdjustment" id="adjustment22">
     <property name="upper">2</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">0.5</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment23">
     <property name="upper">1</property>
-    <property name="step_increment">0.05</property>
-    <property name="page_increment">0.5</property>
+    <property name="step-increment">0.05</property>
+    <property name="page-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment24">
     <property name="lower">1</property>
     <property name="upper">999</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment25">
     <property name="upper">4096</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment26">
     <property name="upper">4096</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment27">
     <property name="lower">1</property>
     <property name="upper">10</property>
     <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment28">
     <property name="lower">0.9</property>
     <property name="upper">4</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment29">
     <property name="lower">1</property>
     <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment3">
     <property name="upper">1000000</property>
-    <property name="step_increment">10</property>
-    <property name="page_increment">100</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
   </object>
   <object class="GtkAdjustment" id="adjustment30">
     <property name="lower">1</property>
     <property name="upper">65535</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment31">
     <property name="lower">-30000</property>
     <property name="upper">30000</property>
-    <property name="step_increment">10</property>
-    <property name="page_increment">100</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
   </object>
   <object class="GtkAdjustment" id="PictureWidthAdjustment">
     <property name="lower">0</property>
     <property name="upper">20480</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="PictureHeightAdjustment">
     <property name="lower">0</property>
     <property name="upper">20480</property>
-    <property name="step_increment">2</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">2</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="adjustment34">
     <property name="upper">2</property>
     <property name="value">1</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">0.5</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">0.5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment35">
     <property name="lower">-20</property>
     <property name="upper">21</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment4">
     <property name="upper">50000</property>
-    <property name="step_increment">100</property>
-    <property name="page_increment">1000</property>
+    <property name="step-increment">100</property>
+    <property name="page-increment">1000</property>
   </object>
   <object class="GtkAdjustment" id="adjustment5">
     <property name="upper">51</property>
     <property name="value">20.25</property>
-    <property name="step_increment">0.25</property>
-    <property name="page_increment">5</property>
+    <property name="step-increment">0.25</property>
+    <property name="page-increment">5</property>
   </object>
   <object class="GtkAdjustment" id="adjustment8">
     <property name="lower">1</property>
     <property name="upper">16</property>
     <property name="value">3</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="adjustment9">
     <property name="upper">16</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="audio_quality_adj">
     <property name="upper">10</property>
-    <property name="step_increment">0.1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">0.1</property>
+    <property name="page-increment">1</property>
   </object>
   <object class="GtkAdjustment" id="DiskFreeLimitAdjustment">
     <property name="upper">1000000</property>
-    <property name="step_increment">500</property>
-    <property name="page_increment">1000</property>
+    <property name="step-increment">500</property>
+    <property name="page-increment">1000</property>
   </object>
   <object class="GtkAdjustment" id="ActivityFontSizeAdjustment">
     <property name="upper">32</property>
     <property name="lower">6</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="DisplayWidthAdjustment">
     <property name="lower">32</property>
     <property name="upper">20480</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAdjustment" id="DisplayHeightAdjustment">
     <property name="lower">32</property>
     <property name="upper">20480</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">16</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">16</property>
   </object>
   <object class="GtkAboutDialog" id="hb_about">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">About HandBrake</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="program_name">HandBrake</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <property name="program-name">HandBrake</property>
     <property name="version">0.9.2</property>
     <property name="copyright" translatable="yes">Copyright © 2008 -  John Stebbins
 Copyright © 2004 - , HandBrake Devs</property>
     <property name="comments" translatable="yes">HandBrake is a GPL-licensed, multiplatform, multithreaded video transcoder.</property>
     <property name="website">https://handbrake.fr</property>
-    <property name="website_label" translatable="yes">https://handbrake.fr</property>
+    <property name="website-label" translatable="yes">https://handbrake.fr</property>
     <property name="license" translatable="yes">HandBrake is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2, as published by the Free Software Foundation.
 
 HandBrake is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
@@ -2114,22 +2114,22 @@ libx264 authors:
   Laurent Aimar
 
 </property>
-    <property name="logo_icon_name">hb-icon</property>
-    <property name="wrap_license">True</property>
+    <property name="logo-icon-name">hb-icon</property>
+    <property name="wrap-license">True</property>
     <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox4">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox" id="dialog-action_area4">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
           </object>
           <packing>
-            <property name="pack_type">end</property>
+            <property name="pack-type">end</property>
             <property name="position">0</property>
           </packing>
         </child>
@@ -2141,12 +2141,12 @@ libx264 authors:
   </object>
 
   <object class="GtkApplicationWindow" id="hb_window">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_VISIBILITY_NOTIFY_MASK</property>
     <property name="title" translatable="yes">HandBrake</property>
-    <property name="default_width">500</property>
-    <property name="default_height">400</property>
-    <property name="icon_name">hb-icon</property>
+    <property name="default-width">500</property>
+    <property name="default-height">400</property>
+    <property name="icon-name">hb-icon</property>
     <signal name="map-event" handler="window_map_cb" swapped="no"/>
     <signal name="size-allocate" handler="hb_win_sz_alloc_cb" swapped="no"/>
     <signal name="delete-event" handler="window_delete_event_cb" swapped="no"/>
@@ -2156,13 +2156,13 @@ libx264 authors:
         <property name="orientation">vertical</property>
         <property name="expand">True</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <child>
           <object class="GtkBox" id="vbox11">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">False</property>
             <property name="halign">GTK_ALIGN_FILL</property>
@@ -2171,19 +2171,19 @@ libx264 authors:
               <object class="GtkToolbar" id="toolbar1">
                 <property name="visible">True</property>
                 <property name="hexpand">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="show-arrow">False</property>
-                <property name="icon_size">5</property>
+                <property name="icon-size">5</property>
                 <property name="toolbar-style">GTK_TOOLBAR_BOTH</property>
                 <child>
                   <object class="GtkToolButton" id="sourcetoolbutton">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Choose Video Source</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Choose Video Source</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Open Source</property>
-                    <property name="icon_name">hb-source</property>
+                    <property name="icon-name">hb-source</property>
                     <property name="action-name">app.source</property>
                   </object>
                   <packing>
@@ -2203,12 +2203,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToolButton" id="queue_add">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Add to Queue</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Add to Queue</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Add To Queue</property>
-                    <property name="icon_name">hb-add-queue</property>
+                    <property name="icon-name">hb-add-queue</property>
                     <property name="action-name">app.queue-add</property>
                   </object>
                   <packing>
@@ -2218,12 +2218,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToolButton" id="queue_start">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Start Encoding</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Start Encoding</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Start</property>
-                    <property name="icon_name">hb-start</property>
+                    <property name="icon-name">hb-start</property>
                     <property name="action-name">app.queue-start</property>
                   </object>
                   <packing>
@@ -2233,12 +2233,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToolButton" id="queue_pause">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Pause Encoding</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Pause Encoding</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Pause</property>
-                    <property name="icon_name">hb-pause</property>
+                    <property name="icon-name">hb-pause</property>
                     <property name="action-name">app.queue-pause</property>
                   </object>
                   <packing>
@@ -2260,12 +2260,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToggleToolButton" id="show_presets">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Show Presets Window</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Show Presets Window</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Presets</property>
-                    <property name="icon_name">hb-presets</property>
+                    <property name="icon-name">hb-presets</property>
                     <property name="action-name">app.show-presets</property>
                   </object>
                   <packing>
@@ -2275,12 +2275,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToggleToolButton" id="show_preview">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Show Preview Window</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Show Preview Window</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Preview</property>
-                    <property name="icon_name">hb-picture</property>
+                    <property name="icon-name">hb-picture</property>
                     <property name="action-name">app.show-preview</property>
                   </object>
                   <packing>
@@ -2290,12 +2290,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToggleToolButton" id="show_queue">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Show Queue</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Show Queue</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Queue</property>
-                    <property name="icon_name">hb-showqueue</property>
+                    <property name="icon-name">hb-showqueue</property>
                     <property name="action-name">app.show-queue</property>
                   </object>
                   <packing>
@@ -2305,12 +2305,12 @@ libx264 authors:
                 <child>
                   <object class="GtkToggleToolButton" id="show_activity">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Show Activity Window</property>
-                    <property name="is_important">True</property>
+                    <property name="tooltip-text" translatable="yes">Show Activity Window</property>
+                    <property name="is-important">True</property>
                     <property name="label" translatable="yes">Activity</property>
-                    <property name="icon_name">hb-activity</property>
+                    <property name="icon-name">hb-activity</property>
                     <property name="action-name">app.show-activity</property>
                   </object>
                   <packing>
@@ -2325,9 +2325,9 @@ libx264 authors:
             <child>
               <object class="GtkGrid" id="source_title_preset_grid">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="row-homogeneous">True</property>
-                <property name="column_spacing">5</property>
+                <property name="column-spacing">5</property>
                 <property name="hexpand">True</property>
                 <property name="halign">GTK_ALIGN_FILL</property>
                 <property name="margin-start">12</property>
@@ -2338,13 +2338,13 @@ libx264 authors:
                     <property name="visible">True</property>
                     <property name="justify">left</property>
                     <property name="xalign">0</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Source:&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2353,7 +2353,7 @@ libx264 authors:
                   <object class="GtkBox" id="SourceInfoBox">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="hexpand">True</property>
                     <property name="spacing">0</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
@@ -2361,7 +2361,7 @@ libx264 authors:
                       <object class="GtkLabel" id="source_label">
                         <property name="visible">True</property>
                         <property name="max-width-chars">60</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="ellipsize">middle</property>
@@ -2375,7 +2375,7 @@ libx264 authors:
                       <object class="GtkLabel" id="source_info_label">
                         <property name="visible">True</property>
                         <property name="hexpand">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes"></property>
@@ -2386,8 +2386,8 @@ libx264 authors:
                     </child>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2396,7 +2396,7 @@ libx264 authors:
                   <object class="GtkBox" id="SourceScanBox">
                     <property name="orientation">horizontal</property>
                     <property name="visible">False</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">6</property>
                     <property name="hexpand">True</property>
                     <property name="halign">GTK_ALIGN_FILL</property>
@@ -2405,7 +2405,7 @@ libx264 authors:
                       <object class="GtkLabel" id="source_scan_label">
                         <property name="visible">True</property>
                         <property name="width-chars">40</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
                         <property name="xalign">0</property>
@@ -2419,8 +2419,8 @@ libx264 authors:
                     <child>
                       <object class="GtkProgressBar" id="scan_prog">
                         <property name="visible">True</property>
-                        <property name="height_request">10</property>
-                        <property name="can_focus">False</property>
+                        <property name="height-request">10</property>
+                        <property name="can-focus">False</property>
                         <property name="valign">center</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="hexpand">True</property>
@@ -2431,8 +2431,8 @@ libx264 authors:
                     </child>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2442,13 +2442,13 @@ libx264 authors:
                     <property name="visible">True</property>
                     <property name="justify">left</property>
                     <property name="xalign">0</property>
-                    <property name="can_focus">False</property>
-                    <property name="use_markup">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="use-markup">True</property>
                     <property name="label" translatable="yes">&lt;b&gt;Title:&lt;/b&gt;</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">1</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2457,7 +2457,7 @@ libx264 authors:
                   <object class="GtkBox" id="hbox42">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="hexpand">False</property>
                     <property name="halign">start</property>
@@ -2466,13 +2466,13 @@ libx264 authors:
                       <object class="GtkComboBox" id="title">
                         <property name="visible">True</property>
                         <property name="valign">GTK_ALIGN_CENTER</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">False</property>
                         <property name="halign">start</property>
                         <property name="width-request">100</property>
                         <property name="wrap-width">1</property>
                         <property name="popup-fixed-width">False</property>
-                        <property name="tooltip_text" translatable="yes">Set the title to encode.
+                        <property name="tooltip-text" translatable="yes">Set the title to encode.
 By default the longest title is chosen.
 This is often the feature title of a DVD.</property>
                         <property name="has-entry">True</property>
@@ -2481,7 +2481,7 @@ This is often the feature title of a DVD.</property>
                                 <property name="width-chars">30</property>
                                 <property name="max-width-chars">30</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="xalign">0.0</property>
                               </object>
@@ -2495,9 +2495,9 @@ This is often the feature title of a DVD.</property>
                     <child>
                       <object class="GtkLabel" id="angle_label">
                         <property name="visible">False</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                         <property name="margin-start">6</property>
                         <property name="label" translatable="yes">&lt;b&gt;Angle:&lt;/b&gt;</property>
                       </object>
@@ -2509,9 +2509,9 @@ This is often the feature title of a DVD.</property>
                       <object class="GtkSpinButton" id="angle">
                         <property name="width-chars">3</property>
                         <property name="visible">False</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">For multi-angle DVD's, select the desired angle to encode.</property>
+                        <property name="tooltip-text" translatable="yes">For multi-angle DVD's, select the desired angle to encode.</property>
                         <property name="adjustment">adjustment27</property>
                         <property name="halign">end</property>
                         <signal name="value-changed" handler="title_angle_changed_cb" swapped="no"/>
@@ -2523,9 +2523,9 @@ This is often the feature title of a DVD.</property>
                     <child>
                       <object class="GtkLabel" id="range_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">end</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                         <property name="margin-start">6</property>
                         <property name="label" translatable="yes">&lt;b&gt;Range:&lt;/b&gt;</property>
                       </object>
@@ -2537,8 +2537,8 @@ This is often the feature title of a DVD.</property>
                       <object class="GtkComboBox" id="PtoPType">
                         <property name="visible">True</property>
                         <property name="valign">GTK_ALIGN_CENTER</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Range of title to encode. Can be chapters, seconds, or frames.</property>
+                        <property name="can-focus">False</property>
+                        <property name="tooltip-text" translatable="yes">Range of title to encode. Can be chapters, seconds, or frames.</property>
                         <signal name="changed" handler="ptop_widget_changed_cb" swapped="no"/>
                       </object>
                       <packing>
@@ -2549,9 +2549,9 @@ This is often the feature title of a DVD.</property>
                       <object class="GtkSpinButton" id="start_point">
                         <property name="width-chars">11</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Set the first chapter to encode.</property>
+                        <property name="tooltip-text" translatable="yes">Set the first chapter to encode.</property>
                         <property name="adjustment">adjustment1</property>
                         <property name="numeric">True</property>
                         <signal name="changed" handler="ptop_edited_cb" swapped="no"/>
@@ -2566,7 +2566,7 @@ This is often the feature title of a DVD.</property>
                     <child>
                       <object class="GtkLabel" id="label56">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">-</property>
                       </object>
                       <packing>
@@ -2577,9 +2577,9 @@ This is often the feature title of a DVD.</property>
                       <object class="GtkSpinButton" id="end_point">
                         <property name="width-chars">11</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Set the last chapter to encode.</property>
+                        <property name="tooltip-text" translatable="yes">Set the last chapter to encode.</property>
                         <property name="adjustment">adjustment2</property>
                         <property name="numeric">True</property>
                         <signal name="changed" handler="ptop_edited_cb" swapped="no"/>
@@ -2593,8 +2593,8 @@ This is often the feature title of a DVD.</property>
                     </child>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">1</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2604,13 +2604,13 @@ This is often the feature title of a DVD.</property>
                     <property name="visible">True</property>
                     <property name="justify">left</property>
                     <property name="xalign">0</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">&lt;b&gt;Preset:&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">2</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2621,28 +2621,28 @@ This is often the feature title of a DVD.</property>
                     <property name="valign">center</property>
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="margin-end">12</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkMenuButton" id="presets_menu_button">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="direction">right</property>
                         <child>
                           <object class="GtkBox" id="presets_menu_button_box">
                             <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <child>
                               <object class="GtkLabel" id="presets_menu_button_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="width-chars">50</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Choose Preset</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                                 <property name="hexpand">True</property>
                               </object>
                               <packing>
@@ -2652,8 +2652,8 @@ This is often the feature title of a DVD.</property>
                             <child>
                               <object class="GtkImage" id="presets_menu_button_arrow">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">pan-end-symbolic</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">pan-end-symbolic</property>
                               </object>
                               <packing>
                                 <property name="position">1</property>
@@ -2669,11 +2669,11 @@ This is often the feature title of a DVD.</property>
                     <child>
                       <object class="GtkLabel" id="preset_selection_modified_label">
                         <property name="visible">False</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="width-chars">10</property>
                         <property name="label" translatable="yes"></property>
                         <property name="label" translatable="yes">&lt;u&gt;&lt;i&gt;Modified&lt;/i&gt;&lt;/u&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
                         <property name="position">2</property>
@@ -2683,10 +2683,10 @@ This is often the feature title of a DVD.</property>
                       <object class="GtkButton" id="preset_selection_reload">
                         <property name="label" translatable="yes">Reload</property>
                         <property name="visible">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Reload the settings for the currently selected preset.
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Reload the settings for the currently selected preset.
 Modifications will be discarded.</property>
-                        <property name="receives_default">True</property>
+                        <property name="receives-default">True</property>
                         <property name="halign">end</property>
                         <property name="action-name">app.preset-reload</property>
                       </object>
@@ -2698,9 +2698,9 @@ Modifications will be discarded.</property>
                       <object class="GtkButton" id="preset_save_new">
                         <property name="label" translatable="yes">Save New Preset</property>
                         <property name="visible">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="tooltip_text" translatable="yes">Save the current settings to a new Preset.</property>
-                        <property name="receives_default">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="tooltip-text" translatable="yes">Save the current settings to a new Preset.</property>
+                        <property name="receives-default">True</property>
                         <property name="halign">end</property>
                         <property name="action-name">app.preset-save-as</property>
                       </object>
@@ -2710,8 +2710,8 @@ Modifications will be discarded.</property>
                     </child>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">2</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -2730,12 +2730,12 @@ Modifications will be discarded.</property>
           <object class="GtkBox" id="settings_tab">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <child>
               <object class="GtkStackSwitcher" id="SettingsStackSwitcher">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="stack">SettingsStack</property>
                 <property name="hexpand">True</property>
@@ -2755,7 +2755,7 @@ Modifications will be discarded.</property>
                 <property name="transition-type">GTK_STACK_TRANSITION_TYPE_SLIDE_LEFT_RIGHT</property>
                 <property name="transition-duration">400</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="margin-start">12</property>
                 <property name="margin-end">12</property>
                 <property name="vexpand">True</property>
@@ -2765,7 +2765,7 @@ Modifications will be discarded.</property>
                     <property name="visible">True</property>
                     <property name="expand">True</property>
                     <property name="margin-top">12</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="spacing">3</property>
                     <child>
@@ -2773,22 +2773,22 @@ Modifications will be discarded.</property>
                         <property name="visible">True</property>
                         <property name="vexpand">True</property>
                         <property name="hexpand">False</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="margin-end">32</property>
                         <property name="row-spacing">2</property>
                         <property name="column-spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="format_summary_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Format:</property>
                             <property name="xalign">0</property>
                             <property name="hexpand">False</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2798,13 +2798,13 @@ Modifications will be discarded.</property>
                             <property name="visible">True</property>
                             <property name="hexpand">False</property>
                             <property name="halign">start</property>
-                            <property name="can_focus">False</property>
-                            <property name="tooltip_text" translatable="yes">Format to mux encoded tracks to.</property>
+                            <property name="can-focus">False</property>
+                            <property name="tooltip-text" translatable="yes">Format to mux encoded tracks to.</property>
                             <signal name="changed" handler="container_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2813,19 +2813,19 @@ Modifications will be discarded.</property>
                           <object class="GtkCheckButton" id="Mp4HttpOptimize">
                             <property name="label" translatable="yes">Web Optimized</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Optimize the layout of the MP4 file for progressive download.
+                            <property name="tooltip-text" translatable="yes">Optimize the layout of the MP4 file for progressive download.
 This allows a player to initiate playback before downloading the entire file.</property>
                             <property name="halign">start</property>
                             <property name="hexpand">False</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2834,20 +2834,20 @@ This allows a player to initiate playback before downloading the entire file.</p
                           <object class="GtkCheckButton" id="AlignAVStart">
                             <property name="label" translatable="yes">Align A/V Start</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Aligns the initial timestamps of all audio and video streams by
+                            <property name="tooltip-text" translatable="yes">Aligns the initial timestamps of all audio and video streams by
 inserting blank frames or dropping frames. May improve audio/video
 sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="halign">start</property>
                             <property name="hexpand">False</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2856,18 +2856,18 @@ sync for broken players that do not honor MP4 edit lists.</property>
                           <object class="GtkCheckButton" id="Mp4iPodCompatible">
                             <property name="label" translatable="yes">iPod 5G Support</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Add iPod Atom needed by some older iPods.</property>
+                            <property name="tooltip-text" translatable="yes">Add iPod Atom needed by some older iPods.</property>
                             <property name="halign">start</property>
                             <property name="hexpand">False</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2876,18 +2876,18 @@ sync for broken players that do not honor MP4 edit lists.</property>
                           <object class="GtkCheckButton" id="MetadataPassthrough">
                             <property name="label" translatable="yes">Passthru Common Metadata</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Copy metadata from source to output.</property>
+                            <property name="tooltip-text" translatable="yes">Copy metadata from source to output.</property>
                             <property name="halign">start</property>
                             <property name="hexpand">False</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="meta_pass_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">4</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">4</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2895,17 +2895,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="label6">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
                             <property name="halign">start</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="margin-top">12</property>
                             <property name="label" translatable="yes">Duration:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">5</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">5</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2913,7 +2913,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="title_duration">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="halign">start</property>
                             <property name="xalign">0</property>
@@ -2924,8 +2924,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="width-chars">8</property>
                           </object>
                           <packing>
-                            <property name="top_attach">5</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">5</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2933,17 +2933,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="tracks_summary_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Tracks:</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
                             <property name="hexpand">False</property>
                             <property name="margin-top">12</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
-                            <property name="top_attach">6</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">6</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2951,7 +2951,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="tracks_summary">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="width-chars">30</property>
                             <property name="max-width-chars">50</property>
                             <property name="halign">start</property>
@@ -2961,11 +2961,11 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="wrap">True</property>
                             <property name="margin-top">12</property>
                             <property name="label" translatable="yes"></property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
-                            <property name="top_attach">6</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">6</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">8</property>
                           </packing>
@@ -2973,17 +2973,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="filters_summary_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Filters:</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
                             <property name="hexpand">False</property>
                             <property name="margin-top">12</property>
                           </object>
                           <packing>
-                            <property name="top_attach">14</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">14</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -2991,7 +2991,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="filters_summary">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="width-chars">30</property>
                             <property name="max-width-chars">50</property>
                             <property name="halign">start</property>
@@ -3001,11 +3001,11 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="wrap">True</property>
                             <property name="margin-top">12</property>
                             <property name="label" translatable="yes"></property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
-                            <property name="top_attach">14</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">14</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">4</property>
                           </packing>
@@ -3013,9 +3013,9 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkLabel" id="dimensions_summary_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Size:</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                             <property name="halign">start</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
@@ -3023,17 +3023,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="margin-top">12</property>
                           </object>
                           <packing>
-                            <property name="top_attach">15</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">15</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel" id="dimensions_summary">
-                            <property name="width_request">85</property>
+                            <property name="width-request">85</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="xalign">0</property>
                             <property name="yalign">0</property>
@@ -3042,8 +3042,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="label" translatable="yes">--</property>
                           </object>
                           <packing>
-                            <property name="top_attach">15</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">15</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -3056,15 +3056,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                     <child>
                       <object class="GtkImage" id="summary_image">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="margin-bottom">4</property>
                         <property name="margin-start">4</property>
                         <property name="margin-end">4</property>
                         <property name="vexpand">True</property>
                         <property name="valign">fill</property>
                         <property name="expand">True</property>
-                        <property name="pixel_size">128</property>
-                        <property name="icon_name">hb-icon</property>
+                        <property name="pixel-size">128</property>
+                        <property name="icon-name">hb-icon</property>
                       </object>
                       <packing>
                         <property name="position">1</property>
@@ -3073,13 +3073,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                     <child>
                       <object class="GtkImage" id="preview_button_image">
                         <property name="visible">False</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="margin-bottom">4</property>
                         <property name="margin-start">4</property>
                         <property name="margin-end">4</property>
                         <property name="expand">True</property>
-                        <property name="pixel_size">128</property>
-                        <property name="icon_name">hb-icon</property>
+                        <property name="pixel-size">128</property>
+                        <property name="icon-name">hb-icon</property>
                         <signal name="size-allocate" handler="preview_button_size_allocate_cb" swapped="no"/>
                       </object>
                       <packing>
@@ -3097,17 +3097,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                   <object class="GtkBox" id="picture_tab">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="margin-top">8</property>
                     <property name="margin-start">0</property>
                     <property name="spacing">24</property>
                     <child>
                       <object class="GtkFrame" id="source_dimensions_frame">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <property name="margin-start">2</property>
                         <property name="margin-end">2</property>
                         <child>
@@ -3116,19 +3116,19 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <property name="row-spacing">4</property>
                             <property name="column-spacing">32</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkBox" id="source_storage_hbox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="source_storage_size_label">
                                     <property name="label" translatable="yes">Storage Size:</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3140,7 +3140,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                   <object class="GtkLabel" id="source_storage_size">
                                     <property name="label" translatable="yes">--</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3150,8 +3150,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -3160,13 +3160,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                               <object class="GtkBox" id="source_display_hbox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="source_display_size_label">
                                     <property name="label" translatable="yes">Display Size:</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3178,7 +3178,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                   <object class="GtkLabel" id="source_display_size">
                                     <property name="label" translatable="yes">--</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3188,8 +3188,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -3198,13 +3198,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                               <object class="GtkBox" id="source_aspect_hbox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="source_aspect_ratio_label">
                                     <property name="label" translatable="yes">Aspect Ratio:</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3216,7 +3216,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                   <object class="GtkLabel" id="source_aspect_ratio">
                                     <property name="label" translatable="yes">--</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -3226,8 +3226,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">2</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">2</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -3237,10 +3237,10 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child type="label">
                           <object class="GtkLabel" id="source_dimensions_frame_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="label" translatable="yes">&lt;b&gt;Source Dimensions&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -3252,22 +3252,22 @@ sync for broken players that do not honor MP4 edit lists.</property>
                       <object class="GtkBox" id="hbox75">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">32</property>
                         <child>
                           <object class="GtkFrame" id="Cropping2">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">none</property>
                             <property name="margin-start">2</property>
                             <property name="margin-end">2</property>
                             <child>
                               <object class="GtkBox" id="vbox6">
                                 <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="margin-top">6</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">4</property>
@@ -3275,8 +3275,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                   <object class="GtkGrid" id="table16">
                                     <property name="row-spacing">2</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="column_spacing">5</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="column-spacing">5</property>
                                     <property name="halign">start</property>
                                     <property name="valign">start</property>
                                     <property name="row-spacing">4</property>
@@ -3284,13 +3284,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="hflip_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Flipping:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3299,17 +3299,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkCheckButton" id="hflip">
                                         <property name="label" translatable="yes">Horizontal ⇌</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Flip video horizontally.</property>
+                                        <property name="tooltip-text" translatable="yes">Flip video horizontally.</property>
                                         <property name="halign">start</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="rotate_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3317,13 +3317,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="PictureRotateLabel">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Rotation:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3331,16 +3331,16 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkComboBox" id="rotate">
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="width_request">100</property>
+                                        <property name="width-request">100</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Rotate the video clockwise in 90 degree increments.</property>
+                                        <property name="tooltip-text" translatable="yes">Rotate the video clockwise in 90 degree increments.</property>
                                         <signal name="changed" handler="rotate_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3348,13 +3348,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="crop_mode_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Cropping:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3362,16 +3362,16 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkComboBox" id="crop_mode">
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="width_request">100</property>
+                                        <property name="width-request">100</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">How to apply crop settings.</property>
+                                        <property name="tooltip-text" translatable="yes">How to apply crop settings.</property>
                                         <signal name="changed" handler="scale_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3380,15 +3380,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureLeftCrop">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Left Crop</property>
+                                        <property name="tooltip-text" translatable="yes">Left Crop</property>
                                         <property name="adjustment">LeftCropAdjustment</property>
                                         <signal name="value-changed" handler="crop_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3397,15 +3397,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureTopCrop">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Top Crop</property>
+                                        <property name="tooltip-text" translatable="yes">Top Crop</property>
                                         <property name="adjustment">TopCropAdjustment</property>
                                         <signal name="value-changed" handler="crop_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3414,15 +3414,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureBottomCrop">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Bottom Crop</property>
+                                        <property name="tooltip-text" translatable="yes">Bottom Crop</property>
                                         <property name="adjustment">BottomCropAdjustment</property>
                                         <signal name="value-changed" handler="crop_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">5</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3431,15 +3431,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureRightCrop">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Right Crop</property>
+                                        <property name="tooltip-text" translatable="yes">Right Crop</property>
                                         <property name="adjustment">RightCropAdjustment</property>
                                         <signal name="value-changed" handler="crop_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">2</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">2</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3455,7 +3455,7 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <property name="column-spacing">8</property>
                                     <property name="column-homogeneous">True</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                   </object>
                                   <packing>
@@ -3467,10 +3467,10 @@ sync for broken players that do not honor MP4 edit lists.</property>
                             <child type="label">
                               <object class="GtkLabel" id="label26">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Orientation &amp;amp; Cropping&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
@@ -3481,17 +3481,17 @@ sync for broken players that do not honor MP4 edit lists.</property>
                         <child>
                           <object class="GtkFrame" id="frame3">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">none</property>
                             <property name="margin-start">2</property>
                             <property name="margin-end">2</property>
                             <child>
                               <object class="GtkBox" id="vbox30">
                                 <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">2</property>
                                 <child>
@@ -3499,20 +3499,20 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <property name="row-spacing">2</property>
                                     <property name="column-spacing">4</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="valign">start</property>
                                     <child>
                                       <object class="GtkLabel" id="resolution_limit_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Resolution Limit:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3521,14 +3521,14 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkComboBox" id="resolution_limit">
                                         <property name="visible">True</property>
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_markup" translatable="yes">Resolution limits for common video formats.</property>
+                                        <property name="tooltip-markup" translatable="yes">Resolution limits for common video formats.</property>
                                         <signal name="changed" handler="resolution_limit_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">3</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3536,14 +3536,14 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="maximum_size_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Maximum Size:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3552,16 +3552,16 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureWidth">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">This is the maximum width that the video will be stored at.</property>
+                                        <property name="tooltip-text" translatable="yes">This is the maximum width that the video will be stored at.</property>
                                         <property name="adjustment">PictureWidthAdjustment</property>
-                                        <property name="snap_to_ticks">True</property>
+                                        <property name="snap-to-ticks">True</property>
                                         <signal name="value-changed" handler="scale_width_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3569,13 +3569,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="label23">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="label" translatable="yes">x</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">2</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">2</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3584,15 +3584,15 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PictureHeight">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">This is the maximum height that the video will be stored at.</property>
+                                        <property name="tooltip-text" translatable="yes">This is the maximum height that the video will be stored at.</property>
                                         <property name="adjustment">PictureHeightAdjustment</property>
                                         <signal name="value-changed" handler="scale_height_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">3</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">3</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3600,13 +3600,13 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="anamorphic_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Anamorphic:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3615,9 +3615,9 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkComboBox" id="PicturePAR">
                                         <property name="visible">True</property>
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_markup" translatable="yes">&lt;b&gt;Anamorphic Modes:&lt;/b&gt;&lt;small&gt;&lt;tt&gt;
+                                        <property name="tooltip-markup" translatable="yes">&lt;b&gt;Anamorphic Modes:&lt;/b&gt;&lt;small&gt;&lt;tt&gt;
     Automatic - Use a pixel aspect ratio that maximizes
         storage resolution while preserving the original
         display aspect ratio.
@@ -3626,8 +3626,8 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                         <signal name="changed" handler="scale_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">3</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3635,14 +3635,14 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                     <child>
                                       <object class="GtkLabel" id="pixel_aspect_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Pixel Aspect:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3651,19 +3651,19 @@ sync for broken players that do not honor MP4 edit lists.</property>
                                       <object class="GtkSpinButton" id="PicturePARWidth">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Pixel aspect defines the shape of the pixels.
+                                        <property name="tooltip-text" translatable="yes">Pixel aspect defines the shape of the pixels.
 
 A 1:1 ratio defines a square pixel.  Other values define rectangular shapes.
 Players will scale the image in order to achieve the specified aspect.</property>
                                         <property name="adjustment">adjustment29</property>
-                                        <property name="snap_to_ticks">True</property>
+                                        <property name="snap-to-ticks">True</property>
                                         <signal name="value-changed" handler="par_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3671,13 +3671,13 @@ Players will scale the image in order to achieve the specified aspect.</property
                                     <child>
                                       <object class="GtkLabel" id="picture_aspect_colon">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="label" translatable="yes">:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">2</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">2</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3686,17 +3686,17 @@ Players will scale the image in order to achieve the specified aspect.</property
                                       <object class="GtkSpinButton" id="PicturePARHeight">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Pixel aspect defines the shape of the pixels.
+                                        <property name="tooltip-text" translatable="yes">Pixel aspect defines the shape of the pixels.
 A 1:1 ratio defines a square pixel.  Other values define rectangular shapes.
 Players will scale the image in order to achieve the specified aspect.</property>
                                         <property name="adjustment">adjustment30</property>
                                         <signal name="value-changed" handler="par_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">3</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">3</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3704,14 +3704,14 @@ Players will scale the image in order to achieve the specified aspect.</property
                                     <child>
                                       <object class="GtkLabel" id="scaled_size_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Scaled Size:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3720,17 +3720,17 @@ Players will scale the image in order to achieve the specified aspect.</property
                                       <object class="GtkSpinButton" id="scale_width">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">This is the width that the video will be stored at.
+                                        <property name="tooltip-text" translatable="yes">This is the width that the video will be stored at.
 The actual display dimensions will differ if the pixel aspect ratio is not 1:1.</property>
                                         <property name="adjustment">scale_width_adjustment</property>
-                                        <property name="snap_to_ticks">True</property>
+                                        <property name="snap-to-ticks">True</property>
                                         <signal name="value-changed" handler="scale_width_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3738,13 +3738,13 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                     <child>
                                       <object class="GtkLabel" id="label28">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                         <property name="label" translatable="yes">x</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">2</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">2</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3753,16 +3753,16 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkSpinButton" id="scale_height">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">This is the height that the video will be stored at.
+                                        <property name="tooltip-text" translatable="yes">This is the height that the video will be stored at.
 The actual display dimensions will differ if the pixel aspect ratio is not 1:1.</property>
                                         <property name="adjustment">scale_height_adjustment</property>
                                         <signal name="value-changed" handler="scale_height_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">3</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">3</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3771,18 +3771,18 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkCheckButton" id="PictureUseMaximumSize">
                                         <property name="label" translatable="yes">Optimal Size</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Use highest resolution permitted by above settings.</property>
+                                        <property name="tooltip-text" translatable="yes">Use highest resolution permitted by above settings.</property>
                                         <property name="halign">start</property>
                                         <property name="active">False</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="scale_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">5</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">5</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3791,18 +3791,18 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkCheckButton" id="PictureAllowUpscaling">
                                         <property name="label" translatable="yes">Allow Upscaling</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">If not enabled, scaled dimensions will be limited to source dimensions.</property>
+                                        <property name="tooltip-text" translatable="yes">If not enabled, scaled dimensions will be limited to source dimensions.</property>
                                         <property name="halign">start</property>
                                         <property name="active">False</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="scale_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">6</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">6</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3817,10 +3817,10 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                             <child type="label">
                               <object class="GtkLabel" id="label25">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Resolution &amp;amp; Scaling&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
@@ -3831,17 +3831,17 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                         <child>
                           <object class="GtkFrame" id="frame4">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="label_xalign">0</property>
-                            <property name="shadow_type">none</property>
+                            <property name="label-xalign">0</property>
+                            <property name="shadow-type">none</property>
                             <property name="margin-start">2</property>
                             <property name="margin-end">2</property>
                             <child>
                               <object class="GtkBox" id="vbox10">
                                 <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">2</property>
                                 <child>
@@ -3849,7 +3849,7 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                     <property name="row-spacing">2</property>
                                     <property name="column-spacing">4</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="valign">start</property>
                                     <property name="column-spacing">8</property>
@@ -3857,13 +3857,13 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                     <child>
                                       <object class="GtkLabel" id="pad_mode_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Fill:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3872,16 +3872,16 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkComboBox" id="PicturePadMode">
                                         <property name="hexpand">False</property>
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="width_request">100</property>
+                                        <property name="width-request">100</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Add a border around the video.</property>
+                                        <property name="tooltip-text" translatable="yes">Add a border around the video.</property>
                                         <signal name="changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">0</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">0</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3891,15 +3891,15 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkSpinButton" id="PicturePadLeft">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Left Pad</property>
+                                        <property name="tooltip-text" translatable="yes">Left Pad</property>
                                         <property name="adjustment">LeftPadAdjustment</property>
                                         <signal name="value-changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3908,15 +3908,15 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkSpinButton" id="PicturePadTop">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Top Pad</property>
+                                        <property name="tooltip-text" translatable="yes">Top Pad</property>
                                         <property name="adjustment">TopPadAdjustment</property>
                                         <signal name="value-changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">1</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3925,15 +3925,15 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkSpinButton" id="PicturePadBottom">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Bottom Pad</property>
+                                        <property name="tooltip-text" translatable="yes">Bottom Pad</property>
                                         <property name="adjustment">BottomPadAdjustment</property>
                                         <signal name="value-changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">3</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3942,15 +3942,15 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkSpinButton" id="PicturePadRight">
                                         <property name="width-chars">4</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Right Pad</property>
+                                        <property name="tooltip-text" translatable="yes">Right Pad</property>
                                         <property name="adjustment">RightPadAdjustment</property>
                                         <signal name="value-changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="left_attach">2</property>
+                                        <property name="top-attach">2</property>
+                                        <property name="left-attach">2</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3958,13 +3958,13 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                     <child>
                                       <object class="GtkLabel" id="pad_color_label">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Color:</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">0</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">0</property>
                                         <property name="width">1</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3973,16 +3973,16 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                       <object class="GtkComboBox" id="PicturePadColor">
                                         <property name="hexpand">False</property>
                                         <property name="valign">GTK_ALIGN_CENTER</property>
-                                        <property name="width_request">100</property>
+                                        <property name="width-request">100</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Color of border added around video.</property>
+                                        <property name="tooltip-text" translatable="yes">Color of border added around video.</property>
                                         <signal name="changed" handler="pad_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="left_attach">1</property>
+                                        <property name="top-attach">4</property>
+                                        <property name="left-attach">1</property>
                                         <property name="width">2</property>
                                         <property name="height">1</property>
                                       </packing>
@@ -3997,10 +3997,10 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                             <child type="label">
                               <object class="GtkLabel" id="label29">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Borders&lt;/b&gt;</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                               </object>
                             </child>
                           </object>
@@ -4016,10 +4016,10 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                     <child>
                       <object class="GtkFrame" id="final_dimensions_frame">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="label-xalign">0</property>
+                        <property name="shadow-type">none</property>
                         <property name="margin-start">2</property>
                         <property name="margin-end">2</property>
                         <child>
@@ -4028,19 +4028,19 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                             <property name="row-spacing">4</property>
                             <property name="column-spacing">32</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkBox" id="final_storage_hbox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="final_storage_size_label">
                                     <property name="label" translatable="yes">Storage Size:</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -4052,7 +4052,7 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                   <object class="GtkLabel" id="final_storage_size">
                                     <property name="label" translatable="yes">--</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -4062,8 +4062,8 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -4073,20 +4073,20 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                 <property name="row-spacing">2</property>
                                 <property name="column-spacing">4</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="valign">start</property>
                                 <child>
                                   <object class="GtkLabel" id="display_size_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">Display Size:</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">0</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">0</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -4095,16 +4095,16 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                   <object class="GtkSpinButton" id="PictureDARWidth">
                                     <property name="width-chars">4</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Changing the display size will stretch the video.</property>
+                                    <property name="tooltip-text" translatable="yes">Changing the display size will stretch the video.</property>
                                     <property name="adjustment">DisplayWidthAdjustment</property>
-                                    <property name="snap_to_ticks">True</property>
+                                    <property name="snap-to-ticks">True</property>
                                     <signal name="value-changed" handler="display_width_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">1</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">1</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -4112,13 +4112,13 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                 <child>
                                   <object class="GtkLabel" id="display_size_x_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="label" translatable="yes">x</property>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">2</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">2</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -4127,15 +4127,15 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                   <object class="GtkSpinButton" id="DisplayHeight">
                                     <property name="width-chars">4</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Changing the display size will stretch the video.</property>
+                                    <property name="tooltip-text" translatable="yes">Changing the display size will stretch the video.</property>
                                     <property name="adjustment">DisplayHeightAdjustment</property>
                                     <signal name="value-changed" handler="display_height_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">3</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">3</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
@@ -4144,26 +4144,26 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                   <object class="GtkCheckButton" id="PictureKeepRatio">
                                     <property name="label" translatable="yes">Automatic</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Changing the display size will stretch the video.</property>
+                                    <property name="tooltip-text" translatable="yes">Changing the display size will stretch the video.</property>
                                     <property name="halign">start</property>
                                     <property name="active">False</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <signal name="toggled" handler="scale_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
-                                    <property name="top_attach">0</property>
-                                    <property name="left_attach">4</property>
+                                    <property name="top-attach">0</property>
+                                    <property name="left-attach">4</property>
                                     <property name="width">1</property>
                                     <property name="height">1</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -4172,13 +4172,13 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                               <object class="GtkBox" id="final_aspect_hbox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="final_aspect_label">
                                     <property name="label" translatable="yes">Aspect Ratio:</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -4190,7 +4190,7 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                   <object class="GtkLabel" id="final_aspect_ratio">
                                     <property name="label" translatable="yes">--</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                   </object>
@@ -4200,8 +4200,8 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">2</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">2</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -4211,10 +4211,10 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                         <child type="label">
                           <object class="GtkLabel" id="final_dimensions_frame_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <property name="label" translatable="yes">&lt;b&gt;Final Dimensions&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                         </child>
                       </object>
@@ -4234,7 +4234,7 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                     <property name="orientation">horizontal</property>
                     <property name="selection-mode">none</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="column-spacing">4</property>
                     <property name="row-spacing">32</property>
                     <property name="margin-top">16</property>
@@ -4245,20 +4245,20 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                       <object class="GtkGrid" id="table10">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="label86">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Detelecine:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4266,34 +4266,34 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                         <child>
                           <object class="GtkComboBox" id="PictureDetelecine">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">This filter removes 'combing' artifacts that are the result of telecining.
+                            <property name="tooltip-text" translatable="yes">This filter removes 'combing' artifacts that are the result of telecining.
 
 Telecining is a process that adjusts film framerates that are 24fps to NTSC video frame rates which are 30fps.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureDetelecineCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom detelecine filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom detelecine filter string format
 
 JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4304,20 +4304,20 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                       <object class="GtkGrid" id="comb_detect_grid">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="comb_detect_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Interlace Detection:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4325,27 +4325,27 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                         <child>
                           <object class="GtkComboBox" id="PictureCombDetectPreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">This filter detects interlaced frames.
+                            <property name="tooltip-text" translatable="yes">This filter detects interlaced frames.
 
 If a deinterlace filter is enabled, only frames that this filter finds
 to be interlaced will be deinterlaced.</property>
                             <signal name="changed" handler="comb_detect_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureCombDetectCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom interlace detection filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom interlace detection filter string format
 
 Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:
 Block Thresh: Block Width: Block Height</property>
@@ -4353,8 +4353,8 @@ Block Thresh: Block Width: Block Height</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4365,20 +4365,20 @@ Block Thresh: Block Width: Block Height</property>
                       <object class="GtkGrid" id="table14">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="PictureDeinterlaceFilterLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Deinterlace:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4386,11 +4386,11 @@ Block Thresh: Block Width: Block Height</property>
                         <child>
                           <object class="GtkComboBox" id="PictureDeinterlaceFilter">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Choose decomb or deinterlace filter.
+                            <property name="tooltip-text" translatable="yes">Choose decomb or deinterlace filter.
 
 The decomb filter supports a variety of interpolation algorithms.
 The deinterlace filter is a classic YADIF deinterlacer.
@@ -4398,8 +4398,8 @@ The deinterlace filter is a classic YADIF deinterlacer.
                             <signal name="changed" handler="deint_filter_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4407,13 +4407,13 @@ The deinterlace filter is a classic YADIF deinterlacer.
                         <child>
                           <object class="GtkLabel" id="PictureDeinterlacePresetLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Deinterlace Preset:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4421,11 +4421,11 @@ The deinterlace filter is a classic YADIF deinterlacer.
                         <child>
                           <object class="GtkComboBox" id="PictureDeinterlacePreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Choose decomb or deinterlace filter options.
+                            <property name="tooltip-text" translatable="yes">Choose decomb or deinterlace filter options.
 
 The decomb filter supports a variety of interpolation algorithms.
 The deinterlace filter is a classic YADIF deinterlacer.
@@ -4433,22 +4433,22 @@ The deinterlace filter is a classic YADIF deinterlacer.
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureDeinterlaceCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes"></property>
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes"></property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4459,20 +4459,20 @@ The deinterlace filter is a classic YADIF deinterlacer.
                       <object class="GtkGrid" id="table90">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="PictureDeblockPresetLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Deblock Filter:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4480,17 +4480,17 @@ The deinterlace filter is a classic YADIF deinterlacer.
                         <child>
                           <object class="GtkComboBox" id="PictureDeblockPreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">The deblocking filter removes a common type of compression artifact.
+                            <property name="tooltip-text" translatable="yes">The deblocking filter removes a common type of compression artifact.
 If your source exhibits 'blockiness', this filter may help clean it up.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4498,13 +4498,13 @@ If your source exhibits 'blockiness', this filter may help clean it up.</propert
                         <child>
                           <object class="GtkLabel" id="PictureDeblockTuneLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Deblock Tune:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4512,33 +4512,33 @@ If your source exhibits 'blockiness', this filter may help clean it up.</propert
                         <child>
                           <object class="GtkComboBox" id="PictureDeblockTune">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">The deblocking filter removes a common type of compression artifact.
+                            <property name="tooltip-text" translatable="yes">The deblocking filter removes a common type of compression artifact.
 If your source exhibits 'blockiness', this filter may help clean it up.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureDeblockCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom deblock filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom deblock filter string format
 
 strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4549,20 +4549,20 @@ strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                       <object class="GtkGrid" id="table1">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="label32">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Denoise Filter:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4570,18 +4570,18 @@ strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                         <child>
                           <object class="GtkComboBox" id="PictureDenoiseFilter">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
+                            <property name="tooltip-text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
 Film grain and other types of high frequency noise are difficult to compress.
 Using this filter on such sources can result in smaller file sizes.</property>
                             <signal name="changed" handler="denoise_filter_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4589,13 +4589,13 @@ Using this filter on such sources can result in smaller file sizes.</property>
                         <child>
                           <object class="GtkLabel" id="PictureDenoisePresetLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Denoise Preset:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4603,18 +4603,18 @@ Using this filter on such sources can result in smaller file sizes.</property>
                         <child>
                           <object class="GtkComboBox" id="PictureDenoisePreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
+                            <property name="tooltip-text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
 Film grain and other types of high frequency noise are difficult to compress.
 Using this filter on such sources can result in smaller file sizes.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4622,13 +4622,13 @@ Using this filter on such sources can result in smaller file sizes.</property>
                         <child>
                           <object class="GtkLabel" id="PictureDenoiseTuneLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Denoise Tune:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4636,34 +4636,34 @@ Using this filter on such sources can result in smaller file sizes.</property>
                         <child>
                           <object class="GtkComboBox" id="PictureDenoiseTune">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
+                            <property name="tooltip-text" translatable="yes">Denoise filtering reduces or removes the appearance of noise and grain.
 Film grain and other types of high frequency noise are difficult to compress.
 Using this filter on such sources can result in smaller file sizes.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureDenoiseCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom denoise filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom denoise filter string format
 
 SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4674,20 +4674,20 @@ SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                       <object class="GtkGrid" id="chroma_smooth_grid">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="PictureChromaSmoothPresetLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Chroma Smooth Filter:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4695,17 +4695,17 @@ SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                         <child>
                           <object class="GtkComboBox" id="PictureChromaSmoothPreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">The chroma smooth filter removes common color artifacts.
+                            <property name="tooltip-text" translatable="yes">The chroma smooth filter removes common color artifacts.
 Lower resolution analog source content may benefit from this filter.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4713,13 +4713,13 @@ Lower resolution analog source content may benefit from this filter.</property>
                         <child>
                           <object class="GtkLabel" id="PictureChromaSmoothTuneLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Chroma Smooth Tune:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4727,33 +4727,33 @@ Lower resolution analog source content may benefit from this filter.</property>
                         <child>
                           <object class="GtkComboBox" id="PictureChromaSmoothTune">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">The chroma smooth filter removes common color artifacts.
+                            <property name="tooltip-text" translatable="yes">The chroma smooth filter removes common color artifacts.
 Lower resolution analog source content may benefit from this filter.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureChromaSmoothCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom deblock filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom deblock filter string format
 
 strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4764,20 +4764,20 @@ strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                       <object class="GtkGrid" id="SharpenTable">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="PictureSharpenFilterLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Sharpen Filter:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4785,17 +4785,17 @@ strength=weak|strong:thresh=0-100:blocksize=4-512</property>
                         <child>
                           <object class="GtkComboBox" id="PictureSharpenFilter">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Sharpen filtering enhances edges and other
+                            <property name="tooltip-text" translatable="yes">Sharpen filtering enhances edges and other
 high frequency components in the video.</property>
                             <signal name="changed" handler="sharpen_filter_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4803,13 +4803,13 @@ high frequency components in the video.</property>
                         <child>
                           <object class="GtkLabel" id="PictureSharpenPresetLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Sharpen Preset:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4817,17 +4817,17 @@ high frequency components in the video.</property>
                         <child>
                           <object class="GtkComboBox" id="PictureSharpenPreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Sharpen filtering enhances edges and other
+                            <property name="tooltip-text" translatable="yes">Sharpen filtering enhances edges and other
 high frequency components in the video.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4835,13 +4835,13 @@ high frequency components in the video.</property>
                         <child>
                           <object class="GtkLabel" id="PictureSharpenTuneLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Sharpen Tune:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4849,33 +4849,33 @@ high frequency components in the video.</property>
                         <child>
                           <object class="GtkComboBox" id="PictureSharpenTune">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Sharpen filtering enhances edges and other
+                            <property name="tooltip-text" translatable="yes">Sharpen filtering enhances edges and other
 high frequency components in the video.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureSharpenCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom denoise filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom denoise filter string format
 
 SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4886,13 +4886,13 @@ SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                       <object class="GtkCheckButton" id="VideoGrayScale">
                         <property name="label" translatable="yes">Grayscale</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">If enabled, filter colour components out of video.</property>
+                        <property name="tooltip-text" translatable="yes">If enabled, filter colour components out of video.</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="filter_widget_changed_cb" swapped="no"/>
                       </object>
                     </child>
@@ -4900,20 +4900,20 @@ SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                       <object class="GtkGrid" id="ColorspaceGrid">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="column_spacing">5</property>
+                        <property name="can-focus">False</property>
+                        <property name="column-spacing">5</property>
                         <property name="halign">start</property>
                         <property name="valign">start</property>
                         <child>
                           <object class="GtkLabel" id="ColorspaceLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="halign">start</property>
                             <property name="label" translatable="yes">Colorspace:</property>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4921,32 +4921,32 @@ SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma</property>
                         <child>
                           <object class="GtkComboBox" id="PictureColorspacePreset">
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="width_request">100</property>
+                            <property name="width-request">100</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Translate the colorspace of the source.</property>
+                            <property name="tooltip-text" translatable="yes">Translate the colorspace of the source.</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkEntry" id="PictureColorspaceCustom">
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Custom detelecine filter string format
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Custom detelecine filter string format
 
 JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                             <property name="width-chars">8</property>
                             <signal name="changed" handler="filter_widget_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">1</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">1</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -4964,35 +4964,35 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                   <object class="GtkBox" id="video_tab">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="spacing">0</property>
                     <child>
                       <object class="GtkBox" id="hbox17">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="spacing">48</property>
                         <child>
                           <object class="GtkGrid" id="table15">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="column_spacing">5</property>
+                            <property name="column-spacing">5</property>
                             <property name="row-spacing">2</property>
                             <property name="margin-top">12</property>
                             <property name="margin-start">0</property>
                             <child>
                               <object class="GtkLabel" id="label46">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Video Encoder:</property>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5001,13 +5001,13 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                               <object class="GtkComboBox" id="VideoEncoder">
                                 <property name="visible">True</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="can_focus">False</property>
-                                <property name="tooltip_text" translatable="yes">Available video encoders.</property>
+                                <property name="can-focus">False</property>
+                                <property name="tooltip-text" translatable="yes">Available video encoders.</property>
                                 <signal name="changed" handler="vcodec_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5015,14 +5015,14 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                             <child>
                               <object class="GtkLabel" id="label47">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Framerate:</property>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5031,17 +5031,17 @@ JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity</property>
                               <object class="GtkComboBox" id="VideoFramerate">
                                 <property name="visible">True</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Output framerate.
+                                <property name="tooltip-text" translatable="yes">Output framerate.
 
 'Same as source' is recommended. If your source video has
 a variable framerate, 'Same as source' will preserve it.</property>
                                 <signal name="changed" handler="framerate_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5050,17 +5050,17 @@ a variable framerate, 'Same as source' will preserve it.</property>
                               <object class="GtkRadioButton" id="VideoFramerateCFR">
                                 <property name="label" translatable="yes">Constant Framerate</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Enables constant framerate output.</property>
+                                <property name="tooltip-text" translatable="yes">Enables constant framerate output.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="framerate_mode_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">2</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5069,21 +5069,21 @@ a variable framerate, 'Same as source' will preserve it.</property>
                               <object class="GtkRadioButton" id="VideoFrameratePFR">
                                 <property name="label" translatable="yes">Peak Framerate (VFR)</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Enables variable framerate output with a peak
+                                <property name="tooltip-text" translatable="yes">Enables variable framerate output with a peak
 rate determined by the framerate setting.
 
 VFR is not compatible with some players.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">VideoFramerateCFR</property>
                                 <signal name="toggled" handler="framerate_mode_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">2</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5092,20 +5092,20 @@ VFR is not compatible with some players.</property>
                               <object class="GtkRadioButton" id="VideoFramerateVFR">
                                 <property name="label" translatable="yes">Variable Framerate</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Enables variable framerate output.
+                                <property name="tooltip-text" translatable="yes">Enables variable framerate output.
 
 VFR is not compatible with some players.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">VideoFramerateCFR</property>
                                 <signal name="toggled" handler="framerate_mode_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">2</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5118,9 +5118,9 @@ VFR is not compatible with some players.</property>
                         <child>
                           <object class="GtkGrid" id="table8">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="column_spacing">5</property>
+                            <property name="column-spacing">5</property>
                             <property name="row-spacing">2</property>
                             <property name="margin-top">12</property>
                             <property name="margin-start">2</property>
@@ -5129,9 +5129,9 @@ VFR is not compatible with some players.</property>
                             <child>
                               <object class="GtkScale" id="VideoQualitySlider">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Set the desired quality factor.
+                                <property name="tooltip-text" translatable="yes">Set the desired quality factor.
 The encoder targets a certain quality.
 The scale used by each video encoder is different.
 
@@ -5150,8 +5150,8 @@ These encoders do not have a lossless mode.</property>
                                 <signal name="value-changed" handler="vquality_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">3</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5160,10 +5160,10 @@ These encoders do not have a lossless mode.</property>
                               <object class="GtkRadioButton" id="vquality_type_constant">
                                 <property name="label" translatable="yes">Constant Quality:</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Set the desired quality factor.
+                                <property name="tooltip-text" translatable="yes">Set the desired quality factor.
 The encoder targets a certain quality.
 The scale used by each video encoder is different.
 
@@ -5177,12 +5177,12 @@ FFMpeg's and Theora's scale is more linear.
 These encoders do not have a lossless mode.</property>
                                 <property name="halign">start</property>
                                 <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="vquality_type_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5191,22 +5191,22 @@ These encoders do not have a lossless mode.</property>
                               <object class="GtkRadioButton" id="vquality_type_bitrate">
                                 <property name="label" translatable="yes">Bitrate (kbps):    </property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Set the average bitrate.
+                                <property name="tooltip-text" translatable="yes">Set the average bitrate.
 
 The instantaneous bitrate can be much higher or lower at any point in time.
 But the average over a long duration will be the value set here.  If you need
 to limit instantaneous bitrate, look into x264's vbv-bufsize and vbv-maxrate settings.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <property name="group">vquality_type_constant</property>
                                 <signal name="toggled" handler="vquality_type_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5214,9 +5214,9 @@ to limit instantaneous bitrate, look into x264's vbv-bufsize and vbv-maxrate set
                             <child>
                               <object class="GtkSpinButton" id="VideoAvgBitrate">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Set the average bitrate.
+                                <property name="tooltip-text" translatable="yes">Set the average bitrate.
 
 The instantaneous bitrate can be much higher or lower at any point in time.
 But the average over a long duration will be the value set here.  If you need
@@ -5225,8 +5225,8 @@ to limit instantaneous bitrate, look into x264's vbv-bufsize and vbv-maxrate set
                                 <signal name="value-changed" handler="vbitrate_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5235,21 +5235,21 @@ to limit instantaneous bitrate, look into x264's vbv-bufsize and vbv-maxrate set
                               <object class="GtkCheckButton" id="VideoTwoPass">
                                 <property name="label" translatable="yes">2-Pass Encoding</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Perform 2 Pass Encoding.
+                                <property name="tooltip-text" translatable="yes">Perform 2 Pass Encoding.
 
 The 'Bitrate' option is prerequisite. During the 1st pass, statistics about
 the video are collected.  Then in the second pass, those statistics are used
 to make bitrate allocation decisions.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5258,18 +5258,18 @@ to make bitrate allocation decisions.</property>
                               <object class="GtkCheckButton" id="VideoTurboTwoPass">
                                 <property name="label" translatable="yes">Turbo First Pass</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">During the 1st pass of a 2 pass encode, use settings that speed things along.</property>
+                                <property name="tooltip-text" translatable="yes">During the 1st pass of a 2 pass encode, use settings that speed things along.</property>
                                 <property name="halign">start</property>
                                 <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="setting_widget_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5288,7 +5288,7 @@ to make bitrate allocation decisions.</property>
                       <object class="GtkBox" id="VideoSettings">
                         <property name="orientation">vertical</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="margin-top">2</property>
                         <property name="margin-bottom">2</property>
@@ -5298,22 +5298,22 @@ to make bitrate allocation decisions.</property>
                         <child>
                           <object class="GtkGrid" id="VideoSettingsTable">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="column_spacing">5</property>
+                            <property name="column-spacing">5</property>
                             <property name="row-spacing">2</property>
                             <property name="vexpand">True</property>
                             <child>
                               <object class="GtkLabel" id="VideoPresetLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Preset:</property>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5321,9 +5321,9 @@ to make bitrate allocation decisions.</property>
                             <child>
                               <object class="GtkScale" id="VideoPresetSlider">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Adjusts encoder settings to trade off compression efficiency against encoding speed.
+                                <property name="tooltip-text" translatable="yes">Adjusts encoder settings to trade off compression efficiency against encoding speed.
 
 This establishes your default encoder settings.
 Tunes, profiles, levels and extra options string will be applied to this.
@@ -5331,14 +5331,14 @@ You should generally set this option to the slowest you can bear since slower
 settings will result in better quality or smaller files.</property>
                                 <property name="adjustment">VideoPresetRange</property>
                                 <property name="digits">0</property>
-                                <property name="value_pos">right</property>
+                                <property name="value-pos">right</property>
                                 <property name="hexpand">True</property>
                                 <signal name="format-value" handler="format_video_preset_cb" swapped="no"/>
                                 <signal name="value-changed" handler="video_preset_slider_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">0</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">0</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">5</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5346,16 +5346,16 @@ settings will result in better quality or smaller files.</property>
                             <child>
                               <object class="GtkLabel" id="VideoTuneLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Tune:</property>
-                                <property name="margin_top">8</property>
-                                <property name="margin_bottom">8</property>
+                                <property name="margin-top">8</property>
+                                <property name="margin-bottom">8</property>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5364,9 +5364,9 @@ settings will result in better quality or smaller files.</property>
                               <object class="GtkComboBox" id="VideoTune">
                                 <property name="visible">True</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Tune settings to optimize for common scenarios.
+                                <property name="tooltip-text" translatable="yes">Tune settings to optimize for common scenarios.
 
 This can improve efficiency for particular source characteristics or set
 characteristics of the output file.  Changes will be applied after the
@@ -5374,8 +5374,8 @@ preset but before all other parameters.</property>
                                 <signal name="changed" handler="video_setting_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5384,20 +5384,20 @@ preset but before all other parameters.</property>
                               <object class="GtkCheckButton" id="x264FastDecode">
                                 <property name="label" translatable="yes">Fast Decode</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Reduce decoder CPU usage.
+                                <property name="tooltip-text" translatable="yes">Reduce decoder CPU usage.
 
 Set this if your device is struggling to play the output (dropped frames).</property>
                                 <property name="halign">start</property>
                                 <property name="margin-start">2</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="video_setting_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">2</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">2</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5406,10 +5406,10 @@ Set this if your device is struggling to play the output (dropped frames).</prop
                               <object class="GtkCheckButton" id="x264ZeroLatency">
                                 <property name="visible">False</property>
                                 <property name="label" translatable="yes">Zero Latency</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Minimize latency between input to encoder and output of decoder.
+                                <property name="tooltip-text" translatable="yes">Minimize latency between input to encoder and output of decoder.
 
 This is useful for broadcast of live streams.
 
@@ -5417,12 +5417,12 @@ Since HandBrake is not suitable for live stream broadcast purposes,
 this setting is of little value here.</property>
                                 <property name="halign">start</property>
                                 <property name="margin-start">2</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="video_setting_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">1</property>
-                                <property name="left_attach">3</property>
+                                <property name="top-attach">1</property>
+                                <property name="left-attach">3</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5430,16 +5430,16 @@ this setting is of little value here.</property>
                             <child>
                               <object class="GtkLabel" id="VideoProfileLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Profile:</property>
-                                <property name="margin_top">8</property>
-                                <property name="margin_bottom">8</property>
+                                <property name="margin-top">8</property>
+                                <property name="margin-bottom">8</property>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5448,16 +5448,16 @@ this setting is of little value here.</property>
                               <object class="GtkComboBox" id="VideoProfile">
                                 <property name="visible">True</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Sets and ensures compliance with the specified profile.
+                                <property name="tooltip-text" translatable="yes">Sets and ensures compliance with the specified profile.
 
 Overrides all other settings.</property>
                                 <signal name="changed" handler="video_setting_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5465,16 +5465,16 @@ Overrides all other settings.</property>
                             <child>
                               <object class="GtkLabel" id="VideoLevelLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Level:</property>
-                                <property name="margin_top">8</property>
-                                <property name="margin_bottom">8</property>
+                                <property name="margin-top">8</property>
+                                <property name="margin-bottom">8</property>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">0</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">0</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5483,16 +5483,16 @@ Overrides all other settings.</property>
                               <object class="GtkComboBox" id="VideoLevel">
                                 <property name="visible">True</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Sets and ensures compliance with the specified level.
+                                <property name="tooltip-text" translatable="yes">Sets and ensures compliance with the specified level.
 
 Overrides all other settings.</property>
                                 <signal name="changed" handler="video_setting_changed_cb" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="top_attach">3</property>
-                                <property name="left_attach">1</property>
+                                <property name="top-attach">3</property>
+                                <property name="left-attach">1</property>
                                 <property name="width">1</property>
                                 <property name="height">1</property>
                               </packing>
@@ -5501,13 +5501,13 @@ Overrides all other settings.</property>
                               <object class="GtkBox" id="hbox43">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">5</property>
                                 <child>
                                   <object class="GtkLabel" id="VideoOptionExtraLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">More Settings:</property>
@@ -5521,18 +5521,18 @@ Overrides all other settings.</property>
                                 <child>
                                   <object class="GtkScrolledWindow" id="VideoOptionExtraWindow">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="shadow_type">etched-in</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="shadow-type">etched-in</property>
                                     <property name="hexpand">True</property>
                                     <child>
                                       <object class="GtkTextView" id="VideoOptionExtra">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">Additional encoder settings.
+                                        <property name="can-focus">True</property>
+                                        <property name="tooltip-text" translatable="yes">Additional encoder settings.
 
 Colon separated list of encoder options.</property>
-                                        <property name="wrap_mode">char</property>
-                                        <property name="accepts_tab">False</property>
+                                        <property name="wrap-mode">char</property>
+                                        <property name="accepts-tab">False</property>
                                       </object>
                                     </child>
                                   </object>
@@ -5542,8 +5542,8 @@ Colon separated list of encoder options.</property>
                                 </child>
                               </object>
                               <packing>
-                                <property name="top_attach">2</property>
-                                <property name="left_attach">2</property>
+                                <property name="top-attach">2</property>
+                                <property name="left-attach">2</property>
                                 <property name="width">4</property>
                                 <property name="height">2</property>
                               </packing>
@@ -5568,18 +5568,18 @@ Colon separated list of encoder options.</property>
                 <child>
                   <object class="GtkBox" id="audio_tab">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">horizontal</property>
                     <property name="margin-start">0</property>
                     <property name="margin-end">0</property>
-                    <property name="margin_top">12</property>
-                    <property name="margin_bottom">0</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">0</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <child>
                       <object class="GtkStackSidebar" id="AudioStackSidebar">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="stack">AudioStack</property>
                         <property name="hexpand">False</property>
@@ -5598,7 +5598,7 @@ Colon separated list of encoder options.</property>
                         <property name="transition-duration">400</property>
                         <property name="visible">True</property>
                         <property name="expand">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
 
                         <property name="margin-top">0</property>
                         <property name="margin-bottom">0</property>
@@ -5607,30 +5607,30 @@ Colon separated list of encoder options.</property>
                           <object class="GtkBox" id="audio_list_tab">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkBox" id="vbox17">
                                 <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">2</property>
                                 <property name="vexpand">True</property>
                                 <child>
                                   <object class="GtkToolbar" id="audio_toolbar">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <child>
                                       <object class="GtkToolButton" id="audio_add">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="is_important">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Add</property>
-                                        <property name="icon_name">list-add</property>
-                                        <property name="tooltip_text" translatable="yes">Add new audio settings to the list</property>
+                                        <property name="icon-name">list-add</property>
+                                        <property name="tooltip-text" translatable="yes">Add new audio settings to the list</property>
                                         <signal name="clicked" handler="audio_add_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -5638,11 +5638,11 @@ Colon separated list of encoder options.</property>
                                       <object class="GtkToolButton" id="audio_add_all">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="is_important">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Add All</property>
-                                        <property name="icon_name">list-add</property>
-                                        <property name="tooltip_text" translatable="yes">Add all audio tracks to the list</property>
+                                        <property name="icon-name">list-add</property>
+                                        <property name="tooltip-text" translatable="yes">Add all audio tracks to the list</property>
                                         <signal name="clicked" handler="audio_add_all_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -5650,12 +5650,12 @@ Colon separated list of encoder options.</property>
                                       <object class="GtkToolButton" id="audio_reset">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="is_important">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Reload</property>
-                                        <property name="icon_name">view-refresh</property>
-                                        <property name="tooltip_text" translatable="yes">Reload all audio settings from defaults</property>
+                                        <property name="icon-name">view-refresh</property>
+                                        <property name="tooltip-text" translatable="yes">Reload all audio settings from defaults</property>
                                         <signal name="clicked" handler="audio_reset_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -5667,18 +5667,18 @@ Colon separated list of encoder options.</property>
                                 <child>
                                   <object class="GtkScrolledWindow" id="scrolledwindow5">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="vexpand">True</property>
                                     <property name="valign">GTK_ALIGN_FILL</property>
                                     <child>
                                       <object class="GtkTreeView" id="audio_list_view">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="headers_visible">False</property>
-                                        <property name="headers_clickable">False</property>
+                                        <property name="headers-visible">False</property>
+                                        <property name="headers-clickable">False</property>
                                         <child internal-child="selection">
                                           <object class="GtkTreeSelection" id="treeview-selection1"/>
                                         </child>
@@ -5705,37 +5705,37 @@ Colon separated list of encoder options.</property>
                         <child>
                           <object class="GtkBox" id="audio_selection_tab">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="hexpand">True</property>
                             <child>
                               <object class="GtkBox" id="audio_selection_box1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="orientation">horizontal</property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkBox" id="audio_defaults_box2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkGrid" id="grid2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <property name="row-spacing">2</property>
                                         <child>
                                           <object class="GtkLabel" id="label4">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Selection Behavior:</property>
                                             <property name="justify">right</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5744,13 +5744,13 @@ Colon separated list of encoder options.</property>
                                           <object class="GtkComboBox" id="AudioTrackSelectionBehavior">
                                             <property name="visible">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">Choose which audio tracks of the source media are used.</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Choose which audio tracks of the source media are used.</property>
                                             <signal name="changed" handler="audio_def_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5763,34 +5763,34 @@ Colon separated list of encoder options.</property>
                                     <child>
                                       <object class="GtkGrid" id="grid3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <property name="row-spacing">2</property>
                                         <property name="halign">GTK_ALIGN_END</property>
-                                        <property name="margin_top">6</property>
-                                        <property name="margin_bottom">6</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
                                         <property name="vexpand">True</property>
                                         <child>
                                           <object class="GtkScrolledWindow" id="scrolledwindow10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="min_content_height">84</property>
+                                            <property name="min-content-height">84</property>
                                             <property name="vexpand">True</property>
                                             <child>
                                               <object class="GtkTreeView" id="audio_avail_lang">
                                                 <property name="visible">True</property>
                                                 <property name="headers-visible">False</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="vexpand">True</property>
                                                 <signal name="row-activated" handler="audio_avail_lang_activated_cb" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">4</property>
                                           </packing>
@@ -5798,23 +5798,23 @@ Colon separated list of encoder options.</property>
                                         <child>
                                           <object class="GtkScrolledWindow" id="scrolledwindow11">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                             <child>
                                               <object class="GtkTreeView" id="audio_selected_lang">
                                                 <property name="visible">True</property>
                                                 <property name="headers-visible">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text" translatable="yes">Create a list of languages you would like to select audio for.
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text" translatable="yes">Create a list of languages you would like to select audio for.
 Tracks matching these languages will be selected using the chosen Selection Behavior.</property>
                                                 <signal name="row-activated" handler="audio_selected_lang_activated_cb" swapped="no"/>
                                               </object>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">4</property>
                                           </packing>
@@ -5823,14 +5823,14 @@ Tracks matching these languages will be selected using the chosen Selection Beha
                                           <object class="GtkButton" id="audio_lang_add">
                                             <property name="label" translatable="yes">Add</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
                                             <signal name="clicked" handler="audio_add_lang_clicked_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5839,14 +5839,14 @@ Tracks matching these languages will be selected using the chosen Selection Beha
                                           <object class="GtkButton" id="audio_lang_remove">
                                             <property name="label" translatable="yes">Remove</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
                                             <signal name="clicked" handler="audio_remove_lang_clicked_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">3</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5854,12 +5854,12 @@ Tracks matching these languages will be selected using the chosen Selection Beha
                                         <child>
                                           <object class="GtkLabel" id="label8">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Available Languages</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5867,12 +5867,12 @@ Tracks matching these languages will be selected using the chosen Selection Beha
                                         <child>
                                           <object class="GtkLabel" id="label24">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Selected Languages</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5886,14 +5886,14 @@ Tracks matching these languages will be selected using the chosen Selection Beha
                                       <object class="GtkCheckButton" id="AudioSecondaryEncoderMode">
                                         <property name="label" translatable="yes">Use only first encoder for secondary audio</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="receives-default">False</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="tooltip_text" translatable="yes">Only the primary audio track will be encoded with the full encoder list.
+                                        <property name="tooltip-text" translatable="yes">Only the primary audio track will be encoded with the full encoder list.
 All other secondary audio output tracks will be encoded with first encoder only.</property>
                                         <property name="halign">start</property>
                                         <property name="active">True</property>
-                                        <property name="draw_indicator">True</property>
+                                        <property name="draw-indicator">True</property>
                                         <signal name="toggled" handler="audio_def_widget_changed_cb" swapped="no"/>
                                       </object>
                                       <packing>
@@ -5908,28 +5908,28 @@ All other secondary audio output tracks will be encoded with first encoder only.
                                 <child>
                                   <object class="GtkBox" id="auto_pass_box">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <property name="margin-start">6</property>
                                     <property name="spacing">2</property>
                                     <child>
                                       <object class="GtkGrid" id="grid4">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <property name="row-spacing">2</property>
                                         <property name="halign">end</property>
                                         <child>
                                           <object class="GtkLabel" id="labela3">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                             <property name="halign">start</property>
                                             <property name="label" translatable="yes">Auto Passthru:</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5938,19 +5938,19 @@ All other secondary audio output tracks will be encoded with first encoder only.
                                           <object class="GtkCheckButton" id="AudioAllowMP2Pass">
                                             <property name="label" translatable="yes">MP2</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports MP2.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports MP2.
 This permits MP2 passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5959,19 +5959,19 @@ This permits MP2 passthru to be selected when automatic passthru selection is en
                                           <object class="GtkCheckButton" id="AudioAllowMP3Pass">
                                             <property name="label" translatable="yes">MP3</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports MP3.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports MP3.
 This permits MP3 passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -5980,19 +5980,19 @@ This permits MP3 passthru to be selected when automatic passthru selection is en
                                           <object class="GtkCheckButton" id="AudioAllowAC3Pass">
                                             <property name="label" translatable="yes">AC-3</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports AC-3.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports AC-3.
 This permits AC-3 passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6001,19 +6001,19 @@ This permits AC-3 passthru to be selected when automatic passthru selection is e
                                           <object class="GtkCheckButton" id="AudioAllowEAC3Pass">
                                             <property name="label" translatable="yes">EAC-3</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports EAC-3.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports EAC-3.
 This permits EAC-3 passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6022,19 +6022,19 @@ This permits EAC-3 passthru to be selected when automatic passthru selection is 
                                           <object class="GtkCheckButton" id="AudioAllowDTSPass">
                                             <property name="label" translatable="yes">DTS</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports DTS.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports DTS.
 This permits DTS passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6043,19 +6043,19 @@ This permits DTS passthru to be selected when automatic passthru selection is en
                                           <object class="GtkCheckButton" id="AudioAllowDTSHDPass">
                                             <property name="label" translatable="yes">DTS-HD</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports DTS-HD.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports DTS-HD.
 This permits DTS-HD passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6064,19 +6064,19 @@ This permits DTS-HD passthru to be selected when automatic passthru selection is
                                           <object class="GtkCheckButton" id="AudioAllowTRUEHDPass">
                                             <property name="label" translatable="yes">TrueHD</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports TrueHD.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports TrueHD.
 This permits TrueHD passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">3</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6085,19 +6085,19 @@ This permits TrueHD passthru to be selected when automatic passthru selection is
                                           <object class="GtkCheckButton" id="AudioAllowFLACPass">
                                             <property name="label" translatable="yes">FLAC</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports FLAC.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports FLAC.
 This permits FLAC passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">3</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6106,19 +6106,19 @@ This permits FLAC passthru to be selected when automatic passthru selection is e
                                           <object class="GtkCheckButton" id="AudioAllowAACPass">
                                             <property name="label" translatable="yes">AAC</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports AAC.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports AAC.
 This permits AAC passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">4</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">4</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6127,19 +6127,19 @@ This permits AAC passthru to be selected when automatic passthru selection is en
                                           <object class="GtkCheckButton" id="AudioAllowOPUSPass">
                                             <property name="label" translatable="yes">Opus</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Enable this if your playback device supports Opus.
+                                            <property name="tooltip-text" translatable="yes">Enable this if your playback device supports Opus.
 This permits Opus passthru to be selected when automatic passthru selection is enabled.</property>
                                             <property name="halign">start</property>
                                             <property name="active">True</property>
-                                            <property name="draw_indicator">True</property>
+                                            <property name="draw-indicator">True</property>
                                             <signal name="toggled" handler="audio_passthru_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">4</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">4</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6152,14 +6152,14 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                     <child>
                                       <object class="GtkBox" id="auto_fallback_box">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
+                                        <property name="can-focus">False</property>
                                         <property name="orientation">horizontal</property>
                                         <property name="spacing">6</property>
                                         <property name="halign">end</property>
                                         <child>
                                           <object class="GtkLabel" id="labela4">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                             <property name="halign">end</property>
                                             <property name="hexpand">True</property>
@@ -6173,9 +6173,9 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                           <object class="GtkComboBox" id="AudioEncoderFallback">
                                             <property name="visible">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="tooltip_text" translatable="yes">Set the audio codec to encode with when a suitable track can not be found for audio passthru.</property>
+                                            <property name="tooltip-text" translatable="yes">Set the audio codec to encode with when a suitable track can not be found for audio passthru.</property>
                                             <signal name="changed" handler="audio_fallback_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
@@ -6200,12 +6200,12 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                             <child>
                               <object class="GtkLabel" id="audio_def_settings_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="margin_top">6</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-top">6</property>
                                 <property name="halign">start</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
                                 <property name="label" translatable="yes">&lt;b&gt;Audio Encoder Settings:&lt;/b&gt;</property>
-                                <property name="tooltip_markup" translatable="yes">Each selected source track will be encoded with all selected encoders</property>
+                                <property name="tooltip-markup" translatable="yes">Each selected source track will be encoded with all selected encoders</property>
                               </object>
                               <packing>
                                 <property name="position">2</property>
@@ -6214,7 +6214,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                             <child>
                               <object class="GtkSeparator" id="sep1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                               </object>
                               <packing>
                                 <property name="position">3</property>
@@ -6224,12 +6224,12 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                               <object class="GtkBox" id="audio_list_default_header">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_encoder_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Encoder</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6240,7 +6240,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_bitrate_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Bitrate/Quality</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6251,7 +6251,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_mixdown_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Mixdown</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6262,7 +6262,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_samplerate_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Samplerate</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6273,7 +6273,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_gain_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">Gain</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6284,7 +6284,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                 <child>
                                   <object class="GtkLabel" id="audio_defaults_drc_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="label" translatable="yes">DRC</property>
                                     <property name="halign">GTK_ALIGN_CENTER</property>
                                   </object>
@@ -6300,17 +6300,17 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                             <child>
                               <object class="GtkScrolledWindow" id="scrolledwindow12">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="hexpand">True</property>
                                 <property name="vexpand">True</property>
                                 <child>
                                   <object class="GtkListBox" id="audio_list_default">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="vexpand">True</property>
-                                    <property name="selection_mode">none</property>
-                                    <property name="activate_on_single_click">False</property>
+                                    <property name="selection-mode">none</property>
+                                    <property name="activate-on-single-click">False</property>
                                   </object>
                                 </child>
                               </object>
@@ -6340,18 +6340,18 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                 <child>
                   <object class="GtkBox" id="subtitle_tab">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="orientation">horizontal</property>
                     <property name="margin-start">0</property>
                     <property name="margin-end">0</property>
-                    <property name="margin_top">12</property>
-                    <property name="margin_bottom">0</property>
+                    <property name="margin-top">12</property>
+                    <property name="margin-bottom">0</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
                     <child>
                       <object class="GtkStackSidebar" id="SubtitleStackSidebar">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="stack">SubtitleStack</property>
                         <property name="hexpand">False</property>
@@ -6370,7 +6370,7 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                         <property name="transition-duration">400</property>
                         <property name="visible">True</property>
                         <property name="expand">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
 
                         <property name="margin-top">0</property>
                         <property name="margin-bottom">0</property>
@@ -6379,30 +6379,30 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                           <object class="GtkBox" id="subtitle_list_tab">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                             <child>
                               <object class="GtkBox" id="vbox12">
                                 <property name="orientation">vertical</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">2</property>
                                 <property name="vexpand">True</property>
                                 <child>
                                   <object class="GtkToolbar" id="subtitle_toolbar">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <child>
                                       <object class="GtkToolButton" id="subtitle_add">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="is_important">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Add</property>
-                                        <property name="icon_name">list-add</property>
-                                        <property name="tooltip_text" translatable="yes">Add new subtitle settings to the list</property>
+                                        <property name="icon-name">list-add</property>
+                                        <property name="tooltip-text" translatable="yes">Add new subtitle settings to the list</property>
                                         <signal name="clicked" handler="subtitle_add_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -6410,11 +6410,11 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                       <object class="GtkToolButton" id="subtitle_add_all">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="is_important">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Add All</property>
-                                        <property name="icon_name">list-add</property>
-                                        <property name="tooltip_text" translatable="yes">Add all subtitle tracks to the list</property>
+                                        <property name="icon-name">list-add</property>
+                                        <property name="tooltip-text" translatable="yes">Add all subtitle tracks to the list</property>
                                         <signal name="clicked" handler="subtitle_add_all_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -6422,11 +6422,11 @@ This permits Opus passthru to be selected when automatic passthru selection is e
                                       <object class="GtkToolButton" id="subtitle_add_fas">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="is_important">True</property>
+                                        <property name="can-focus">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Foreign Audio Scan</property>
-                                        <property name="icon_name">list-add</property>
-                                        <property name="tooltip_text" translatable="yes">Add an extra pass to the encode which searches
+                                        <property name="icon-name">list-add</property>
+                                        <property name="tooltip-text" translatable="yes">Add an extra pass to the encode which searches
 for subtitle candidates that provide subtitles for
 segments of the audio that are in a foreign language.</property>
                                         <signal name="clicked" handler="subtitle_add_fas_clicked_cb" swapped="no"/>
@@ -6436,12 +6436,12 @@ segments of the audio that are in a foreign language.</property>
                                       <object class="GtkToolButton" id="subtitle_reset">
                                         <property name="visible">True</property>
                                         <property name="sensitive">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="is_important">True</property>
+                                        <property name="is-important">True</property>
                                         <property name="label" translatable="yes">Reload</property>
-                                        <property name="icon_name">view-refresh</property>
-                                        <property name="tooltip_text" translatable="yes">Reload all subtitle settings from defaults</property>
+                                        <property name="icon-name">view-refresh</property>
+                                        <property name="tooltip-text" translatable="yes">Reload all subtitle settings from defaults</property>
                                         <signal name="clicked" handler="subtitle_reset_clicked_cb" swapped="no"/>
                                       </object>
                                     </child>
@@ -6453,18 +6453,18 @@ segments of the audio that are in a foreign language.</property>
                                 <child>
                                   <object class="GtkScrolledWindow" id="scrolledwindow4">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                     <property name="vexpand">True</property>
                                     <property name="valign">GTK_ALIGN_FILL</property>
                                     <child>
                                       <object class="GtkTreeView" id="subtitle_list_view">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can-focus">True</property>
                                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                        <property name="headers_visible">False</property>
-                                        <property name="headers_clickable">False</property>
+                                        <property name="headers-visible">False</property>
+                                        <property name="headers-clickable">False</property>
                                         <child internal-child="selection">
                                           <object class="GtkTreeSelection" id="treeview-selection2"/>
                                         </child>
@@ -6491,41 +6491,41 @@ segments of the audio that are in a foreign language.</property>
                         <child>
                           <object class="GtkBox" id="subtitle_selection_tab">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="orientation">vertical</property>
                             <property name="margin-start">12</property>
                             <property name="margin-end">12</property>
-                            <property name="margin_top">12</property>
-                            <property name="margin_bottom">12</property>
+                            <property name="margin-top">12</property>
+                            <property name="margin-bottom">12</property>
                             <property name="hexpand">True</property>
                             <child>
                               <object class="GtkBox" id="subtitle_selection_box1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="orientation">horizontal</property>
                                 <property name="spacing">6</property>
                                 <child>
                                   <object class="GtkBox" id="subtitle_selection_box2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="orientation">vertical</property>
                                     <child>
                                       <object class="GtkGrid" id="sub_grid2">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <property name="row-spacing">2</property>
                                         <child>
                                           <object class="GtkLabel" id="sub_label4">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Selection Behavior:</property>
                                             <property name="justify">right</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6534,13 +6534,13 @@ segments of the audio that are in a foreign language.</property>
                                           <object class="GtkComboBox" id="SubtitleTrackSelectionBehavior">
                                             <property name="visible">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="tooltip_text" translatable="yes">Choose which subtitle tracks of the source media are used.</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="tooltip-text" translatable="yes">Choose which subtitle tracks of the source media are used.</property>
                                             <signal name="changed" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6553,27 +6553,27 @@ segments of the audio that are in a foreign language.</property>
                                     <child>
                                       <object class="GtkGrid" id="sub_grid3">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="column_spacing">5</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="column-spacing">5</property>
                                         <property name="row-spacing">2</property>
                                         <property name="halign">GTK_ALIGN_END</property>
-                                        <property name="margin_top">6</property>
-                                        <property name="margin_bottom">6</property>
+                                        <property name="margin-top">6</property>
+                                        <property name="margin-bottom">6</property>
                                         <property name="vexpand">True</property>
                                         <child>
                                           <object class="GtkScrolledWindow" id="sub_scrolledwindow10">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                            <property name="min_content_height">108</property>
+                                            <property name="min-content-height">108</property>
                                             <property name="vexpand">True</property>
                                             <property name="halign">GTK_ALIGN_FILL</property>
                                             <child>
                                               <object class="GtkTreeView" id="subtitle_avail_lang">
                                                 <property name="visible">True</property>
                                                 <property name="headers-visible">False</property>
-                                                <property name="can_focus">True</property>
+                                                <property name="can-focus">True</property>
                                                 <property name="vexpand">True</property>
                                                 <property name="halign">GTK_ALIGN_FILL</property>
                                                 <signal name="row-activated" handler="subtitle_avail_lang_activated_cb" swapped="no"/>
@@ -6581,8 +6581,8 @@ segments of the audio that are in a foreign language.</property>
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">4</property>
                                           </packing>
@@ -6590,8 +6590,8 @@ segments of the audio that are in a foreign language.</property>
                                         <child>
                                           <object class="GtkScrolledWindow" id="sub_scrolledwindow11">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+                                            <property name="can-focus">False</property>
+                                            <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
                                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                             <property name="vexpand">True</property>
                                             <property name="halign">GTK_ALIGN_FILL</property>
@@ -6599,8 +6599,8 @@ segments of the audio that are in a foreign language.</property>
                                               <object class="GtkTreeView" id="subtitle_selected_lang">
                                                 <property name="visible">True</property>
                                                 <property name="headers-visible">False</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="tooltip_text" translatable="yes">Create a list of languages you would like to select subtitles for.
+                                                <property name="can-focus">True</property>
+                                                <property name="tooltip-text" translatable="yes">Create a list of languages you would like to select subtitles for.
 Tracks matching these languages will be selected using the chosen Selection Behavior.
 
 The first language in this list is your "preferred" language and will be used
@@ -6612,8 +6612,8 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                             </child>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">4</property>
                                           </packing>
@@ -6622,14 +6622,14 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                           <object class="GtkButton" id="subtitle_lang_add">
                                             <property name="label" translatable="yes">Add</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
                                             <signal name="clicked" handler="subtitle_add_lang_clicked_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">2</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">2</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6638,14 +6638,14 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                           <object class="GtkButton" id="subtitle_lang_remove">
                                             <property name="label" translatable="yes">Remove</property>
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">True</property>
+                                            <property name="can-focus">True</property>
+                                            <property name="receives-default">True</property>
                                             <property name="valign">GTK_ALIGN_CENTER</property>
                                             <signal name="clicked" handler="subtitle_remove_lang_clicked_cb" swapped="no"/>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="top_attach">3</property>
+                                            <property name="left-attach">1</property>
+                                            <property name="top-attach">3</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6653,12 +6653,12 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                         <child>
                                           <object class="GtkLabel" id="sub_label8">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Available Languages</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">0</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">0</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6666,12 +6666,12 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                         <child>
                                           <object class="GtkLabel" id="sub_label24">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="label" translatable="yes">Selected Languages</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">2</property>
-                                            <property name="top_attach">0</property>
+                                            <property name="left-attach">2</property>
+                                            <property name="top-attach">0</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6679,14 +6679,14 @@ for determining subtitle selection settings when there is foreign audio.</proper
                                         <child>
                                           <object class="GtkLabel" id="subtitle_preferred_language">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
+                                            <property name="can-focus">False</property>
                                             <property name="halign">end</property>
                                             <property name="label" translatable="yes">Preferred Language: None</property>
                                             <property name="justify">right</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">3</property>
-                                            <property name="top_attach">1</property>
+                                            <property name="left-attach">3</property>
+                                            <property name="top-attach">1</property>
                                             <property name="width">1</property>
                                             <property name="height">1</property>
                                           </packing>
@@ -6710,16 +6710,16 @@ for determining subtitle selection settings when there is foreign audio.</proper
                               <object class="GtkCheckButton" id="SubtitleAddForeignAudioSearch">
                                 <property name="label" translatable="yes">Add Foreign Audio Scan Pass</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Add "Foreign Audio Scan" when the default audio track is your preferred language.
+                                <property name="tooltip-text" translatable="yes">Add "Foreign Audio Scan" when the default audio track is your preferred language.
 This search pass finds short sequences of foreign audio and provides subtitles for them.
 
 This option requires a language to be set in the Selected Languages list.</property>
                                 <property name="halign">start</property>
                                 <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -6730,15 +6730,15 @@ This option requires a language to be set in the Selected Languages list.</prope
                               <object class="GtkCheckButton" id="SubtitleAddForeignAudioSubtitle">
                                 <property name="label" translatable="yes">Add subtitle track if default audio is foreign</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">When the default audio track is not your preferred language, add a subtitle track.
+                                <property name="tooltip-text" translatable="yes">When the default audio track is not your preferred language, add a subtitle track.
 
 This option requires a language to be set in the Selected Languages list.</property>
                                 <property name="halign">start</property>
                                 <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -6749,12 +6749,12 @@ This option requires a language to be set in the Selected Languages list.</prope
                               <object class="GtkCheckButton" id="SubtitleAddCC">
                                 <property name="label" translatable="yes">Add Closed Captions when available</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="tooltip_text" translatable="yes">Closed captions are text subtitles that can be added to any container as a soft subtitle track</property>
+                                <property name="tooltip-text" translatable="yes">Closed captions are text subtitles that can be added to any container as a soft subtitle track</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -6765,13 +6765,13 @@ This option requires a language to be set in the Selected Languages list.</prope
                               <object class="GtkBox" id="subtitle_burn_box">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="sub_burn_behavior_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="label" translatable="yes">Burn-In Behavior*:</property>
                                     <property name="justify">right</property>
@@ -6784,8 +6784,8 @@ This option requires a language to be set in the Selected Languages list.</prope
                                   <object class="GtkComboBox" id="SubtitleBurnBehavior">
                                     <property name="visible">True</property>
                                     <property name="valign">GTK_ALIGN_CENTER</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="tooltip_text" translatable="yes">Set the behavior of subtitle "Burn-In".
+                                    <property name="can-focus">False</property>
+                                    <property name="tooltip-text" translatable="yes">Set the behavior of subtitle "Burn-In".
 
 Burned-In subtitles are part of the video and can not be disabled during playback.
 Only one subtitle track can be burned! Since conflicts can occur, the first chosen wins.</property>
@@ -6804,13 +6804,13 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                               <object class="GtkBox" id="subtitle_additional_burn_box">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="spacing">4</property>
                                 <child>
                                   <object class="GtkLabel" id="sub_additional_burn_label">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">end</property>
                                     <property name="label" translatable="yes">Burn-In for deficient players*:</property>
                                     <property name="justify">right</property>
@@ -6823,15 +6823,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                                   <object class="GtkCheckButton" id="SubtitleBurnDVDSub">
                                     <property name="label" translatable="yes">DVD Subtitles</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Burn the first selected DVD subtitle track. All other DVD subtitle tracks will be discarded.
+                                    <property name="tooltip-text" translatable="yes">Burn the first selected DVD subtitle track. All other DVD subtitle tracks will be discarded.
 Use this option if your player software or device does not support DVD subtitles.
 
 Only one subtitle track can be burned! Since conflicts can occur, the first chosen wins.</property>
                                     <property name="halign">start</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <signal name="toggled" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
@@ -6842,15 +6842,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                                   <object class="GtkCheckButton" id="SubtitleBurnBDSub">
                                     <property name="label" translatable="yes">Blu-ray Subtitles</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">False</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle tracks will be discarded.
+                                    <property name="tooltip-text" translatable="yes">Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle tracks will be discarded.
 Use this option if your player software or device does not support Blu-ray subtitles.
 
 Only one subtitle track can be burned! Since conflicts can occur, the first chosen wins.</property>
                                     <property name="halign">start</property>
-                                    <property name="draw_indicator">True</property>
+                                    <property name="draw-indicator">True</property>
                                     <signal name="toggled" handler="subtitle_def_widget_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
@@ -6865,11 +6865,11 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             <child>
                               <object class="GtkLabel" id="sub_burn_warning_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">&lt;small&gt;* Only one of the above subtitle burn options will be applied, starting with the top.&lt;/small&gt;</property>
-                                <property name="tooltip_text" translatable="yes">Only one subtitle track can be burned! Since conflicts can occur, the first chosen wins.</property>
-                                <property name="use_markup">True</property>
+                                <property name="tooltip-text" translatable="yes">Only one subtitle track can be burned! Since conflicts can occur, the first chosen wins.</property>
+                                <property name="use-markup">True</property>
                                 <property name="justify">left</property>
                               </object>
                               <packing>
@@ -6899,22 +6899,22 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                   <object class="GtkBox" id="chapters_tab">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkBox" id="hbox30">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <object class="GtkCheckButton" id="ChapterMarkers">
                             <property name="label" translatable="yes">Chapter Markers</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                            <property name="tooltip_text" translatable="yes">Add chapter markers to output file.</property>
+                            <property name="tooltip-text" translatable="yes">Add chapter markers to output file.</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="chapter_markers_changed_cb" swapped="no"/>
                           </object>
                           <packing>
@@ -6929,7 +6929,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkSeparator" id="chapter_sep1">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                       </object>
                       <packing>
                         <property name="position">1</property>
@@ -6939,12 +6939,12 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkBox" id="chapter_list_header">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">6</property>
                         <child>
                           <object class="GtkLabel" id="chapter_list_index_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="width-chars">5</property>
                             <property name="label" translatable="yes">Index</property>
                             <property name="xalign">0</property>
@@ -6956,7 +6956,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="chapter_list_start_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="width-chars">10</property>
                             <property name="label" translatable="yes">Start</property>
                             <property name="xalign">1</property>
@@ -6968,7 +6968,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="chapter_list_duration_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="width-chars">10</property>
                             <property name="label" translatable="yes">Duration</property>
                             <property name="xalign">1</property>
@@ -6980,7 +6980,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="chapter_list_title_label">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Title</property>
                             <property name="margin-start">12</property>
                             <property name="hexpand">True</property>
@@ -6998,14 +6998,14 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkScrolledWindow" id="scrolledwindow3">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="vexpand">True</property>
                         <child>
                           <object class="GtkListBox" id="chapters_list">
                             <property name="visible">True</property>
                             <property name="selection-mode">none</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                           </object>
                         </child>
@@ -7029,21 +7029,21 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <property name="margin-start">0</property>
                     <property name="margin-end">0</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="column_spacing">5</property>
+                    <property name="column-spacing">5</property>
                     <child>
                       <object class="GtkLabel" id="tag_title_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Title:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">0</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">0</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7051,18 +7051,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaName">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_name_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">0</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">0</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7070,15 +7070,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_actors_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Actors:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">1</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">1</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7086,18 +7086,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaArtist">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_artist_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">1</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">1</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7105,15 +7105,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_director_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Director:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">2</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">2</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7121,18 +7121,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaAlbumArtist">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_album_artist_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">2</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">2</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7140,15 +7140,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_release_date_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Release Date:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">3</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">3</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7156,18 +7156,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaReleaseDate">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_release_date_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">3</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">3</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7175,15 +7175,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_comment_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Comment:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">4</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">4</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7191,18 +7191,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaComment">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_comment_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">4</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">4</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7210,15 +7210,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_genre_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Genre:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">5</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">5</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7226,18 +7226,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaGenre">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_genre_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">5</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">5</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7245,15 +7245,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_description_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Description:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">6</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">6</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7261,18 +7261,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkEntry" id="MetaDescription">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="hexpand">True</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="max_length">80</property>
-                        <property name="activates_default">False</property>
+                        <property name="max-length">80</property>
+                        <property name="activates-default">False</property>
                         <property name="width-chars">50</property>
-                        <property name="truncate_multiline">True</property>
+                        <property name="truncate-multiline">True</property>
                         <signal name="changed" handler="meta_description_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="top_attach">6</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">6</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7280,39 +7280,39 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                     <child>
                       <object class="GtkLabel" id="tag_long_description_label">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">end</property>
                         <property name="label" translatable="yes">Plot:</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                       <packing>
-                        <property name="top_attach">7</property>
-                        <property name="left_attach">0</property>
+                        <property name="top-attach">7</property>
+                        <property name="left-attach">0</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkScrolledWindow" id="MetaLongDescriptionScroll">
-                        <property name="height_request">40</property>
+                        <property name="height-request">40</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <property name="vexpand">True</property>
-                        <property name="shadow_type">etched-in</property>
+                        <property name="shadow-type">etched-in</property>
                         <child>
                           <object class="GtkTextView" id="MetaLongDescription">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="wrap_mode">char</property>
-                            <property name="accepts_tab">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="wrap-mode">char</property>
+                            <property name="accepts-tab">False</property>
                           </object>
                         </child>
                       </object>
                       <packing>
-                        <property name="top_attach">7</property>
-                        <property name="left_attach">1</property>
+                        <property name="top-attach">7</property>
+                        <property name="left-attach">1</property>
                         <property name="width">1</property>
                         <property name="height">1</property>
                       </packing>
@@ -7339,7 +7339,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             <property name="row-spacing">2</property>
             <property name="column-spacing">2</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="margin-top">6</property>
             <property name="margin-start">6</property>
             <property name="margin-end">6</property>
@@ -7347,15 +7347,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             <child>
               <object class="GtkLabel" id="label18">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
                 <property name="margin-end">6</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="label" translatable="yes">&lt;b&gt;Save As:&lt;/b&gt;</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -7364,15 +7364,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
               <object class="GtkEntry" id="dest_file">
                 <property name="hexpand">True</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Destination filename for your encode.</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Destination filename for your encode.</property>
                 <accelerator key="d" signal="grab-focus" modifiers="GDK_MOD1_MASK"/>
                 <signal name="changed" handler="dest_file_changed_cb" swapped="no"/>
                 <signal name="grab-focus" handler="destination_grab_cb" after="yes" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -7380,16 +7380,16 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             <child>
               <object class="GtkLabel" id="dest_to_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="halign">end</property>
                 <property name="margin-start">6</property>
                 <property name="margin-end">6</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="label" translatable="yes">&lt;b&gt;To:&lt;/b&gt;</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">2</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">2</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -7397,16 +7397,16 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             <child>
               <object class="GtkFileChooserButton" id="dest_dir">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Destination directory for your encode.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Destination directory for your encode.</property>
                 <property name="action">select-folder</property>
-                <property name="local_only">False</property>
+                <property name="local-only">False</property>
                 <property name="title" translatable="yes">Destination Directory</property>
                 <signal name="selection-changed" handler="dest_dir_set_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">3</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">3</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -7474,7 +7474,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                     <property name="label" translatable="yes">&lt;b&gt;When Done:&lt;/b&gt;</property>
                   </object>
                   <packing>
@@ -7502,38 +7502,42 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
   <object class="GtkAdjustment" id="min_title_adj">
     <property name="upper">7200</property>
     <property name="value">10</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkAdjustment" id="preview_count_adj">
     <property name="lower">5</property>
     <property name="upper">60</property>
     <property name="value">10</property>
-    <property name="step_increment">5</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">5</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkDialog" id="title_add_multiple_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
-    <property name="type_hint">dialog</property>
+    <property name="title" translatable="yes">Add Multiple Items</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <child type="action">
       <object class="GtkButton" id="title_add_multiple_cancel">
         <property name="label" translatable="yes">Cancel</property>
-        <property name="image">gtk-cancel</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="title_add_multiple_ok">
-        <property name="label" translatable="yes">OK</property>
-        <property name="image">gtk-ok</property>
+        <property name="label" translatable="yes">Add</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -7544,29 +7548,29 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
       <object class="GtkBox" id="title_add_multiple_vbox1">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <property name="spacing">2</property>
         <child>
           <object class="GtkBox" id="title_add_multiple_hbox1">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
               <object class="GtkCheckButton" id="title_add_multiple_select_all">
                 <property name="label" translatable="yes">Select All</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Mark all titles for adding to the queue</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Mark all titles for adding to the queue</property>
                 <property name="halign">start</property>
                 <property name="vexpand">False</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="title_add_multiple_select_all_cb" swapped="no"/>
               </object>
               <packing>
@@ -7577,13 +7581,13 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
               <object class="GtkCheckButton" id="title_add_multiple_clear_all">
                 <property name="label" translatable="yes">Clear All</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Unmark all titles</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Unmark all titles</property>
                 <property name="halign">start</property>
                 <property name="vexpand">False</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="title_add_multiple_clear_all_cb" swapped="no"/>
               </object>
               <packing>
@@ -7598,18 +7602,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
         <child>
           <object class="GtkScrolledWindow" id="title_add_multiple_scrolledwindow">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="hscrollbar_policy">GTK_POLICY_NEVER</property>
+            <property name="can-focus">False</property>
+            <property name="hscrollbar-policy">GTK_POLICY_NEVER</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="min_content_height">400</property>
+            <property name="min-content-height">400</property>
             <child>
               <object class="GtkListBox" id="title_add_multiple_list">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="vexpand">True</property>
                 <property name="hexpand">True</property>
-                <property name="selection_mode">none</property>
-                <property name="activate_on_single_click">False</property>
+                <property name="selection-mode">none</property>
+                <property name="activate-on-single-click">False</property>
               </object>
             </child>
           </object>
@@ -7620,13 +7624,13 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
         <child>
           <object class="GtkInfoBar" id="title_add_multiple_infobar">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="message_type">info</property>
+            <property name="can-focus">False</property>
+            <property name="message-type">info</property>
             <child internal-child="action_area">
               <object class="GtkButtonBox" id="title_add_multiple_infobar-action_area1">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">6</property>
-                <property name="layout_style">end</property>
+                <property name="layout-style">end</property>
               </object>
               <packing>
                 <property name="position">0</property>
@@ -7634,12 +7638,12 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             </child>
             <child internal-child="content_area">
               <object class="GtkBox" id="title_add_multiple_infobar_content_area">
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="spacing">16</property>
                 <child>
                   <object class="GtkLabel" id="title_add_multiple_label1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="label" translatable="yes">Destination files OK.  No duplicates detected.</property>
                   </object>
                   <packing>
@@ -7660,15 +7664,15 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
     </child>
   </object>
   <object class="GtkDialog" id="prefs_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Preferences</property>
     <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
+    <property name="window-position">center-on-parent</property>
     <property name="use-header-bar">1</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child type="titlebar">
       <object class="GtkHeaderBar">
@@ -7689,36 +7693,36 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox6">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">2</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <child>
           <object class="GtkBox" id="hbox59">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <child>
               <object class="GtkBox" id="vbox20">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <child>
                   <object class="GtkEventBox" id="eventbox1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
                     <signal name="button-press-event" handler="easter_egg_cb" swapped="no"/>
                     <child>
                       <object class="GtkImage" id="image3">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="pixel_size">64</property>
-                        <property name="icon_name">hb-icon</property>
+                        <property name="pixel-size">64</property>
+                        <property name="icon-name">hb-icon</property>
                       </object>
                     </child>
                   </object>
@@ -7737,18 +7741,18 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
             <child>
               <object class="GtkStack" id="prefs_stack">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <child>
                   <object class="GtkBox" id="vbox42">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkBox" id="check_updates_box">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">4</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
@@ -7757,7 +7761,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                           <object class="GtkComboBox" id="check_updates">
                             <property name="valign">GTK_ALIGN_CENTER</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <signal name="changed" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
@@ -7767,9 +7771,9 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="label74">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Automatically check for updates</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -7784,7 +7788,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkBox" id="hbox82">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">4</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
@@ -7794,7 +7798,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                           <object class="GtkComboBox" id="WhenComplete">
                             <property name="visible">True</property>
                             <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <signal name="changed" handler="when_complete_changed_cb" swapped="no"/>
                           </object>
                           <packing>
@@ -7804,9 +7808,9 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="labela1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Default action when all encodes are complete</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -7821,19 +7825,19 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkBox" id="vbox5">
                         <property name="orientation">vertical</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
                         <property name="margin-start">12</property>
                         <child>
                           <object class="GtkCheckButton" id="auto_name">
                             <property name="label" translatable="yes">Use automatic naming (uses modified source name)</property>
-                            <property name="tooltip_text" translatable="yes">Create destination filename from source filename or volume label</property>
+                            <property name="tooltip-text" translatable="yes">Create destination filename from source filename or volume label</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
@@ -7844,16 +7848,16 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                           <object class="GtkBox" id="autoname_box">
                             <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">4</property>
                             <property name="margin-start">18</property>
                             <property name="margin-end">8</property>
                             <child>
                               <object class="GtkLabel" id="auto_name_template_label">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="label" translatable="yes">Auto-Name Template</property>
-                                <property name="use_markup">True</property>
+                                <property name="use-markup">True</property>
 
                                 <property name="halign">end</property>
                               </object>
@@ -7863,13 +7867,13 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             </child>
                             <child>
                               <object class="GtkEntry" id="auto_name_template">
-                                <property name="tooltip_text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {quality} {bitrate}</property>
+                                <property name="tooltip-text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {quality} {bitrate}</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="activates_default">True</property>
+                                <property name="activates-default">True</property>
                                 <property name="width-chars">40</property>
-                                <property name="truncate_multiline">True</property>
+                                <property name="truncate-multiline">True</property>
                                 <signal name="changed" handler="pref_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -7885,10 +7889,10 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                           <object class="GtkCheckButton" id="UseM4v">
                             <property name="label" translatable="yes">Use iPod/iTunes friendly (.m4v) file extension for MP4</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="use_m4v_changed_cb" swapped="no"/>
                           </object>
                           <packing>
@@ -7904,7 +7908,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkBox" id="hbox66">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">4</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
@@ -7912,7 +7916,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkSpinButton" id="preview_count">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="width-chars">6</property>
                             <property name="adjustment">preview_count_adj</property>
                             <property name="numeric">True</property>
@@ -7925,9 +7929,9 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="label77">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Number of previews</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -7942,7 +7946,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkBox" id="hbox60">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">4</property>
                         <property name="margin-top">6</property>
                         <property name="margin-bottom">6</property>
@@ -7950,7 +7954,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkSpinButton" id="MinTitleDuration">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="width-chars">6</property>
                             <property name="adjustment">min_title_adj</property>
                             <property name="numeric">True</property>
@@ -7963,9 +7967,9 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                         <child>
                           <object class="GtkLabel" id="label70">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">Filter short DVD and Blu-ray titles (seconds)</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="position">1</property>
@@ -7980,13 +7984,13 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       <object class="GtkCheckButton" id="RemoveFinishedJobs">
                         <property name="label" translatable="yes">Clear completed queue items after an encode completes</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">By default, completed jobs remain in the queue and are marked as complete.
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">By default, completed jobs remain in the queue and are marked as complete.
 Check this if you want the queue to clean itself up by deleting completed jobs.</property>
                         <property name="halign">start</property>
                         <property name="margin-start">12</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                       </object>
                       <packing>
@@ -8002,29 +8006,29 @@ Check this if you want the queue to clean itself up by deleting completed jobs.<
                   <object class="GtkBox" id="vbox1">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="margin-top">6</property>
                     <property name="margin-bottom">6</property>
                     <property name="margin-start">12</property>
                     <child>
                       <object class="GtkGrid" id="AdvancedPrefsTable">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="row-spacing">2</property>
                         <child>
                           <object class="GtkBox" id="CustomTmpBox">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">2</property>
                             <child>
                               <object class="GtkCheckButton" id="CustomTmpEnable">
                                 <property name="label" translatable="yes">Set a custom directory for Handbrake temporary files</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Temporary files that HandBrake creates will be placed under this directory.
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Temporary files that HandBrake creates will be placed under this directory.
 
 Changing this setting will require restarting HandBrake.
 
@@ -8032,7 +8036,7 @@ This setting overrides the TEMP environment variable that is normally used to de
 
 Flatpak users may need to set this for certain workflows to work properly. The default size of the TEMP directory in a flatpak sandbox is 1/2 physical memory size and may be too small for things like the 2-pass stats file.</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="tmp_dir_enable_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -8043,8 +8047,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                               <object class="GtkFileChooserButton" id="CustomTmpDir">
                                 <property name="visible">True</property>
                                 <property name="sensitive">False</property>
-                                <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Temporary files that HandBrake creates will be placed under this directory.
+                                <property name="can-focus">True</property>
+                                <property name="tooltip-text" translatable="yes">Temporary files that HandBrake creates will be placed under this directory.
 
 Changing this setting will require restarting HandBrake.
 
@@ -8052,7 +8056,7 @@ This setting overrides the TEMP environment variable that is normally used to de
 
 Flatpak users may need to set this for certain workflows to work properly. The default size of the TEMP directory in a flatpak sandbox is 1/2 physical memory size and may be too small for things like the 2-pass stats file.</property>
                                 <property name="action">select-folder</property>
-                                <property name="local_only">False</property>
+                                <property name="local-only">False</property>
                                 <property name="hexpand">True</property>
                                 <property name="title" translatable="yes">Temp Directory</property>
                                 <signal name="selection-changed" handler="temp_dir_changed_cb" swapped="no"/>
@@ -8065,8 +8069,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             </child>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8075,14 +8079,14 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkBox" id="hbox6">
                             <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">4</property>
                             <child>
                               <object class="GtkComboBox" id="VideoQualityGranularity">
                                 <property name="valign">GTK_ALIGN_CENTER</property>
-                                <property name="width_request">55</property>
+                                <property name="width-request">55</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <signal name="changed" handler="vqual_granularity_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -8092,7 +8096,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             <child>
                               <object class="GtkLabel" id="label85">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Constant Quality fractional granularity</property>
                                 <property name="hexpand">True</property>
@@ -8103,8 +8107,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             </child>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8113,15 +8117,15 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkCheckButton" id="use_dvdnav">
                             <property name="label" translatable="yes">Use dvdnav (instead of libdvdread)</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">2</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">2</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8130,17 +8134,17 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkBox" id="DiskFreeBox">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">2</property>
                             <child>
                               <object class="GtkCheckButton" id="DiskFreeCheck">
                                 <property name="label" translatable="yes">Monitor destination disk free space</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="tooltip_text" translatable="yes">Pause encoding if free disk space drops below limit</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
+                                <property name="tooltip-text" translatable="yes">Pause encoding if free disk space drops below limit</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -8151,19 +8155,19 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                               <object class="GtkBox" id="DiskFreeLimitBox">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <property name="margin-start">21</property>
                                 <child>
                                   <object class="GtkSpinButton" id="DiskFreeLimit">
                                     <property name="width-chars">7</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
+                                    <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip_text" translatable="yes">Pause encoding if free disk space drops below limit</property>
+                                    <property name="tooltip-text" translatable="yes">Pause encoding if free disk space drops below limit</property>
                                     <property name="valign">GTK_ALIGN_CENTER</property>
                                     <property name="adjustment">DiskFreeLimitAdjustment</property>
-                                    <property name="width_request">55</property>
+                                    <property name="width-request">55</property>
                                     <signal name="value-changed" handler="pref_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
@@ -8173,7 +8177,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                                 <child>
                                   <object class="GtkLabel" id="DiskFreeLimitLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">MB Limit</property>
                                     <property name="hexpand">True</property>
@@ -8189,8 +8193,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             </child>
                           </object>
                           <packing>
-                            <property name="top_attach">3</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">3</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8199,16 +8203,16 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkBox" id="vbox2">
                             <property name="orientation">vertical</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">2</property>
                             <child>
                               <object class="GtkCheckButton" id="EncodeLogLocation">
                                 <property name="label" translatable="yes">Put individual encode logs in same location as movie</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">False</property>
                                 <property name="halign">start</property>
-                                <property name="draw_indicator">True</property>
+                                <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                               </object>
                               <packing>
@@ -8219,15 +8223,15 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                               <object class="GtkBox" id="hbox50">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <property name="margin-start">21</property>
                                 <child>
                                   <object class="GtkComboBox" id="LoggingLevel">
                                     <property name="valign">GTK_ALIGN_CENTER</property>
-                                    <property name="width_request">55</property>
+                                    <property name="width-request">55</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <signal name="changed" handler="log_level_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
@@ -8237,7 +8241,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                                 <child>
                                   <object class="GtkLabel" id="label1">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">Activity Log Verbosity Level</property>
                                     <property name="hexpand">True</property>
@@ -8255,14 +8259,14 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                               <object class="GtkBox" id="hbox83">
                                 <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="spacing">4</property>
                                 <property name="margin-start">21</property>
                                 <child>
                                   <object class="GtkComboBox" id="LogLongevity">
                                     <property name="valign">GTK_ALIGN_CENTER</property>
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <signal name="changed" handler="pref_changed_cb" swapped="no"/>
                                   </object>
                                   <packing>
@@ -8272,7 +8276,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                                 <child>
                                   <object class="GtkLabel" id="labela2">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
+                                    <property name="can-focus">False</property>
                                     <property name="halign">start</property>
                                     <property name="label" translatable="yes">Activity Log Longevity</property>
                                   </object>
@@ -8287,8 +8291,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             </child>
                           </object>
                           <packing>
-                            <property name="top_attach">4</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">4</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8297,15 +8301,15 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkCheckButton" id="reduce_hd_preview">
                             <property name="label" translatable="yes">Scale down High Definition previews</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">5</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">5</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8314,16 +8318,16 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkCheckButton" id="AutoScan">
                             <property name="label" translatable="yes">Automatically Scan DVD when loaded</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="tooltip_text" translatable="yes">Scans the DVD whenever a new disc is loaded</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="tooltip-text" translatable="yes">Scans the DVD whenever a new disc is loaded</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">6</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">6</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8332,14 +8336,14 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkBox" id="ActivityFontSizeBox">
                             <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="spacing">4</property>
                             <property name="margin-start">0</property>
                             <child>
                               <object class="GtkSpinButton" id="ActivityFontSize">
                                 <property name="width-chars">3</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
+                                <property name="can-focus">True</property>
                                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                                 <property name="valign">GTK_ALIGN_CENTER</property>
                                 <property name="adjustment">ActivityFontSizeAdjustment</property>
@@ -8352,7 +8356,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             <child>
                               <object class="GtkLabel" id="ActivityFontSizeLabel">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can-focus">False</property>
                                 <property name="halign">start</property>
                                 <property name="label" translatable="yes">Activity Window Font Size</property>
                                 <property name="hexpand">True</property>
@@ -8363,8 +8367,8 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             </child>
                           </object>
                           <packing>
-                            <property name="top_attach">7</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">7</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8373,19 +8377,19 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                           <object class="GtkCheckButton" id="SyncTitleSettings">
                             <property name="label" translatable="yes">Use the same settings for all titles in a batch</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
-                            <property name="tooltip_text" translatable="yes">When checked, every title will use the same settings when adding a
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
+                            <property name="tooltip-text" translatable="yes">When checked, every title will use the same settings when adding a
 batch of titles to the queue.
 
 Uncheck this if you want to allow changing each title's settings independently.</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">8</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">8</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8393,17 +8397,17 @@ Uncheck this if you want to allow changing each title's settings independently.<
                         <child>
                           <object class="GtkCheckButton" id="ShowMiniPreview">
                             <property name="label" translatable="yes">Show preview image in Summary tab</property>
-                            <property name="can_focus">True</property>
+                            <property name="can-focus">True</property>
                             <property name="visible">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <property name="tooltip-text" translatable="yes">Uncheck this if you want to hide the video preview image on the Summary tab for privacy reasons.</property>
                             <signal name="toggled" handler="show_preview_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">9</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">9</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8417,20 +8421,20 @@ Uncheck this if you want to allow changing each title's settings independently.<
                       <object class="GtkGrid" id="hidden_prefs">
                         <property name="row-spacing">2</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <child>
                           <object class="GtkCheckButton" id="allow_tweaks">
                             <property name="label" translatable="yes">Allow Tweaks</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="tweaks_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">0</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">0</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8438,15 +8442,15 @@ Uncheck this if you want to allow changing each title's settings independently.<
                         <child>
                           <object class="GtkCheckButton" id="hbfd_feature">
                             <property name="label" translatable="yes">Allow HandBrake For Dummies</property>
-                            <property name="can_focus">True</property>
-                            <property name="receives_default">False</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">False</property>
                             <property name="halign">start</property>
-                            <property name="draw_indicator">True</property>
+                            <property name="draw-indicator">True</property>
                             <signal name="toggled" handler="hbfd_feature_changed_cb" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="top_attach">1</property>
-                            <property name="left_attach">0</property>
+                            <property name="top-attach">1</property>
+                            <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>
                           </packing>
@@ -8476,31 +8480,35 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
   </object>
   <object class="GtkDialog" id="preset_rename_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Rename Preset</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child type="action">
       <object class="GtkButton" id="preset_rename_cancel">
         <property name="label" translatable="yes">Cancel</property>
-        <property name="image">gtk-cancel</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="can-default">False</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="preset_rename_ok">
-        <property name="label" translatable="yes">OK</property>
-        <property name="image">gtk-ok</property>
+        <property name="label" translatable="yes">Rename</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -8510,29 +8518,29 @@ Uncheck this if you want to allow changing each title's settings independently.<
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-preset-rename-box">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="spacing">2</property>
         <property name="hexpand">False</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <child>
           <object class="GtkBox" id="preset_rename_vbox">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="vexpand">True</property>
             <child>
               <object class="GtkLabel" id="preset_dialog_rename_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="halign">start</property>
                 <property name="margin-bottom">12</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="label" translatable="yes">&lt;span size="x-large"&gt;Rename Preset&lt;/span&gt;</property>
               </object>
               <packing>
@@ -8543,14 +8551,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkBox" id="preset_rename_hbox">
                 <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="hexpand">True</property>
                 <property name="spacing">4</property>
                 <child>
                   <object class="GtkLabel" id="preset_rename_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">end</property>
                     <property name="label" translatable="yes">Name:</property>
@@ -8562,12 +8570,12 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkEntry" id="PresetReName">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="max_length">40</property>
-                    <property name="activates_default">True</property>
+                    <property name="max-length">40</property>
+                    <property name="activates-default">True</property>
                     <property name="width-chars">40</property>
-                    <property name="truncate_multiline">True</property>
+                    <property name="truncate-multiline">True</property>
                     <property name="hexpand">True</property>
                     <signal name="changed" handler="preset_name_changed_cb" swapped="no"/>
                   </object>
@@ -8583,10 +8591,10 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <child>
               <object class="GtkFrame" id="preset_rename_desc_frame">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">etched-out</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">etched-out</property>
                 <property name="margin-top">10</property>
                 <property name="margin-bottom">10</property>
                 <child>
@@ -8595,23 +8603,23 @@ Uncheck this if you want to allow changing each title's settings independently.<
                     <property name="margin-bottom">4</property>
                     <property name="margin-start">12</property>
                     <property name="margin-end">4</property>
-                    <property name="height_request">60</property>
+                    <property name="height-request">60</property>
                     <property name="visible">True</property>
                     <property name="hexpand">True</property>
                     <property name="vexpand">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="wrap_mode">word</property>
-                    <property name="accepts_tab">False</property>
+                    <property name="wrap-mode">word</property>
+                    <property name="accepts-tab">False</property>
                   </object>
                 </child>
                 <child type="label">
                   <object class="GtkLabel" id="preset_rename_desc_frame_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="label" translatable="yes">&lt;b&gt;Description&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -8628,31 +8636,35 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
   </object>
   <object class="GtkDialog" id="preset_save_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Save Preset</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
     <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <signal name="delete-event" handler="gtk_widget_hide_on_delete" swapped="no"/>
     <child type="action">
       <object class="GtkButton" id="preset_cancel">
         <property name="label" translatable="yes">Cancel</property>
-        <property name="image">gtk-cancel</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="preset_ok">
-        <property name="label" translatable="yes">OK</property>
-        <property name="image">gtk-ok</property>
+        <property name="label" translatable="yes">Save</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -8662,18 +8674,18 @@ Uncheck this if you want to allow changing each title's settings independently.<
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox3">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
         <property name="spacing">2</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <child>
           <object class="GtkBox" id="vbox28">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="vexpand">True</property>
             <child>
@@ -8681,21 +8693,21 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <property name="visible">True</property>
                 <property name="row-spacing">2</property>
                 <property name="column-spacing">6</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="margin-top">10</property>
                 <property name="margin-bottom">10</property>
                 <child>
                   <object class="GtkLabel" id="preset_save_category_label">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">end</property>
                     <property name="label" translatable="yes">Category:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8704,14 +8716,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
                   <object class="GtkComboBox" id="PresetCategory">
                     <property name="valign">GTK_ALIGN_CENTER</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Set the category that this preset will be shown under.</property>
+                    <property name="tooltip-text" translatable="yes">Set the category that this preset will be shown under.</property>
                     <signal name="changed" handler="preset_category_changed_cb" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8719,14 +8731,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkLabel" id="PresetCategoryEntryLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">end</property>
                     <property name="label" translatable="yes">Category Name:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">1</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8734,17 +8746,17 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkEntry" id="PresetCategoryName">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="max_length">40</property>
-                    <property name="activates_default">True</property>
+                    <property name="max-length">40</property>
+                    <property name="activates-default">True</property>
                     <property name="width-chars">30</property>
-                    <property name="truncate_multiline">True</property>
+                    <property name="truncate-multiline">True</property>
                     <signal name="changed" handler="preset_category_changed_cb" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">1</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8752,14 +8764,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkLabel" id="label64">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">end</property>
                     <property name="label" translatable="yes">Preset Name:</property>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">2</property>
+                    <property name="left-attach">0</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8767,17 +8779,17 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkEntry" id="PresetName">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="max_length">40</property>
-                    <property name="activates_default">True</property>
+                    <property name="max-length">40</property>
+                    <property name="activates-default">True</property>
                     <property name="width-chars">30</property>
-                    <property name="truncate_multiline">True</property>
+                    <property name="truncate-multiline">True</property>
                     <signal name="changed" handler="preset_name_changed_cb" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="top_attach">2</property>
-                    <property name="left_attach">1</property>
+                    <property name="top-attach">2</property>
+                    <property name="left-attach">1</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8791,13 +8803,13 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkCheckButton" id="PresetSetDefault">
                 <property name="label" translatable="yes">Default Preset</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Make this the default Preset when HandBrake starts</property>
+                <property name="tooltip-text" translatable="yes">Make this the default Preset when HandBrake starts</property>
                 <property name="halign">start</property>
                 <property name="margin-bottom">12</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="preset_widget_changed_cb" swapped="no"/>
               </object>
               <packing>
@@ -8808,7 +8820,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkGrid" id="PicturePresetBox">
                 <property name="visible">True</property>
                 <property name="row-spacing">2</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="vexpand">False</property>
                 <child>
@@ -8817,15 +8829,15 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkLabel" id="UsingCurrentPicLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">&lt;b&gt;Dimensions&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                   <packing>
-                    <property name="top_attach">0</property>
-                    <property name="left_attach">0</property>
+                    <property name="top-attach">0</property>
+                    <property name="left-attach">0</property>
                     <property name="width">3</property>
                     <property name="height">1</property>
                   </packing>
@@ -8833,13 +8845,13 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <child>
                   <object class="GtkLabel" id="fillerlabel1">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="halign">start</property>
                   </object>
                   <packing>
-                    <property name="top_attach">1</property>
-                    <property name="left_attach">2</property>
+                    <property name="top-attach">1</property>
+                    <property name="left-attach">2</property>
                     <property name="width">1</property>
                     <property name="height">1</property>
                   </packing>
@@ -8852,10 +8864,10 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <child>
               <object class="GtkFrame" id="frame14">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="label_xalign">0</property>
-                <property name="shadow_type">etched-out</property>
+                <property name="label-xalign">0</property>
+                <property name="shadow-type">etched-out</property>
                 <property name="vexpand">True</property>
                 <property name="margin-top">10</property>
                 <property name="margin-bottom">10</property>
@@ -8865,21 +8877,21 @@ Uncheck this if you want to allow changing each title's settings independently.<
                     <property name="margin-bottom">4</property>
                     <property name="margin-start">12</property>
                     <property name="margin-end">4</property>
-                    <property name="height_request">60</property>
+                    <property name="height-request">60</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="wrap_mode">word</property>
-                    <property name="accepts_tab">False</property>
+                    <property name="wrap-mode">word</property>
+                    <property name="accepts-tab">False</property>
                   </object>
                 </child>
                 <child type="label">
                   <object class="GtkLabel" id="label67">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <property name="label" translatable="yes">&lt;b&gt;Description&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                 </child>
               </object>
@@ -8897,16 +8909,16 @@ Uncheck this if you want to allow changing each title's settings independently.<
   </object>
   <object class="GtkAdjustment" id="preview_progress_adj">
     <property name="upper">100</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">10</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">10</property>
   </object>
   <object class="GtkWindow" id="preview_window">
     <property name="title" translatable="yes">HandBrake Preview</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_STRUCTURE_MASK</property>
     <property name="resizable">True</property>
-    <property name="window_position">center</property>
-    <property name="type_hint">normal</property>
+    <property name="window-position">center</property>
+    <property name="type-hint">normal</property>
     <property name="icon-name">hb-icon</property>
     <signal name="window-state-event" handler="preview_state_cb" swapped="no"/>
     <signal name="configure-event" handler="preview_configure_cb" swapped="no"/>
@@ -8920,10 +8932,10 @@ Uncheck this if you want to allow changing each title's settings independently.<
         <property name="valign">fill</property>
         <child>
           <object class="GtkDrawingArea" id="preview_image">
-            <property name="width_request">854</property>
-            <property name="height_request">480</property>
+            <property name="width-request">854</property>
+            <property name="height-request">480</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
             <property name="vexpand">True</property>
             <property name="halign">fill</property>
@@ -8939,7 +8951,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
         <child type="overlay">
           <object class="GtkEventBox" id="preview_hud">
             <property name="visible">False</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">center</property>
             <property name="valign">end</property>
             <property name="margin-bottom">30</property>
@@ -8954,7 +8966,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkBox" id="vbox35">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="margin-top">5</property>
                 <property name="margin-bottom">5</property>
                 <property name="margin-start">10</property>
@@ -8962,13 +8974,13 @@ Uncheck this if you want to allow changing each title's settings independently.<
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <child>
                   <object class="GtkScale" id="preview_frame">
-                    <property name="width_request">400</property>
+                    <property name="width-request">400</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="tooltip_text" translatable="yes">Select preview frames.</property>
+                    <property name="can-focus">True</property>
+                    <property name="tooltip-text" translatable="yes">Select preview frames.</property>
                     <property name="adjustment">adjustment19</property>
                     <property name="digits">0</property>
-                    <property name="value_pos">bottom</property>
+                    <property name="value-pos">bottom</property>
                     <signal name="value-changed" handler="preview_frame_value_changed_cb" swapped="no"/>
                   </object>
                   <packing>
@@ -8979,22 +8991,22 @@ Uncheck this if you want to allow changing each title's settings independently.<
                   <object class="GtkBox" id="live_preview_box">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkButton" id="live_preview_play">
-                        <property name="height_request">30</property>
+                        <property name="height-request">30</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Encode and play a short sequence of video starting from the current preview position.</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Encode and play a short sequence of video starting from the current preview position.</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="live_preview_start_cb" swapped="no"/>
                         <child>
                           <object class="GtkImage" id="live_preview_play_image">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">media-playbck-start</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">media-playbck-start</property>
                           </object>
                         </child>
                       </object>
@@ -9004,10 +9016,10 @@ Uncheck this if you want to allow changing each title's settings independently.<
                     </child>
                     <child>
                       <object class="GtkScale" id="live_preview_progress">
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="adjustment">preview_progress_adj</property>
-                        <property name="draw_value">False</property>
-                        <property name="value_pos">right</property>
+                        <property name="draw-value">False</property>
+                        <property name="value-pos">right</property>
                         <property name="hexpand">True</property>
                         <signal name="value-changed" handler="live_preview_seek_cb" swapped="no"/>
                       </object>
@@ -9019,13 +9031,13 @@ Uncheck this if you want to allow changing each title's settings independently.<
                       <object class="GtkBox" id="live_progress_box">
                         <property name="orientation">vertical</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="hexpand">True</property>
                         <child>
                           <object class="GtkProgressBar" id="live_encode_progress">
-                            <property name="height_request">20</property>
+                            <property name="height-request">20</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                           </object>
                           <packing>
@@ -9039,18 +9051,18 @@ Uncheck this if you want to allow changing each title's settings independently.<
                     </child>
                     <child>
                       <object class="GtkToggleButton" id="live_preview_fullscreen">
-                        <property name="height_request">30</property>
+                        <property name="height-request">30</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">True</property>
-                        <property name="tooltip_text" translatable="yes">Click to toggle full screen mode</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="tooltip-text" translatable="yes">Click to toggle full screen mode</property>
                         <property name="relief">none</property>
                         <property name="action-name">app.preview-fullscreen</property>
                         <child>
                           <object class="GtkImage" id="live_preview_fullscreen_image">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="icon_name">view-fullscreen</property>
+                            <property name="can-focus">False</property>
+                            <property name="icon-name">view-fullscreen</property>
                           </object>
                         </child>
                       </object>
@@ -9067,20 +9079,20 @@ Uncheck this if you want to allow changing each title's settings independently.<
                   <object class="GtkBox" id="hbox26">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkBox" id="live_preview_duration_box">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="spacing">2</property>
                         <child>
                           <object class="GtkLabel" id="label37">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
+                            <property name="can-focus">False</property>
                             <property name="label" translatable="yes">&lt;b&gt;Duration:&lt;/b&gt;</property>
-                            <property name="use_markup">True</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="position">0</property>
@@ -9090,8 +9102,8 @@ Uncheck this if you want to allow changing each title's settings independently.<
                           <object class="GtkSpinButton" id="live_duration">
                             <property name="width-chars">7</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="tooltip_text" translatable="yes">Set the duration of the live preview in seconds.</property>
+                            <property name="can-focus">True</property>
+                            <property name="tooltip-text" translatable="yes">Set the duration of the live preview in seconds.</property>
                             <property name="adjustment">adjustment21</property>
                             <property name="numeric">True</property>
                             <signal name="value-changed" handler="preview_duration_changed_cb" swapped="no"/>
@@ -9109,11 +9121,11 @@ Uncheck this if you want to allow changing each title's settings independently.<
                       <object class="GtkCheckButton" id="preview_show_crop">
                         <property name="label" translatable="yes">Show Crop</property>
                         <property name="visible">False</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Show Cropped area of the preview</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Show Cropped area of the preview</property>
                         <property name="halign">start</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="draw-indicator">True</property>
                         <signal name="toggled" handler="show_crop_changed_cb" swapped="no"/>
                       </object>
                       <packing>
@@ -9124,9 +9136,9 @@ Uncheck this if you want to allow changing each title's settings independently.<
                       <object class="GtkButton" id="preview_reset">
                         <property name="label" translatable="yes">Source Resolution</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Reset preview window to the source video's resolution</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Reset preview window to the source video's resolution</property>
                         <property name="relief">none</property>
                         <signal name="clicked" handler="preview_reset_clicked_cb" swapped="no"/>
                       </object>
@@ -9147,25 +9159,23 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
   </object>
   <object class="GtkFileChooserDialog" id="source_dialog">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="modal">True</property>
     <property name="title" translatable="yes">Open Source</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
-    <property name="create_folders">False</property>
-    <property name="local_only">False</property>
-    <property name="transient_for">hb_window</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
+    <property name="create-folders">False</property>
+    <property name="local-only">False</property>
+    <property name="transient-for">hb_window</property>
     <signal name="selection-changed" handler="chooser_file_selected_cb" swapped="no"/>
     <child type="action">
       <object class="GtkButton" id="source_cancel">
         <property name="label" translatable="yes">_Cancel</property>
         <property name="use-underline">True</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="can_default">False</property>
-        <property name="has_default">False</property>
-        <property name="receives_default">False</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
       </object>
     </child>
     <child type="action">
@@ -9173,15 +9183,18 @@ Uncheck this if you want to allow changing each title's settings independently.<
         <property name="label" translatable="yes">_Open</property>
         <property name="use-underline">True</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="can_default">True</property>
-        <property name="has_default">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
-      <action-widget response="-6">source_cancel</action-widget>
-      <action-widget response="-5">source_ok</action-widget>
+      <action-widget response="cancel">source_cancel</action-widget>
+      <action-widget response="ok">source_ok</action-widget>
     </action-widgets>
   </object>
   <object class="GtkBox" id="source_extra">
@@ -9189,17 +9202,17 @@ Uncheck this if you want to allow changing each title's settings independently.<
     <property name="visible">True</property>
     <property name="spacing">10</property>
     <property name="expand">False</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <child>
       <object class="GtkBox" id="single_title_box">
         <property name="orientation">horizontal</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">4</property>
         <child>
           <object class="GtkLabel" id="label89">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">Title Number:</property>
           </object>
           <packing>
@@ -9210,7 +9223,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
           <object class="GtkSpinButton" id="single_title">
             <property name="width-chars">5</property>
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can-focus">True</property>
             <property name="halign">start</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
             <property name="adjustment">adjustment24</property>
@@ -9230,12 +9243,12 @@ Uncheck this if you want to allow changing each title's settings independently.<
       <object class="GtkBox" id="hbox74">
         <property name="orientation">horizontal</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">4</property>
         <child>
           <object class="GtkLabel" id="label90">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="label" translatable="yes">Detected DVD devices:</property>
           </object>
           <packing>
@@ -9245,7 +9258,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
         <child>
           <object class="GtkComboBoxText" id="source_device">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="halign">start</property>
             <property name="hexpand">True</property>
             <signal name="changed" handler="dvd_device_changed_cb" swapped="no"/>
@@ -9262,55 +9275,59 @@ Uncheck this if you want to allow changing each title's settings independently.<
   </object>
   <object class="GtkImage" id="gtk-cancel">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="icon_name">gtk-cancel</property>
+    <property name="icon-name">gtk-cancel</property>
   </object>
   <object class="GtkImage" id="gtk-ok">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="icon_name">gtk-ok</property>
+    <property name="icon-name">gtk-ok</property>
   </object>
   <object class="GtkImage" id="import_add_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="icon_name">gtk-add</property>
+    <property name="icon-name">gtk-add</property>
   </object>
   <object class="GtkImage" id="subtitle_add_image">
     <property name="visible">True</property>
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-    <property name="icon_name">gtk-add</property>
+    <property name="icon-name">gtk-add</property>
   </object>
   <object class="GtkDialog" id="subtitle_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Edit Subtitles</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="modal">True</property>
     <property name="resizable">False</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <child type="action">
       <object class="GtkButton" id="subtitle_cancel">
         <property name="label" translatable="yes">Cancel</property>
-        <property name="image">gtk-cancel</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="subtitle_ok">
-        <property name="label" translatable="yes">OK</property>
-        <property name="image">gtk-ok</property>
+        <property name="label" translatable="yes">Save</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -9321,28 +9338,28 @@ Uncheck this if you want to allow changing each title's settings independently.<
       <object class="GtkBox" id="dialog-subtitle-vbox">
         <property name="orientation">vertical</property>
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">6</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <child>
           <object class="GtkBox" id="subtitle_import_switch_box">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_bottom">24</property>
+            <property name="can-focus">False</property>
+            <property name="margin-bottom">24</property>
             <child>
               <object class="GtkRadioButton" id="SubtitleSrtEnable">
                 <property name="label" translatable="yes">Import SRT</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Enable settings to import an SRT subtitle file</property>
+                <property name="tooltip-text" translatable="yes">Enable settings to import an SRT subtitle file</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="subtitle_import_radio_toggled_cb" swapped="no"/>
               </object>
               <packing>
@@ -9353,12 +9370,12 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkRadioButton" id="SubtitleSsaEnable">
                 <property name="label" translatable="yes">Import SSA</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Enable settings to import an SSA subtitle file</property>
+                <property name="tooltip-text" translatable="yes">Enable settings to import an SSA subtitle file</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <property name="group">SubtitleSrtEnable</property>
                 <signal name="toggled" handler="subtitle_import_radio_toggled_cb" swapped="no"/>
               </object>
@@ -9370,12 +9387,12 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkRadioButton" id="SubtitleImportDisable">
                 <property name="label" translatable="yes">Embedded Subtitle List</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Enable settings to select embedded subtitles</property>
+                <property name="tooltip-text" translatable="yes">Enable settings to select embedded subtitles</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <property name="group">SubtitleSrtEnable</property>
                 <signal name="toggled" handler="subtitle_import_radio_toggled_cb" swapped="no"/>
               </object>
@@ -9392,19 +9409,19 @@ Uncheck this if you want to allow changing each title's settings independently.<
           <object class="GtkGrid" id="subtitle_track_grid">
             <property name="row-spacing">2</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="column_spacing">5</property>
+            <property name="can-focus">False</property>
+            <property name="column-spacing">5</property>
             <property name="halign">center</property>
             <child>
               <object class="GtkLabel" id="subtitle_track_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Source Track</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9413,14 +9430,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
               <object class="GtkComboBox" id="SubtitleTrack">
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">List of subtitle tracks available from your source.</property>
+                <property name="tooltip-text" translatable="yes">List of subtitle tracks available from your source.</property>
                 <signal name="changed" handler="subtitle_track_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9428,14 +9445,14 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <child>
               <object class="GtkLabel" id="subtitle_name_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Track Name:</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9443,20 +9460,20 @@ Uncheck this if you want to allow changing each title's settings independently.<
             <child>
               <object class="GtkEntry" id="SubtitleTrackName">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the subtitle track name.
+                <property name="tooltip-text" translatable="yes">Set the subtitle track name.
 
 Players may use this in the subtitle selection list.</property>
-                <property name="max_length">80</property>
+                <property name="max-length">80</property>
                 <property name="width-chars">40</property>
-                <property name="activates_default">True</property>
-                <property name="truncate_multiline">True</property>
+                <property name="activates-default">True</property>
+                <property name="truncate-multiline">True</property>
                 <signal name="changed" handler="subtitle_name_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9470,19 +9487,19 @@ Players may use this in the subtitle selection list.</property>
           <object class="GtkGrid" id="subtitle_import_grid">
             <property name="visible">True</property>
             <property name="row-spacing">2</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-            <property name="column_spacing">4</property>
+            <property name="column-spacing">4</property>
             <child>
               <object class="GtkLabel" id="import_lang_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Language</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9490,13 +9507,13 @@ Players may use this in the subtitle selection list.</property>
             <child>
               <object class="GtkLabel" id="srt_code_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Character Code</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">2</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">2</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9504,14 +9521,14 @@ Players may use this in the subtitle selection list.</property>
             <child>
               <object class="GtkLabel" id="import_file_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">File:</property>
                 <property name="halign">end</property>
               </object>
               <packing>
-                <property name="top_attach">2</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">2</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9519,13 +9536,13 @@ Players may use this in the subtitle selection list.</property>
             <child>
               <object class="GtkLabel" id="import_offset_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Offset (ms)</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">4</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">4</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9534,15 +9551,15 @@ Players may use this in the subtitle selection list.</property>
               <object class="GtkComboBox" id="ImportLanguage">
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the language of this subtitle.
+                <property name="tooltip-text" translatable="yes">Set the language of this subtitle.
 This value will be used by players in subtitle menus.</property>
                 <signal name="changed" handler="import_lang_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9550,26 +9567,26 @@ This value will be used by players in subtitle menus.</property>
             <child>
               <object class="GtkComboBox" id="SrtCodeset">
                 <property name="valign">GTK_ALIGN_FILL</property>
-                <property name="width_request">150</property>
+                <property name="width-request">150</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the character code used by the SRT file you are importing.
+                <property name="tooltip-text" translatable="yes">Set the character code used by the SRT file you are importing.
 
 SRTs come in all flavours of character sets.
 We translate the character set to UTF-8.
 The source's character code is needed in order to perform this translation.</property>
                 <signal name="changed" handler="srt_codeset_changed_cb" swapped="no"/>
-                <property name="has_entry">True</property>
+                <property name="has-entry">True</property>
                 <child internal-child="entry">
                   <object class="GtkEntry" id="combobox-entry1">
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">2</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">2</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9577,16 +9594,16 @@ The source's character code is needed in order to perform this translation.</pro
             <child>
               <object class="GtkFileChooserButton" id="ImportFile">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Select the SRT file to import.</property>
-                <property name="local_only">False</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Select the SRT file to import.</property>
+                <property name="local-only">False</property>
                 <property name="hexpand">True</property>
                 <property name="title" translatable="yes">Import File</property>
                 <signal name="selection-changed" handler="import_file_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">2</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">2</property>
+                <property name="left-attach">1</property>
                 <property name="width">2</property>
                 <property name="height">1</property>
               </packing>
@@ -9597,15 +9614,15 @@ The source's character code is needed in order to perform this translation.</pro
                 <property name="vexpand">False</property>
                 <property name="width-chars">8</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
+                <property name="tooltip-text" translatable="yes">Adjust the offset in milliseconds between video and SRT timestamps</property>
                 <property name="adjustment">adjustment31</property>
                 <signal name="value-changed" handler="import_offset_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">4</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">4</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9619,23 +9636,23 @@ The source's character code is needed in order to perform this translation.</pro
           <object class="GtkBox" id="subtitle_options_box">
             <property name="orientation">vertical</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">12</property>
+            <property name="can-focus">False</property>
+            <property name="margin-top">12</property>
             <child>
               <object class="GtkCheckButton" id="SubtitleForced">
                 <property name="label" translatable="yes">Forced Subtitles Only</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Use only subtitles that have been flagged
+                <property name="tooltip-text" translatable="yes">Use only subtitles that have been flagged
 as forced in the source subtitle track
 
 "Forced" subtitles are usually used to show
 subtitles during scenes where someone is speaking
 a foreign language.</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="subtitle_forced_toggled_cb" swapped="no"/>
               </object>
               <packing>
@@ -9646,13 +9663,13 @@ a foreign language.</property>
               <object class="GtkCheckButton" id="SubtitleBurned">
                 <property name="label" translatable="yes">Burn into video</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Render the subtitle over the video.
+                <property name="tooltip-text" translatable="yes">Render the subtitle over the video.
 The subtitle will be part of the video and can not be disabled.</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="subtitle_burned_toggled_cb" swapped="no"/>
               </object>
               <packing>
@@ -9663,10 +9680,10 @@ The subtitle will be part of the video and can not be disabled.</property>
               <object class="GtkCheckButton" id="SubtitleDefaultTrack">
                 <property name="label" translatable="yes">Set Default Track</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the default output subtitle track.
+                <property name="tooltip-text" translatable="yes">Set the default output subtitle track.
 
 Most players will automatically display this
 subtitle track whenever the video is played.
@@ -9674,7 +9691,7 @@ subtitle track whenever the video is played.
 This is useful for creating a "forced" track
 in your output.</property>
                 <property name="halign">start</property>
-                <property name="draw_indicator">True</property>
+                <property name="draw-indicator">True</property>
                 <signal name="toggled" handler="subtitle_default_toggled_cb" swapped="no"/>
               </object>
               <packing>
@@ -9690,32 +9707,36 @@ in your output.</property>
     </child>
   </object>
   <object class="GtkDialog" id="audio_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Edit Audio Track</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="modal">True</property>
     <property name="resizable">False</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <child type="action">
       <object class="GtkButton" id="audio_cancel">
         <property name="label" translatable="yes">Cancel</property>
-        <property name="image">gtk-cancel</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">False</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="audio_ok">
-        <property name="label" translatable="yes">OK</property>
-        <property name="image">gtk-ok</property>
+        <property name="label" translatable="yes">Save</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
+        <property name="can-default">True</property>
+        <property name="has-default">True</property>
+        <style>
+          <class name="default"/>
+        </style>
       </object>
     </child>
     <action-widgets>
@@ -9725,29 +9746,29 @@ in your output.</property>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-audio-vbox">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">6</property>
         <property name="margin-start">12</property>
         <property name="margin-end">12</property>
-        <property name="margin_top">12</property>
-        <property name="margin_bottom">12</property>
+        <property name="margin-top">12</property>
+        <property name="margin-bottom">12</property>
         <child>
           <object class="GtkGrid" id="audio_dialog_grid1">
             <property name="row-spacing">2</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="column_spacing">5</property>
+            <property name="can-focus">False</property>
+            <property name="column-spacing">5</property>
             <property name="vexpand">True</property>
             <child>
               <object class="GtkLabel" id="label35">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Source Track</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9756,15 +9777,15 @@ in your output.</property>
               <object class="GtkComboBox" id="AudioTrack">
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">List of audio tracks available from your source.</property>
+                <property name="tooltip-text" translatable="yes">List of audio tracks available from your source.</property>
                 <signal name="changed" handler="audio_track_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9772,14 +9793,14 @@ in your output.</property>
             <child>
               <object class="GtkLabel" id="audio_name_label">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Track Name:</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9787,21 +9808,21 @@ in your output.</property>
             <child>
               <object class="GtkEntry" id="AudioTrackName">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the audio track name.
+                <property name="tooltip-text" translatable="yes">Set the audio track name.
 
 Players may use this in the audio selection list.</property>
-                <property name="max_length">80</property>
+                <property name="max-length">80</property>
                 <property name="width-chars">40</property>
                 <property name="hexpand">True</property>
-                <property name="activates_default">True</property>
-                <property name="truncate_multiline">True</property>
+                <property name="activates-default">True</property>
+                <property name="truncate-multiline">True</property>
                 <signal name="changed" handler="audio_name_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9815,19 +9836,19 @@ Players may use this in the audio selection list.</property>
           <object class="GtkGrid" id="audio_dialog_grid2">
             <property name="row-spacing">2</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="margin_top">24</property>
+            <property name="can-focus">False</property>
+            <property name="margin-top">24</property>
             <property name="vexpand">True</property>
             <child>
               <object class="GtkLabel" id="AudioEncoderLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Encoder</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9835,14 +9856,14 @@ Players may use this in the audio selection list.</property>
             <child>
               <object class="GtkLabel" id="AudioBitrateLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Bitrate/Quality</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9850,13 +9871,13 @@ Players may use this in the audio selection list.</property>
             <child>
               <object class="GtkLabel" id="AudioMixdownLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="label" translatable="yes">Mix</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">2</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">2</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9864,14 +9885,14 @@ Players may use this in the audio selection list.</property>
             <child>
               <object class="GtkLabel" id="AudioSamplerateLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Sample Rate</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">3</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">3</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9879,14 +9900,14 @@ Players may use this in the audio selection list.</property>
             <child>
               <object class="GtkLabel" id="AudioTrackGainLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Gain</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">4</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">4</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9894,18 +9915,18 @@ Players may use this in the audio selection list.</property>
             <child>
               <object class="GtkLabel" id="AudioTrackDRCSliderLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_markup" translatable="yes">&lt;b&gt;Dynamic Range Compression:&lt;/b&gt; Adjust the dynamic range of the output audio track.
+                <property name="can-focus">False</property>
+                <property name="tooltip-markup" translatable="yes">&lt;b&gt;Dynamic Range Compression:&lt;/b&gt; Adjust the dynamic range of the output audio track.
 
 For source audio that has a wide dynamic range (very loud and very soft sequences),
 DRC allows you to 'compress' the range by making loud sounds softer and soft sounds louder.</property>
                 <property name="label" translatable="yes">DRC</property>
-                <property name="use_markup">True</property>
+                <property name="use-markup">True</property>
                 <property name="halign">center</property>
               </object>
               <packing>
-                <property name="top_attach">0</property>
-                <property name="left_attach">5</property>
+                <property name="top-attach">0</property>
+                <property name="left-attach">5</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9913,15 +9934,15 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
             <child>
               <object class="GtkComboBox" id="AudioEncoder">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the audio codec to encode this track with.</property>
+                <property name="tooltip-text" translatable="yes">Set the audio codec to encode this track with.</property>
                 <signal name="changed" handler="audio_codec_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">0</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">0</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -9930,22 +9951,22 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
               <object class="GtkBox" id="audio_dialog_hbox24">
                 <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkBox" id="AudioTrackQualityEnableBox">
                     <property name="orientation">vertical</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <child>
                       <object class="GtkRadioButton" id="AudioTrackBitrateEnable">
                         <property name="label" translatable="yes">Bitrate</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Enable bitrate setting</property>
+                        <property name="tooltip-text" translatable="yes">Enable bitrate setting</property>
                         <property name="halign">start</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="draw-indicator">True</property>
                       </object>
                       <packing>
                         <property name="position">0</property>
@@ -9955,12 +9976,12 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                       <object class="GtkRadioButton" id="AudioTrackQualityEnable">
                         <property name="label" translatable="yes">Quality</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_text" translatable="yes">Enable quality setting</property>
+                        <property name="tooltip-text" translatable="yes">Enable quality setting</property>
                         <property name="halign">start</property>
-                        <property name="draw_indicator">True</property>
+                        <property name="draw-indicator">True</property>
                         <property name="group">AudioTrackBitrateEnable</property>
                         <signal name="toggled" handler="audio_quality_radio_changed_cb" swapped="no"/>
                       </object>
@@ -9976,10 +9997,10 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                 <child>
                   <object class="GtkComboBox" id="AudioBitrate">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="valign">GTK_ALIGN_CENTER</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_text" translatable="yes">Set the bitrate to encode this track with.</property>
+                    <property name="tooltip-text" translatable="yes">Set the bitrate to encode this track with.</property>
                     <signal name="changed" handler="audio_bitrate_changed_cb" swapped="no"/>
                   </object>
                   <packing>
@@ -9990,16 +10011,16 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                   <object class="GtkBox" id="AudioTrackQualityBox">
                     <property name="orientation">horizontal</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                     <child>
                       <object class="GtkScaleButton" id="AudioTrackQualityX">
                         <property name="visible">True</property>
-                        <property name="can_focus">True</property>
+                        <property name="can-focus">True</property>
                         <property name="valign">GTK_ALIGN_CENTER</property>
-                        <property name="receives_default">False</property>
+                        <property name="receives-default">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="tooltip_markup" translatable="yes">&lt;b&gt;Quality:&lt;/b&gt; For output codec's that support it, adjust the quality of the output.</property>
+                        <property name="tooltip-markup" translatable="yes">&lt;b&gt;Quality:&lt;/b&gt; For output codec's that support it, adjust the quality of the output.</property>
                         <property name="orientation">vertical</property>
                         <property name="adjustment">audio_quality_adj</property>
                         <property name="icons">weather-storm
@@ -10019,10 +10040,10 @@ weather-clear</property>
                     <child>
                       <object class="GtkLabel" id="AudioTrackQualityValue">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="halign">start</property>
                         <property name="label" translatable="yes">00.0</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                         <property name="width-chars">4</property>
                       </object>
                       <packing>
@@ -10036,8 +10057,8 @@ weather-clear</property>
                 </child>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">1</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">1</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -10045,15 +10066,15 @@ weather-clear</property>
             <child>
               <object class="GtkComboBox" id="AudioMixdown">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the mixdown of the output audio track.</property>
+                <property name="tooltip-text" translatable="yes">Set the mixdown of the output audio track.</property>
                 <signal name="changed" handler="audio_mix_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">2</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">2</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -10061,15 +10082,15 @@ weather-clear</property>
             <child>
               <object class="GtkComboBox" id="AudioSamplerate">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="valign">GTK_ALIGN_CENTER</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                <property name="tooltip_text" translatable="yes">Set the sample rate of the output audio track.</property>
+                <property name="tooltip-text" translatable="yes">Set the sample rate of the output audio track.</property>
                 <signal name="changed" handler="audio_samplerate_changed_cb" swapped="no"/>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">3</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">3</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -10078,16 +10099,16 @@ weather-clear</property>
               <object class="GtkBox" id="hbox34">
                 <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <child>
                   <object class="GtkScaleButton" id="AudioTrackGainSlider">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="receives_default">False</property>
+                    <property name="receives-default">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_markup" translatable="yes">&lt;b&gt;Audio Gain:&lt;/b&gt; Adjust the amplification or attenuation of the output audio track.</property>
+                    <property name="tooltip-markup" translatable="yes">&lt;b&gt;Audio Gain:&lt;/b&gt; Adjust the amplification or attenuation of the output audio track.</property>
                     <property name="orientation">vertical</property>
                     <property name="adjustment">adjustment35</property>
                     <property name="icons">audio-volume-muted
@@ -10103,10 +10124,10 @@ audio-volume-medium</property>
                 <child>
                   <object class="GtkLabel" id="AudioTrackGainValue">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">0dB</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                     <property name="width-chars">6</property>
                   </object>
                   <packing>
@@ -10115,8 +10136,8 @@ audio-volume-medium</property>
                 </child>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">4</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">4</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -10125,16 +10146,16 @@ audio-volume-medium</property>
               <object class="GtkBox" id="hbox33">
                 <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <child>
                   <object class="GtkScaleButton" id="AudioTrackDRCSlider">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
+                    <property name="can-focus">True</property>
                     <property name="valign">GTK_ALIGN_CENTER</property>
-                    <property name="receives_default">False</property>
+                    <property name="receives-default">False</property>
                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                    <property name="tooltip_markup" translatable="yes">&lt;b&gt;Dynamic Range Compression:&lt;/b&gt; Adjust the dynamic range of the output audio track.
+                    <property name="tooltip-markup" translatable="yes">&lt;b&gt;Dynamic Range Compression:&lt;/b&gt; Adjust the dynamic range of the output audio track.
 
 For source audio that has a wide dynamic range (very loud and very soft sequences),
 DRC allows you to 'compress' the range by making loud sounds softer and soft sounds louder.</property>
@@ -10150,10 +10171,10 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                 <child>
                   <object class="GtkLabel" id="AudioTrackDRCValue">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">Off</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                     <property name="width-chars">4</property>
                   </object>
                   <packing>
@@ -10162,8 +10183,8 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                 </child>
               </object>
               <packing>
-                <property name="top_attach">1</property>
-                <property name="left_attach">5</property>
+                <property name="top-attach">1</property>
+                <property name="left-attach">5</property>
                 <property name="width">1</property>
                 <property name="height">1</property>
               </packing>
@@ -10177,29 +10198,30 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
     </child>
   </object>
   <object class="GtkDialog" id="update_dialog">
-    <property name="transient_for">hb_window</property>
-    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">HandBrake Updater</property>
+    <property name="transient-for">hb_window</property>
+    <property name="can-focus">False</property>
     <property name="modal">True</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
-    <property name="skip_taskbar_hint">True</property>
-    <property name="skip_pager_hint">True</property>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
+    <property name="skip-taskbar-hint">True</property>
+    <property name="skip-pager-hint">True</property>
     <property name="deletable">False</property>
     <property name="use-header-bar">1</property>
     <child type="action">
       <object class="GtkButton" id="update_skip">
         <property name="label" translatable="yes">Skip This Version</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
       </object>
     </child>
     <child type="action">
       <object class="GtkButton" id="update_remind">
         <property name="label" translatable="yes">Remind Me Later</property>
         <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
+        <property name="can-focus">True</property>
+        <property name="receives-default">True</property>
       </object>
     </child>
     <action-widgets>
@@ -10209,32 +10231,32 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox8">
         <property name="visible">True</property>
-        <property name="can_focus">False</property>
+        <property name="can-focus">False</property>
         <property name="spacing">2</property>
         <child>
           <object class="GtkBox" id="hbox24">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="vexpand">True</property>
             <child>
               <object class="GtkBox" id="vbox19">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <child>
                   <object class="GtkEventBox" id="eventbox2">
-                    <property name="visible_window">False</property>
+                    <property name="visible-window">False</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="events">GDK_BUTTON_MOTION_MASK | GDK_BUTTON_PRESS_MASK | GDK_STRUCTURE_MASK</property>
                     <child>
                       <object class="GtkImage" id="image10">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                        <property name="pixel_size">64</property>
-                        <property name="icon_name">hb-icon</property>
+                        <property name="pixel-size">64</property>
+                        <property name="icon-name">hb-icon</property>
                       </object>
                     </child>
                   </object>
@@ -10254,19 +10276,19 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
               <object class="GtkBox" id="vbox41">
                 <property name="orientation">vertical</property>
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
+                <property name="can-focus">False</property>
                 <property name="hexpand">True</property>
                 <child>
                   <object class="GtkLabel" id="label22">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin-start">10</property>
                     <property name="margin-end">10</property>
                     <property name="margin-top">5</property>
                     <property name="margin-bottom">5</property>
                     <property name="label" translatable="yes">&lt;b&gt;A new version of HandBrake is available!&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
+                    <property name="use-markup">True</property>
                   </object>
                   <packing>
                     <property name="position">0</property>
@@ -10275,7 +10297,7 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                 <child>
                   <object class="GtkLabel" id="update_message">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
+                    <property name="can-focus">False</property>
                     <property name="halign">start</property>
                     <property name="margin-start">10</property>
                     <property name="margin-end">10</property>
@@ -10290,16 +10312,16 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                 <child>
                   <object class="GtkFrame" id="frame15">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">etched-out</property>
+                    <property name="can-focus">False</property>
+                    <property name="label-xalign">0</property>
+                    <property name="shadow-type">etched-out</property>
                     <property name="vexpand">True</property>
                     <child>
                       <object class="GtkScrolledWindow" id="update_scroll">
                         <property name="margin-start">12</property>
                         <property name="halign">start</property>
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <child>
                           <placeholder/>
                         </child>
@@ -10308,9 +10330,9 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
                     <child type="label">
                       <object class="GtkLabel" id="label88">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
+                        <property name="can-focus">False</property>
                         <property name="label" translatable="yes">&lt;b&gt;Release Notes&lt;/b&gt;</property>
-                        <property name="use_markup">True</property>
+                        <property name="use-markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -10333,7 +10355,7 @@ DRC allows you to 'compress' the range by making loud sounds softer and soft sou
   </object>
   <object class="GtkAdjustment" id="VideoPresetRange">
     <property name="upper">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
   </object>
 </interface>

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -238,6 +238,16 @@ conjunction with the "Forced" option.</property>
   <menu id="queue_options_menu">
     <section>
       <item>
+        <attribute name="label" translatable="yes">Move to Top</attribute>
+        <attribute name="action">app.queue-move-top</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Move to Bottom</attribute>
+        <attribute name="action">app.queue-move-bottom</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
         <attribute name="label" translatable="yes">Reset Failed Jobs</attribute>
         <attribute name="action">app.queue-reset-fail</attribute>
       </item>
@@ -253,6 +263,8 @@ conjunction with the "Forced" option.</property>
         <attribute name="label" translatable="yes">Clear All Jobs</attribute>
         <attribute name="action">app.queue-delete-all</attribute>
       </item>
+    </section>
+    <section>
       <item>
         <attribute name="label" translatable="yes">Import Queue</attribute>
         <attribute name="action">app.queue-import</attribute>

--- a/gtk/src/ghbcompat.c
+++ b/gtk/src/ghbcompat.c
@@ -25,7 +25,7 @@
 G_MODULE_EXPORT gboolean
 ghb_widget_hide_on_close(
     GtkWidget *widget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     gpointer *ud)

--- a/gtk/src/ghbcompat.h
+++ b/gtk/src/ghbcompat.h
@@ -39,24 +39,12 @@
 #define GHB_ICON_SIZE_BUTTON GTK_ICON_SIZE_BUTTON
 #endif
 
-#if !GTK_CHECK_VERSION(3, 10, 0)
-#define gtk_image_set_from_icon_name gtk_image_set_from_stock
-#define GHB_PLAY_ICON "gtk-media-play"
-#define GHB_PAUSE_ICON "gtk-media-pause"
-#else
 #define GHB_PLAY_ICON "media-playback-start"
 #define GHB_PAUSE_ICON "media-playback-pause"
-#endif
 
-#if !GTK_CHECK_VERSION(3, 10, 0)
-#define GHB_STOCK_OPEN      GTK_STOCK_OPEN
-#define GHB_STOCK_CANCEL    GTK_STOCK_CANCEL
-#define GHB_STOCK_SAVE      GTK_STOCK_SAVE
-#else
 #define GHB_STOCK_OPEN      "_Open"
 #define GHB_STOCK_CANCEL    "_Cancel"
 #define GHB_STOCK_SAVE      "_Save"
-#endif
 
 static inline void ghb_widget_get_preferred_width(
     GtkWidget *widget, gint *min_width, gint * natural_width)
@@ -155,52 +143,31 @@ static inline void ghb_css_provider_load_from_data(GtkCssProvider *provider,
 
 static inline GdkEventType ghb_event_get_event_type(const GdkEvent *event)
 {
-#if GTK_CHECK_VERSION(3, 10, 0)
     return gdk_event_get_event_type(event);
-#else
-    return event->type;
-#endif
 }
 
 static inline gboolean ghb_event_get_keyval(const GdkEvent *event,
                                             guint *keyval)
 {
-#if GTK_CHECK_VERSION(3, 2, 0)
     return gdk_event_get_keyval(event, keyval);
-#else
-    *keyval = ((GdkEventKey*)event)->keyval;
-    return TRUE;
-#endif
 }
 
 static inline gboolean ghb_event_get_button(const GdkEvent *event,
                                             guint *button)
 {
-#if GTK_CHECK_VERSION(3, 2, 0)
     return gdk_event_get_button(event, button);
-#else
-    *keyval = ((GdkEventButton*)event)->button;
-    return TRUE;
-#endif
 }
 
 static inline PangoFontDescription* ghb_widget_get_font(GtkWidget *widget)
 {
     PangoFontDescription *font = NULL;
 
-#if GTK_CHECK_VERSION(3, 0, 0)
     GtkStyleContext *style;
 
     style = gtk_widget_get_style_context(widget);
 
-#if GTK_CHECK_VERSION(3, 8, 0)
     gtk_style_context_get(style, GTK_STATE_FLAG_NORMAL,
                           "font", &font, NULL);
-#else
-    font = gtk_style_context_get_font(style, GTK_STATE_FLAG_NORMAL);
-#endif
-#endif
-
     return font;
 }
 
@@ -254,7 +221,6 @@ static inline void ghb_monitor_get_size(GtkWidget *widget, gint *w, gint *h)
 {
     *w = *h = 0;
 
-#if GTK_CHECK_VERSION(3, 22, 0)
     GdkDisplay * display = gtk_widget_get_display(widget);
     GhbSurface * surface = ghb_widget_get_surface(widget);
     if (surface != NULL && display != NULL)
@@ -271,16 +237,6 @@ static inline void ghb_monitor_get_size(GtkWidget *widget, gint *w, gint *h)
             *h = rect.height;
         }
     }
-#else
-    GdkScreen *ss;
-
-    ss = gdk_screen_get_default();
-    if (ss != NULL)
-    {
-        *w = gdk_screen_get_width(ss);
-        *h = gdk_screen_get_height(ss);
-    }
-#endif
 }
 
 static inline gboolean ghb_strv_contains(const char ** strv, const char * str)

--- a/gtk/src/ghbcompat.h
+++ b/gtk/src/ghbcompat.h
@@ -33,7 +33,7 @@
 #define GHB_UNSAFE_FILENAME_CHARS "/"
 #endif
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 #define GHB_ICON_SIZE_BUTTON GTK_ICON_SIZE_NORMAL
 #else
 #define GHB_ICON_SIZE_BUTTON GTK_ICON_SIZE_BUTTON
@@ -49,7 +49,7 @@
 static inline void ghb_widget_get_preferred_width(
     GtkWidget *widget, gint *min_width, gint * natural_width)
 {
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GtkRequisition min_req, nat_req;
 
     gtk_widget_get_preferred_size(widget, &min_req, &nat_req);
@@ -69,7 +69,7 @@ static inline void ghb_widget_get_preferred_width(
 static inline void ghb_widget_get_preferred_height(
     GtkWidget *widget, gint *min_height, gint * natural_height)
 {
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GtkRequisition min_req, nat_req;
 
     gtk_widget_get_preferred_size(widget, &min_req, &nat_req);
@@ -89,7 +89,7 @@ static inline void ghb_widget_get_preferred_height(
 static inline void ghb_button_set_icon_name(GtkButton *button,
                                             const char * name)
 {
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     gtk_button_set_icon_name(button, name);
 #else
     GtkImage *image;
@@ -117,7 +117,7 @@ static inline void ghb_get_expand_fill(GtkBox * box, GtkWidget * child,
 
 static inline void ghb_box_append_child(GtkBox * box, GtkWidget * child)
 {
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GtkWidget * sibling = NULL;
 
     sibling = gtk_widget_get_last_child(GTK_WIDGET(box));
@@ -134,7 +134,7 @@ static inline void ghb_css_provider_load_from_data(GtkCssProvider *provider,
                                                    const gchar *data,
                                                    gssize length)
 {
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     gtk_css_provider_load_from_data(provider, data, length);
 #else
     gtk_css_provider_load_from_data(provider, data, length, NULL);
@@ -171,7 +171,7 @@ static inline PangoFontDescription* ghb_widget_get_font(GtkWidget *widget)
     return font;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 typedef GdkSurface      GhbSurface;
 typedef GdkSurfaceHints GhbSurfaceHints;
 
@@ -261,7 +261,7 @@ static inline gboolean ghb_strv_contains(const char ** strv, const char * str)
 #endif
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 
 #define ghb_editable_get_text(e) gtk_editable_get_text(GTK_EDITABLE(e))
 #define ghb_editable_set_text(e,t) gtk_editable_set_text(GTK_EDITABLE(e), (t))
@@ -273,7 +273,7 @@ static inline gboolean ghb_strv_contains(const char ** strv, const char * str)
 
 #endif
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static inline void
 ghb_image_set_from_icon_name(GtkImage * image, const gchar * name,
                              GtkIconSize size)
@@ -333,7 +333,7 @@ ghb_scale_button_new(gdouble min, gdouble max, gdouble step,
 }
 #endif
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static inline void ghb_drag_status(GdkDrop * ctx, GdkDragAction action,
                                    guint32 time)
 {
@@ -347,7 +347,7 @@ static inline void ghb_drag_status(GdkDragContext * ctx, GdkDragAction action,
 }
 #endif
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static inline void ghb_entry_set_width_chars(GtkEntry * entry, gint n_chars)
 {
     gtk_editable_set_width_chars(GTK_EDITABLE(entry), n_chars);
@@ -359,7 +359,7 @@ static inline void ghb_entry_set_width_chars(GtkEntry * entry, gint n_chars)
 }
 #endif
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static inline GdkAtom ghb_atom_string(const char * str)
 {
     return g_intern_static_string(str);

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -2202,7 +2202,7 @@ language_opts_set(signal_user_data_t *ud, const gchar *name,
                            -1);
         g_free(lang);
     }
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     // This is handled by GtkEventControllerKey in gtk4
     // Initialized in ghb_combo_init()
     g_signal_connect(combo, "key-press-event", combo_search_key_press_cb, ud);
@@ -3509,7 +3509,7 @@ ghb_combo_init(signal_user_data_t *ud)
     // Populate all the combos
     ghb_update_ui_combo_box(ud, NULL, NULL, TRUE);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GtkWidget          * combo;
     GtkEventController * econ;
 

--- a/gtk/src/icons.c
+++ b/gtk/src/icons.c
@@ -26,60 +26,7 @@
 void
 ghb_load_icons()
 {
-#if GTK_CHECK_VERSION(3, 14, 0)
     ghb_icons_register_resource();
     gtk_icon_theme_add_resource_path(gtk_icon_theme_get_default(),
                                      "/fr/handbrake/ghb/icons");
-#else
-    ghb_icons_register_resource();
-    GResource *icon_res = ghb_icons_get_resource();
-
-    char ** children = g_resource_enumerate_children(icon_res,
-                            "/fr/handbrake/ghb/icons/scalable/apps", 0, NULL);
-
-    if (children == NULL)
-    {
-        g_warning("No icons in resources!");
-        return;
-    }
-    int ii;
-    for (ii = 0; children[ii] != NULL; ii++)
-    {
-        char * path;
-
-        path = g_strdup_printf("/fr/handbrake/ghb/icons/scalable/apps/%s",
-                               children[ii]);
-        GBytes *gbytes = g_resource_lookup_data(icon_res, path, 0, NULL);
-        gsize data_size;
-        gconstpointer data = g_bytes_get_data(gbytes, &data_size);
-        g_free(path);
-
-        char *pos;
-        char *name = g_strdup(children[ii]);
-        pos = g_strstr_len(name, -1, ".");
-        if (pos != NULL)
-            *pos = '\0';
-
-        int jj;
-        int sizes[] = {16, 22, 24, 32, 48, 64, 128, 256, 0};
-        for (jj = 0; sizes[jj]; jj++)
-        {
-            GdkPixbuf *pb;
-            GInputStream *gis;
-            int size;
-
-            gis = g_memory_input_stream_new_from_data(data, data_size,
-                                                      NULL);
-            pb = gdk_pixbuf_new_from_stream_at_scale(gis,
-                                                     sizes[jj], sizes[jj],
-                                                     TRUE, NULL, NULL);
-            g_input_stream_close(gis, NULL, NULL);
-            size = gdk_pixbuf_get_height(pb);
-            gtk_icon_theme_add_builtin_icon(name, size, pb);
-            g_object_unref(pb);
-        }
-        g_bytes_unref(gbytes);
-    }
-    g_strfreev(children);
-#endif
 }

--- a/gtk/src/internal_defaults.json.template
+++ b/gtk/src/internal_defaults.json.template
@@ -80,6 +80,7 @@
         "AutoScan": false,
         "AddCC": false,
         "EncodeLogLocation": false,
+        "ShowMiniPreview": true,
         "allow_tweaks": false,
         "last_update_check": 0,
         "check_updates": "weekly",

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -669,21 +669,17 @@ const gchar *MyCSS =
 "    padding: 0px 0px 0px 0px;"
 "}"
 
-#if GTK_CHECK_VERSION(3, 20, 0)
 "stackswitcher button.text-button"
 "{"
 "    min-width: 50px;"
 "}"
-#endif
 
-#if GTK_CHECK_VERSION(3, 16, 0)
 "#activity_view"
 "{"
 "    font-family: monospace;"
 "    font-size: 8pt;"
 "    font-weight: 300;"
 "}"
-#endif
 
 ".row:not(:first-child)"
 "{"
@@ -1147,14 +1143,6 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     ghb_add_file_filter(chooser, ud, "FLV", "SourceFilterFLV");
     ghb_add_file_filter(chooser, ud, "WMV", "SourceFilterWMV");
 
-
-#if !GTK_CHECK_VERSION(3, 16, 0)
-    PangoFontDescription *font_desc;
-    font_desc = pango_font_description_from_string("monospace 10");
-    textview = GTK_TEXT_VIEW(GHB_WIDGET(ud->builder, "activity_view"));
-    gtk_widget_override_font(GTK_WIDGET(textview), font_desc);
-    pango_font_description_free(font_desc);
-#endif
 
     // Grrrr!  Gtk developers !!!hard coded!!! the width of the
     // radio buttons in GtkStackSwitcher to 100!!!

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -326,7 +326,7 @@ extern G_MODULE_EXPORT void presets_drag_motion_cb(void);
 extern G_MODULE_EXPORT void preset_edited_cb(void);
 extern void presets_row_expanded_cb(void);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static const char * presets_drag_entries[] = {
     "widget/presets-list-row-drop"
 };
@@ -364,7 +364,7 @@ bind_presets_tree_model(signal_user_data_t *ud)
     gtk_tree_view_column_set_expand(column, TRUE);
     gtk_tree_view_set_tooltip_column(treeview, 3);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkContentFormats * targets;
 
     targets = gdk_content_formats_new(presets_drag_entries,
@@ -924,7 +924,7 @@ ghb_idle_ui_init(signal_user_data_t *ud)
     return FALSE;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 extern G_MODULE_EXPORT void easter_egg_multi_cb(void);
 extern G_MODULE_EXPORT void preview_leave_cb(void);
 extern G_MODULE_EXPORT void preview_motion_cb(void);
@@ -942,7 +942,7 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     ghb_css_provider_load_from_data(provider, MyCSS, -1);
     color_scheme_set(APP_PREFERS_LIGHT);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkDisplay *dd = gdk_display_get_default();
     gtk_style_context_add_provider_for_display(dd,
                                 GTK_STYLE_PROVIDER(provider),
@@ -1185,7 +1185,7 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     GMenuModel *menu = G_MENU_MODEL(gtk_builder_get_object(ud->builder, "handbrake-menu"));
     gtk_application_set_menubar(GTK_APPLICATION(app), menu);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     // GTK4 Event handling.
     GtkGesture         * gest;
     GtkEventController * econ;

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -738,7 +738,7 @@ dvd_source_activate_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 source_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
-single_title_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
+source_dir_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 destination_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
@@ -834,7 +834,7 @@ static void map_actions(GApplication * app, signal_user_data_t * ud)
     const GActionEntry entries[] =
     {
         { "source",                source_action_cb                },
-        { "single",                single_title_action_cb          },
+        { "source-dir",             source_dir_action_cb           },
         { "destination",           destination_action_cb           },
         { "preferences",           preferences_action_cb           },
         { "quit",                  quit_action_cb                  },
@@ -1121,28 +1121,6 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     gint window_width, window_height;
     window_width = ghb_dict_get_int(ud->prefs, "window_width");
     window_height = ghb_dict_get_int(ud->prefs, "window_height");
-
-    /*
-     * Filter objects in GtkBuilder xml
-     * Add filters to source chooser
-     */
-    GtkFileChooser *chooser;
-    chooser = GTK_FILE_CHOOSER(GHB_WIDGET(ud->builder, "source_dialog"));
-    ghb_add_file_filter(chooser, ud, _("All"), "FilterAll");
-    ghb_add_file_filter(chooser, ud, _("Video"), "SourceFilterVideo");
-    ghb_add_file_filter(chooser, ud, "TS", "SourceFilterTS");
-    ghb_add_file_filter(chooser, ud, "MPG", "SourceFilterMPG");
-    ghb_add_file_filter(chooser, ud, "EVO", "SourceFilterEVO");
-    ghb_add_file_filter(chooser, ud, "VOB", "SourceFilterVOB");
-    ghb_add_file_filter(chooser, ud, "MKV", "SourceFilterMKV");
-    ghb_add_file_filter(chooser, ud, "WebM", "SourceFilterWebM");
-    ghb_add_file_filter(chooser, ud, "MP4", "SourceFilterMP4");
-    ghb_add_file_filter(chooser, ud, "MOV", "SourceFilterMOV");
-    ghb_add_file_filter(chooser, ud, "AVI", "SourceFilterAVI");
-    ghb_add_file_filter(chooser, ud, "OGG", "SourceFilterOGG");
-    ghb_add_file_filter(chooser, ud, "FLV", "SourceFilterFLV");
-    ghb_add_file_filter(chooser, ud, "WMV", "SourceFilterWMV");
-
 
     // Grrrr!  Gtk developers !!!hard coded!!! the width of the
     // radio buttons in GtkStackSwitcher to 100!!!

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -762,6 +762,10 @@ queue_export_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 queue_import_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
+queue_move_top_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
+G_MODULE_EXPORT void
+queue_move_bottom_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
+G_MODULE_EXPORT void
 queue_open_source_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 queue_open_dest_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
@@ -837,6 +841,8 @@ static void map_actions(GApplication * app, signal_user_data_t * ud)
         { "queue-add-all",         queue_add_all_action_cb         },
         { "queue-start",           queue_start_action_cb           },
         { "queue-pause",           queue_pause_action_cb           },
+        { "queue-move-top",        queue_move_top_action_cb        },
+        { "queue-move-bottom",     queue_move_bottom_action_cb     },
         { "queue-open-source",     queue_open_source_action_cb     },
         { "queue-open-dest",       queue_open_dest_action_cb       },
         { "queue-open-log-dir",    queue_open_log_dir_action_cb    },

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -758,6 +758,8 @@ queue_start_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 queue_pause_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
+queue_play_file_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
+G_MODULE_EXPORT void
 queue_export_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 queue_import_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
@@ -778,6 +780,9 @@ queue_delete_all_action_cb(GSimpleAction *action, GVariant *param,
                            gpointer ud);
 G_MODULE_EXPORT void
 queue_delete_complete_action_cb(GSimpleAction *action, GVariant *param,
+                                gpointer ud);
+G_MODULE_EXPORT void
+queue_delete_action_cb(GSimpleAction *action, GVariant *param,
                                 gpointer ud);
 G_MODULE_EXPORT void
 queue_reset_fail_action_cb(GSimpleAction *action, GVariant *param,
@@ -841,6 +846,7 @@ static void map_actions(GApplication * app, signal_user_data_t * ud)
         { "queue-add-all",         queue_add_all_action_cb         },
         { "queue-start",           queue_start_action_cb           },
         { "queue-pause",           queue_pause_action_cb           },
+        { "queue-play-file",       queue_play_file_action_cb       },
         { "queue-move-top",        queue_move_top_action_cb        },
         { "queue-move-bottom",     queue_move_bottom_action_cb     },
         { "queue-open-source",     queue_open_source_action_cb     },
@@ -850,6 +856,7 @@ static void map_actions(GApplication * app, signal_user_data_t * ud)
         { "queue-reset-fail",      queue_reset_fail_action_cb      },
         { "queue-reset-all",       queue_reset_all_action_cb       },
         { "queue-reset",           queue_reset_action_cb           },
+        { "queue-delete",          queue_delete_action_cb          },
         { "queue-delete-complete", queue_delete_complete_action_cb },
         { "queue-delete-all",      queue_delete_all_action_cb      },
         { "queue-export",          queue_export_action_cb          },

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -654,59 +654,8 @@ const gchar *MyCSS =
 
 "#preview_hud"
 "{"
-"    border-radius: 20px;"
-"    background-color: alpha(@gray18, 0.8);"
-"    color: @white;"
-"}"
-
-"#live_preview_play,"
-"#live_duration,"
-"#preview_reset"
-"{"
-"    background: @black;"
-"    background-color: @gray18;"
-"    color: @white;"
-"}"
-
-"#preview_show_crop"
-"{"
-"    background-color: @gray22;"
-"    border-color: @white;"
-"    color: @white;"
-"}"
-
-"#live_encode_progress,"
-"#live_preview_progress,"
-"#preview_frame"
-"{"
-"    background: @black;"
-"    background-color: alpha(@gray18, 0.0);"
-"    color: @white;"
-"}"
-
-#if GTK_CHECK_VERSION(3, 20, 0)
-"#preview_reset:hover"
-#else
-"#preview_reset:prelight"
-#endif
-"{"
-"    background: @black;"
-"    background-color: @gray32;"
-"    color: @white;"
-"}"
-
-"#preview_reset:active"
-"{"
-"    background: @black;"
-"    background-color: @gray32;"
-"    color: @white;"
-"}"
-
-"#preview_reset:active"
-"{"
-"    background: @black;"
-"    background-color: @gray32;"
-"    color: @white;"
+"    border-radius: 16px;"
+"    border-width: 1px;"
 "}"
 
 "textview"
@@ -865,6 +814,8 @@ preset_import_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 presets_reload_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
+preview_fullscreen_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
+G_MODULE_EXPORT void
 about_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
 G_MODULE_EXPORT void
 guide_action_cb(GSimpleAction *action, GVariant *param, gpointer ud);
@@ -920,7 +871,9 @@ static void map_actions(GApplication * app, signal_user_data_t * ud)
         { "about",                 about_action_cb                 },
         { "guide",                 guide_action_cb                 },
         { "preset-select",         preset_select_action_cb, "s"    },
-        { "preset-reload",         preset_reload_action_cb,        },
+        { "preset-reload",         preset_reload_action_cb         },
+        { "preview-fullscreen",    NULL,
+          NULL, "false",           preview_fullscreen_action_cb    },
     };
     g_action_map_add_action_entries(G_ACTION_MAP(app), entries,
                                     G_N_ELEMENTS(entries), ud);
@@ -1050,6 +1003,7 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "preview_hud"), "preview_hud");
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "preview_frame"), "preview_frame");
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "live_preview_play"), "live_preview_play");
+    gtk_widget_set_name(GHB_WIDGET(ud->builder, "live_preview_fullscreen"), "live_preview_fullscreen");
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "live_preview_progress"), "live_preview_progress");
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "live_encode_progress"), "live_encode_progress");
     gtk_widget_set_name(GHB_WIDGET(ud->builder, "live_duration"), "live_duration");
@@ -1223,6 +1177,8 @@ ghb_activate_cb(GApplication * app, signal_user_data_t * ud)
     GtkWidget * window = GHB_WIDGET(ud->builder, "presets_window");
     gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(window));
     window = GHB_WIDGET(ud->builder, "queue_window");
+    gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(window));
+    window = GHB_WIDGET(ud->builder, "preview_window");
     gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(window));
 
     GMenuModel *menu = G_MENU_MODEL(gtk_builder_get_object(ud->builder, "handbrake-menu"));

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -681,7 +681,7 @@ const gchar *MyCSS =
 "{"
 "    font-family: monospace;"
 "    font-size: 8pt;"
-"    font-weight: lighter;"
+"    font-weight: 300;"
 "}"
 #endif
 

--- a/gtk/src/menu.ui
+++ b/gtk/src/menu.ui
@@ -8,12 +8,12 @@
       <section>
         <item>
           <attribute name="action">app.source</attribute>
-          <attribute name="label" translatable="yes">Open _Source</attribute>
+          <attribute name="label" translatable="yes">_Open Source</attribute>
           <attribute name="accel">&lt;control&gt;O</attribute>
         </item>
         <item>
-          <attribute name="action">app.single</attribute>
-          <attribute name="label" translatable="yes">Open Single _Title</attribute>
+          <attribute name="action">app.source-dir</attribute>
+          <attribute name="label" translatable="yes">Open _Directory</attribute>
           <attribute name="accel">&lt;shift&gt;&lt;control&gt;O</attribute>
         </item>
         <item>

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -85,47 +85,7 @@ ghb_tree_path_new_from_index(const hb_preset_index_t *path)
     if (path == NULL || path->depth == 0)
         return NULL;
 
-#if GTK_CHECK_VERSION(3, 12, 0)
     return gtk_tree_path_new_from_indicesv((int*)path->index, path->depth);
-#else
-    switch (path->depth)
-    {
-        case 1:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], -1);
-        case 2:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], -1);
-        case 3:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2], -1);
-        case 4:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2],
-                path->index[3], -1);
-        case 5:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2],
-                path->index[3], path->index[4], -1);
-        case 6:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2],
-                path->index[3], path->index[4], path->index[5], -1);
-        case 7:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2],
-                path->index[3], path->index[4], path->index[5],
-                path->index[6], -1);
-        case 8:
-            return gtk_tree_path_new_from_indices(
-                path->index[0], path->index[1], path->index[2],
-                path->index[3], path->index[4], path->index[5],
-                path->index[6], path->index[7], -1);
-        default:
-            g_warning("Preset path depth too deep");
-            return NULL;
-    }
-#endif
 }
 
 #if 0

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1124,7 +1124,7 @@ get_selected_path(signal_user_data_t *ud)
 G_MODULE_EXPORT gboolean
 presets_window_delete_cb(
     GtkWidget *xwidget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -1141,7 +1141,7 @@ presets_window_delete_cb(
 G_MODULE_EXPORT void
 presets_sz_alloc_cb(
     GtkWidget *widget,
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     int width,
     int height,
     int baseline,
@@ -2510,7 +2510,7 @@ preset_remove_action_cb(GSimpleAction *action, GVariant *param,
 
 // controls where valid drop locations are
 G_MODULE_EXPORT gboolean
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 presets_drag_motion_cb(
     GtkTreeView        *tv,
     GdkDrop            *ctx,
@@ -2538,7 +2538,7 @@ presets_drag_motion_cb(
     gboolean                 src_folder, dst_folder;
     GhbValue                *src_preset, *dst_preset;
     GtkWidget               *widget;
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     // Dummy time for backwards compatibility
     guint                    time = 0;
 #endif
@@ -2550,7 +2550,7 @@ presets_drag_motion_cb(
     }
     g_object_set_data(G_OBJECT(tv), "dst-tree-path", NULL);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkDrag *drag_ctx = gdk_drop_get_drag(ctx);
     widget = gtk_drag_get_source_widget(drag_ctx);
 #else
@@ -2670,7 +2670,7 @@ presets_drag_motion_cb(
 }
 
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 presets_drag_data_received_cb(
     GtkTreeView        *tv,
     GdkDrop            *dc,
@@ -2710,7 +2710,7 @@ presets_drag_data_received_cb(
     GtkTreeSelection  *select;
     hb_preset_index_t *dst_path, *src_path;
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkDrag *drag_ctx = gdk_drop_get_drag(dc);
     src_widget = GTK_TREE_VIEW(gtk_drag_get_source_widget(drag_ctx));
 #else

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -2029,7 +2029,7 @@ preset_import_action_cb(GSimpleAction *action, GVariant *param,
     GtkFileFilter   *filter;
 
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new("Import Preset", hb_window,
+    dialog = gtk_file_chooser_dialog_new(_("Import Preset"), hb_window,
                 GTK_FILE_CHOOSER_ACTION_OPEN,
                 GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
                 GHB_STOCK_OPEN, GTK_RESPONSE_ACCEPT,

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -920,7 +920,7 @@ static void set_mini_preview_image(signal_user_data_t *ud, GdkPixbuf * pix)
             GtkWidget * widget;
 
             widget = GHB_WIDGET (ud->builder, "preview_button_image");
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
             gtk_picture_set_pixbuf(GTK_PICTURE(widget), scaled_preview);
 #else
             gtk_image_set_from_pixbuf(GTK_IMAGE(widget), scaled_preview);
@@ -1090,7 +1090,7 @@ ghb_reset_preview_image(signal_user_data_t *ud)
     gtk_widget_queue_draw(widget);
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 preview_draw_cb(
     GtkDrawingArea * da,
@@ -1124,7 +1124,7 @@ preview_draw_cb(
 G_MODULE_EXPORT void
 preview_button_size_allocate_cb(
     GtkWidget *widget,
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     int width,
     int height,
     int baseline,
@@ -1133,7 +1133,7 @@ preview_button_size_allocate_cb(
 #endif
     signal_user_data_t *ud)
 {
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     int width  = rect->width;
     int height = rect->height;
 #endif
@@ -1164,7 +1164,7 @@ ghb_preview_set_visible(signal_user_data_t *ud, gboolean visible)
     widget = GHB_WIDGET(ud->builder, "preview_window");
     if (visible)
     {
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
         // TODO: can this be done in GTK4?
         gint x, y;
         x = ghb_dict_get_int(ud->prefs, "preview_x");
@@ -1227,7 +1227,7 @@ preview_frame_value_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
 G_MODULE_EXPORT gboolean
 preview_window_delete_cb(
     GtkWidget *widget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -1264,7 +1264,7 @@ hud_timeout(signal_user_data_t *ud)
     return FALSE;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 hud_enter_cb(
     GtkEventControllerMotion * econ,
@@ -1299,12 +1299,12 @@ hud_enter_cb(
     }
     hud_timeout_id = 0;
     in_hud = TRUE;
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     return FALSE;
 #endif
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 hud_leave_cb(
     GtkEventControllerMotion * econ,
@@ -1320,7 +1320,7 @@ hud_leave_cb(
 #endif
 {
     in_hud = FALSE;
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     return FALSE;
 #endif
 }
@@ -1334,7 +1334,7 @@ preview_click_cb(GtkWidget *widget, GdkEvent *event, signal_user_data_t *ud)
     return FALSE;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 preview_leave_cb(
     GtkEventControllerMotion * econ,
@@ -1360,12 +1360,12 @@ preview_leave_cb(
             g_source_destroy(source);
     }
     hud_timeout_id = g_timeout_add(300, (GSourceFunc)hud_timeout, ud);
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     return FALSE;
 #endif
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 preview_motion_cb(
     GtkEventControllerMotion * econ,
@@ -1401,7 +1401,7 @@ preview_motion_cb(
     {
         hud_timeout_id = g_timeout_add_seconds(4, (GSourceFunc)hud_timeout, ud);
     }
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     return FALSE;
 #endif
 }
@@ -1413,7 +1413,7 @@ preview_motion_cb(
 //
 // Hopefully they will fix this or provide a better alternative
 // before gtk4 is released.
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT gboolean
 preview_configure_cb(
     GtkWidget *widget,
@@ -1436,7 +1436,7 @@ preview_configure_cb(
 }
 #endif
 
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
 // GTK4 no longer has GDK_WINDOW_STATE events :*(
 G_MODULE_EXPORT gboolean
 preview_state_cb(
@@ -1468,7 +1468,7 @@ preview_state_cb(
 G_MODULE_EXPORT void
 preview_resize_cb(
     GtkWidget     *widget,
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     int width,
     int height,
     int baseline,
@@ -1477,7 +1477,7 @@ preview_resize_cb(
 #endif
     signal_user_data_t *ud)
 {
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     int width  = rect->width;
     int height = rect->height;
 #endif

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -586,16 +586,25 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         track         = ghb_dict_get_int(asettings, "Track");
         asource       = ghb_array_get(sourceAudioList, track);
         lang          = ghb_dict_get_string(asource, "Language");
+        name          = ghb_dict_get_string(asettings, "Name");
         audio_encoder = ghb_settings_audio_encoder(asettings, "Encoder");
+        if (name)
+        {
+            g_string_append_printf(str, "%s%s - ", sep, name);
+        }
+        else
+        {
+            g_string_append_printf(str, "%s", sep);
+        }
         if (audio_encoder->codec & HB_ACODEC_PASS_FLAG)
         {
-            g_string_append_printf(str, "%s%s, %s", sep, lang,
+            g_string_append_printf(str, "%s, %s", lang,
                                    audio_encoder->name);
         }
         else
         {
             audio_mix = ghb_settings_mixdown(asettings, "Mixdown");
-            g_string_append_printf(str, "%s%s, %s, %s", sep, lang,
+            g_string_append_printf(str, "%s, %s, %s", lang,
                                    audio_encoder->name, audio_mix->name);
         }
         sep = "\n";
@@ -627,8 +636,13 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         force = ghb_dict_get_bool(searchDict, "Forced");
         burn  = ghb_dict_get_bool(searchDict, "Burn");
         def   = ghb_dict_get_bool(searchDict, "Default");
+        name  = ghb_dict_get_string(searchDict, "Name");
 
-        g_string_append_printf(str, _("Foreign Audio Scan"));
+        if (name)
+        {
+            g_string_append_printf(str, "%s - ", name);
+        }
+        g_string_append_printf(str, "%s", _("Foreign Audio Scan"));
         if (force)
         {
             g_string_append_printf(str, _(", Forced Only"));
@@ -657,8 +671,14 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         force       = ghb_dict_get_bool(subsettings, "Forced");
         burn        = ghb_dict_get_bool(subsettings, "Burn");
         def         = ghb_dict_get_bool(subsettings, "Default");
+        name        = ghb_dict_get_string(subsettings, "Name");
 
-        g_string_append_printf(str, "%s%s", sep, desc);
+        g_string_append_printf(str, sep);
+        if (name)
+        {
+            g_string_append_printf(str, "%s - ", name);
+        }
+        g_string_append_printf(str, desc);
         free(desc);
         if (force)
         {

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1487,20 +1487,9 @@ ghb_update_all_status(signal_user_data_t *ud, int status)
 }
 
 static void
-save_queue_file(signal_user_data_t *ud)
+save_queue_file_cb(GtkFileChooserNative *dialog, gint response, signal_user_data_t *ud)
 {
-    GtkWidget *dialog;
-    GtkWindow *hb_window;
-
-    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new(_("Export Queue"),
-                      hb_window,
-                      GTK_FILE_CHOOSER_ACTION_SAVE,
-                      GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                      GHB_STOCK_SAVE, GTK_RESPONSE_ACCEPT,
-                      NULL);
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "queue.json");
-    if (gtk_dialog_run(GTK_DIALOG (dialog)) == GTK_RESPONSE_ACCEPT)
+    if (response == GTK_RESPONSE_ACCEPT)
     {
         char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER (dialog));
  
@@ -1522,7 +1511,27 @@ save_queue_file(signal_user_data_t *ud)
         g_free (filename); 
         ghb_value_free(&queue);
     }
-    gtk_widget_destroy(dialog);
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+}
+
+static void
+save_queue_file(signal_user_data_t *ud)
+{
+    GtkFileChooserNative *dialog;
+    GtkWindow *hb_window;
+
+    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
+    dialog = gtk_file_chooser_native_new(_("Export Queue"),
+                      hb_window,
+                      GTK_FILE_CHOOSER_ACTION_SAVE,
+                      GHB_STOCK_SAVE,
+                      GHB_STOCK_CANCEL);
+    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "queue.json");
+    gtk_file_chooser_set_do_overwrite_confirmation(GTK_FILE_CHOOSER(dialog), TRUE);
+
+    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
+    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(save_queue_file_cb), ud);
+    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
 }
 
 static void
@@ -1632,32 +1641,17 @@ add_to_queue_list(signal_user_data_t *ud, GhbValue *queueDict)
 }
 
 static void
-open_queue_file(signal_user_data_t *ud)
+open_queue_file_cb(GtkFileChooserNative *chooser, gint response, signal_user_data_t *ud)
 {
-    GtkWidget *dialog;
-    GtkWindow *hb_window;
-
-    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
-    dialog = gtk_file_chooser_dialog_new(_("Import Queue"),
-                      hb_window,
-                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                      GHB_STOCK_CANCEL, GTK_RESPONSE_CANCEL,
-                      GHB_STOCK_OPEN, GTK_RESPONSE_ACCEPT,
-                      NULL);
-
-    // Add filters
-    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), ud, _("All"), "FilterAll");
-    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), ud, "JSON", "FilterJSON");
-
-    if (gtk_dialog_run(GTK_DIALOG (dialog)) != GTK_RESPONSE_ACCEPT)
+    if (response != GTK_RESPONSE_ACCEPT)
     {
-        gtk_widget_destroy(dialog);
+        gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
         return;
     }
 
     GhbValue *queue;
-    char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
-    gtk_widget_destroy(dialog);
+    char *filename = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(chooser));
+    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
 
     queue = ghb_read_settings_file(filename);
     if (queue != NULL)
@@ -1684,6 +1678,28 @@ open_queue_file(signal_user_data_t *ud)
         ghb_value_free(&queue);
     }
     g_free (filename);
+}
+
+static void
+open_queue_file(signal_user_data_t *ud)
+{
+    GtkFileChooserNative *dialog;
+    GtkWindow *hb_window;
+
+    hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
+    dialog = gtk_file_chooser_native_new(_("Import Queue"),
+                      hb_window,
+                      GTK_FILE_CHOOSER_ACTION_OPEN,
+                      GHB_STOCK_OPEN,
+                      GHB_STOCK_CANCEL);
+
+    // Add filters
+    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), ud, _("All Files"), "FilterAll");
+    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), ud, g_content_type_get_description("application/json"), "FilterJSON");
+
+    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
+    g_signal_connect(G_OBJECT(dialog), "response", G_CALLBACK(open_queue_file_cb), ud);
+    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
 }
 
 gint64

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -580,6 +580,7 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         const hb_mixdown_t * audio_mix;
         const hb_encoder_t * audio_encoder;
         const char         * lang;
+        int                  gain;
         int                  track;
 
         asettings     = ghb_array_get(audioList, ii);
@@ -587,6 +588,7 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         asource       = ghb_array_get(sourceAudioList, track);
         lang          = ghb_dict_get_string(asource, "Language");
         name          = ghb_dict_get_string(asettings, "Name");
+        gain          = ghb_dict_get_int(asettings, "Gain");
         audio_encoder = ghb_settings_audio_encoder(asettings, "Encoder");
         if (name)
         {
@@ -606,6 +608,10 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
             audio_mix = ghb_settings_mixdown(asettings, "Mixdown");
             g_string_append_printf(str, "%s, %s, %s", lang,
                                    audio_encoder->name, audio_mix->name);
+        }
+        if (gain)
+        {
+            g_string_append_printf(str, ", %ddB %s", gain, _("Gain"));
         }
         sep = "\n";
     }

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -45,7 +45,7 @@ void ghb_queue_buttons_grey(signal_user_data_t *ud);
 G_MODULE_EXPORT void
 queue_remove_clicked_cb(GtkWidget *widget, signal_user_data_t *ud);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT void
 queue_drag_begin_cb(GtkWidget * widget, GdkDrag * context,
                     signal_user_data_t * ud);
@@ -80,7 +80,7 @@ title_dest_file_cb(GtkWidget *widget, signal_user_data_t *ud);
 G_MODULE_EXPORT void
 title_dest_dir_cb(GtkWidget *widget, signal_user_data_t *ud);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 static const char * queue_drag_entries[] = {
     "application/queue-list-row-drop"
 };
@@ -1548,7 +1548,7 @@ add_to_queue_list(signal_user_data_t *ud, GhbValue *queueDict)
     gtk_widget_set_margin_start(GTK_WIDGET(vbox), 12);
     hbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6));
     dbox = GTK_BOX(gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6));
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     ebox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
 #else
     ebox = gtk_event_box_new();
@@ -1607,7 +1607,7 @@ add_to_queue_list(signal_user_data_t *ud, GhbValue *queueDict)
     // style class for CSS settings
     gtk_style_context_add_class(gtk_widget_get_style_context(row), "row");
     // set row as a source for drag & drop
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkContentFormats * targets;
 
     targets = gdk_content_formats_new(queue_drag_entries,
@@ -1623,7 +1623,7 @@ add_to_queue_list(signal_user_data_t *ud, GhbValue *queueDict)
     g_signal_connect(ebox, "drag-data-get",
                     G_CALLBACK(queue_drag_data_get_cb), NULL);
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     // connect key event controller to capture "delete" key press on row
     GtkEventController * econ = gtk_event_controller_key_new();
     gtk_widget_add_controller(row, econ);
@@ -2585,7 +2585,7 @@ queue_row_key(guint keyval, signal_user_data_t * ud)
     return TRUE;
 }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 G_MODULE_EXPORT gboolean
 queue_row_key_cb(
     GtkEventControllerKey * keycon,
@@ -2671,7 +2671,7 @@ show_queue_action_cb(GSimpleAction *action, GVariant *value,
 G_MODULE_EXPORT gboolean
 queue_window_delete_cb(
     GtkWidget *xwidget,
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
     GdkEvent *event,
 #endif
     signal_user_data_t *ud)
@@ -3454,7 +3454,7 @@ title_dest_dir_cb(GtkWidget *widget, signal_user_data_t *ud)
 
 // Set up view of row to be dragged
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_begin_cb(GtkWidget          * widget,
                     GdkDrag            * context,
                     signal_user_data_t * ud)
@@ -3477,7 +3477,7 @@ queue_drag_begin_cb(GtkWidget          * widget,
         gtk_list_box_select_row(lb, GTK_LIST_BOX_ROW(row));
     }
 
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
     GdkPaintable * paintable = gtk_widget_paintable_new(row);
     gtk_drag_set_icon_paintable(context, paintable, 0, 0);
     g_object_unref(paintable);
@@ -3510,7 +3510,7 @@ queue_drag_begin_cb(GtkWidget          * widget,
 }
 
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_end_cb(GtkWidget          * widget,
                   GdkDrag            * context,
                   signal_user_data_t * ud)
@@ -3532,7 +3532,7 @@ queue_drag_end_cb(GtkWidget          * widget,
 
 // Set selection to the row being dragged
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_data_get_cb(GtkWidget          * widget,
                        GdkDrag            * context,
                        GtkSelectionData   * selection_data,
@@ -3555,7 +3555,7 @@ queue_drag_data_get_cb(GtkWidget          * widget,
 }
 
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_leave_cb(
     GtkListBox         * lb,
     GdkDrop            * ctx,
@@ -3623,7 +3623,7 @@ get_row_after (GtkListBox    * list, GtkListBoxRow * row)
 }
 
 G_MODULE_EXPORT gboolean
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_motion_cb(
     GtkListBox         * lb,
     GdkDrop            * ctx,
@@ -3795,7 +3795,7 @@ queue_move_bottom_action_cb (GSimpleAction *action, GVariant *param,
 }
 
 G_MODULE_EXPORT void
-#if GTK_CHECK_VERSION(3, 90, 0)
+#if GTK_CHECK_VERSION(4, 4, 0)
 queue_drag_data_received_cb(GtkListBox         * lb,
                             GdkDrop            * context,
                             GtkSelectionData   * selection_data,

--- a/gtk/src/settings.c
+++ b/gtk/src/settings.c
@@ -572,4 +572,3 @@ ghb_ui_settings_update(
     ghb_widget_to_setting(settings, (GtkWidget*)object);
     return 0;
 }
-

--- a/gtk/src/settings.c
+++ b/gtk/src/settings.c
@@ -108,7 +108,7 @@ ghb_widget_value(GtkWidget *widget)
     else if (type == GTK_TYPE_RADIO_BUTTON)
     {
         gboolean bval;
-#if !GTK_CHECK_VERSION(3, 90, 0)
+#if !GTK_CHECK_VERSION(4, 4, 0)
         bval = gtk_toggle_button_get_inconsistent(GTK_TOGGLE_BUTTON(widget));
         if (bval)
         {

--- a/gtk/src/settings.h
+++ b/gtk/src/settings.h
@@ -27,6 +27,7 @@
 #include "values.h"
 
 #define GHB_WIDGET(b,n) GTK_WIDGET(gtk_builder_get_object ((b), (n)))
+#define GHB_ACTION(b,n) g_action_map_lookup_action(G_ACTION_MAP(gtk_builder_get_application (b)), (n))
 //#define GHB_WIDGET(b,n)   GTK_WIDGET(debug_get_object((b), (n)))
 #define GHB_OBJECT(b,n) gtk_builder_get_object ((b), (n))
 

--- a/gtk/src/settings.h
+++ b/gtk/src/settings.h
@@ -81,6 +81,7 @@ typedef struct
     gint                  appcast_len;
     int                   stderr_src_id;
     GtkApplication      * app;
+    GtkFileChooserNative* source_dialog;
 } signal_user_data_t;
 
 enum

--- a/gtk/src/subtitlehandler.c
+++ b/gtk/src/subtitlehandler.c
@@ -1187,6 +1187,7 @@ subtitle_add_clicked_cb(GtkWidget *xwidget, signal_user_data_t *ud)
         // Pop up the edit dialog
         GtkResponseType response;
         GtkWidget *dialog = GHB_WIDGET(ud->builder, "subtitle_dialog");
+        gtk_window_set_title(GTK_WINDOW(dialog), _("Add Subtitles"));
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_hide(dialog);
         if (response != GTK_RESPONSE_OK)
@@ -1240,6 +1241,7 @@ subtitle_add_fas_clicked_cb(GtkWidget *xwidget, signal_user_data_t *ud)
 
     GtkResponseType response;
     GtkWidget *dialog = GHB_WIDGET(ud->builder, "subtitle_dialog");
+    gtk_window_set_title(GTK_WINDOW(dialog), _("Foreign Audio Scan"));
     response = gtk_dialog_run(GTK_DIALOG(dialog));
     gtk_widget_hide(dialog);
     if (response != GTK_RESPONSE_OK)
@@ -1251,7 +1253,7 @@ subtitle_add_fas_clicked_cb(GtkWidget *xwidget, signal_user_data_t *ud)
     }
     else
     {
-        // Disabel FAS button
+        // Disable FAS button
         GtkWidget *w = GHB_WIDGET(ud->builder, "subtitle_add_fas");
         gtk_widget_set_sensitive(w, 0);
 
@@ -1737,6 +1739,7 @@ subtitle_edit(GtkTreeView *tv, GtkTreePath *tp, signal_user_data_t *ud)
         // Pop up the edit dialog
         GtkResponseType response;
         GtkWidget *dialog = GHB_WIDGET(ud->builder, "subtitle_dialog");
+        gtk_window_set_title(GTK_WINDOW(dialog), _("Edit Subtitles"));
         response = gtk_dialog_run(GTK_DIALOG(dialog));
         gtk_widget_hide(dialog);
         if (response != GTK_RESPONSE_OK)

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -7,7 +7,7 @@
     "finish-args": [
         "--device=dri",
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--filesystem=host",
         "--filesystem=xdg-run/gvfs",


### PR DESCRIPTION
**Description of Change:**
This allows the use of native file dialogs for users of KDE and other desktop environments by using xdg-desktop-portal. Users will see the native dialogs if they're running the Flatpak version, or if they export the environment variable `GTK_USE_PORTAL=1` before launching. Otherwise the standard GTK file chooser will be used.

However, there are some issues that need to be considered before this is merged. So I'm leaving this as a draft for now.

- The minimum GTK version has increased to 3.22
- The open dialogs always start at the same folder instead of the one specified by the program
- Some of the portal implementations have bugs which could cause problems. I've filed issues for them, so hopefully they will be fixed before this makes it into an official release.
- The Qt-based implementations also handle filtering in a different way, so the filter list will be different as well as the files that show up. This one should be fixed on the KDE portal [soon](https://invent.kde.org/frameworks/kio/-/merge_requests/769).

I also had to make some changes to the workflow of the dialogs themselves (adding an 'Open Directory' menu option, moving the Single Title choice to a separate dialog box). These were necessary due to the limitations of the native dialogs. 

**Test on:**
- [x] Ubuntu 22.04
- [x] Fedora 37 KDE
- [x] Linux Mint 21