### PR TITLE
Add x-ms-wmv mimetype, harmonize metainfo files

### DIFF
--- a/gtk/src/fr.handbrake.ghb.desktop
+++ b/gtk/src/fr.handbrake.ghb.desktop
@@ -7,4 +7,4 @@ Icon=fr.handbrake.ghb
 Terminal=false
 Type=Application
 Categories=GTK;AudioVideo;Video;
-MimeType=application/ogg;application/x-extension-mp4;application/x-flac;application/x-matroska;application/x-ogg;audio/ac3;audio/mp4;audio/mpeg;audio/ogg;audio/x-flac;audio/x-matroska;audio/x-mp2;audio/x-mp3;audio/x-mpeg;audio/x-vorbis;video/mp4;video/mp4v-es;video/mpeg;video/msvideo;video/quicktime;video/vnd.divx;video/x-avi;video/x-m4v;video/x-matroska;video/x-mpeg;video/ogg;video/x-ogm+ogg;video/x-theora+ogg;x-content/video-dvd;x-content/video-vcd;x-content/video-svcd;
+MimeType=application/ogg;application/x-extension-mp4;application/x-flac;application/x-matroska;application/x-ogg;audio/ac3;audio/mp4;audio/mpeg;audio/ogg;audio/x-flac;audio/x-matroska;audio/x-mp2;audio/x-mp3;audio/x-mpeg;audio/x-vorbis;video/mp4;video/mp4v-es;video/mpeg;video/msvideo;video/quicktime;video/vnd.divx;video/x-avi;video/x-m4v;video/x-matroska;video/x-mpeg;video/x-ms-wmv;video/ogg;video/x-ogm+ogg;video/x-theora+ogg;x-content/video-dvd;x-content/video-vcd;x-content/video-svcd;

--- a/gtk/src/fr.handbrake.ghb.metainfo.template.xml
+++ b/gtk/src/fr.handbrake.ghb.metainfo.template.xml
@@ -50,6 +50,7 @@
     <mimetype>video/x-m4v</mimetype>
     <mimetype>video/x-matroska</mimetype>
     <mimetype>video/x-mpeg</mimetype>
+    <mimetype>video/x-ms-wmv</mimetype>
     <mimetype>video/ogg</mimetype>
     <mimetype>video/x-ogm+ogg</mimetype>
     <mimetype>video/x-theora+ogg</mimetype>

--- a/test/fr.handbrake.HandBrakeCLI.metainfo.xml.template
+++ b/test/fr.handbrake.HandBrakeCLI.metainfo.xml.template
@@ -2,16 +2,14 @@
 <!-- Copyright 2018-2022 John Stebbins <your@email.com> -->
 <component type="console-application">
   <id>fr.handbrake.HandBrakeCLI</id>
-  <metadata_license>CC0</metadata_license>
+  <update_contact>jstebbins.hb_AT_gmail.com</update_contact>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>HandBrakeCLI</name>
   <summary>Video Transcoder</summary>
 
   <description>
-    <p>
-      HandBrake is a tool for converting video from nearly any format to a
-      selection of modern, widely supported codecs.
-    </p>
+    <p>HandBrake is a tool for converting video from nearly any format to a selection of modern, widely supported codecs.</p>
     <p>Reasons you'll love Handbrake:</p>
     <ul>
       <li>Convert video from nearly any format</li>
@@ -35,6 +33,7 @@
     <mimetype>audio/ogg</mimetype>
     <mimetype>audio/x-flac</mimetype>
     <mimetype>audio/x-matroska</mimetype>
+    <mimetype>audio/x-mp2</mimetype>
     <mimetype>audio/x-mp3</mimetype>
     <mimetype>audio/x-mpeg</mimetype>
     <mimetype>audio/x-vorbis</mimetype>
@@ -48,6 +47,7 @@
     <mimetype>video/x-m4v</mimetype>
     <mimetype>video/x-matroska</mimetype>
     <mimetype>video/x-mpeg</mimetype>
+    <mimetype>video/x-ms-wmv</mimetype>
     <mimetype>video/ogg</mimetype>
     <mimetype>video/x-ogm+ogg</mimetype>
     <mimetype>video/x-theora+ogg</mimetype>


### PR DESCRIPTION
**Before Posting:**

Not done: It's a small enough change that "better to ask forgiveness than permission" applies.

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
This PR contains two commits.

1. Add the mimetype `video/x-ms-wmv` to the `.desktop` and `.metainfo.template.xml` files in `gtk/src/`.
2. Sync the metainfo templates in `gtk/src/` and `test/` to remove as many differences as practical. This adds not only the  `video/x-ms-wmv` mimetype, but also `audio/x-mp2` which was missing, and adds/updates several other fields.

     (The different names of the tools, and intentional lack of translation or screenshot metadata in the `test/fr.handbrake.HandBrakeCLI...` file, were preserved.)

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
