### PR TITLE
NaturalSort has been implemented

### DIFF
--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -1,4 +1,4 @@
-﻿// --------------------------------------------------------------------------------------------------------------------
+// --------------------------------------------------------------------------------------------------------------------
 // <copyright file="LibScan.cs" company="HandBrake Project (http://handbrake.fr)">
 //   This file is part of the HandBrake source code - It may be used under the terms of the GNU General Public License.
 // </copyright>
@@ -12,6 +12,10 @@ namespace HandBrakeWPF.Services.Scan
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
+    using System.Text.RegularExpressions;
+    using System.Windows;
+    using System.Windows.Documents;
     using System.Windows.Media.Imaging;
 
     using HandBrake.Interop.Interop;
@@ -338,16 +342,28 @@ namespace HandBrakeWPF.Services.Scan
         /// <returns>
         /// The convert titles.
         /// </returns>
+        /// 
+
+        //This will implement Naturalsort
+        public IEnumerable<T> OrderByAlphaNumeric<T>(IEnumerable<T> source, Func<T, string> selector)
+        {
+            int max = source.SelectMany(i => Regex.Matches(selector(i), @"\d+").Cast<Match>().Select(m => (int?)m.Value.Length)).Max() ?? 0;
+            return source.OrderBy(i => Regex.Replace(selector(i), @"\d+", m => m.Value.PadLeft(max, '0')));
+        }
+
         private List<Title> ConvertTitles(JsonScanObject titles)
         {
             List<Title> titleList = new List<Title>();
+
+            
             foreach (SourceTitle title in titles.TitleList)
             {
                 Title converted = this.titleFactory.CreateTitle(title, titles.MainFeature);
                 titleList.Add(converted);
             }
+            var naturalSortedList = OrderByAlphaNumeric(titleList, x => x.SourceName).ToList();
 
-            return titleList;
+            return naturalSortedList; 
         }
 
         public void Dispose()

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -354,15 +354,12 @@ namespace HandBrakeWPF.Services.Scan
         private List<Title> ConvertTitles(JsonScanObject titles)
         {
             List<Title> titleList = new List<Title>();
-
-            
             foreach (SourceTitle title in titles.TitleList)
             {
                 Title converted = this.titleFactory.CreateTitle(title, titles.MainFeature);
                 titleList.Add(converted);
             }
             var naturalSortedList = OrderByAlphaNumeric(titleList, x => x.SourceName).ToList();
-
             return naturalSortedList; 
         }
 


### PR DESCRIPTION
NaturalSort has been implemed.
Before:
0.mp4
10.mp4
2.mp4

After:
0.mp4
2.mp4
10.mp4

This is also the default behavior of Windows 10 explorer.


**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**





**Test on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
