### PR TITLE
Linux: Fixes for translation issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,4 @@ gtk/m4
 gtk/missing
 gtk/po/Makevars.template
 gtk/po/*.gmo
-gtk/po/*.po~
+gtk/po/*~

--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -1,14 +1,14 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR Free Software Foundation, Inc.
+# Copyright (C) 2022 HandBrake Team
 # This file is distributed under the same license as the ghb package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ghb 0.1\n"
+"Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-29 22:31+0200\n"
+"POT-Creation-Date: 2022-12-22 23:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,18 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/ghb3.ui:23
+#: src/ghb3.ui:113
 msgid ""
 "Render the subtitle over the video.\n"
 "\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:26
+#: src/ghb3.ui:116
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:32 src/ghb3.ui:9785
+#: src/ghb3.ui:122 src/ghb3.ui:9808
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -39,11 +39,11 @@ msgid ""
 "in your output."
 msgstr ""
 
-#: src/ghb3.ui:39
+#: src/ghb3.ui:129
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:45 src/ghb3.ui:9747
+#: src/ghb3.ui:135 src/ghb3.ui:9770
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -53,11 +53,11 @@ msgid ""
 "a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:51
+#: src/ghb3.ui:141
 msgid "<b>Forced Only</b>"
 msgstr ""
 
-#: src/ghb3.ui:57
+#: src/ghb3.ui:147
 msgid ""
 "Add (or subtract) an offset (in milliseconds)\n"
 "to the start of the SRT subtitle track.\n"
@@ -67,11 +67,11 @@ msgid ""
 "This setting allows you to synchronize the files."
 msgstr ""
 
-#: src/ghb3.ui:63
+#: src/ghb3.ui:153
 msgid "<b>SRT Offset</b>"
 msgstr ""
 
-#: src/ghb3.ui:69
+#: src/ghb3.ui:159
 msgid ""
 "The source subtitle track\n"
 "\n"
@@ -86,248 +86,277 @@ msgid ""
 "conjunction with the \"Forced\" option."
 msgstr ""
 
-#: src/ghb3.ui:80
+#: src/ghb3.ui:170
 msgid "<b>Track</b>"
 msgstr ""
 
-#: src/ghb3.ui:87
-msgid "Open Source Directory"
-msgstr ""
-
-#: src/ghb3.ui:91
-msgid "Open Destination Directory"
-msgstr ""
-
-#: src/ghb3.ui:95
-msgid "Open Encode Log Directory"
-msgstr ""
-
-#: src/ghb3.ui:99
-msgid "Open Encode Log"
-msgstr ""
-
-#: src/ghb3.ui:108
-msgid "Reset Failed Jobs"
-msgstr ""
-
-#: src/ghb3.ui:112
-msgid "Reset All Jobs"
-msgstr ""
-
-#: src/ghb3.ui:116
-msgid "Clear Completed Jobs"
-msgstr ""
-
-#: src/ghb3.ui:120
-msgid "Clear All Jobs"
-msgstr ""
-
-#: src/ghb3.ui:124 src/queuehandler.c:1615
-msgid "Import Queue"
-msgstr ""
-
-#: src/ghb3.ui:128 src/queuehandler.c:1470
-msgid "Export Queue"
-msgstr ""
-
-#: src/ghb3.ui:135
-msgid "HandBrake Presets"
-msgstr ""
-
-#: src/ghb3.ui:163 src/ghb3.ui:2169
-msgid "_Presets"
-msgstr ""
-
-#: src/ghb3.ui:171 src/ghb3.ui:2177
+#: src/ghb3.ui:178 src/ghb3.ui:412
 msgid "Set De_fault"
 msgstr ""
 
-#: src/ghb3.ui:185 src/ghb3.ui:2191
+#: src/ghb3.ui:184 src/ghb3.ui:426 src/ghb3.ui:8762 src/ghb3.ui:9443
+#: src/ghb3.ui:9853
 msgid "_Save"
 msgstr ""
 
-#: src/ghb3.ui:194 src/ghb3.ui:2200
+#: src/ghb3.ui:188 src/ghb3.ui:308 src/ghb3.ui:435
 msgid "Save _As"
 msgstr ""
 
-#: src/ghb3.ui:203 src/ghb3.ui:2209
+#: src/ghb3.ui:192 src/ghb3.ui:444 src/ghb3.ui:8605
 msgid "_Rename"
 msgstr ""
 
-#: src/ghb3.ui:212 src/ghb3.ui:2218
+#: src/ghb3.ui:196 src/ghb3.ui:453
 msgid "_Delete"
 msgstr ""
 
-#: src/ghb3.ui:226 src/ghb3.ui:2232
+#: src/ghb3.ui:202
 msgid "_Import"
 msgstr ""
 
-#: src/ghb3.ui:235 src/ghb3.ui:2241
+#: src/ghb3.ui:206 src/ghb3.ui:467
 msgid "_Export"
 msgstr ""
 
-#: src/ghb3.ui:249 src/ghb3.ui:2255
+#: src/ghb3.ui:212
 msgid "Reset _Built-in Presets"
 msgstr ""
 
-#: src/ghb3.ui:304
-msgid "<b>Presets List</b>"
+#: src/ghb3.ui:220
+msgid "Play File"
 msgstr ""
 
-#: src/ghb3.ui:318
+#: src/ghb3.ui:224
+msgid "Open Source Directory"
+msgstr ""
+
+#: src/ghb3.ui:228
+msgid "Open Destination Directory"
+msgstr ""
+
+#: src/ghb3.ui:234
+msgid "Open Encode Log Directory"
+msgstr ""
+
+#: src/ghb3.ui:238
+msgid "Open Encode Log"
+msgstr ""
+
+#: src/ghb3.ui:247
+msgid "Reset Failed Jobs"
+msgstr ""
+
+#: src/ghb3.ui:251
+msgid "Reset All Jobs"
+msgstr ""
+
+#: src/ghb3.ui:255
+msgid "Clear Completed Jobs"
+msgstr ""
+
+#: src/ghb3.ui:259
+msgid "Clear All Jobs"
+msgstr ""
+
+#: src/ghb3.ui:265 src/queuehandler.c:1641
+msgid "Import Queue"
+msgstr ""
+
+#: src/ghb3.ui:269 src/queuehandler.c:1496
+msgid "Export Queue"
+msgstr ""
+
+#: src/ghb3.ui:276
+msgid "HandBrake Presets"
+msgstr ""
+
+#: src/ghb3.ui:371 src/ghb3.ui:998
+msgid "Actions"
+msgstr ""
+
+#: src/ghb3.ui:404
+msgid "_Presets"
+msgstr ""
+
+#: src/ghb3.ui:521
 msgid "HandBrake Queue"
 msgstr ""
 
-#: src/ghb3.ui:352
+#: src/ghb3.ui:550
+msgid "_Play File"
+msgstr ""
+
+#: src/ghb3.ui:559
+msgid "Open _Source Directory"
+msgstr ""
+
+#: src/ghb3.ui:568
+msgid "Open _Destination Directory"
+msgstr ""
+
+#: src/ghb3.ui:582
+msgid "Move to _Top"
+msgstr ""
+
+#: src/ghb3.ui:591
+msgid "Move to _Bottom"
+msgstr ""
+
+#: src/ghb3.ui:605
+msgid "_Edit"
+msgstr ""
+
+#: src/ghb3.ui:614
+msgid "_Reset"
+msgstr ""
+
+#: src/ghb3.ui:628
+msgid "Re_move"
+msgstr ""
+
+#: src/ghb3.ui:658
 msgid "<span size=\"x-large\">Queue</span>"
 msgstr ""
 
-#: src/ghb3.ui:367
+#: src/ghb3.ui:673
 msgid "0 jobs pending"
 msgstr ""
 
-#: src/ghb3.ui:404 src/ghb3.ui:2365 src/queuehandler.c:2400
-#: src/queuehandler.c:2413 src/queuehandler.c:2424
+#: src/ghb3.ui:710 src/ghb3.ui:2331 src/queuehandler.c:2436
+#: src/queuehandler.c:2449 src/queuehandler.c:2462
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:406 src/ghb3.ui:2367 src/ghb3.ui:7116 src/queuehandler.c:2399
-#: src/queuehandler.c:2412
+#: src/ghb3.ui:712 src/ghb3.ui:2333 src/ghb3.ui:7063 src/queuehandler.c:2435
+#: src/queuehandler.c:2448
 msgid "Start"
 msgstr ""
 
-#: src/ghb3.ui:420 src/ghb3.ui:2380 src/queuehandler.c:2438
-#: src/queuehandler.c:2451 src/queuehandler.c:2462
+#: src/ghb3.ui:726 src/ghb3.ui:2346 src/queuehandler.c:2478
+#: src/queuehandler.c:2491
 msgid "Pause Encoding"
 msgstr ""
 
-#: src/ghb3.ui:422 src/ghb3.ui:2382 src/queuehandler.c:2437
-#: src/queuehandler.c:2450
+#: src/ghb3.ui:728 src/ghb3.ui:2348 src/queuehandler.c:2477
+#: src/queuehandler.c:2490
 msgid "Pause"
 msgstr ""
 
-#: src/ghb3.ui:480
+#: src/ghb3.ui:787
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:549
+#: src/ghb3.ui:856 src/ghb3.ui:7580
 msgid "When Done:"
 msgstr ""
 
-#: src/ghb3.ui:630
+#: src/ghb3.ui:935
 msgid "Reset"
 msgstr ""
 
-#: src/ghb3.ui:632
+#: src/ghb3.ui:937
 msgid ""
 "Mark selected queue entry as pending.\n"
 "Resets the queue job to pending and ready to run again."
 msgstr ""
 
-#: src/ghb3.ui:647
+#: src/ghb3.ui:952
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:692
-msgid "Actions"
-msgstr ""
-
-#: src/ghb3.ui:741 src/ghb3.ui:5467
+#: src/ghb3.ui:1047 src/ghb3.ui:5418
 msgid "Preset:"
 msgstr ""
 
-#: src/ghb3.ui:777
+#: src/ghb3.ui:1083
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:818 src/ghb3.ui:7196
+#: src/ghb3.ui:1124 src/ghb3.ui:7143
 msgid "Title:"
 msgstr ""
 
-#: src/ghb3.ui:858
+#: src/ghb3.ui:1164
 msgid "Destination:"
 msgstr ""
 
-#: src/ghb3.ui:899
+#: src/ghb3.ui:1205
 msgid "Dimensions:"
 msgstr ""
 
-#: src/ghb3.ui:935
+#: src/ghb3.ui:1241
 msgid "Video:"
 msgstr ""
 
-#: src/ghb3.ui:971
+#: src/ghb3.ui:1277
 msgid "Audio:"
 msgstr ""
 
-#: src/ghb3.ui:1007
+#: src/ghb3.ui:1313
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1046 src/ghb3.ui:3248
+#: src/ghb3.ui:1352 src/ghb3.ui:3199
 msgid "Summary"
 msgstr ""
 
-#: src/ghb3.ui:1084
+#: src/ghb3.ui:1390
 msgid "Pass:"
 msgstr ""
 
-#: src/ghb3.ui:1120
+#: src/ghb3.ui:1426
 msgid "Start Time:"
 msgstr ""
 
-#: src/ghb3.ui:1156
+#: src/ghb3.ui:1462
 msgid "End Time:"
 msgstr ""
 
-#: src/ghb3.ui:1196
+#: src/ghb3.ui:1502
 msgid "Paused Duration:"
 msgstr ""
 
-#: src/ghb3.ui:1236
+#: src/ghb3.ui:1542
 msgid "Encode Time:"
 msgstr ""
 
-#: src/ghb3.ui:1272
+#: src/ghb3.ui:1578
 msgid "File Size:"
 msgstr ""
 
-#: src/ghb3.ui:1308
+#: src/ghb3.ui:1614
 msgid "Status:"
 msgstr ""
 
-#: src/ghb3.ui:1347
+#: src/ghb3.ui:1653
 msgid "Statistics"
 msgstr ""
 
-#: src/ghb3.ui:1412
+#: src/ghb3.ui:1718
 msgid "Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1435
+#: src/ghb3.ui:1741
 msgid "HandBrake Activity Log"
 msgstr ""
 
-#: src/ghb3.ui:1751
+#: src/ghb3.ui:2057
 msgid "About HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1757
+#: src/ghb3.ui:2063
 msgid ""
 "Copyright © 2008 -  John Stebbins\n"
 "Copyright © 2004 - , HandBrake Devs"
 msgstr ""
 
-#: src/ghb3.ui:1759
+#: src/ghb3.ui:2065
 msgid ""
 "HandBrake is a GPL-licensed, multiplatform, multithreaded video transcoder."
 msgstr ""
 
-#: src/ghb3.ui:1761
-msgid "https://handbrake.fr"
-msgstr ""
-
-#: src/ghb3.ui:1762
+#: src/ghb3.ui:2068
 msgid ""
 "HandBrake is free software; you can redistribute it and/or modify it under "
 "the terms of the GNU General Public License version 2, as published by the "
@@ -343,393 +372,305 @@ msgid ""
 "Street, Fifth Floor, Boston, MA 02110-1301, USA."
 msgstr ""
 
-#: src/ghb3.ui:1948
+#: src/ghb3.ui:2254
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:1971
-msgid "_File"
-msgstr ""
-
-#: src/ghb3.ui:1979
-msgid "Open _Source"
-msgstr ""
-
-#: src/ghb3.ui:1988
-msgid "Open Single _Title"
-msgstr ""
-
-#: src/ghb3.ui:1997
-msgid "Set _Destination"
-msgstr ""
-
-#: src/ghb3.ui:2012
-msgid "_Preferences"
-msgstr ""
-
-#: src/ghb3.ui:2027
-msgid "_Quit"
-msgstr ""
-
-#: src/ghb3.ui:2042 src/ghb3.ui:2136
-msgid "_Queue"
-msgstr ""
-
-#: src/ghb3.ui:2050
-msgid "_Add"
-msgstr ""
-
-#: src/ghb3.ui:2059
-msgid "Add _Multiple"
-msgstr ""
-
-#: src/ghb3.ui:2068 src/queuehandler.c:2423
-msgid "_Start Encoding"
-msgstr ""
-
-#: src/ghb3.ui:2077 src/queuehandler.c:2461
-msgid "_Pause Encoding"
-msgstr ""
-
-#: src/ghb3.ui:2086
-msgid "S_ave Queue"
-msgstr ""
-
-#: src/ghb3.ui:2095
-msgid "_Load Queue File"
-msgstr ""
-
-#: src/ghb3.ui:2110
-msgid "_View"
-msgstr ""
-
-#: src/ghb3.ui:2118
-msgid "HandBrake For _Dummies"
-msgstr ""
-
-#: src/ghb3.ui:2127
-msgid "Presets _List"
-msgstr ""
-
-#: src/ghb3.ui:2145
-msgid "_Preview"
-msgstr ""
-
-#: src/ghb3.ui:2154
-msgid "_Activity Window"
-msgstr ""
-
-#: src/ghb3.ui:2270
-msgid "_Help"
-msgstr ""
-
-#: src/ghb3.ui:2278
-msgid "_About"
-msgstr ""
-
-#: src/ghb3.ui:2287
-msgid "_Guide"
-msgstr ""
-
-#: src/ghb3.ui:2325 src/callbacks.c:4338
+#: src/ghb3.ui:2291 src/callbacks.c:4318
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2327 src/callbacks.c:4337
+#: src/ghb3.ui:2293 src/ghb3.ui:9285 src/callbacks.c:4317
 msgid "Open Source"
 msgstr ""
 
-#: src/ghb3.ui:2350
+#: src/ghb3.ui:2316
 msgid "Add to Queue"
 msgstr ""
 
-#: src/ghb3.ui:2352
+#: src/ghb3.ui:2318
 msgid "Add To Queue"
 msgstr ""
 
-#: src/ghb3.ui:2407
+#: src/ghb3.ui:2373
 msgid "Show Presets Window"
 msgstr ""
 
-#: src/ghb3.ui:2409
+#: src/ghb3.ui:2375
 msgid "Presets"
 msgstr ""
 
-#: src/ghb3.ui:2422
+#: src/ghb3.ui:2388
 msgid "Show Preview Window"
 msgstr ""
 
-#: src/ghb3.ui:2424
+#: src/ghb3.ui:2390
 msgid "Preview"
 msgstr ""
 
-#: src/ghb3.ui:2437
+#: src/ghb3.ui:2403
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2439 src/callbacks.c:4783
+#: src/ghb3.ui:2405 src/callbacks.c:4748
 msgid "Queue"
 msgstr ""
 
-#: src/ghb3.ui:2452
+#: src/ghb3.ui:2418
 msgid "Show Activity Window"
 msgstr ""
 
-#: src/ghb3.ui:2454
+#: src/ghb3.ui:2420
 msgid "Activity"
 msgstr ""
 
-#: src/ghb3.ui:2484
+#: src/ghb3.ui:2450
 msgid "<b>Source:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2510 src/hb-backend.c:60 src/hb-backend.c:72 src/hb-backend.c:85
-#: src/hb-backend.c:124 src/hb-backend.c:238 src/hb-backend.c:269
-#: src/hb-backend.c:280 src/hb-backend.c:307 src/hb-backend.c:392
-#: src/hb-backend.c:2592 src/hb-backend.c:2818 src/subtitlehandler.c:1365
+#: src/ghb3.ui:2476 src/hb-backend.c:60 src/hb-backend.c:72 src/hb-backend.c:85
+#: src/hb-backend.c:124 src/hb-backend.c:237 src/hb-backend.c:270
+#: src/hb-backend.c:281 src/hb-backend.c:308 src/hb-backend.c:393
+#: src/hb-backend.c:2593 src/hb-backend.c:2819 src/subtitlehandler.c:1367
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2555 src/callbacks.c:4310
+#: src/ghb3.ui:2521 src/callbacks.c:4290
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2589
+#: src/ghb3.ui:2555
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2617
+#: src/ghb3.ui:2583
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2639
-msgid "<small>No Titles</small>"
-msgstr ""
-
-#: src/ghb3.ui:2657
+#: src/ghb3.ui:2610
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2669
+#: src/ghb3.ui:2622
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2685
+#: src/ghb3.ui:2638
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2696
+#: src/ghb3.ui:2649
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2709
+#: src/ghb3.ui:2662
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2725
+#: src/ghb3.ui:2678
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2737
+#: src/ghb3.ui:2690
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2763
+#: src/ghb3.ui:2716
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2799
+#: src/ghb3.ui:2752
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2830
+#: src/ghb3.ui:2783
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2839 src/ghb3.ui:5811 src/ghb3.ui:6597
+#: src/ghb3.ui:2792 src/ghb3.ui:5760 src/ghb3.ui:6544
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2842
+#: src/ghb3.ui:2795
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2854
+#: src/ghb3.ui:2807
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2857
+#: src/ghb3.ui:2810
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2939
+#: src/ghb3.ui:2890
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2957
+#: src/ghb3.ui:2908
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2969 src/queuehandler.c:290
+#: src/ghb3.ui:2920 src/queuehandler.c:290
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2974
+#: src/ghb3.ui:2925
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2990
+#: src/ghb3.ui:2941
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2995
+#: src/ghb3.ui:2946
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:3012
+#: src/ghb3.ui:2963
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:3017
+#: src/ghb3.ui:2968
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:3032
+#: src/ghb3.ui:2983
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:3037
+#: src/ghb3.ui:2988
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:3059
+#: src/ghb3.ui:3010
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3077
+#: src/ghb3.ui:3028
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3092
+#: src/ghb3.ui:3043
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3132
+#: src/ghb3.ui:3083
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3172
+#: src/ghb3.ui:3123
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3197 src/ghb3.ui:3296 src/ghb3.ui:3334 src/ghb3.ui:3372
-#: src/ghb3.ui:4208 src/ghb3.ui:4346
+#: src/ghb3.ui:3148 src/ghb3.ui:3247 src/ghb3.ui:3285 src/ghb3.ui:3323
+#: src/ghb3.ui:4159 src/ghb3.ui:4297
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3284 src/ghb3.ui:4196
+#: src/ghb3.ui:3235 src/ghb3.ui:4147
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3322 src/ghb3.ui:4240
+#: src/ghb3.ui:3273 src/ghb3.ui:4191
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3360 src/ghb3.ui:4334
+#: src/ghb3.ui:3311 src/ghb3.ui:4285
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3397
+#: src/ghb3.ui:3348
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3444
+#: src/ghb3.ui:3395
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3455
+#: src/ghb3.ui:3406
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3460
+#: src/ghb3.ui:3411
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3477
+#: src/ghb3.ui:3428
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3493
+#: src/ghb3.ui:3444
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3508
+#: src/ghb3.ui:3459
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3524
+#: src/ghb3.ui:3475
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3540
+#: src/ghb3.ui:3491
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3557
+#: src/ghb3.ui:3508
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3574
+#: src/ghb3.ui:3525
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3591
+#: src/ghb3.ui:3542
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3627
+#: src/ghb3.ui:3578
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3666
+#: src/ghb3.ui:3617
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3681
+#: src/ghb3.ui:3632
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3697
+#: src/ghb3.ui:3648
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3712
+#: src/ghb3.ui:3663
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3729 src/ghb3.ui:3898 src/ghb3.ui:4272
+#: src/ghb3.ui:3680 src/ghb3.ui:3849 src/ghb3.ui:4223
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3744
+#: src/ghb3.ui:3695
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3760
+#: src/ghb3.ui:3711
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3775
+#: src/ghb3.ui:3726
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -739,11 +680,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3796
+#: src/ghb3.ui:3747
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3811
+#: src/ghb3.ui:3762
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -752,11 +693,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3831
+#: src/ghb3.ui:3782
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3846
+#: src/ghb3.ui:3797
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -764,102 +705,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3865
+#: src/ghb3.ui:3816
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3880
+#: src/ghb3.ui:3831
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3913
+#: src/ghb3.ui:3864
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3927
+#: src/ghb3.ui:3878
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3932
+#: src/ghb3.ui:3883
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3947
+#: src/ghb3.ui:3898
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3952
+#: src/ghb3.ui:3903
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3977
+#: src/ghb3.ui:3928
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:4017
+#: src/ghb3.ui:3968
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:4034
+#: src/ghb3.ui:3985
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:4051
+#: src/ghb3.ui:4002
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4068
+#: src/ghb3.ui:4019
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4085
+#: src/ghb3.ui:4036
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4102
+#: src/ghb3.ui:4053
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4118
+#: src/ghb3.ui:4069
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4135
+#: src/ghb3.ui:4086
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4157
+#: src/ghb3.ui:4108
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4255 src/ghb3.ui:4287 src/ghb3.ui:4305
+#: src/ghb3.ui:4206 src/ghb3.ui:4238 src/ghb3.ui:4256
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4300 src/hb-backend.c:123 src/hb-backend.c:237
-#: src/hb-backend.c:310
+#: src/ghb3.ui:4251 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4371
+#: src/ghb3.ui:4322
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4384
+#: src/ghb3.ui:4335
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4412
+#: src/ghb3.ui:4363
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4428
+#: src/ghb3.ui:4379
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -867,18 +808,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4443 src/ghb3.ui:5096
+#: src/ghb3.ui:4394 src/ghb3.ui:5047
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4471
+#: src/ghb3.ui:4422
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4487
+#: src/ghb3.ui:4438
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -886,7 +827,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4503
+#: src/ghb3.ui:4454
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -894,11 +835,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4532
+#: src/ghb3.ui:4483
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4548
+#: src/ghb3.ui:4499
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -906,11 +847,11 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4567
+#: src/ghb3.ui:4518
 msgid "Deinterlace Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4583
+#: src/ghb3.ui:4534
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -918,32 +859,32 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4626
+#: src/ghb3.ui:4577
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4642 src/ghb3.ui:4674
+#: src/ghb3.ui:4593 src/ghb3.ui:4625
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4658
+#: src/ghb3.ui:4609
 msgid "Deblock Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4903
+#: src/ghb3.ui:4639 src/ghb3.ui:4854
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4716
+#: src/ghb3.ui:4667
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4732 src/ghb3.ui:4765 src/ghb3.ui:4798
+#: src/ghb3.ui:4683 src/ghb3.ui:4716 src/ghb3.ui:4749
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -951,86 +892,86 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4749
+#: src/ghb3.ui:4700
 msgid "Denoise Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4782
+#: src/ghb3.ui:4733
 msgid "Denoise Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4813 src/ghb3.ui:5025
+#: src/ghb3.ui:4764 src/ghb3.ui:4976
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4841
+#: src/ghb3.ui:4792
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4857 src/ghb3.ui:4889
+#: src/ghb3.ui:4808 src/ghb3.ui:4840
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4873
+#: src/ghb3.ui:4824
 msgid "Chroma Smooth Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4931
+#: src/ghb3.ui:4882
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4947 src/ghb3.ui:4979 src/ghb3.ui:5011
+#: src/ghb3.ui:4898 src/ghb3.ui:4930 src/ghb3.ui:4962
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4963
+#: src/ghb3.ui:4914
 msgid "Sharpen Preset:"
 msgstr ""
 
-#: src/ghb3.ui:4995
+#: src/ghb3.ui:4946
 msgid "Sharpen Tune:"
 msgstr ""
 
-#: src/ghb3.ui:5042
+#: src/ghb3.ui:4993
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:4998
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:5067
+#: src/ghb3.ui:5018
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:5083
+#: src/ghb3.ui:5034
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:5115
+#: src/ghb3.ui:5066
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:5146
+#: src/ghb3.ui:5097
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5160
+#: src/ghb3.ui:5111
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5176
+#: src/ghb3.ui:5127
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5191
+#: src/ghb3.ui:5142
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1038,19 +979,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5206
+#: src/ghb3.ui:5157
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5211
+#: src/ghb3.ui:5162
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5225
+#: src/ghb3.ui:5176
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5230
+#: src/ghb3.ui:5181
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1058,18 +999,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5248
+#: src/ghb3.ui:5199
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5253
+#: src/ghb3.ui:5204
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5289 src/ghb3.ui:5321
+#: src/ghb3.ui:5240 src/ghb3.ui:5272
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1085,15 +1026,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5316
+#: src/ghb3.ui:5267
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5347
+#: src/ghb3.ui:5298
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5352 src/ghb3.ui:5374
+#: src/ghb3.ui:5303 src/ghb3.ui:5325
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1104,11 +1045,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5391
+#: src/ghb3.ui:5342
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5396
+#: src/ghb3.ui:5347
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1118,16 +1059,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5414
+#: src/ghb3.ui:5365
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5419
+#: src/ghb3.ui:5370
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5481
+#: src/ghb3.ui:5432
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1139,11 +1080,11 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5507
+#: src/ghb3.ui:5458
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:5524
+#: src/ghb3.ui:5475
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1152,22 +1093,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5540
+#: src/ghb3.ui:5491
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5545
+#: src/ghb3.ui:5496
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5563
+#: src/ghb3.ui:5514
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5567
+#: src/ghb3.ui:5518
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1177,301 +1118,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5591
+#: src/ghb3.ui:5542
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5608
+#: src/ghb3.ui:5559
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5626
+#: src/ghb3.ui:5577
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5643
+#: src/ghb3.ui:5594
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5668
+#: src/ghb3.ui:5619
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5686
+#: src/ghb3.ui:5637
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5720 src/main.c:1172
+#: src/ghb3.ui:5671 src/main.c:1148
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5786 src/ghb3.ui:5979 src/ghb3.ui:6558 src/ghb3.ui:6778
-#: src/audiohandler.c:1752
+#: src/ghb3.ui:5735 src/ghb3.ui:5928 src/ghb3.ui:6505 src/ghb3.ui:6725
+#: src/ghb3.ui:7637 src/audiohandler.c:1754
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5788
+#: src/ghb3.ui:5737
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5798 src/ghb3.ui:6570
+#: src/ghb3.ui:5747 src/ghb3.ui:6517
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5800
+#: src/ghb3.ui:5749
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5813
+#: src/ghb3.ui:5762
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5857 src/ghb3.ui:6643
+#: src/ghb3.ui:5806 src/ghb3.ui:6590
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5888 src/ghb3.ui:6678
+#: src/ghb3.ui:5837 src/ghb3.ui:6625
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5903
+#: src/ghb3.ui:5852
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5964
+#: src/ghb3.ui:5913
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5995 src/ghb3.ui:6794
+#: src/ghb3.ui:5944 src/ghb3.ui:6741
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:6013 src/ghb3.ui:6812
+#: src/ghb3.ui:5962 src/ghb3.ui:6759
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:6026 src/ghb3.ui:6825
+#: src/ghb3.ui:5975 src/ghb3.ui:6772
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:6042
+#: src/ghb3.ui:5991
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:6047
+#: src/ghb3.ui:5996
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:6083
+#: src/ghb3.ui:6032
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:6094
+#: src/ghb3.ui:6043
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:6099
+#: src/ghb3.ui:6048
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6115
+#: src/ghb3.ui:6064
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:6120
+#: src/ghb3.ui:6069
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6136
+#: src/ghb3.ui:6085
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:6141
+#: src/ghb3.ui:6090
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6157
+#: src/ghb3.ui:6106
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6162
+#: src/ghb3.ui:6111
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6178
+#: src/ghb3.ui:6127
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6183
+#: src/ghb3.ui:6132
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6199
+#: src/ghb3.ui:6148
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6204
+#: src/ghb3.ui:6153
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6220
+#: src/ghb3.ui:6169
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6225
+#: src/ghb3.ui:6174
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6241
+#: src/ghb3.ui:6190
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6246
+#: src/ghb3.ui:6195
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6262
+#: src/ghb3.ui:6211
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6267
+#: src/ghb3.ui:6216
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6283
+#: src/ghb3.ui:6232
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6288
+#: src/ghb3.ui:6237
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6321
+#: src/ghb3.ui:6270
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6333
+#: src/ghb3.ui:6282
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6362
+#: src/ghb3.ui:6311
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6363
+#: src/ghb3.ui:6312
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6388 src/ghb3.ui:9942
+#: src/ghb3.ui:6337 src/ghb3.ui:9970
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6399 src/ghb3.ui:9955
+#: src/ghb3.ui:6348 src/ghb3.ui:9983
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6410
+#: src/ghb3.ui:6359
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6370
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6432 src/ghb3.ui:9999
+#: src/ghb3.ui:6381 src/ghb3.ui:10027 src/queuehandler.c:614
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6443 src/ghb3.ui:10018
+#: src/ghb3.ui:6392 src/ghb3.ui:10046
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6480 src/ghb3.ui:7038
+#: src/ghb3.ui:6429 src/ghb3.ui:6985
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6492
+#: src/ghb3.ui:6441
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6560
+#: src/ghb3.ui:6507
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6572
+#: src/ghb3.ui:6519
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6582 src/queuehandler.c:631 src/queuehandler.c:1062
-#: src/subtitlehandler.c:413
-#, c-format
+#: src/ghb3.ui:6529 src/queuehandler.c:651 src/queuehandler.c:1088
+#: src/subtitlehandler.c:413 src/subtitlehandler.c:1244
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6584
+#: src/ghb3.ui:6531
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6599
+#: src/ghb3.ui:6546
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6693
+#: src/ghb3.ui:6640
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6758
+#: src/ghb3.ui:6705
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1482,15 +1422,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6839
+#: src/ghb3.ui:6786
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6866
+#: src/ghb3.ui:6813
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6871
+#: src/ghb3.ui:6818
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1500,11 +1440,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6886
+#: src/ghb3.ui:6833
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6891
+#: src/ghb3.ui:6838
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1512,21 +1452,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6905
+#: src/ghb3.ui:6852
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6857
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6931
+#: src/ghb3.ui:6878
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6943
+#: src/ghb3.ui:6890
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1536,15 +1476,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6970
+#: src/ghb3.ui:6917
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6979
+#: src/ghb3.ui:6926
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6984
+#: src/ghb3.ui:6931
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1555,11 +1495,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6945
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:7003
+#: src/ghb3.ui:6950
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1570,196 +1510,195 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:7025
+#: src/ghb3.ui:6972
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:7026
+#: src/ghb3.ui:6973
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:7050
+#: src/ghb3.ui:6997
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:7065 src/queuehandler.c:280
+#: src/ghb3.ui:7012 src/queuehandler.c:280
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:7070
+#: src/ghb3.ui:7017
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:7104
+#: src/ghb3.ui:7051
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:7128
+#: src/ghb3.ui:7075
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7139
+#: src/ghb3.ui:7086
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7176
+#: src/ghb3.ui:7123
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7231
+#: src/ghb3.ui:7178
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7266
+#: src/ghb3.ui:7213
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7301
+#: src/ghb3.ui:7248
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7336
+#: src/ghb3.ui:7283
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7371
+#: src/ghb3.ui:7318
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7406
+#: src/ghb3.ui:7353
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7441
+#: src/ghb3.ui:7388
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7479
+#: src/ghb3.ui:7426
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7508
+#: src/ghb3.ui:7456
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7522
+#: src/ghb3.ui:7470
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7542
+#: src/ghb3.ui:7490
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7555
+#: src/ghb3.ui:7503
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7558 src/queuehandler.c:2247
+#: src/ghb3.ui:7506 src/queuehandler.c:2269
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7651 src/ghb3.ui:8617 src/ghb3.ui:8769 src/ghb3.ui:9416
-#: src/ghb3.ui:9821 src/callbacks.c:5713 src/callbacks.c:5723
-#: src/callbacks.c:5731 src/hb-backend.c:4307 src/hb-backend.c:4340
-#: src/hb-backend.c:4379 src/hb-backend.c:4410 src/hb-backend.c:4438
-#: src/hb-backend.c:4484 src/hb-backend.c:4541 src/hb-backend.c:4561
-#: src/hb-backend.c:4581 src/hb-backend.c:4642 src/hb-backend.c:4697
-#: src/queuehandler.c:1854 src/queuehandler.c:1871 src/queuehandler.c:1885
-#: src/queuehandler.c:1900
+#: src/ghb3.ui:7621
+msgid "Add Multiple Items"
+msgstr ""
+
+#: src/ghb3.ui:7629 src/ghb3.ui:8597 src/ghb3.ui:8754 src/ghb3.ui:9435
+#: src/ghb3.ui:9845 src/callbacks.c:5608 src/callbacks.c:5616
+#: src/callbacks.c:5625 src/hb-backend.c:4316 src/hb-backend.c:4349
+#: src/hb-backend.c:4388 src/hb-backend.c:4419 src/hb-backend.c:4447
+#: src/hb-backend.c:4493 src/hb-backend.c:4550 src/hb-backend.c:4570
+#: src/hb-backend.c:4590 src/hb-backend.c:4651 src/hb-backend.c:4706
+#: src/presets.c:2463 src/queuehandler.c:1877 src/queuehandler.c:1894
+#: src/queuehandler.c:1908 src/queuehandler.c:1923
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7660 src/ghb3.ui:7804 src/ghb3.ui:8626 src/ghb3.ui:8778
-#: src/ghb3.ui:9425 src/ghb3.ui:9830
-msgid "OK"
-msgstr ""
-
-#: src/ghb3.ui:7689
+#: src/ghb3.ui:7670
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7693
+#: src/ghb3.ui:7674
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7706
+#: src/ghb3.ui:7687
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7710
+#: src/ghb3.ui:7691
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7771
+#: src/ghb3.ui:7752
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7793
+#: src/ghb3.ui:7774 src/ghb3.ui:7786
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7899
+#: src/ghb3.ui:7877
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7936
+#: src/ghb3.ui:7914
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7936
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7959
+#: src/ghb3.ui:7937
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7983
+#: src/ghb3.ui:7961
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7994
+#: src/ghb3.ui:7972
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {quality} {bitrate}"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:7992
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:8057
+#: src/ghb3.ui:8035
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:8095
+#: src/ghb3.ui:8073
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8109
+#: src/ghb3.ui:8087
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8113
+#: src/ghb3.ui:8091
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8130
+#: src/ghb3.ui:8104
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8158
+#: src/ghb3.ui:8129
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8162 src/ghb3.ui:8182
+#: src/ghb3.ui:8133 src/ghb3.ui:8153
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1773,63 +1712,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8192
+#: src/ghb3.ui:8163
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8232
+#: src/ghb3.ui:8203
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8249
+#: src/ghb3.ui:8220
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8272
+#: src/ghb3.ui:8243
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8276 src/ghb3.ui:8298
+#: src/ghb3.ui:8247 src/ghb3.ui:8269
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8313
+#: src/ghb3.ui:8284
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8341
+#: src/ghb3.ui:8312
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8377
+#: src/ghb3.ui:8348
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8412
+#: src/ghb3.ui:8383
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8433
+#: src/ghb3.ui:8404
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8450
+#: src/ghb3.ui:8421
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8454
+#: src/ghb3.ui:8425
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8492
+#: src/ghb3.ui:8463
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8509
+#: src/ghb3.ui:8480
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8513
+#: src/ghb3.ui:8484
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1838,178 +1777,204 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8541
+#: src/ghb3.ui:8501
+msgid "Show preview image in Summary tab"
+msgstr ""
+
+#: src/ghb3.ui:8507
+msgid ""
+"Uncheck this if you want to hide the video preview image on the Summary tab "
+"for privacy reasons."
+msgstr ""
+
+#: src/ghb3.ui:8530
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8557
+#: src/ghb3.ui:8546
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8585
+#: src/ghb3.ui:8568
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8663
+#: src/ghb3.ui:8585
+msgid "Rename Preset"
+msgstr ""
+
+#: src/ghb3.ui:8647
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8683
+#: src/ghb3.ui:8667
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8740 src/ghb3.ui:9008
+#: src/ghb3.ui:8724 src/ghb3.ui:8997
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8821
+#: src/ghb3.ui:8742
+msgid "Save Preset"
+msgstr ""
+
+#: src/ghb3.ui:8810
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8836
+#: src/ghb3.ui:8825
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8852
+#: src/ghb3.ui:8841
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8885
+#: src/ghb3.ui:8874
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8919
+#: src/ghb3.ui:8908
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8924
+#: src/ghb3.ui:8913
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8950
+#: src/ghb3.ui:8939
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9031
+#: src/ghb3.ui:9020
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9090
+#: src/ghb3.ui:9101
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9112
+#: src/ghb3.ui:9123
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9183
-msgid "<b>Duration:</b>"
-msgstr ""
-
-#: src/ghb3.ui:9195
-msgid "Set the duration of the live preview in seconds."
-msgstr ""
-
-#: src/ghb3.ui:9211
-msgid "Show Crop"
+#: src/ghb3.ui:9179
+msgid "Click to toggle full screen mode"
 msgstr ""
 
 #: src/ghb3.ui:9215
+msgid "<b>Duration:</b>"
+msgstr ""
+
+#: src/ghb3.ui:9227
+msgid "Set the duration of the live preview in seconds."
+msgstr ""
+
+#: src/ghb3.ui:9243
+msgid "Show Crop"
+msgstr ""
+
+#: src/ghb3.ui:9247
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9226
+#: src/ghb3.ui:9258
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9230
+#: src/ghb3.ui:9262
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9262
+#: src/ghb3.ui:9295
 msgid "_Cancel"
 msgstr ""
 
-#: src/ghb3.ui:9274
+#: src/ghb3.ui:9304
 msgid "_Open"
 msgstr ""
 
-#: src/ghb3.ui:9308
+#: src/ghb3.ui:9337
 msgid "Title Number:"
 msgstr ""
 
-#: src/ghb3.ui:9344
+#: src/ghb3.ui:9373
 msgid "Detected DVD devices:"
 msgstr ""
 
-#: src/ghb3.ui:9454
+#: src/ghb3.ui:9422 src/subtitlehandler.c:1742
+msgid "Edit Subtitles"
+msgstr ""
+
+#: src/ghb3.ui:9477
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9459
+#: src/ghb3.ui:9482
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9470
+#: src/ghb3.ui:9493
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9475
+#: src/ghb3.ui:9498
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9487
+#: src/ghb3.ui:9510
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9492
+#: src/ghb3.ui:9515
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9519 src/ghb3.ui:9862
+#: src/ghb3.ui:9542 src/ghb3.ui:9890
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9534
+#: src/ghb3.ui:9557
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9548 src/ghb3.ui:9892
+#: src/ghb3.ui:9571 src/ghb3.ui:9920
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9564
+#: src/ghb3.ui:9587
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9620
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9611
+#: src/ghb3.ui:9634
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9625
+#: src/ghb3.ui:9648
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9640
+#: src/ghb3.ui:9663
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9655
+#: src/ghb3.ui:9678
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9673
+#: src/ghb3.ui:9696
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2018,56 +1983,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9697
+#: src/ghb3.ui:9720
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9700
+#: src/ghb3.ui:9723
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9718
+#: src/ghb3.ui:9741
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9742
+#: src/ghb3.ui:9765
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9763
+#: src/ghb3.ui:9786
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9768
+#: src/ghb3.ui:9791
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9780
+#: src/ghb3.ui:9803
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9878
+#: src/ghb3.ui:9832 src/audiohandler.c:1470
+msgid "Edit Audio Track"
+msgstr ""
+
+#: src/ghb3.ui:9906
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9908
+#: src/ghb3.ui:9936
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9971
+#: src/ghb3.ui:9999
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9984
+#: src/ghb3.ui:10012
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:10014 src/ghb3.ui:10253 src/audiohandler.c:1925
+#: src/ghb3.ui:10042 src/ghb3.ui:10281 src/audiohandler.c:1927
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2078,86 +2047,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:10035 src/audiohandler.c:1776
+#: src/ghb3.ui:10063 src/audiohandler.c:1778
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10057 src/audiohandler.c:1790
+#: src/ghb3.ui:10085 src/audiohandler.c:1792
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:10062
+#: src/ghb3.ui:10090
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1795
+#: src/ghb3.ui:10100 src/audiohandler.c:1797
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:10077
+#: src/ghb3.ui:10105
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10098 src/audiohandler.c:1809
+#: src/ghb3.ui:10126 src/audiohandler.c:1811
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10118
+#: src/ghb3.ui:10146
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10140
+#: src/ghb3.ui:10168
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10167 src/audiohandler.c:1861
+#: src/ghb3.ui:10195 src/audiohandler.c:1863
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10183 src/audiohandler.c:1874
+#: src/ghb3.ui:10211 src/audiohandler.c:1876
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10206 src/audiohandler.c:1895
+#: src/ghb3.ui:10234 src/audiohandler.c:1897
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10224 src/audiohandler.c:1905
+#: src/ghb3.ui:10252 src/audiohandler.c:1907
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10271 src/audiohandler.c:424 src/audiohandler.c:762
-#: src/audiohandler.c:1165 src/audiohandler.c:1939 src/callbacks.c:5482
+#: src/ghb3.ui:10299 src/audiohandler.c:424 src/audiohandler.c:762
+#: src/audiohandler.c:1165 src/audiohandler.c:1941 src/callbacks.c:5380
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
-#: src/hb-backend.c:249 src/hb-backend.c:320 src/hb-backend.c:332
-#: src/hb-backend.c:344 src/hb-backend.c:405
+#: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
+#: src/hb-backend.c:345 src/hb-backend.c:406
 #, c-format
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10307
+#: src/ghb3.ui:10324
+msgid "HandBrake Updater"
+msgstr ""
+
+#: src/ghb3.ui:10336
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10315
+#: src/ghb3.ui:10344
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10384
+#: src/ghb3.ui:10413
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10400
+#: src/ghb3.ui:10429
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10428
+#: src/ghb3.ui:10457
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2210,51 +2183,55 @@ msgid ""
 "DRC: %s"
 msgstr ""
 
-#: src/audiohandler.c:1754
+#: src/audiohandler.c:1388
+msgid "Add Audio Track"
+msgstr ""
+
+#: src/audiohandler.c:1756
 msgid ""
 "Add an audio encoder.\n"
 "Each selected source track will be encoded with all selected encoders."
 msgstr ""
 
-#: src/audiohandler.c:1834
+#: src/audiohandler.c:1836
 msgid ""
 "<b>Audio Quality:</b>\n"
 "For encoders that support it, adjust the quality of the output."
 msgstr ""
 
-#: src/audiohandler.c:1954
+#: src/audiohandler.c:1956
 msgid "Remove this audio encoder"
 msgstr ""
 
-#: src/callbacks.c:793 src/callbacks.c:2144
+#: src/callbacks.c:733 src/callbacks.c:2081
 msgid "Closing HandBrake will terminate encoding.\n"
 msgstr ""
 
-#: src/callbacks.c:1378
+#: src/callbacks.c:1315
 msgid "Not Selected"
 msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1711 src/callbacks.c:4397
+#: src/callbacks.c:1651 src/callbacks.c:4372
 msgid "Scanning ..."
 msgstr ""
 
-#: src/callbacks.c:1747 src/callbacks.c:1748
+#: src/callbacks.c:1687 src/callbacks.c:1688
 msgid "Stop Scan"
 msgstr ""
 
-#: src/callbacks.c:2748 src/hb-backend.c:2256 src/hb-backend.c:2376
-#: src/hb-backend.c:2388
+#: src/callbacks.c:2698 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2749
+#: src/callbacks.c:2699
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3737 src/callbacks.c:3759 src/callbacks.c:3778
-#: src/callbacks.c:3810
+#: src/callbacks.c:3680 src/callbacks.c:3693 src/callbacks.c:3715
+#: src/callbacks.c:3753
 #, c-format
 msgid ""
 "%s\n"
@@ -2262,133 +2239,129 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3881 src/callbacks.c:3923
+#: src/callbacks.c:3847 src/callbacks.c:3898
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3884 src/callbacks.c:3926 src/queuehandler.c:1796
+#: src/callbacks.c:3850 src/callbacks.c:3901 src/queuehandler.c:1814
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3885
+#: src/callbacks.c:3851
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3886
+#: src/callbacks.c:3852
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3887 src/callbacks.c:3927
+#: src/callbacks.c:3853 src/callbacks.c:3902
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4105
+#: src/callbacks.c:4085
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4109
+#: src/callbacks.c:4089
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4166 src/callbacks.c:4234
+#: src/callbacks.c:4146 src/callbacks.c:4214
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4176
+#: src/callbacks.c:4156
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4181
+#: src/callbacks.c:4161
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4194
+#: src/callbacks.c:4174
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4204 src/callbacks.c:4244
+#: src/callbacks.c:4184 src/callbacks.c:4224
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4214 src/callbacks.c:4253
+#: src/callbacks.c:4194 src/callbacks.c:4233
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4240
+#: src/callbacks.c:4220
 #, c-format
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4315
+#: src/callbacks.c:4295
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4319
+#: src/callbacks.c:4299
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4408
+#: src/callbacks.c:4383
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4439
+#: src/callbacks.c:4414
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4443
+#: src/callbacks.c:4418
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4423
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4490
+#: src/callbacks.c:4465
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5127
-msgid "Scan this DVD source"
-msgstr ""
-
-#: src/callbacks.c:5515
+#: src/callbacks.c:5413
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5696
+#: src/callbacks.c:5593
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5698
+#: src/callbacks.c:5595
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5711 src/callbacks.c:5721 src/callbacks.c:5729
+#: src/callbacks.c:5606 src/callbacks.c:5614 src/callbacks.c:5623
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5712
-msgid "Shutting down the computer"
+#: src/callbacks.c:5607
+msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5722
+#: src/callbacks.c:5615
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5730
-msgid "Quitting Handbrake"
+#: src/callbacks.c:5624
+msgid "Shutting down the computer"
 msgstr ""
 
 #: src/hb-backend.c:61 src/hb-backend.c:86
@@ -2443,8 +2416,8 @@ msgstr ""
 msgid "Shutdown Computer"
 msgstr ""
 
-#: src/hb-backend.c:125 src/hb-backend.c:239 src/hb-backend.c:270
-#: src/hb-backend.c:284 src/hb-backend.c:395
+#: src/hb-backend.c:125 src/hb-backend.c:240 src/hb-backend.c:271
+#: src/hb-backend.c:285 src/hb-backend.c:396
 msgid "Custom"
 msgstr ""
 
@@ -2508,245 +2481,251 @@ msgstr ""
 msgid "Lapsharp"
 msgstr ""
 
-#: src/hb-backend.c:250
-msgid "90°"
+#: src/hb-backend.c:238
+msgid "Conservative"
 msgstr ""
 
 #: src/hb-backend.c:251
-msgid "180°"
+msgid "90°"
 msgstr ""
 
 #: src/hb-backend.c:252
+msgid "180°"
+msgstr ""
+
+#: src/hb-backend.c:253
 msgid "270°"
 msgstr ""
 
-#: src/hb-backend.c:262
+#: src/hb-backend.c:263
 msgid "4320p 8K Ultra HD"
 msgstr ""
 
-#: src/hb-backend.c:263
+#: src/hb-backend.c:264
 msgid "2160p 4K Ultra HD"
 msgstr ""
 
-#: src/hb-backend.c:264
+#: src/hb-backend.c:265
 msgid "1440p 2.5K Quad HD"
 msgstr ""
 
-#: src/hb-backend.c:265
+#: src/hb-backend.c:266
 msgid "1080p Full HD"
 msgstr ""
 
-#: src/hb-backend.c:266
+#: src/hb-backend.c:267
 msgid "720p HD"
 msgstr ""
 
-#: src/hb-backend.c:267
+#: src/hb-backend.c:268
 msgid "576p PAL"
 msgstr ""
 
-#: src/hb-backend.c:268
+#: src/hb-backend.c:269
 msgid "480p NTSC"
 msgstr ""
 
-#: src/hb-backend.c:281
+#: src/hb-backend.c:282
 msgid "Height (Letterbox)"
 msgstr ""
 
-#: src/hb-backend.c:282
+#: src/hb-backend.c:283
 msgid "Width (Pillarbox)"
 msgstr ""
 
-#: src/hb-backend.c:283
+#: src/hb-backend.c:284
 msgid "Width &amp; Height"
 msgstr ""
 
-#: src/hb-backend.c:294
+#: src/hb-backend.c:295
 msgid "Black"
 msgstr ""
 
-#: src/hb-backend.c:295
+#: src/hb-backend.c:296
 msgid "Dark Gray"
 msgstr ""
 
-#: src/hb-backend.c:296
+#: src/hb-backend.c:297
 msgid "Gray"
 msgstr ""
 
-#: src/hb-backend.c:297
+#: src/hb-backend.c:298
 msgid "White"
 msgstr ""
 
-#: src/hb-backend.c:308
+#: src/hb-backend.c:309
 msgid "Spatial"
 msgstr ""
 
-#: src/hb-backend.c:309
+#: src/hb-backend.c:310
 msgid "Temporal"
 msgstr ""
 
-#: src/hb-backend.c:321
+#: src/hb-backend.c:322
 msgid "Fast"
 msgstr ""
 
-#: src/hb-backend.c:322
+#: src/hb-backend.c:323
 msgid "Optimal"
 msgstr ""
 
-#: src/hb-backend.c:333
+#: src/hb-backend.c:334
 msgid "Strict"
 msgstr ""
 
-#: src/hb-backend.c:334
+#: src/hb-backend.c:335
 msgid "Normal"
 msgstr ""
 
-#: src/hb-backend.c:345
+#: src/hb-backend.c:346
 msgid "Simple"
 msgstr ""
 
-#: src/hb-backend.c:346
+#: src/hb-backend.c:347
 msgid "Smart"
 msgstr ""
 
-#: src/hb-backend.c:356
+#: src/hb-backend.c:357
 msgid "Diamond"
 msgstr ""
 
-#: src/hb-backend.c:357
+#: src/hb-backend.c:358
 msgid "Hexagon"
 msgstr ""
 
-#: src/hb-backend.c:358
+#: src/hb-backend.c:359
 msgid "Uneven Multi-Hexagon"
 msgstr ""
 
-#: src/hb-backend.c:359
+#: src/hb-backend.c:360
 msgid "Exhaustive"
 msgstr ""
 
-#: src/hb-backend.c:360
+#: src/hb-backend.c:361
 msgid "Hadamard Exhaustive"
 msgstr ""
 
-#: src/hb-backend.c:370
+#: src/hb-backend.c:371
 msgid "0: SAD, no subpel"
 msgstr ""
 
-#: src/hb-backend.c:371
+#: src/hb-backend.c:372
 msgid "1: SAD, qpel"
 msgstr ""
 
-#: src/hb-backend.c:372
+#: src/hb-backend.c:373
 msgid "2: SATD, qpel"
 msgstr ""
 
-#: src/hb-backend.c:373
+#: src/hb-backend.c:374
 msgid "3: SATD: multi-qpel"
 msgstr ""
 
-#: src/hb-backend.c:374
+#: src/hb-backend.c:375
 msgid "4: SATD, qpel on all"
 msgstr ""
 
-#: src/hb-backend.c:375
+#: src/hb-backend.c:376
 msgid "5: SATD, multi-qpel on all"
 msgstr ""
 
-#: src/hb-backend.c:376
+#: src/hb-backend.c:377
 msgid "6: RD in I/P-frames"
 msgstr ""
 
-#: src/hb-backend.c:377
+#: src/hb-backend.c:378
 msgid "7: RD in all frames"
 msgstr ""
 
-#: src/hb-backend.c:378
+#: src/hb-backend.c:379
 msgid "8: RD refine in I/P-frames"
 msgstr ""
 
-#: src/hb-backend.c:379
+#: src/hb-backend.c:380
 msgid "9: RD refine in all frames"
 msgstr ""
 
-#: src/hb-backend.c:380
+#: src/hb-backend.c:381
 msgid "10: QPRD in all frames"
 msgstr ""
 
-#: src/hb-backend.c:381
+#: src/hb-backend.c:382
 msgid "11: No early terminations in analysis"
 msgstr ""
 
-#: src/hb-backend.c:391
+#: src/hb-backend.c:392
 msgid "Most"
 msgstr ""
 
-#: src/hb-backend.c:393
+#: src/hb-backend.c:394
 msgid "Some"
 msgstr ""
 
-#: src/hb-backend.c:394 src/main.c:1168 src/queuehandler.c:1626
+#. Add filters
+#: src/hb-backend.c:395 src/main.c:1147 src/presets.c:2038
+#: src/queuehandler.c:1649
 msgid "All"
 msgstr ""
 
-#: src/hb-backend.c:406
+#: src/hb-backend.c:407
 msgid "Encode only"
 msgstr ""
 
-#: src/hb-backend.c:407
+#: src/hb-backend.c:408
 msgid "Always"
 msgstr ""
 
-#: src/hb-backend.c:1517 src/hb-backend.c:1577 src/hb-backend.c:1656
+#: src/hb-backend.c:1524 src/hb-backend.c:1584 src/hb-backend.c:1663
 msgid "Same as source"
 msgstr ""
 
-#: src/hb-backend.c:1670
+#: src/hb-backend.c:1677
 msgid "(NTSC Film)"
 msgstr ""
 
-#: src/hb-backend.c:1674
+#: src/hb-backend.c:1681
 msgid "(PAL Film/Video)"
 msgstr ""
 
-#: src/hb-backend.c:1678
+#: src/hb-backend.c:1685
 msgid "(NTSC Video)"
 msgstr ""
 
-#: src/hb-backend.c:2245
+#: src/hb-backend.c:2252
 #, c-format
 msgid "%s - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2395
+#: src/hb-backend.c:2402
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - %s"
 msgstr ""
 
-#: src/hb-backend.c:2414
+#: src/hb-backend.c:2421
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2420
+#: src/hb-backend.c:2427
 #, c-format
 msgid "%3d - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2426
+#: src/hb-backend.c:2433
 #, c-format
 msgid "%3d - %02dh%02dm%02ds"
 msgstr ""
 
-#: src/hb-backend.c:2460
+#: src/hb-backend.c:2466
 msgid "No Titles"
 msgstr ""
 
 #. No audio. set some default
-#: src/hb-backend.c:2745
+#: src/hb-backend.c:2746
 msgid "No Audio"
 msgstr ""
 
-#: src/hb-backend.c:4296
+#: src/hb-backend.c:4305
 #, c-format
 msgid ""
 "Invalid Detelecine Settings:\n"
@@ -2755,7 +2734,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4303
+#: src/hb-backend.c:4312
 #, c-format
 msgid ""
 "Invalid Detelecine Settings:\n"
@@ -2763,7 +2742,7 @@ msgid ""
 "Preset:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4329
+#: src/hb-backend.c:4338
 #, c-format
 msgid ""
 "Invalid Comb Detect Settings:\n"
@@ -2772,22 +2751,12 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4336
+#: src/hb-backend.c:4345
 #, c-format
 msgid ""
 "Invalid Comb Detect Settings:\n"
 "\n"
 "Preset:\t%s\n"
-msgstr ""
-
-#: src/hb-backend.c:4365
-#, c-format
-msgid ""
-"Invalid Deinterlace Settings:\n"
-"\n"
-"Filter:\t%s\n"
-"Preset:\t%s\n"
-"Custom:\t%s\n"
 msgstr ""
 
 #: src/hb-backend.c:4374
@@ -2797,9 +2766,19 @@ msgid ""
 "\n"
 "Filter:\t%s\n"
 "Preset:\t%s\n"
+"Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4403
+#: src/hb-backend.c:4383
+#, c-format
+msgid ""
+"Invalid Deinterlace Settings:\n"
+"\n"
+"Filter:\t%s\n"
+"Preset:\t%s\n"
+msgstr ""
+
+#: src/hb-backend.c:4412
 #, c-format
 msgid ""
 "Invalid Denoise Settings:\n"
@@ -2810,7 +2789,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4431
+#: src/hb-backend.c:4440
 #, c-format
 msgid ""
 "Invalid Sharpen Settings:\n"
@@ -2821,7 +2800,7 @@ msgid ""
 "Custom:\t%s\n"
 msgstr ""
 
-#: src/hb-backend.c:4465
+#: src/hb-backend.c:4474
 #, c-format
 msgid ""
 "Theora is not supported in the MP4 container.\n"
@@ -2830,7 +2809,7 @@ msgid ""
 "If you continue, FFMPEG will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4475
+#: src/hb-backend.c:4484
 #, c-format
 msgid ""
 "Only VP8, VP9 and AV1 is supported in the WebM container.\n"
@@ -2839,17 +2818,17 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4484 src/hb-backend.c:4541 src/hb-backend.c:4561
-#: src/hb-backend.c:4581 src/hb-backend.c:4642 src/hb-backend.c:4697
+#: src/hb-backend.c:4493 src/hb-backend.c:4550 src/hb-backend.c:4570
+#: src/hb-backend.c:4590 src/hb-backend.c:4651 src/hb-backend.c:4706
 msgid "Continue"
 msgstr ""
 
 #. No valid title, stop right there
-#: src/hb-backend.c:4510 src/hb-backend.c:4606
+#: src/hb-backend.c:4519 src/hb-backend.c:4615
 msgid "No title found.\n"
 msgstr ""
 
-#: src/hb-backend.c:4537
+#: src/hb-backend.c:4546
 #, c-format
 msgid ""
 "Only one subtitle may be burned into the video.\n"
@@ -2858,7 +2837,7 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4557
+#: src/hb-backend.c:4566
 #, c-format
 msgid ""
 "WebM in HandBrake only supports burned subtitles.\n"
@@ -2867,7 +2846,7 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4577
+#: src/hb-backend.c:4586
 #, c-format
 msgid ""
 "SRT file does not exist or not a regular file.\n"
@@ -2876,7 +2855,7 @@ msgid ""
 "If you continue, this subtitle will be ignored."
 msgstr ""
 
-#: src/hb-backend.c:4638
+#: src/hb-backend.c:4647
 #, c-format
 msgid ""
 "The source does not support Pass-Thru.\n"
@@ -2885,7 +2864,7 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4693
+#: src/hb-backend.c:4702
 #, c-format
 msgid ""
 "%s is not supported in the %s container.\n"
@@ -2899,51 +2878,51 @@ msgstr ""
 msgid ""
 "<b><big>Unable to create %s.</big></b>\n"
 "\n"
-"Internal error. Could not parse UI description.\n"
+"Internal error. Could not parse menu description.\n"
 "%s"
 msgstr ""
 
-#: src/main.c:235 src/main.c:300
+#: src/main.c:232 src/main.c:297
 msgid "Track Information"
 msgstr ""
 
-#: src/main.c:249 src/main.c:254 src/main.c:314 src/main.c:318
+#: src/main.c:246 src/main.c:251 src/main.c:311 src/main.c:315
 msgid " "
 msgstr ""
 
-#: src/main.c:362
+#: src/main.c:358
 msgid "Preset Name"
 msgstr ""
 
-#: src/main.c:579
+#: src/main.c:573
 msgid "The device or file to encode"
 msgstr ""
 
-#: src/main.c:580
+#: src/main.c:574
 msgid "The preset values to use for encoding"
 msgstr ""
 
-#: src/main.c:581
+#: src/main.c:575
 msgid "Spam a lot"
 msgstr ""
 
-#: src/main.c:582
+#: src/main.c:576
 msgid "The path to override user config dir"
 msgstr ""
 
-#: src/main.c:584
+#: src/main.c:578
 msgid "Open a console for debug output"
 msgstr ""
 
-#: src/presets.c:1249
+#: src/presets.c:1250
 msgid "ghb_presets_menu_init: Failed to find presets folder."
 msgstr ""
 
-#: src/presets.c:1405
+#: src/presets.c:1406
 msgid "Failed to find parent folder when adding child."
 msgstr ""
 
-#: src/presets.c:1868
+#: src/presets.c:1890
 #, c-format
 msgid ""
 "Presets found are newer than what is supported by this version of "
@@ -2952,31 +2931,31 @@ msgid ""
 "Would you like to continue?"
 msgstr ""
 
-#: src/presets.c:1871
+#: src/presets.c:1893
 msgid "Get me out of here!"
 msgstr ""
 
-#: src/presets.c:1871
+#: src/presets.c:1893
 msgid "Load backup presets"
 msgstr ""
 
-#: src/presets.c:2017
-msgid "All (*)"
+#: src/presets.c:2032
+msgid "Import Preset"
 msgstr ""
 
-#: src/presets.c:2022
+#: src/presets.c:2039
 msgid "Presets (*.json)"
 msgstr ""
 
-#: src/presets.c:2028
+#: src/presets.c:2041
 msgid "Legacy Presets (*.plist)"
 msgstr ""
 
-#: src/presets.c:2124
+#: src/presets.c:2135
 msgid "Export Preset"
 msgstr ""
 
-#: src/presets.c:2448
+#: src/presets.c:2457
 #, c-format
 msgid ""
 "Confirm deletion of %s:\n"
@@ -2984,21 +2963,29 @@ msgid ""
 "%s"
 msgstr ""
 
-#: src/presets.c:2449
+#: src/presets.c:2458
 msgid "folder"
 msgstr ""
 
-#: src/presets.c:2449
+#: src/presets.c:2458
 msgid "preset"
 msgstr ""
 
-#: src/preview.c:522
+#: src/presets.c:2464
+msgid "Delete"
+msgstr ""
+
+#: src/preview.c:531
 #, c-format
 msgid ""
 "Missing GStreamer plugin\n"
 "Audio or Video may not play as expected\n"
 "\n"
 "%s"
+msgstr ""
+
+#: src/preview.c:535
+msgid "OK"
 msgstr ""
 
 #: src/queuehandler.c:196
@@ -3079,115 +3066,115 @@ msgid ""
 "Variable Framerate %s fps"
 msgstr ""
 
-#: src/queuehandler.c:634 src/queuehandler.c:665
+#: src/queuehandler.c:654 src/queuehandler.c:691
 #, c-format
 msgid ", Forced Only"
 msgstr ""
 
-#: src/queuehandler.c:638 src/queuehandler.c:669
+#: src/queuehandler.c:658 src/queuehandler.c:695
 #, c-format
 msgid ", Burned"
 msgstr ""
 
-#: src/queuehandler.c:642 src/queuehandler.c:673
+#: src/queuehandler.c:662 src/queuehandler.c:699
 #, c-format
 msgid ", Default"
 msgstr ""
 
-#: src/queuehandler.c:729 src/queuehandler.c:1228
+#: src/queuehandler.c:755 src/queuehandler.c:1254
 msgid "Completed"
 msgstr ""
 
-#: src/queuehandler.c:733 src/queuehandler.c:1232
+#: src/queuehandler.c:759 src/queuehandler.c:1258
 msgid "Canceled"
 msgstr ""
 
-#: src/queuehandler.c:737 src/queuehandler.c:1236
+#: src/queuehandler.c:763 src/queuehandler.c:1262
 msgid "Failed"
 msgstr ""
 
-#: src/queuehandler.c:742
+#: src/queuehandler.c:768
 msgid "Pending"
 msgstr ""
 
-#: src/queuehandler.c:778 src/queuehandler.c:806 src/queuehandler.c:1276
-#: src/queuehandler.c:1304
+#: src/queuehandler.c:804 src/queuehandler.c:832 src/queuehandler.c:1302
+#: src/queuehandler.c:1330
 #, c-format
 msgid "%d Day %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:781 src/queuehandler.c:809 src/queuehandler.c:1279
-#: src/queuehandler.c:1307
+#: src/queuehandler.c:807 src/queuehandler.c:835 src/queuehandler.c:1305
+#: src/queuehandler.c:1333
 #, c-format
 msgid "%d Days %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:822 src/queuehandler.c:1320
+#: src/queuehandler.c:848 src/queuehandler.c:1346
 msgid "B"
 msgstr ""
 
-#: src/queuehandler.c:826 src/queuehandler.c:1324
+#: src/queuehandler.c:852 src/queuehandler.c:1350
 msgid "KB"
 msgstr ""
 
-#: src/queuehandler.c:831 src/queuehandler.c:1329
+#: src/queuehandler.c:857 src/queuehandler.c:1355
 msgid "MB"
 msgstr ""
 
-#: src/queuehandler.c:836 src/queuehandler.c:1334
+#: src/queuehandler.c:862 src/queuehandler.c:1360
 msgid "GB"
 msgstr ""
 
-#: src/queuehandler.c:847 src/queuehandler.c:1345
+#: src/queuehandler.c:873 src/queuehandler.c:1371
 msgid "Not Available"
 msgstr ""
 
-#: src/queuehandler.c:1180
+#: src/queuehandler.c:1206
 msgid "Foreign Audio Search"
 msgstr ""
 
-#: src/queuehandler.c:1184
+#: src/queuehandler.c:1210
 msgid "Encode"
 msgstr ""
 
-#: src/queuehandler.c:1188
+#: src/queuehandler.c:1214
 msgid "Encode First Pass (Analysis)"
 msgstr ""
 
-#: src/queuehandler.c:1192
+#: src/queuehandler.c:1218
 msgid "Encode Second Pass (Final)"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1197
+#: src/queuehandler.c:1223
 msgid "Error"
 msgstr ""
 
-#: src/queuehandler.c:1201
+#: src/queuehandler.c:1227
 #, c-format
 msgid ""
 "pass %d of %d\n"
 "%s"
 msgstr ""
 
-#: src/queuehandler.c:1213
+#: src/queuehandler.c:1239
 msgid "Scanning Title"
 msgstr ""
 
-#: src/queuehandler.c:1217
+#: src/queuehandler.c:1243
 msgid "Encoding Paused"
 msgstr ""
 
-#: src/queuehandler.c:1221
+#: src/queuehandler.c:1247
 msgid "Encoding In Progress"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1241
+#: src/queuehandler.c:1267
 msgid "Unknown"
 msgstr ""
 
-#: src/queuehandler.c:1789
+#: src/queuehandler.c:1807
 #, c-format
 msgid ""
 "%sThe destination filesystem is almost full: %<PRId64> MB free.\n"
@@ -3195,15 +3182,15 @@ msgid ""
 "Encode may be incomplete if you proceed.\n"
 msgstr ""
 
-#: src/queuehandler.c:1794
+#: src/queuehandler.c:1812
 msgid "Resume, I've fixed the problem"
 msgstr ""
 
-#: src/queuehandler.c:1795
+#: src/queuehandler.c:1813
 msgid "Resume, Don't tell me again"
 msgstr ""
 
-#: src/queuehandler.c:1849
+#: src/queuehandler.c:1872
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3212,11 +3199,11 @@ msgid ""
 "Do you want to overwrite?"
 msgstr ""
 
-#: src/queuehandler.c:1854 src/queuehandler.c:1900
+#: src/queuehandler.c:1877 src/queuehandler.c:1923
 msgid "Overwrite"
 msgstr ""
 
-#: src/queuehandler.c:1867
+#: src/queuehandler.c:1890
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3224,7 +3211,7 @@ msgid ""
 "This is not a valid directory."
 msgstr ""
 
-#: src/queuehandler.c:1881
+#: src/queuehandler.c:1904
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3232,7 +3219,7 @@ msgid ""
 "Can not read or write the directory."
 msgstr ""
 
-#: src/queuehandler.c:1895
+#: src/queuehandler.c:1918
 #, c-format
 msgid ""
 "Destination: %s\n"
@@ -3241,63 +3228,67 @@ msgid ""
 "Do you want to overwrite?"
 msgstr ""
 
-#: src/queuehandler.c:2211
+#: src/queuehandler.c:2233
 msgid "Select this title for adding to the queue.\n"
 msgstr ""
 
 #. Title label
-#: src/queuehandler.c:2219
+#: src/queuehandler.c:2241
 msgid "No Title"
 msgstr ""
 
-#: src/queuehandler.c:2229
+#: src/queuehandler.c:2251
 msgid ""
 "There is another title with the same destination file name.\n"
 "This title will not be added to the queue unless you change\n"
 "the output file name.\n"
 msgstr ""
 
-#: src/queuehandler.c:2393 src/queuehandler.c:2406
+#: src/queuehandler.c:2429 src/queuehandler.c:2442
 msgid "Stop"
 msgstr ""
 
-#: src/queuehandler.c:2394 src/queuehandler.c:2407 src/queuehandler.c:2419
+#: src/queuehandler.c:2430 src/queuehandler.c:2443
 msgid "Stop Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2418
+#: src/queuehandler.c:2455
 msgid "S_top Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2431 src/queuehandler.c:2444
+#: src/queuehandler.c:2471 src/queuehandler.c:2484
 msgid "Resume"
 msgstr ""
 
-#: src/queuehandler.c:2432 src/queuehandler.c:2445 src/queuehandler.c:2457
+#: src/queuehandler.c:2472 src/queuehandler.c:2485 src/queuehandler.c:2496
 msgid "Resume Encoding"
 msgstr ""
 
-#: src/queuehandler.c:2456
-msgid "_Resume Encoding"
+#: src/queuehandler.c:2503
+msgid "_Pause Encoding"
 msgstr ""
 
-#: src/queuehandler.c:3087
+#: src/queuehandler.c:3213
 msgid ""
 "You are currently encoding.  What would you like to do?\n"
 "\n"
 msgstr ""
 
-#: src/subtitlehandler.c:1379
+#: src/subtitlehandler.c:1190
+msgid "Add Subtitles"
+msgstr ""
+
+#: src/subtitlehandler.c:1381
 #, c-format
 msgid "Preferred Language: %s"
 msgstr ""
 
-#: src/subtitlehandler.c:1393
+#: src/subtitlehandler.c:1395
 #, c-format
 msgid "Add %s subtitle track if default audio is not %s"
 msgstr ""
 
-#: src/subtitlehandler.c:1398
+#: src/subtitlehandler.c:1400
 #, c-format
 msgid "Add subtitle track if default audio is not your preferred language"
 msgstr ""

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -4627,15 +4627,6 @@ ghb_log_cb(GIOChannel *source, GIOCondition cond, gpointer data)
     return TRUE;
 }
 
-static void
-update_activity_labels(signal_user_data_t *ud, gboolean active)
-{
-    GtkToolButton *button;
-
-    button   = GTK_TOOL_BUTTON(GHB_WIDGET(ud->builder, "show_activity"));
-    gtk_tool_button_set_label(button, "Activity");
-}
-
 G_MODULE_EXPORT void
 show_activity_action_cb(GSimpleAction *action, GVariant *value,
                         signal_user_data_t *ud)
@@ -4646,7 +4637,6 @@ show_activity_action_cb(GSimpleAction *action, GVariant *value,
     g_simple_action_set_state(action, value);
     activity_window = GHB_WIDGET(ud->builder, "activity_window");
     gtk_widget_set_visible(activity_window, state);
-    update_activity_labels(ud, state);
 }
 
 G_MODULE_EXPORT gboolean

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -305,7 +305,8 @@ conjunction with the "Forced" option.</property>
                 <property name="can-focus">True</property>
                 <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                 <property name="is-important">True</property>
-                <property name="label" translatable="yes">Save As</property>
+                <property name="label" translatable="yes">Save _As</property>
+                <property name="use-underline">True</property>
                 <property name="icon-name">document-save-as</property>
                 <property name="action-name">app.preset-save-as</property>
               </object>
@@ -2063,7 +2064,7 @@ Resets the queue job to pending and ready to run again.</property>
 Copyright © 2004 - , HandBrake Devs</property>
     <property name="comments" translatable="yes">HandBrake is a GPL-licensed, multiplatform, multithreaded video transcoder.</property>
     <property name="website">https://handbrake.fr</property>
-    <property name="website-label" translatable="yes">https://handbrake.fr</property>
+    <property name="website-label">https://handbrake.fr</property>
     <property name="license" translatable="yes">HandBrake is free software; you can redistribute it and/or modify it under the terms of the GNU General Public License version 2, as published by the Free Software Foundation.
 
 HandBrake is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
@@ -7575,8 +7576,11 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="use-markup">True</property>
-                    <property name="label" translatable="yes">&lt;b&gt;When Done:&lt;/b&gt;</property>
+                    <property name="use-markup">False</property>
+                    <property name="label" translatable="yes">When Done:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
                   </object>
                   <packing>
                     <property name="position">3</property>
@@ -7779,7 +7783,7 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
       <object class="GtkHeaderBar">
         <property name="visible">True</property>
         <property name="show-close-button">True</property>
-        <property name="title" translatable="yes">HandBrake Settings</property>
+        <property name="title" translatable="yes">Preferences</property>
         <property name="has-subtitle">False</property>
         <child type="title">
           <object class="GtkStackSwitcher" id="prefs_switcher">
@@ -8097,7 +8101,7 @@ Check this if you want the queue to clean itself up by deleting completed jobs.<
                     </child>
                   </object>
                   <packing>
-                    <property name="title" translatable="yes">Settings</property>
+                    <property name="title" translatable="yes">General</property>
                   </packing>
                 </child>
                 <child>
@@ -8561,7 +8565,7 @@ Uncheck this if you want to allow changing each title's settings independently.<
                   </object>
                   <packing>
                     <property name="position">1</property>
-                    <property name="title">Advanced</property>
+                    <property name="title" translatable="yes">Advanced</property>
                   </packing>
                 </child>
               </object>
@@ -8598,7 +8602,8 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
     <child type="action">
       <object class="GtkButton" id="preset_rename_ok">
-        <property name="label" translatable="yes">Rename</property>
+        <property name="label" translatable="yes">_Rename</property>
+        <property name="use-underline">True</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">True</property>
@@ -8754,7 +8759,8 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
     <child type="action">
       <object class="GtkButton" id="preset_ok">
-        <property name="label" translatable="yes">Save</property>
+        <property name="label" translatable="yes">_Save</property>
+        <property name="use-underline">True</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">True</property>
@@ -9434,7 +9440,8 @@ Uncheck this if you want to allow changing each title's settings independently.<
     </child>
     <child type="action">
       <object class="GtkButton" id="subtitle_ok">
-        <property name="label" translatable="yes">Save</property>
+        <property name="label" translatable="yes">_Save</property>
+        <property name="use-underline">True</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">True</property>
@@ -9843,7 +9850,8 @@ in your output.</property>
     </child>
     <child type="action">
       <object class="GtkButton" id="audio_ok">
-        <property name="label" translatable="yes">Save</property>
+        <property name="label" translatable="yes">_Save</property>
+        <property name="use-underline">True</property>
         <property name="visible">True</property>
         <property name="can-focus">True</property>
         <property name="receives-default">True</property>

--- a/gtk/src/ghbcompat.h
+++ b/gtk/src/ghbcompat.h
@@ -53,9 +53,9 @@
 #define GHB_STOCK_CANCEL    GTK_STOCK_CANCEL
 #define GHB_STOCK_SAVE      GTK_STOCK_SAVE
 #else
-#define GHB_STOCK_OPEN      "_Open"
-#define GHB_STOCK_CANCEL    "_Cancel"
-#define GHB_STOCK_SAVE      "_Save"
+#define GHB_STOCK_OPEN      _("_Open")
+#define GHB_STOCK_CANCEL    _("_Cancel")
+#define GHB_STOCK_SAVE      _("_Save")
 #endif
 
 static inline void ghb_widget_get_preferred_width(


### PR DESCRIPTION
When testing HandBrake with different locales, I found that some of the changes I'd made had caused a few strings to no longer be translated. Sorry about that.
This pull request changes the strings so that the existing translations work wherever possible. There are still a few strings that will need to be translated, so I updated ghb.pot as well. Please let me know if there's anything else I can do to help.