### PR TITLE
gtk/src/makedeps: Fix print() output destination

### DIFF
--- a/gtk/src/makedeps.py
+++ b/gtk/src/makedeps.py
@@ -66,13 +66,13 @@ def main():
     try:
         depsfile = open("widget.deps", "w")
     except Exception as err:
-        print("Error: %s" % str(err), stream=sys.stderr)
+        print("Error: %s" % str(err), file=sys.stderr)
         sys.exit(1)
 
     try:
         revfile = open("widget_reverse.deps", "w")
     except Exception as err:
-        print("Error: %s" % str(err), stream=sys.stderr)
+        print("Error: %s" % str(err), file=sys.stderr)
         sys.exit(1)
 
     fwd = dict()


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
Followup to #4733, correcting an error in `print()` function semantics.



**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
