### PR TITLE
libhb: preserve and propagate sidedata in the pipeline.

### DIFF
--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -389,7 +389,7 @@ static int chroma_smooth_work_thread(hb_filter_object_t *filter,
                       ctx, tctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -545,7 +545,7 @@ static void process_frame(hb_filter_private_t *pv)
             pv->filter(pv, buf, parity, tff);
 
             // Copy buffered settings to output buffer settings
-            buf->s = pv->ref[1]->s;
+            hb_buffer_copy_props(buf, pv->ref[1]);
 
             hb_buffer_list_append(&pv->out_list, buf);
         }

--- a/libhb/denoise.c
+++ b/libhb/denoise.c
@@ -358,7 +358,7 @@ static int hb_denoise_work(hb_filter_object_t *filter,
                        pv->hqdn3d_coef[coef_index+1]);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1147,7 +1147,7 @@ static int hb_detelecine_work( hb_filter_object_t * filter,
 
     pullup_release_frame( frame );
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
 output_frame:

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -12,6 +12,7 @@
 
 #include "libavutil/imgutils.h"
 #include "libavutil/pixdesc.h"
+#include "libavutil/frame.h"
 #include "handbrake/project.h"
 
 /***********************************************************************
@@ -173,6 +174,9 @@ struct hb_buffer_s
     // Store this data here when read and pass to decoder.
     hb_buffer_t * palette;
 
+    void **side_data;
+    int    nb_side_data;
+
     // Packets in a list:
     //   the next packet in the list
     hb_buffer_t * next;
@@ -199,6 +203,14 @@ hb_image_t  * hb_buffer_to_image(hb_buffer_t *buf);
 int           hb_picture_fill(uint8_t *data[], int stride[], hb_buffer_t *b);
 int           hb_picture_crop(uint8_t *data[], int stride[], hb_buffer_t *b,
                               int top, int left);
+
+AVFrameSideData *hb_buffer_new_side_data_from_buf(hb_buffer_t *buf,
+                                                  enum AVFrameSideDataType type,
+                                                  AVBufferRef *side_data_buf);
+void             hb_buffer_wipe_side_data(hb_buffer_t *buf);
+void             hb_buffer_copy_side_data(hb_buffer_t *dst, const hb_buffer_t *src);
+
+void             hb_buffer_copy_props(hb_buffer_t *dst, const hb_buffer_t *src);
 
 hb_fifo_t   * hb_fifo_init( int capacity, int thresh );
 void          hb_fifo_register_full_cond( hb_fifo_t * f, hb_cond_t * c );

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -297,25 +297,29 @@ int hb_avfilter_get_frame(hb_avfilter_graph_t * graph, AVFrame * frame)
 
 int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in)
 {
+    int ret;
     if (in != NULL)
     {
 #if HB_PROJECT_FEATURE_QSV
         if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
             hb_video_buffer_to_avframe(in->qsv_details.frame, in);
-            return hb_avfilter_add_frame(graph, in->qsv_details.frame);
+            ret = hb_avfilter_add_frame(graph, in->qsv_details.frame);
         }
         else
 #endif
         {
             hb_video_buffer_to_avframe(graph->frame, in);
-            return av_buffersrc_add_frame(graph->input, graph->frame);
+            ret = av_buffersrc_add_frame(graph->input, graph->frame);
+            av_frame_unref(graph->frame);
         }
     }
     else
     {
-        return av_buffersrc_add_frame(graph->input, NULL);
+        ret = av_buffersrc_add_frame(graph->input, NULL);
     }
+
+    return ret;
 }
 
 hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -31,6 +31,26 @@ static int get_frame_type(int type)
     }
 }
 
+static void free_side_data(AVFrameSideData **ptr_sd)
+{
+    AVFrameSideData *sd = *ptr_sd;
+
+    av_buffer_unref(&sd->buf);
+    av_dict_free(&sd->metadata);
+    av_freep(ptr_sd);
+}
+
+static void wipe_avframe_side_data(AVFrame *frame)
+{
+    for (int i = 0; i < frame->nb_side_data; i++)
+    {
+        free_side_data(&frame->side_data[i]);
+    }
+    frame->nb_side_data = 0;
+
+    av_freep(&frame->side_data);
+}
+
 void hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf)
 {
     frame->data[0]     = buf->plane[0].data;
@@ -54,6 +74,18 @@ void hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf)
     frame->colorspace      = hb_colr_mat_hb_to_ff(buf->f.color_matrix);
     frame->color_range     = buf->f.color_range;
     frame->chroma_location = buf->f.chroma_location;
+
+    for (int i = 0; i < buf->nb_side_data; i++)
+    {
+        const AVFrameSideData *sd_src = buf->side_data[i];
+        AVBufferRef *ref = av_buffer_ref(sd_src->buf);
+        AVFrameSideData *sd_dst = av_frame_new_side_data_from_buf(frame, sd_src->type, ref);
+        if (!sd_dst)
+        {
+            av_buffer_unref(&ref);
+            wipe_avframe_side_data(frame);
+        }
+    }
 }
 
 void hb_avframe_set_video_buffer_flags(hb_buffer_t * buf, AVFrame *frame,
@@ -150,6 +182,18 @@ hb_buffer_t * hb_avframe_to_video_buffer(AVFrame *frame, AVRational time_base)
         }
     }
 #endif
+
+    for (int i = 0; i < frame->nb_side_data; i++)
+    {
+        const AVFrameSideData *sd_src = frame->side_data[i];
+        AVBufferRef *ref = av_buffer_ref(sd_src->buf);
+        AVFrameSideData *sd_dst = hb_buffer_new_side_data_from_buf(buf, sd_src->type, ref);
+        if (!sd_dst)
+        {
+            av_buffer_unref(&ref);
+            hb_buffer_wipe_side_data(buf);
+        }
+    }
 
     return buf;
 }

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -342,7 +342,7 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
                     ctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -106,7 +106,7 @@ typedef struct
     int height;
     int fmt;
     BorderedPlane plane[3];
-    hb_buffer_settings_t s;
+    hb_buffer_t *buf;        // input buf sidedata
 } Frame;
 
 struct PixelSum
@@ -504,9 +504,9 @@ static void nlmeans_filter_work(void *thread_args_v)
                           pv->weight_fact_table[c],
                           pv->diff_max[c]);
     }
-    buf->s = pv->frame[segment].s;
+    hb_buffer_copy_props(buf, pv->frame[segment].buf);
+    hb_buffer_close(&pv->frame[segment].buf);
     thread_data->out = buf;
-
 }
 
 static void nlmeans_add_frame(hb_filter_private_t *pv, hb_buffer_t *buf)
@@ -521,11 +521,13 @@ static void nlmeans_add_frame(hb_filter_private_t *pv, hb_buffer_t *buf)
                           buf->plane[c].height,
                           &pv->frame[pv->next_frame].plane[c],
                           border);
-        pv->frame[pv->next_frame].s = buf->s;
-        pv->frame[pv->next_frame].width = buf->f.width;
-        pv->frame[pv->next_frame].height = buf->f.height;
-        pv->frame[pv->next_frame].fmt = buf->f.fmt;
     }
+    pv->frame[pv->next_frame].width = buf->f.width;
+    pv->frame[pv->next_frame].height = buf->f.height;
+    pv->frame[pv->next_frame].fmt = buf->f.fmt;
+    pv->frame[pv->next_frame].buf = hb_buffer_init(0);
+    hb_buffer_copy_props(pv->frame[pv->next_frame].buf, buf);
+
     pv->next_frame++;
 }
 
@@ -642,7 +644,8 @@ static hb_buffer_t * nlmeans_filter_flush(hb_filter_private_t *pv)
                               pv->weight_fact_table[c],
                               pv->diff_max[c]);
         }
-        buf->s = frame->s;
+        hb_buffer_copy_props(buf, frame->buf);
+        hb_buffer_close(&frame->buf);
         hb_buffer_list_append(&list, buf);
     }
     return hb_buffer_list_clear(&list);

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -372,7 +372,7 @@ static int unsharp_work_thread(hb_filter_object_t *filter,
                 ctx, tctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;


### PR DESCRIPTION
AVFrame side data contains a lot useful information, for example HDR dynamic metadata, that were lost before.
This PR duplicate some AVFrame code in hb_buffer to preserve them.

A future step would be to wrap AVFrame directly in hb_buffer to avoid some unneeded memory copies, but there are some height stride difference that will require some further changes, so let's do one step at time.

I tested it with clang address sanitiser and checked for leaks. The only unknown is QSV zero-copy path.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux