### PR TITLE
Passthru Dolby Vision dynamic metadata

### DIFF
--- a/contrib/ffmpeg/A31-enable-dvh1.patch
+++ b/contrib/ffmpeg/A31-enable-dvh1.patch
@@ -1,0 +1,12 @@
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index 5608afd..f46df18 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -7689,6 +7689,7 @@ static const AVCodecTag codec_mp4_tags[] = {
+     { AV_CODEC_ID_H264,            MKTAG('a', 'v', 'c', '3') },
+     { AV_CODEC_ID_HEVC,            MKTAG('h', 'e', 'v', '1') },
+     { AV_CODEC_ID_HEVC,            MKTAG('h', 'v', 'c', '1') },
++    { AV_CODEC_ID_HEVC,            MKTAG('d', 'v', 'h', '1') },
+     { AV_CODEC_ID_MPEG2VIDEO,      MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_MPEG1VIDEO,      MKTAG('m', 'p', '4', 'v') },
+     { AV_CODEC_ID_MJPEG,           MKTAG('m', 'p', '4', 'v') },

--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,0 +1,43 @@
+$(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
+$(eval $(call import.CONTRIB.defs,LIBDOVI))
+
+LIBDOVI.FETCH.url      = https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.1.0.tar.gz
+LIBDOVI.FETCH.sha256   = aa2c8451be6c8ace014b79dbbccb06f9f4e4fd80f851b1c9d3f4ae9aa443569d
+LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.1.0.tar.gz
+
+define LIBDOVI.CONFIGURE
+     $(CARGO.exe) fetch $(LIBDOVI.manifest)
+     $(TOUCH.exe) $@
+endef
+
+ifeq (1,$(HOST.cross))
+    ifeq ($(HOST.system),darwin)
+        ifneq ($(HOST.machine),$(BUILD.machine))
+            LIBDOVI.target += --target="$(HOST.machine:arm64=aarch64)-$(HOST.vendor)-$(HOST.system)"
+        endif
+    else ifeq ($(HOST.system),mingw)
+        LIBDOVI.target += --target="$(HOST.machine)-pc-windows-gnu"
+    else
+        LIBDOVI.target += --target="$(HOST.machine)-$(HOST.vendor)-$(HOST.system)"
+    endif
+endif
+
+LIBDOVI.manifest = --manifest-path="$(LIBDOVI.EXTRACT.dir/)dolby_vision/Cargo.toml"
+LIBDOVI.prefix   = --prefix "$(LIBDOVI.CONFIGURE.prefix)"
+LIBDOVI.extra    = --offline --release --library-type staticlib $(LIBDOVI.prefix) $(LIBDOVI.target)
+
+LIBDOVI.BUILD.make       = $(CARGO.exe) cbuild
+LIBDOVI.BUILD.extra      = $(LIBDOVI.extra)
+LIBDOVI.BUILD.args.dir   = $(LIBDOVI.manifest)
+
+LIBDOVI.INSTALL.make     = $(CARGO.exe) cinstall
+LIBDOVI.INSTALL.extra    = $(LIBDOVI.extra)
+LIBDOVI.INSTALL.args.dir = $(LIBDOVI.manifest)
+
+LIBDOVI.CLEAN.make       = $(CARGO.exe) clean
+LIBDOVI.CLEAN.args.dir   = $(LIBDOVI.manifest)
+LIBDOVI.CLEAN.ntargets   =
+
+## optional static libs need to be marked
+LIBDOVI.OSL.libs  = dovi
+LIBDOVI.OSL.files = $(foreach i,$(LIBDOVI.OSL.libs),$(call fn.ABSOLUTE,$(CONTRIB.build/)lib/lib$(i).a))

--- a/contrib/libdovi/module.rules
+++ b/contrib/libdovi/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBDOVI))
+$(eval $(call import.CONTRIB.rules,LIBDOVI))

--- a/gtk/configure.ac
+++ b/gtk/configure.ac
@@ -94,6 +94,10 @@ AC_ARG_ENABLE(mf,
 	AS_HELP_STRING([--enable-mf], [enable MediaFoundation encoder]),
 	use_mf=yes, use_mf=no)
 
+AC_ARG_ENABLE(libdovi,
+    AS_HELP_STRING([--enable-libdovi], [enable libdovi]),
+    use_libdovi=yes, use_libdovi=no)
+
 AC_ARG_ENABLE(gst,
 	AS_HELP_STRING([--disable-gst], [disable gstreamer (live preview)]),
 	gst_disable=yes, gst_disable=no)
@@ -225,6 +229,10 @@ fi
 
 if test "x$use_qsv" = "xyes" ; then
 	HB_LIBS="$HB_LIBS -lvpl"
+fi
+
+if test "x$use_libdovi" = "xyes" ; then
+    HB_LIBS="$HB_LIBS -ldovi"
 fi
 
 case $host in

--- a/gtk/module.defs
+++ b/gtk/module.defs
@@ -51,6 +51,11 @@ ifeq (1,$(FEATURE.qsv))
 	GTK.CONFIGURE.extra += --enable-qsv
 endif
 
+ifeq (1,$(FEATURE.libdovi))
+    GTK.CONFIGURE.extra += --enable-libdovi
+endif
+
+
 ifeq (1,$(FEATURE.flatpak))
 	GTK.CONFIGURE.extra += --enable-flatpak
 endif

--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -389,7 +389,7 @@ static int chroma_smooth_work_thread(hb_filter_object_t *filter,
                       ctx, tctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4136,8 +4136,11 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->color_prim_override     = HB_COLR_PRI_UNDEF;
     job->color_transfer_override = HB_COLR_TRA_UNDEF;
     job->color_matrix_override   = HB_COLR_MAT_UNDEF;
+
     job->mastering      = title->mastering;
     job->coll           = title->coll;
+    job->dovi           = title->dovi;
+    job->passthru_dynamic_hdr_metadata = ALL;
 
     job->mux = HB_MUX_MP4;
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4519,6 +4519,10 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             filter = &hb_filter_render_sub;
             break;
 
+        case HB_FILTER_RPU:
+            filter = &hb_filter_rpu;
+            break;
+
         case HB_FILTER_CROP_SCALE:
             filter = &hb_filter_crop_scale;
             break;

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -545,7 +545,7 @@ static void process_frame(hb_filter_private_t *pv)
             pv->filter(pv, buf, parity, tff);
 
             // Copy buffered settings to output buffer settings
-            buf->s = pv->ref[1]->s;
+            hb_buffer_copy_props(buf, pv->ref[1]);
 
             hb_buffer_list_append(&pv->out_list, buf);
         }

--- a/libhb/denoise.c
+++ b/libhb/denoise.c
@@ -358,7 +358,7 @@ static int hb_denoise_work(hb_filter_object_t *filter,
                        pv->hqdn3d_coef[coef_index+1]);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1147,7 +1147,7 @@ static int hb_detelecine_work( hb_filter_object_t * filter,
 
     pullup_release_frame( frame );
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
 output_frame:

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -533,6 +533,20 @@ static void free_side_data(AVFrameSideData **ptr_sd)
     av_freep(ptr_sd);
 }
 
+void hb_frame_remove_side_data(hb_buffer_t *buf, enum AVFrameSideDataType type)
+{
+    for (int i = buf->nb_side_data - 1; i >= 0; i--)
+    {
+        AVFrameSideData *sd = buf->side_data[i];
+        if (sd->type == type)
+        {
+            free_side_data((AVFrameSideData **)&buf->side_data[i]);
+            buf->side_data[i] = buf->side_data[buf->nb_side_data - 1];
+            buf->nb_side_data--;
+        }
+    }
+}
+
 void hb_buffer_wipe_side_data(hb_buffer_t *buf)
 {
     for (int i = 0; i < buf->nb_side_data; i++)

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1496,6 +1496,7 @@ enum
     HB_FILTER_PAD,
     HB_FILTER_COLORSPACE,
     HB_FILTER_FORMAT,
+    HB_FILTER_RPU,
 
     // Finally filters that don't care what order they are in,
     // except that they must be after the above filters

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -333,7 +333,8 @@ struct hb_subtitle_config_s
     int64_t      offset;
 };
 
-struct hb_mastering_display_metadata_s {
+struct hb_mastering_display_metadata_s
+{
     hb_rational_t display_primaries[3][2];
     hb_rational_t white_point[2];
     hb_rational_t min_luminance;
@@ -342,9 +343,22 @@ struct hb_mastering_display_metadata_s {
     int has_luminance;
 };
 
-struct hb_content_light_metadata_s {
+struct hb_content_light_metadata_s
+{
     unsigned max_cll;
     unsigned max_fall;
+};
+
+struct hb_dovi_conf_s
+{
+    unsigned dv_version_major;
+    unsigned dv_version_minor;
+    unsigned dv_profile;
+    unsigned dv_level;
+    unsigned rpu_present_flag;
+    unsigned el_present_flag;
+    unsigned bl_present_flag;
+    unsigned dv_bl_signal_compatibility_id;
 };
 
 /*******************************************************************************
@@ -704,6 +718,10 @@ struct hb_job_s
 
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t coll;
+    hb_dovi_conf_t dovi;
+
+    enum {NONE = 0x0, ALL = 0x3, DOVI = 0x1, HDR_PLUS = 0x2} passthru_dynamic_hdr_metadata;
+
 
     hb_list_t     * list_chapter;
 
@@ -1169,6 +1187,7 @@ struct hb_title_s
     int             chroma_location;
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t     coll;
+    hb_dovi_conf_t  dovi;
     hb_rational_t   vrate;
     int             crop[4];
     int             loose_crop[4];

--- a/libhb/handbrake/dovi_common.h
+++ b/libhb/handbrake/dovi_common.h
@@ -1,0 +1,41 @@
+/* h265_common.h
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HANDBRAKE_DOVI_COMMON_H
+#define HANDBRAKE_DOVI_COMMON_H
+
+#include "handbrake/project.h"
+
+static struct
+{
+    const uint32_t id;
+    const uint32_t max_pps;
+    const uint32_t max_width;
+    const uint32_t max_bitrate_main_tier;
+    const uint32_t max_bitrate_high_tier;
+}
+hb_dolby_vision_levels[] =
+{
+    { 1,  22118400,   1280, 20,  50  },
+    { 2,  27648000,   1280, 20,  50  },
+    { 3,  49766400,   1920, 20,  70  },
+    { 4,  62208000,   2560, 20,  70  },
+    { 5,  124416000,  3840, 20,  70  },
+    { 6,  199065600,  3840, 25,  130 },
+    { 7,  248832000,  3840, 25,  130 },
+    { 8,  398131200,  3840, 40,  130 },
+    { 9,  497664000,  3840, 40,  130 },
+    { 10, 995328000,  3840, 60,  240 },
+    { 11, 995328000,  7680, 60,  240 },
+    { 12, 1990656000, 7680, 120, 480 },
+    { 13, 3981312000, 7680, 240, 800 },
+    { 0, 0, 0, 0, 0 }
+};
+
+#endif // HANDBRAKE_DOVI_COMMON_H

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -20,6 +20,7 @@
 #include "libavutil/downmix_info.h"
 #include "libavutil/display.h"
 #include "libavutil/mastering_display_metadata.h"
+#include "libavutil/dovi_meta.h"
 #include "libswscale/swscale.h"
 #include "libswresample/swresample.h"
 #include "handbrake/common.h"
@@ -45,6 +46,9 @@ int hb_colr_mat_ff_to_hb(int colr_mat);
 
 hb_mastering_display_metadata_t hb_mastering_ff_to_hb(AVMasteringDisplayMetadata mastering);
 AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t mastering);
+
+AVDOVIDecoderConfigurationRecord hb_dovi_hb_to_ff(hb_dovi_conf_t dovi);
+hb_dovi_conf_t hb_dovi_ff_to_hb(AVDOVIDecoderConfigurationRecord dovi);
 
 struct SwsContext*
 hb_sws_get_context(int srcW, int srcH, enum AVPixelFormat srcFormat, int srcRange,

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -46,5 +46,6 @@ typedef struct hb_fifo_s hb_fifo_t;
 typedef struct hb_lock_s hb_lock_t;
 typedef struct hb_mastering_display_metadata_s hb_mastering_display_metadata_t;
 typedef struct hb_content_light_metadata_s hb_content_light_metadata_t;
+typedef struct hb_dovi_conf_s hb_dovi_conf_t;
 
 #endif // HANDBRAKE_TYPES_H

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -207,6 +207,7 @@ int           hb_picture_crop(uint8_t *data[], int stride[], hb_buffer_t *b,
 AVFrameSideData *hb_buffer_new_side_data_from_buf(hb_buffer_t *buf,
                                                   enum AVFrameSideDataType type,
                                                   AVBufferRef *side_data_buf);
+void hb_frame_remove_side_data(hb_buffer_t *buf, enum AVFrameSideDataType type);
 void             hb_buffer_wipe_side_data(hb_buffer_t *buf);
 void             hb_buffer_copy_side_data(hb_buffer_t *dst, const hb_buffer_t *src);
 
@@ -490,6 +491,7 @@ extern hb_filter_object_t hb_filter_denoise;
 extern hb_filter_object_t hb_filter_nlmeans;
 extern hb_filter_object_t hb_filter_chroma_smooth;
 extern hb_filter_object_t hb_filter_render_sub;
+extern hb_filter_object_t hb_filter_rpu;
 extern hb_filter_object_t hb_filter_crop_scale;
 extern hb_filter_object_t hb_filter_rotate;
 extern hb_filter_object_t hb_filter_grayscale;

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -12,6 +12,7 @@
 
 #include "libavutil/imgutils.h"
 #include "libavutil/pixdesc.h"
+#include "libavutil/frame.h"
 #include "handbrake/project.h"
 
 /***********************************************************************
@@ -173,6 +174,9 @@ struct hb_buffer_s
     // Store this data here when read and pass to decoder.
     hb_buffer_t * palette;
 
+    void **side_data;
+    int    nb_side_data;
+
     // Packets in a list:
     //   the next packet in the list
     hb_buffer_t * next;
@@ -199,6 +203,14 @@ hb_image_t  * hb_buffer_to_image(hb_buffer_t *buf);
 int           hb_picture_fill(uint8_t *data[], int stride[], hb_buffer_t *b);
 int           hb_picture_crop(uint8_t *data[], int stride[], hb_buffer_t *b,
                               int top, int left);
+
+AVFrameSideData *hb_buffer_new_side_data_from_buf(hb_buffer_t *buf,
+                                                  enum AVFrameSideDataType type,
+                                                  AVBufferRef *side_data_buf);
+void             hb_buffer_wipe_side_data(hb_buffer_t *buf);
+void             hb_buffer_copy_side_data(hb_buffer_t *dst, const hb_buffer_t *src);
+
+void             hb_buffer_copy_props(hb_buffer_t *dst, const hb_buffer_t *src);
 
 hb_fifo_t   * hb_fifo_init( int capacity, int thresh );
 void          hb_fifo_register_full_cond( hb_fifo_t * f, hb_cond_t * c );

--- a/libhb/handbrake/project.h.m4
+++ b/libhb/handbrake/project.h.m4
@@ -54,6 +54,7 @@ dnl
 <<#>>define HB_PROJECT_FEATURE_VCE               __FEATURE_vce
 <<#>>define HB_PROJECT_FEATURE_X265              __FEATURE_x265
 <<#>>define HB_PROJECT_FEATURE_NUMA              __FEATURE_numa
+<<#>>define HB_PROJECT_FEATURE_LIBDOVI           __FEATURE_libdovi
 
 <<#>>define HB_PROJECT_SECURITY_HARDEN           __SECURITY_harden
 

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -298,25 +298,29 @@ int hb_avfilter_get_frame(hb_avfilter_graph_t * graph, AVFrame * frame)
 
 int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in)
 {
+    int ret;
     if (in != NULL)
     {
 #if HB_PROJECT_FEATURE_QSV
         if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
             hb_video_buffer_to_avframe(in->qsv_details.frame, in);
-            return hb_avfilter_add_frame(graph, in->qsv_details.frame);
+            ret = hb_avfilter_add_frame(graph, in->qsv_details.frame);
         }
         else
 #endif
         {
             hb_video_buffer_to_avframe(graph->frame, in);
-            return av_buffersrc_add_frame(graph->input, graph->frame);
+            ret = av_buffersrc_add_frame(graph->input, graph->frame);
+            av_frame_unref(graph->frame);
         }
     }
     else
     {
-        return av_buffersrc_add_frame(graph->input, NULL);
+        ret = av_buffersrc_add_frame(graph->input, NULL);
     }
+
+    return ret;
 }
 
 hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -543,6 +543,38 @@ AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t
     return ff_mastering;
 }
 
+AVDOVIDecoderConfigurationRecord hb_dovi_hb_to_ff(hb_dovi_conf_t dovi)
+{
+    AVDOVIDecoderConfigurationRecord ff_dovi;
+
+    ff_dovi.dv_version_major = dovi.dv_version_major;
+    ff_dovi.dv_version_minor = dovi.dv_version_minor;
+    ff_dovi.dv_profile = dovi.dv_profile;
+    ff_dovi.dv_level = dovi.dv_level;
+    ff_dovi.rpu_present_flag = dovi.rpu_present_flag;
+    ff_dovi.el_present_flag = dovi.el_present_flag;
+    ff_dovi.bl_present_flag = dovi.bl_present_flag;
+    ff_dovi.dv_bl_signal_compatibility_id = dovi.dv_bl_signal_compatibility_id;
+
+    return ff_dovi;
+}
+
+hb_dovi_conf_t hb_dovi_ff_to_hb(AVDOVIDecoderConfigurationRecord dovi)
+{
+    hb_dovi_conf_t hb_dovi;
+
+    hb_dovi.dv_version_major = dovi.dv_version_major;
+    hb_dovi.dv_version_minor = dovi.dv_version_minor;
+    hb_dovi.dv_profile = dovi.dv_profile;
+    hb_dovi.dv_level = dovi.dv_level;
+    hb_dovi.rpu_present_flag = dovi.rpu_present_flag;
+    hb_dovi.el_present_flag = dovi.el_present_flag;
+    hb_dovi.bl_present_flag = dovi.bl_present_flag;
+    hb_dovi.dv_bl_signal_compatibility_id = dovi.dv_bl_signal_compatibility_id;
+
+    return hb_dovi;
+}
+
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
     uint64_t ff_layout = 0;

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -31,6 +31,26 @@ static int get_frame_type(int type)
     }
 }
 
+static void free_side_data(AVFrameSideData **ptr_sd)
+{
+    AVFrameSideData *sd = *ptr_sd;
+
+    av_buffer_unref(&sd->buf);
+    av_dict_free(&sd->metadata);
+    av_freep(ptr_sd);
+}
+
+static void wipe_avframe_side_data(AVFrame *frame)
+{
+    for (int i = 0; i < frame->nb_side_data; i++)
+    {
+        free_side_data(&frame->side_data[i]);
+    }
+    frame->nb_side_data = 0;
+
+    av_freep(&frame->side_data);
+}
+
 void hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf)
 {
     frame->data[0]     = buf->plane[0].data;
@@ -54,6 +74,18 @@ void hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf)
     frame->colorspace      = hb_colr_mat_hb_to_ff(buf->f.color_matrix);
     frame->color_range     = buf->f.color_range;
     frame->chroma_location = buf->f.chroma_location;
+
+    for (int i = 0; i < buf->nb_side_data; i++)
+    {
+        const AVFrameSideData *sd_src = buf->side_data[i];
+        AVBufferRef *ref = av_buffer_ref(sd_src->buf);
+        AVFrameSideData *sd_dst = av_frame_new_side_data_from_buf(frame, sd_src->type, ref);
+        if (!sd_dst)
+        {
+            av_buffer_unref(&ref);
+            wipe_avframe_side_data(frame);
+        }
+    }
 }
 
 void hb_avframe_set_video_buffer_flags(hb_buffer_t * buf, AVFrame *frame,
@@ -150,6 +182,18 @@ hb_buffer_t * hb_avframe_to_video_buffer(AVFrame *frame, AVRational time_base)
         }
     }
 #endif
+
+    for (int i = 0; i < frame->nb_side_data; i++)
+    {
+        const AVFrameSideData *sd_src = frame->side_data[i];
+        AVBufferRef *ref = av_buffer_ref(sd_src->buf);
+        AVFrameSideData *sd_dst = hb_buffer_new_side_data_from_buf(buf, sd_src->type, ref);
+        if (!sd_dst)
+        {
+            av_buffer_unref(&ref);
+            hb_buffer_wipe_side_data(buf);
+        }
+    }
 
     return buf;
 }

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -342,7 +342,7 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
                     ctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,7 +1,7 @@
 __deps__ := A52DEC BZIP2 LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS LIBDCA \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBSAMPLERATE LIBTHEORA LIBVORBIS LIBOGG \
     LIBXML2 X264 X265 ZLIB LIBBLURAY FDKAAC LIBVPL LIBGNURX JANSSON \
-    HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D LIBJPEGTURBO
+    HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D LIBJPEGTURBO LIBDOVI
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     __deps__ += FONTCONFIG
@@ -140,6 +140,10 @@ ifeq (1,$(FEATURE.x265))
 LIBHB.dll.libs += $(CONTRIB.build/)lib/libx265.a
 endif
 
+ifeq (1,$(FEATURE.libdovi))
+LIBHB.dll.libs += $(CONTRIB.build/)lib/libdovi.a
+endif
+
 ifneq ($(HAS.iconv),1)
 LIBHB.dll.libs += $(CONTRIB.build/)lib/libiconv.a
 else
@@ -181,7 +185,7 @@ else
 endif
 
 LIBHB.GCC.args.extra.dylib++ += -Wl,--out-implib,$(LIBHB.lib)
-LIBHB.GCC.l += bcrypt ws2_32 uuid ole32 gdi32
+LIBHB.GCC.l += bcrypt ws2_32 uuid ole32 gdi32 userenv
 ifeq (1,$(FEATURE.mf))
     LIBHB.GCC.l += mfplat strmiids
 endif

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -106,7 +106,7 @@ typedef struct
     int height;
     int fmt;
     BorderedPlane plane[3];
-    hb_buffer_settings_t s;
+    hb_buffer_t *buf;        // input buf sidedata
 } Frame;
 
 struct PixelSum
@@ -504,9 +504,9 @@ static void nlmeans_filter_work(void *thread_args_v)
                           pv->weight_fact_table[c],
                           pv->diff_max[c]);
     }
-    buf->s = pv->frame[segment].s;
+    hb_buffer_copy_props(buf, pv->frame[segment].buf);
+    hb_buffer_close(&pv->frame[segment].buf);
     thread_data->out = buf;
-
 }
 
 static void nlmeans_add_frame(hb_filter_private_t *pv, hb_buffer_t *buf)
@@ -521,11 +521,13 @@ static void nlmeans_add_frame(hb_filter_private_t *pv, hb_buffer_t *buf)
                           buf->plane[c].height,
                           &pv->frame[pv->next_frame].plane[c],
                           border);
-        pv->frame[pv->next_frame].s = buf->s;
-        pv->frame[pv->next_frame].width = buf->f.width;
-        pv->frame[pv->next_frame].height = buf->f.height;
-        pv->frame[pv->next_frame].fmt = buf->f.fmt;
     }
+    pv->frame[pv->next_frame].width = buf->f.width;
+    pv->frame[pv->next_frame].height = buf->f.height;
+    pv->frame[pv->next_frame].fmt = buf->f.fmt;
+    pv->frame[pv->next_frame].buf = hb_buffer_init(0);
+    hb_buffer_copy_props(pv->frame[pv->next_frame].buf, buf);
+
     pv->next_frame++;
 }
 
@@ -642,7 +644,8 @@ static hb_buffer_t * nlmeans_filter_flush(hb_filter_private_t *pv)
                               pv->weight_fact_table[c],
                               pv->diff_max[c]);
         }
-        buf->s = frame->s;
+        hb_buffer_copy_props(buf, frame->buf);
+        hb_buffer_close(&frame->buf);
         hb_buffer_list_append(&list, buf);
     }
     return hb_buffer_list_clear(&list);

--- a/libhb/rpu.c
+++ b/libhb/rpu.c
@@ -1,0 +1,301 @@
+/* rpu.c
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+
+#if HB_PROJECT_FEATURE_LIBDOVI
+#include "libdovi/rpu_parser.h"
+#endif
+
+#define RPU_DEFAULT_MODE 1
+
+struct hb_filter_private_s
+{
+    int        mode;
+
+    double     scale_factor_x;
+    double     scale_factor_y;
+
+    int        crop_top;
+    int        crop_bottom;
+    int        crop_left;
+    int        crop_right;
+
+    int        pad_top;
+    int        pad_bottom;
+    int        pad_left;
+    int        pad_right;
+
+    hb_filter_init_t         input;
+    hb_filter_init_t         output;
+
+    AVBufferRef        *rpu;
+};
+
+static int rpu_init(hb_filter_object_t *filter,
+                              hb_filter_init_t   *init);
+
+
+static int rpu_work(hb_filter_object_t *filter,
+                              hb_buffer_t ** buf_in,
+                              hb_buffer_t ** buf_out);
+
+static void rpu_close(hb_filter_object_t *filter);
+
+static const char rpu_template[] =
+    "mode=^"HB_INT_REG"$:scale-factor-x=^"HB_FLOAT_REG"$:scale-factor-y=^"HB_FLOAT_REG"$:"
+    "crop-top=^"HB_INT_REG"$:crop-bottom=^"HB_INT_REG"$:"
+    "crop-left=^"HB_INT_REG"$:crop-right=^"HB_INT_REG"$:"
+    "pad-top=^"HB_INT_REG"$:pad-bottom=^"HB_INT_REG"$:"
+    "pad-left=^"HB_INT_REG"$:pad-right=^"HB_INT_REG"$";
+
+hb_filter_object_t hb_filter_rpu =
+{
+    .id                = HB_FILTER_RPU,
+    .enforce_order     = 1,
+    .name              = "RPU converter",
+    .settings          = NULL,
+    .init              = rpu_init,
+    .work              = rpu_work,
+    .close             = rpu_close,
+    .settings_template = rpu_template,
+};
+
+
+static int rpu_init(hb_filter_object_t *filter,
+                    hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("RPU calloc failed");
+        return -1;
+    }
+    hb_filter_private_t * pv = filter->private_data;
+
+    pv->input = *init;
+
+    int mode = RPU_DEFAULT_MODE;
+    double scale_factor_x = 1, scale_factor_y = 1;
+    int crop_top = 0, crop_bottom = 0, crop_left = 0, crop_right = 0;
+    int pad_top = 0, pad_bottom = 0, pad_left = 0, pad_right = 0;
+
+    if (filter->settings != NULL)
+    {
+        hb_dict_t *dict = filter->settings;
+        hb_dict_extract_int(&mode, dict, "mode");
+
+        hb_dict_extract_double(&scale_factor_x, dict, "scale-factor-x");
+        hb_dict_extract_double(&scale_factor_y, dict, "scale-factor-y");
+
+        hb_dict_extract_int(&crop_top, dict, "crop-top");
+        hb_dict_extract_int(&crop_bottom, dict, "crop-bottom");
+        hb_dict_extract_int(&crop_left, dict, "crop-left");
+        hb_dict_extract_int(&crop_right, dict, "crop-right");
+
+        hb_dict_extract_int(&pad_top, dict, "pad-top");
+        hb_dict_extract_int(&pad_bottom, dict, "pad-bottom");
+        hb_dict_extract_int(&pad_left, dict, "pad-left");
+        hb_dict_extract_int(&pad_right, dict, "pad-right");
+    }
+
+    pv->mode = mode;
+
+    pv->scale_factor_x = scale_factor_x;
+    pv->scale_factor_y = scale_factor_y;
+
+    pv->crop_top    = crop_top;
+    pv->crop_bottom = crop_bottom;
+    pv->crop_left   = crop_left;
+    pv->crop_right  = crop_right;
+
+    pv->pad_top    =  pad_top;
+    pv->pad_bottom =  pad_bottom;
+    pv->pad_left   =  pad_left;
+    pv->pad_right  =  pad_right;
+
+    pv->output = *init;
+
+    return 0;
+}
+
+static void rpu_close(hb_filter_object_t * filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    av_buffer_unref(&pv->rpu);
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void apply_rpu_if_needed(hb_filter_private_t *pv, hb_buffer_t *buf)
+{
+    int rpu_available = 0;
+
+    for (int i = 0; i < buf->nb_side_data; i++)
+    {
+        const AVFrameSideData *side_data = buf->side_data[i];
+        if (side_data->type == AV_FRAME_DATA_DOVI_RPU_BUFFER)
+        {
+            rpu_available = 1;
+        }
+    }
+
+    if (rpu_available == 0)
+    {
+        if (pv->rpu)
+        {
+            AVBufferRef *ref = av_buffer_ref(pv->rpu);
+            AVFrameSideData *sd_dst = hb_buffer_new_side_data_from_buf(buf, AV_FRAME_DATA_DOVI_RPU_BUFFER, ref);
+            if (!sd_dst)
+            {
+                av_buffer_unref(&ref);
+            }
+            hb_log("rpu: missing rpu, falling back to last seen rpu");
+        }
+        else
+        {
+            hb_log("rpu: missing rpu, no fallback available");
+        }
+    }
+}
+
+static void save_rpu(hb_filter_private_t *pv, AVBufferRef *ref)
+{
+    av_buffer_unref(&pv->rpu);
+    pv->rpu = av_buffer_ref(ref);
+}
+
+static int rpu_work(hb_filter_object_t *filter,
+                    hb_buffer_t **buf_in,
+                    hb_buffer_t **buf_out)
+{
+#if HB_PROJECT_FEATURE_LIBDOVI
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    // libavcodec hevc decoder seems to be missing some rpu
+    // a specific sample file, work around the issue
+    // by using the last seen rpu
+    apply_rpu_if_needed(pv, in);
+
+    for (int i = 0; i < in->nb_side_data; i++)
+    {
+        const AVFrameSideData *side_data = in->side_data[i];
+        if (side_data->type == AV_FRAME_DATA_DOVI_RPU_BUFFER)
+        {
+            DoviRpuOpaque *rpu_in = dovi_parse_unspec62_nalu(side_data->data, side_data->size);
+
+            if (pv->mode & 2)
+            {
+                const DoviRpuDataHeader *header = dovi_rpu_get_header(rpu_in);
+                if (header && header->guessed_profile == 7)
+                {
+                    // Convert the BL to 8.1
+                    int ret = dovi_convert_rpu_with_mode(rpu_in, 2);
+                    if (ret < 0)
+                    {
+                        hb_log("rpu: dovi_convert_rpu_with_mode failed");
+                    }
+                }
+
+                if (header)
+                {
+                    dovi_rpu_free_header(header);
+                }
+            }
+
+            if (pv->mode & 1)
+            {
+                uint16_t left_offset = 0, right_offset = 0;
+                uint16_t top_offset  = 0, bottom_offset = 0;
+
+                const DoviVdrDmData *vdr_dm_data = dovi_rpu_get_vdr_dm_data(rpu_in);
+
+                if (vdr_dm_data)
+                {
+                    const DoviExtMetadataBlockLevel5 *level5 = vdr_dm_data->dm_data.level5;
+                    if (level5)
+                    {
+                        left_offset   = level5->active_area_left_offset;
+                        right_offset  = level5->active_area_right_offset;
+                        top_offset    = level5->active_area_top_offset;
+                        bottom_offset = level5->active_area_bottom_offset;
+                    }
+                }
+
+                // First subtract the crop values
+                left_offset   -= left_offset   > pv->crop_left   ? pv->crop_left   : left_offset;
+                right_offset  -= right_offset  > pv->crop_right  ? pv->crop_right  : right_offset;
+                top_offset    -= top_offset    > pv->crop_top    ? pv->crop_right  : top_offset;
+                bottom_offset -= bottom_offset > pv->crop_bottom ? pv->crop_bottom : bottom_offset;
+
+                // Then rescale
+                left_offset   = (double)left_offset   / pv->scale_factor_x;
+                right_offset  = (double)right_offset  / pv->scale_factor_x;
+                top_offset    = (double)top_offset    / pv->scale_factor_y;
+                bottom_offset = (double)bottom_offset / pv->scale_factor_y;
+
+                // At last add pad values
+                left_offset   += pv->pad_left;
+                right_offset  += pv->pad_right;
+                top_offset    += pv->pad_top;
+                bottom_offset += pv->pad_bottom;
+
+                dovi_rpu_set_active_area_offsets(rpu_in,
+                                                 left_offset,
+                                                 right_offset,
+                                                 top_offset,
+                                                 bottom_offset);
+
+                if (vdr_dm_data)
+                {
+                    dovi_rpu_free_vdr_dm_data(vdr_dm_data);
+                }
+            }
+
+            save_rpu(pv, side_data->buf);
+
+            if (pv->mode)
+            {
+                const DoviData *rpu_data = dovi_write_unspec62_nalu(rpu_in);
+                if (!rpu_data)
+                {
+                    hb_log("dovi_write_unspec62_nalu failed");
+                }
+
+                hb_frame_remove_side_data(in, side_data->type);
+
+                AVBufferRef *ref = av_buffer_alloc(rpu_data->len - 2);
+                memcpy(ref->data, rpu_data->data + 2, rpu_data->len - 2);
+                AVFrameSideData *sd_dst = hb_buffer_new_side_data_from_buf(in, AV_FRAME_DATA_DOVI_RPU_BUFFER, ref);
+
+                if (!sd_dst)
+                {
+                    av_buffer_unref(&ref);
+                }
+
+                dovi_data_free(rpu_data);
+            }
+
+            break;
+        }
+    }
+#endif
+
+    *buf_out = *buf_in;
+    *buf_in = NULL;
+
+    return HB_FILTER_OK;
+}

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1178,7 +1178,9 @@ skip_preview:
             title->color_transfer = get_color_transfer(title->color_transfer);
             title->color_matrix   = get_color_matrix(title->color_matrix, vid_info.geometry);
         }
-        else
+        // Let's try to guess a color profile only if the source is not Dolby Vision 5
+        // which requires the values to be unset
+        else if (title->dovi.dv_profile != 5)
         {
             title->color_prim     = get_color_prim(vid_info.color_prim, vid_info.geometry, vid_info.rate);
             title->color_transfer = get_color_transfer(vid_info.color_transfer);
@@ -1325,6 +1327,19 @@ skip_preview:
             hb_log("scan: content light level: max_cll=%u, max_fall=%u",
                    title->coll.max_cll,
                    title->coll.max_fall);
+        }
+
+        if (title->dovi.dv_profile > 0)
+        {
+            hb_log("scan: dolby vision configuration record: version: %d.%d, profile: %d, level: %d, rpu flag: %d, el flag: %d, bl flag: %d, compatibility id: %d",
+                   title->dovi.dv_version_major,
+                   title->dovi.dv_version_minor,
+                   title->dovi.dv_profile,
+                   title->dovi.dv_level,
+                   title->dovi.rpu_present_flag,
+                   title->dovi.el_present_flag,
+                   title->dovi.bl_present_flag,
+                   title->dovi.dv_bl_signal_compatibility_id);
         }
 
         if (title->video_decode_support != HB_DECODE_SUPPORT_SW)

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5887,6 +5887,12 @@ static hb_title_t *ffmpeg_title_scan( hb_stream_t *stream, hb_title_t *title )
                         title->coll.max_fall = coll->MaxFALL;
                         break;
                     }
+                    case AV_PKT_DATA_DOVI_CONF:
+                    {
+                        AVDOVIDecoderConfigurationRecord *dovi = (AVDOVIDecoderConfigurationRecord *)sd.data;
+                        title->dovi = hb_dovi_ff_to_hb(*dovi);
+                        break;
+                    }
                     default:
                         break;
                 }

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -372,7 +372,7 @@ static int unsharp_work_thread(hb_filter_object_t *filter,
                 ctx, tctx);
     }
 
-    out->s = in->s;
+    hb_buffer_copy_props(out, in);
     *buf_out = out;
 
     return HB_FILTER_OK;

--- a/macosx/HBTitle.m
+++ b/macosx/HBTitle.m
@@ -355,6 +355,11 @@ fail:
         dynamicRange = @"HDR";
     }
 
+    if (_hb_title->dovi.dv_profile)
+    {
+        dynamicRange = [NSString stringWithFormat:@"Dolby Vision %d.%d", _hb_title->dovi.dv_profile, _hb_title->dovi.dv_bl_signal_compatibility_id];
+    }
+
     [format appendFormat:@", %@ (", dynamicRange];
 
     int bit_depth = hb_get_bit_depth(_hb_title->pix_fmt);

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -140,7 +140,6 @@
 		A91CE2C61C7DABBC0068F46F /* libvorbisenc.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27D6C73E14B102DA00B785E4 /* libvorbisenc.a */; };
 		A91CE2C71C7DABBC0068F46F /* libvpx.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22DD2C49177B94DB00EF50D3 /* libvpx.a */; };
 		A91CE2C81C7DABBC0068F46F /* libx264.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27D6C73F14B102DA00B785E4 /* libx264.a */; };
-		A91CE2C91C7DABBC0068F46F /* libx265.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 22CC9E74191EBEA500C69D81 /* libx265.a */; };
 		A91CE2CA1C7DABBC0068F46F /* libxml2.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27D6C74014B102DA00B785E4 /* libxml2.a */; };
 		A91CE2D01C7DABCE0068F46F /* libbz2.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A91CE2CF1C7DABCE0068F46F /* libbz2.tbd */; };
 		A91CE2D21C7DABDA0068F46F /* libz.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = A91CE2D11C7DABDA0068F46F /* libz.tbd */; };
@@ -890,6 +889,7 @@
 		A9E165511C523016003EF30E /* libavfilter.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libavfilter.a; path = external/contrib/lib/libavfilter.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E2FD241A21BC4A000E8D3F /* HBAddPresetController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HBAddPresetController.h; sourceTree = "<group>"; };
 		A9E2FD251A21BC4A000E8D3F /* HBAddPresetController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HBAddPresetController.m; sourceTree = "<group>"; };
+		A9E34AD4297871FE00C5DD82 /* libdovi.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libdovi.a; path = external/contrib/lib/libdovi.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A9E52CD7218DD52A00E17B86 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/ExceptionAlert.xib; sourceTree = "<group>"; };
 		A9E8F80423003B2F00AA14E9 /* HandBrakeXPCService1.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = HandBrakeXPCService1.plist; sourceTree = "<group>"; };
 		A9EA43661A2210C400785E95 /* HBTableView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HBTableView.h; sourceTree = "<group>"; };
@@ -1083,26 +1083,26 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9C3A8F7278DFFA500839EDF /* Foundation.framework in Frameworks */,
-				A97D8DD124DBD3F800B16AF5 /* libiconv.tbd in Frameworks */,
-				A97D8DD024DBD3EF00B16AF5 /* libbz2.tbd in Frameworks */,
-				A97D8DCF24DBD3C000B16AF5 /* libz.tbd in Frameworks */,
 				A9A25D9C21182741005A8A0F /* CoreMedia.framework in Frameworks */,
 				A9AB9AA821181CC700BB3C7E /* CoreVideo.framework in Frameworks */,
 				A9AB9AA621181CA900BB3C7E /* VideoToolbox.framework in Frameworks */,
 				A9ABD1A91E2A0F8200EC8B65 /* CoreGraphics.framework in Frameworks */,
 				A9ABD1A71E2A0F7500EC8B65 /* CoreText.framework in Frameworks */,
-				A9E165521C523016003EF30E /* libavfilter.a in Frameworks */,
 				273F203014ADB9790021BE6D /* AudioToolbox.framework in Frameworks */,
 				273F203314ADB9F00021BE6D /* CoreServices.framework in Frameworks */,
 				273F202314ADB8650021BE6D /* IOKit.framework in Frameworks */,
+				A99B98A127957FD400DCD062 /* Metal.framework in Frameworks */,
+				A97D8DD124DBD3F800B16AF5 /* libiconv.tbd in Frameworks */,
+				A97D8DD024DBD3EF00B16AF5 /* libbz2.tbd in Frameworks */,
+				A97D8DCF24DBD3C000B16AF5 /* libz.tbd in Frameworks */,
 				A900E6BE1D7B1B6800CB6C0A /* libopus.a in Frameworks */,
 				27D6C72614B1019100B785E4 /* libhandbrake.a in Frameworks */,
 				27D6C74414B102DA00B785E4 /* libass.a in Frameworks */,
+				A9E165521C523016003EF30E /* libavfilter.a in Frameworks */,
 				27D6C74614B102DA00B785E4 /* libavcodec.a in Frameworks */,
 				27D6C74814B102DA00B785E4 /* libavformat.a in Frameworks */,
 				27D6C74A14B102DA00B785E4 /* libavutil.a in Frameworks */,
 				27D6C74C14B102DA00B785E4 /* libbluray.a in Frameworks */,
-				A99B98A127957FD400DCD062 /* Metal.framework in Frameworks */,
 				D0DC8F682331573500C12A24 /* libdav1d.a in Frameworks */,
 				27D6C75014B102DA00B785E4 /* libdvdnav.a in Frameworks */,
 				27D6C75214B102DA00B785E4 /* libdvdread.a in Frameworks */,
@@ -1182,19 +1182,19 @@
 				A9ABD1AA1E2A0F8F00EC8B65 /* CoreGraphics.framework in Frameworks */,
 				A9ABD1A61E2A0F0700EC8B65 /* CoreText.framework in Frameworks */,
 				A91119A31C7DD591001C463C /* IOKit.framework in Frameworks */,
-				1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */,
 				A91119A21C7DD58B001C463C /* Cocoa.framework in Frameworks */,
-				1C53DE8D20BD598D006BBCA8 /* libspeex.a in Frameworks */,
 				A91CE2B21C7DAB550068F46F /* AudioToolbox.framework in Frameworks */,
+				A99B98A027957FCE00DCD062 /* Metal.framework in Frameworks */,
 				A91CE2D41C7DABE40068F46F /* libiconv.tbd in Frameworks */,
 				A91CE2D21C7DABDA0068F46F /* libz.tbd in Frameworks */,
-				1C0695AF20BD193D001543DA /* libswresample.a in Frameworks */,
 				A91CE2D01C7DABCE0068F46F /* libbz2.tbd in Frameworks */,
+				1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */,
+				1C53DE8D20BD598D006BBCA8 /* libspeex.a in Frameworks */,
+				1C0695AF20BD193D001543DA /* libswresample.a in Frameworks */,
 				A900E6BD1D7B1B5A00CB6C0A /* libopus.a in Frameworks */,
 				A99E13392833B97A0006D720 /* libSvtAv1Enc.a in Frameworks */,
 				A91CE2B31C7DABBC0068F46F /* libass.a in Frameworks */,
 				A91CE2B41C7DABBC0068F46F /* libavcodec.a in Frameworks */,
-				A99B98A027957FCE00DCD062 /* Metal.framework in Frameworks */,
 				A91CE2B51C7DABBC0068F46F /* libavfilter.a in Frameworks */,
 				A91CE2B61C7DABBC0068F46F /* libavformat.a in Frameworks */,
 				A91CE2B81C7DABBC0068F46F /* libavutil.a in Frameworks */,
@@ -1216,7 +1216,6 @@
 				A91CE2C61C7DABBC0068F46F /* libvorbisenc.a in Frameworks */,
 				A91CE2C71C7DABBC0068F46F /* libvpx.a in Frameworks */,
 				A91CE2C81C7DABBC0068F46F /* libx264.a in Frameworks */,
-				A91CE2C91C7DABBC0068F46F /* libx265.a in Frameworks */,
 				A91CE2CA1C7DABBC0068F46F /* libxml2.a in Frameworks */,
 				A9C3A8F8278DFFC900839EDF /* libzimg.a in Frameworks */,
 				A91CE2B11C7DAA530068F46F /* libhandbrake.a in Frameworks */,
@@ -1237,6 +1236,7 @@
 		271BA4C714B1236D00BC1D2C /* Static Libraries */ = {
 			isa = PBXGroup;
 			children = (
+				A9E34AD4297871FE00C5DD82 /* libdovi.a */,
 				1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */,
 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
 				1CBC683320BE014800A26CC2 /* liblzma.a */,
@@ -2080,7 +2080,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = HB;
-				LastUpgradeCheck = 1400;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = HandBrake;
 				TargetAttributes = {
 					273F203814ADBC200021BE6D = {

--- a/make/configure.py
+++ b/make/configure.py
@@ -1460,6 +1460,11 @@ def createCLI( cross = None ):
     grp.add_argument( '--enable-vce', dest="enable_vce", default=IfHost(True, 'x86_64-w64-mingw32', none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-vce', dest="enable_vce", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
+    h = IfHost( 'libdovi', '*-*-*', none=argparse.SUPPRESS ).value
+    grp.add_argument( '--enable-libdovi', dest="enable_libdovi", default=not Tools.cargo.fail and not Tools.cargoc.fail, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
+    grp.add_argument( '--disable-libdovi', dest="enable_libdovi", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
+
+
     cli.add_argument_group( grp )
 
     ## add launch options
@@ -1667,6 +1672,8 @@ try:
         meson      = ToolProbe( 'MESON.exe',      'meson',      'meson', abort=True, minversion=[0,47,0] )
         nasm       = ToolProbe( 'NASM.exe',       'asm',        'nasm', abort=True, minversion=[2,13,0] )
         ninja      = ToolProbe( 'NINJA.exe',      'ninja',      'ninja-build', 'ninja', abort=True )
+        cargo      = ToolProbe( 'CARGO.exe',      'cargo',        'cargo', abort=False )
+        cargoc     = ToolProbe( 'CARGO-C.exe',    'cargo-cbuild', 'cargo-cbuild', abort=False )
 
         xcodebuild = ToolProbe( 'XCODEBUILD.exe', 'xcodebuild', 'xcodebuild', abort=(True if (not xcode_opts['disabled'] and (build_tuple.match('*-*-darwin*') and cross is None)) else False), versionopt='-version', minversion=[10,3,0] )
 
@@ -2070,6 +2077,7 @@ int main()
     doc.add( 'FEATURE.vce',        int( options.enable_vce ))
     doc.add( 'FEATURE.x265',       int( options.enable_x265 ))
     doc.add( 'FEATURE.numa',       int( options.enable_numa ))
+    doc.add( 'FEATURE.libdovi',    int( options.enable_libdovi ))
 
     if build_tuple.match( '*-*-darwin*' ) and options.cross is None:
         doc.add( 'FEATURE.xcode',      int( not (Tools.xcodebuild.fail or options.disable_xcode) ))
@@ -2202,6 +2210,8 @@ int main()
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.match( 'x86_64-w64-mingw32' ) or host_tuple.system == 'freebsd') else stdout.write( '\n' )
     stdout.write( 'Enable VCE:         %s' % options.enable_vce )
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.match( 'x86_64-w64-mingw32' )) else stdout.write( '\n' )
+    stdout.write( 'Enable libdovi:     %s\n' % options.enable_libdovi )
+
 
     if options.launch:
         stdout.write( '%s\n' % ('-' * 79) )

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -70,6 +70,10 @@ ifeq (1,$(FEATURE.nvenc))
     MODULES += contrib/nvenc
 endif
 
+ifeq (1,$(FEATURE.libdovi))
+    MODULES += contrib/libdovi
+endif
+
 ifneq (,$(filter $(HOST.system),darwin))
     MODULES += contrib/xz
 endif

--- a/make/xcodemake
+++ b/make/xcodemake
@@ -106,6 +106,9 @@ fi
 if [ -n "$reconfigure" ]; then
     echo "reconfiguring ($reconfigure)"
 
+    ## export rustc
+    export PATH="$HOME/.cargo/bin:$PATH"
+
     ## respect PATH priority
     OIFS="${IFS}"
     IFS=':'

--- a/test/module.defs
+++ b/test/module.defs
@@ -93,7 +93,7 @@ ifeq (1,$(HAS.pthread))
 else
     TEST.GCC.l += pthreadGC2
 endif
-    TEST.GCC.l += bcrypt iconv ws2_32 regex uuid ole32 gdi32
+    TEST.GCC.l += bcrypt iconv ws2_32 regex uuid ole32 gdi32 userenv
     ifeq (1,$(FEATURE.mf))
         TEST.GCC.l += mfplat strmiids
     endif


### PR DESCRIPTION
Implements reading and writing the Dolby Vision Configuration Record and the passing of the RPU buffers to x265.
I tested it on some profile 5 samples and the exported mp4 files can be played back properly in QuickTime Player.
Profile 5 seems to require the "dvh1" fourcc.

It adds a function to check whether to enable the dynamic metadata passthru or not, right now it's enabled only if there is no scaling or crop or rotation or pad and if the encoder is x265 10-bit.

x265 requires vbv-bufsize and vbv-maxrate to be set, I added some arbitrary values if they are not set by the user, if someone has got better ideas please tell.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux