### PR TITLE
Remove last vestiges of Python3 incompatibility

### DIFF
--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -273,7 +273,7 @@ AM_CONDITIONAL([GHB_FLATPAK], [test "$use_flatpak" = "yes"])
 if test "x$PYTHON" != "x" ; then
 	HB_PYTHON="$PYTHON"
 else
-	HB_PYTHON="python2"
+	HB_PYTHON="python3"
 fi
 
 AC_SUBST(HB_PYTHON)

--- a/gtk/src/makedeps.py
+++ b/gtk/src/makedeps.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import collections
 import sys
 import json
@@ -65,41 +66,35 @@ def main():
     try:
         depsfile = open("widget.deps", "w")
     except Exception as err:
-        print >> sys.stderr, ( "Error: %s"  % str(err) )
+        print("Error: %s" % str(err), stream=sys.stderr)
         sys.exit(1)
 
     try:
         revfile = open("widget_reverse.deps", "w")
     except Exception as err:
-        print >> sys.stderr, ( "Error: %s"  % str(err))
+        print("Error: %s" % str(err), stream=sys.stderr)
         sys.exit(1)
 
-    top = dict()
+    fwd = dict()
     for ii in dep_map:
-        if ii.widget in top:
+        if ii.widget in fwd:
             continue
-        deps = list()
-        for jj in dep_map:
-            if jj.widget == ii.widget:
-                deps.append(jj.dep)
-        top[ii.widget] = deps
-    json.dump(top, depsfile, indent=4)
+        fwd.update({
+            ii.widget: [jj.dep for jj in dep_map if jj.widget == ii.widget]
+        })
+    json.dump(fwd, depsfile, indent=4)
 
-    top = dict()
+    rev = dict()
     for ii in dep_map:
-        if ii.dep in top:
+        if ii.dep in rev:
             continue
-        deps = list()
-        for jj in dep_map:
-            if ii.dep == jj.dep:
-                rec = list()
-                rec.append(jj.widget)
-                rec.append(jj.enable)
-                rec.append(jj.die)
-                rec.append(jj.hide)
-                deps.append(rec)
-        top[ii.dep] = deps
-    json.dump(top, revfile, indent=4)
+        rev.update({
+            ii.dep: [
+                list([jj.widget, jj.enable, jj.die, jj.hide])
+                for jj in dep_map if ii.dep == jj.dep
+            ]
+        })
+    json.dump(rev, revfile, indent=4)
 
 main()
 

--- a/make/df-fetch.py
+++ b/make/df-fetch.py
@@ -73,7 +73,7 @@ class Tool(hb_distfile.Tool):
     def __init__(self):
         super(Tool, self).__init__()
         self.parser.prog = self.name
-        self.parser.usage = '%prog [OPTIONS] URL...'
+        self.parser.usage = '%(prog)s [OPTIONS] URL...'
         self.parser.description = 'Fetch and verify distfile data integrity.'
         self.parser.add_argument('--disable', default=False, action='store_true', help='do nothing and exit with error')
         self.parser.add_argument('--jobs', default=1, action='store', metavar='N', help='allow N download jobs at once')

--- a/make/df-verify.py
+++ b/make/df-verify.py
@@ -36,7 +36,7 @@ class Tool(hb_distfile.Tool):
     def __init__(self):
         super(Tool, self).__init__()
         self.parser.prog = self.name
-        self.parser.usage = '%prog [OPTIONS] FILE'
+        self.parser.usage = '%(prog)s [OPTIONS] FILE'
         self.parser.description = 'Verify distfile data integrity.'
         self.parser.add_argument('--disable', default=False, action='store_true', help='do nothing and exit without error')
         self.parser.add_argument('--sha256', default=None, action='store', metavar='HASH', help='verify sha256 HASH against data')

--- a/make/lib/hb_distfile.py
+++ b/make/lib/hb_distfile.py
@@ -1,8 +1,6 @@
 ###############################################################################
 ##
-## Coded for minimum version of Python 2.7 .
-##
-## Python3 is incompatible.
+## This script is coded for Python 2.7 through Python 3.x
 ##
 ## Authors: konablend
 ##

--- a/scripts/create_flatpak_manifest.py
+++ b/scripts/create_flatpak_manifest.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from __future__ import print_function
 import types
 import os
 import sys
@@ -8,10 +9,10 @@ import getopt
 import posixpath
 from collections import OrderedDict
 try:
+    from urllib.parse import urlsplit, unquote
+except ImportError:  # Python 2
     from urlparse import urlsplit
     from urllib import unquote
-except ImportError: # Python 3
-    from urllib.parse import urlsplit, unquote
 
 
 def url2filename(url):
@@ -34,7 +35,7 @@ class SourceEntry:
 
 class FlatpakPluginManifest:
     def __init__(self, runtime, template=None):
-        if template != None:
+        if template is not None and os.path.exists(template):
             with open(template, 'r') as fp:
                 self.manifest = json.load(fp, object_pairs_hook=OrderedDict)
 
@@ -46,7 +47,7 @@ class FlatpakPluginManifest:
 
 class FlatpakManifest:
     def __init__(self, source_list, runtime, qsv, nvenc, template=None):
-        if template != None:
+        if template is not None and os.path.exists(template):
             with open(template, 'r') as fp:
                 self.manifest = json.load(fp, object_pairs_hook=OrderedDict)
 
@@ -69,12 +70,12 @@ class FlatpakManifest:
             self.hbmodule["sources"]     = self.sources
             self.hbconfig                = [None]
 
-        if runtime != None:
+        if runtime is not None:
             self.manifest["runtime-version"] = runtime
 
         if qsv:
             self.hbconfig.append("--enable-qsv");
-        
+
         if nvenc:
             self.hbconfig.append("--enable-nvenc");
             self.hbconfig.append("--enable-nvdec");
@@ -87,7 +88,7 @@ class FlatpakManifest:
             if islocal(value.url):
                 source["path"] = value.url
             else:
-                if value.sha256 == "" or value.sha256 == None:
+                if value.sha256 is None or value.sha256 == "":
                     continue
                 source["url"] = value.url
                 source["sha256"] = value.sha256
@@ -149,19 +150,19 @@ if __name__ == "__main__":
             usage()
             sys.exit()
         elif opt in ("-a", "--archive"):
-            if arg != None and arg != "":
+            if arg is not None and arg != "":
                 current_source = arg
                 source_list[arg] = SourceEntry(arg, SourceType.archive)
             else:
                 current_source = None
         elif opt in ("-c", "--contrib"):
-            if arg != None and arg != "":
+            if arg is not None and arg != "":
                 current_source = arg
                 source_list[arg] = SourceEntry(arg, SourceType.contrib)
             else:
                 current_source = None
         elif opt in ("-s", "--sha256"):
-            if current_source != None:
+            if current_source is not None:
                 source_list[current_source].sha256 = arg
         elif opt in ("-t", "--template"):
             template = arg
@@ -172,7 +173,7 @@ if __name__ == "__main__":
 
         elif opt in ("-e", "--nvenc"):
             print("NVENC ON")
-            nvenc = 1; 
+            nvenc = 1;
         elif opt in ("-p", "--plugin"):
             plugin = 1;
 
@@ -186,7 +187,7 @@ if __name__ == "__main__":
     else:
         manifest = FlatpakManifest(source_list, runtime, qsv, nvenc, template)
 
-    if dst != None:
+    if dst is not None:
         with open(dst, 'w') as fp:
             json.dump(manifest.manifest, fp, ensure_ascii=False, indent=4)
     else:

--- a/scripts/create_resources.py
+++ b/scripts/create_resources.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 #
 
+from __future__ import print_function
 import types
 import os
 import sys
@@ -42,9 +43,9 @@ def start_element_handler(tag, attr):
                 with open(fname) as fp:
                     val = json.load(fp)
             except Exception as err:
-                print >> sys.stderr, ("Error: %s" % str(err))
+                print("Error: %s" % str(err), file=sys.stderr)
         elif fname is None:
-            print >> sys.stderr, ("Error: No such json file %s" % fbase)
+            print("Error: No such json file %s" % fbase, file=sys.stderr)
             sys.exit(1)
     elif tag == "plist":
         fbase = attr["file"]
@@ -53,7 +54,7 @@ def start_element_handler(tag, attr):
         if fname is not None and key is not None:
             val = plistlib.readPlist(fname)
         elif fname is None:
-            print >> sys.stderr, ("Error: No such plist file %s" % fbase)
+            print("Error: No such plist file %s" % fbase, file=sys.stderr)
             sys.exit(1)
     elif tag == "text":
         fbase = attr["file"]
@@ -64,10 +65,10 @@ def start_element_handler(tag, attr):
                 with open(fname) as fp:
                     val = fp.read()
             except Exception as err:
-                print >> sys.stderr, ("Error: %s" % str(err))
+                print("Error: %s" % str(err), file=sys.stderr)
                 sys.exit(1)
         elif fname is None:
-            print >> sys.stderr, ("Error: No such string file %s" % fbase)
+            print("Error: No such string file %s" % fbase, file=sys.stderr)
             sys.exit(1)
     elif tag == "string":
         key = attr["name"]
@@ -94,7 +95,7 @@ def resource_parse_file(infile):
         with open(infile.name, 'rb') as file:
             parser.ParseFile(file)
     except ExpatError as err:
-        print >> sys.stderr, ("Error: %s" % str(err))
+        print("Error: %s" % str(err), file=sys.stderr)
         return None
 
     return resources


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

**Description of Change:**
This PR updates the build tree to remove the last vestiges of Python 3 incompatibility, ensuring that all Python scripts used in the production of HandBrake binaries and packages are fully compatible with Python3 and do not require an available Python2.7 binary to produce. (The scripts do remain _backward-compatible_ with Python 2.7, if you're into that sort of thing).

It also:

* Changes the default Python executable used when running `gtk/src/makedeps.py` from `python2` to `python3` (Note that the default can still be overridden with the `$PYTHON` envvar.)
* Streamlines `gtk/src/makedeps.py` some, while still producing output that is byte-for-byte identical to the previous version.
* Fixes the `--help` output of `make/df-fetch.py` and `make/df-verify.py`, which had a formatting bug, and corrects a clearly-false comment about Python3 incompatibility at the top of `make/lib/hb_distfile.py`
* Fixes `scripts/create_flatpak_manifest.py` to test for existence of its input files before trying to read them, as attempting to read nonexistent files results in difficult-to-decipher tracebacks from the `json` module.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux

