### PR TITLE
LinGUI: fix build with -Werror=format-security

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -3790,7 +3790,7 @@ ghb_title_message_dialog(GtkWindow *parent, GtkMessageType type, const gchar *ti
                             type, GTK_BUTTONS_NONE,
                             "%s", title);
     if (message)
-        gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), message);
+        gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", message);
 
     gtk_dialog_add_buttons(GTK_DIALOG(dialog),
                            no, GTK_RESPONSE_NO,

--- a/gtk/src/color-scheme.c
+++ b/gtk/src/color-scheme.c
@@ -173,7 +173,7 @@ DesktopColorScheme color_scheme_get_desktop_scheme (void)
                                     DBUS_TIMEOUT, NULL, &error);
     if (!result)
     {
-        g_debug(error->message);
+        g_debug("%s", error->message);
         return DESKTOP_NO_PREFERENCE;
     }
 

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -682,12 +682,12 @@ queue_update_summary(GhbValue * queueDict, signal_user_data_t *ud)
         def         = ghb_dict_get_bool(subsettings, "Default");
         name        = ghb_dict_get_string(subsettings, "Name");
 
-        g_string_append_printf(str, sep);
+        g_string_append_printf(str, "%s", sep);
         if (name)
         {
             g_string_append_printf(str, "%s - ", name);
         }
-        g_string_append_printf(str, desc);
+        g_string_append_printf(str, "%s", desc);
         free(desc);
         if (force)
         {


### PR DESCRIPTION
Add missing format strings where needed.

Fixes: f6c0971c0042 ("Added XDG color-scheme implementation")
Fixes: 3c71841d7716 ("LinGUI: Add warning color to dialog buttons")
Fixes: 23f067ef4186 ("LinGUI: Add subtitle and audio track names to queue")