### PR TITLE
Fixed an issue where the completion fraction was being reported as 100 instead of 1

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -431,7 +431,7 @@ namespace HandBrake.Interop.Interop
                     var progressEventArgs = new EncodeProgressEventArgs(0, 0, 0, TimeSpan.MinValue, 0, 0, 0, taskState.Code);
                     if (taskState == TaskState.Muxing || state.Working == null)
                     {
-                        progressEventArgs = new EncodeProgressEventArgs(100, 0, 0, TimeSpan.MinValue, 0, 0, 0, taskState.Code);
+                        progressEventArgs = new EncodeProgressEventArgs(1, 0, 0, TimeSpan.MinValue, 0, 0, 0, taskState.Code);
                     }
                     else
                     {


### PR DESCRIPTION
The first argument is a completion fraction from 0 to 1.

Passing 100 here was causing brief flashes of 10000% complete to show in the UI.

@sr55 