### PR TITLE
Passthru HDR10 Plus dynamic metadata

### DIFF
--- a/contrib/x265/A04-sei-length-crash-fix.patch
+++ b/contrib/x265/A04-sei-length-crash-fix.patch
@@ -1,0 +1,29 @@
+From 8454caf458c5f5d20cce711ff8ea8de55ec1ae50 Mon Sep 17 00:00:00 2001
+From: harlanc <hailiang8@staff.weibo.com>
+Date: Thu, 1 Dec 2022 07:46:13 +0000
+Subject: [PATCH] fix crash when SEI length is variable
+
+---
+ source/encoder/encoder.cpp | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/source/encoder/encoder.cpp b/source/encoder/encoder.cpp
+index 0fea6553c..5a3fcafc7 100644
+--- a/source/encoder/encoder.cpp
++++ b/source/encoder/encoder.cpp
+@@ -1103,6 +1103,12 @@ void Encoder::copyUserSEIMessages(Frame *frame, const x265_picture* pic_in)
+                 input = seiMsg;
+             else
+                 input = pic_in->userSEI.payloads[i];
++            
++            if (frame->m_userSEI.payloads[i].payload && (frame->m_userSEI.payloads[i].payloadSize < input.payloadSize))
++            {
++                delete[] frame->m_userSEI.payloads[i].payload;
++                frame->m_userSEI.payloads[i].payload = NULL;
++            }
+ 
+             if (!frame->m_userSEI.payloads[i].payload)
+                 frame->m_userSEI.payloads[i].payload = new uint8_t[input.payloadSize];
+-- 
+2.37.1 (Apple Git-137.1)
+

--- a/libhb/bitstream.c
+++ b/libhb/bitstream.c
@@ -1,0 +1,170 @@
+/* bitstream.c
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include <string.h>
+#include "handbrake/bitstream.h"
+
+void hb_bitstream_init(hb_bitstream_t *bs,
+                       uint8_t *buf,
+                       uint32_t buf_size,
+                       int clear)
+{
+    bs->pos = 0;
+    bs->buf = buf;
+    bs->buf_size = buf_size << 3;
+    if (clear)
+    {
+        memset(bs->buf, 0, buf_size);
+    }
+}
+
+void hb_bitstream_put_bytes(hb_bitstream_t *bs,
+                            uint8_t *bytes,
+                            uint32_t num_bytes)
+{
+    uint32_t num_bits = num_bytes << 3;
+
+    if (num_bits + bs->pos > bs->buf_size)
+    {
+        return;
+    }
+
+    if ((bs->pos & 7) == 0)
+    {
+        memcpy(&bs->buf[bs->pos >> 3], bytes, num_bytes);
+        bs->pos += num_bits;
+    }
+    else
+    {
+        for (uint32_t i = 0; i < num_bytes; i++)
+        {
+            hb_bitstream_put_bits(bs, bytes[i], 8);
+        }
+    }
+}
+
+void hb_bitstream_put_bits(hb_bitstream_t *bs,
+                           uint32_t bits,
+                           uint32_t num_bits)
+{
+    if (num_bits + bs->pos > bs->buf_size)
+    {
+        return;
+    }
+    if (num_bits > 32) {
+        return;
+    }
+
+    for (int8_t i = num_bits - 1; i >= 0; i--)
+    {
+        bs->buf[bs->pos >> 3] |= ((bits >> i) & 1) << (7 - (bs->pos & 7));
+        bs->pos++;
+    }
+
+}
+
+uint32_t hb_bitstream_peak_bits(hb_bitstream_t *bs,
+                                uint32_t num_bits)
+{
+    if (num_bits + bs->pos > bs->buf_size)
+    {
+        return 0;
+    }
+    if (num_bits > 32) {
+        return 0;
+    }
+
+    uint32_t value = 0;
+    uint32_t pos = bs->pos;
+
+    for (uint8_t i = 0; i < num_bits; i++)
+    {
+        value <<= 1;
+        value |= (bs->buf[pos >> 3] >> (7 - (pos & 7))) & 1;
+        pos++;
+    }
+
+    return value;
+}
+
+uint32_t hb_bitstream_get_bits(hb_bitstream_t *bs,
+                               uint32_t num_bits)
+{
+    if (num_bits + bs->pos > bs->buf_size)
+    {
+        return 0;
+    }
+    if (num_bits > 32)
+    {
+        return 0;
+    }
+
+    uint32_t value = 0;
+
+    for (uint8_t i = 0; i < num_bits; i++)
+    {
+        value <<= 1;
+        value |= (bs->buf[bs->pos >> 3] >> (7 - (bs->pos & 7))) & 1;
+        bs->pos++;
+    }
+
+    return value;
+}
+
+void hb_bitstream_skip_bytes(hb_bitstream_t *bs,
+                             uint32_t num_bytes)
+{
+    hb_bitstream_skip_bits(bs, num_bytes << 3);
+}
+
+void hb_bitstream_skip_bits(hb_bitstream_t *bs,
+                            uint32_t num_bits)
+{
+    hb_bitstream_set_bit_position(bs, hb_bitstream_get_bit_position(bs) + num_bits);
+}
+
+uint32_t hb_bitstream_get_bit_position(hb_bitstream_t *bs)
+{
+    return bs->pos;
+}
+
+void hb_bitstream_set_bit_position(hb_bitstream_t *bs,
+                                   uint32_t pos)
+{
+    if (pos > bs->buf_size)
+    {
+        return;
+    }
+    bs->pos = pos;
+}
+
+uint8_t * hb_bitstream_get_buffer(hb_bitstream_t *bs)
+{
+    return bs->buf;
+}
+
+uint32_t hb_bitstream_get_count_of_bytes(hb_bitstream_t *bs)
+{
+    return (hb_bitstream_get_count_of_bits(bs) + 7) / 8;
+}
+
+uint32_t hb_bitstream_get_count_of_bits(hb_bitstream_t *bs)
+{
+    return bs->buf_size;
+}
+
+uint32_t hb_bitstream_get_count_of_used_bytes(hb_bitstream_t *bs)
+{
+    return (bs->pos + 7) / 8;
+}
+
+uint32_t hb_bitstream_get_remaining_bits(hb_bitstream_t *bs)
+{
+    return bs->buf_size - bs->pos;
+}

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4140,7 +4140,8 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     job->mastering      = title->mastering;
     job->coll           = title->coll;
     job->dovi           = title->dovi;
-    job->passthru_dynamic_hdr_metadata = ALL;
+    job->passthru_dynamic_hdr_metadata |= title->dovi.dv_profile ? DOVI : NONE;
+    job->passthru_dynamic_hdr_metadata |= title->hdr_10_plus ? HDR_PLUS : NONE;
 
     job->mux = HB_MUX_MP4;
 

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1115,26 +1115,30 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
         }
     }
 
-    // Check for HDR mastering data
-    sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
-    if (sd != NULL)
+    if (!pv->job && pv->title)
     {
-        if (!pv->job && pv->title && sd->size > 0)
+        // Check for HDR mastering data
+        sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_MASTERING_DISPLAY_METADATA);
+        if (sd != NULL && sd->size > 0)
         {
             AVMasteringDisplayMetadata *mastering = (AVMasteringDisplayMetadata *)sd->data;
             pv->title->mastering = hb_mastering_ff_to_hb(*mastering);
         }
-    }
 
-    // Check for HDR content light level data
-    sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
-    if (sd != NULL)
-    {
-        if (!pv->job && pv->title && sd->size > 0)
+        // Check for HDR content light level data
+        sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_CONTENT_LIGHT_LEVEL);
+        if (sd != NULL && sd->size > 0)
         {
             AVContentLightMetadata *coll = (AVContentLightMetadata *)sd->data;
             pv->title->coll.max_cll = coll->MaxCLL;
             pv->title->coll.max_fall = coll->MaxFALL;
+        }
+
+        // Check for HDR Plus dynamic metadata
+        sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_DYNAMIC_HDR_PLUS);
+        if (sd != NULL && sd->size > 0)
+        {
+            pv->title->hdr_10_plus = 1;
         }
     }
 

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -16,6 +16,7 @@
 #include "handbrake/hb_dict.h"
 #include "handbrake/h265_common.h"
 #include "handbrake/dovi_common.h"
+#include "handbrake/hdr10plus.h"
 #include "x265.h"
 
 int  encx265Init (hb_work_object_t*, hb_job_t*);
@@ -742,8 +743,7 @@ static hb_buffer_t* x265_encode(hb_work_object_t *w, hb_buffer_t *in)
                 void *tmp;
                 x265_sei_payload *sei_payload = NULL;
 
-                // TODO: Convert side data to sei
-                //hb_dynamic_hdr10_plus_to_itu_t_t35((AVDynamicHDRPlus *)side_data->data, &payload, &playload_size);
+                hb_dynamic_hdr10_plus_to_itu_t_t35((AVDynamicHDRPlus *)side_data->data, &payload, &playload_size);
                 if (!playload_size)
                 {
                     continue;

--- a/libhb/handbrake/bitstream.h
+++ b/libhb/handbrake/bitstream.h
@@ -1,0 +1,62 @@
+/* bitstream.h
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HANDBRAKE_BITSTREAM_H
+#define HANDBRAKE_BITSTREAM_H
+
+#include <stdint.h>
+
+typedef struct
+{
+    uint8_t    *buf;
+    uint32_t    pos;
+    uint32_t    buf_size;
+} hb_bitstream_t;
+
+void hb_bitstream_init(hb_bitstream_t *bs,
+                       uint8_t *buf,
+                       uint32_t bufsize,
+                       int clear);
+
+void hb_bitstream_put_bytes(hb_bitstream_t *bs,
+                            uint8_t *bytes,
+                            uint32_t num_bytes);
+
+void hb_bitstream_put_bits(hb_bitstream_t *bs,
+                           uint32_t bits,
+                           uint32_t num_bits);
+
+uint32_t hb_bitstream_peak_bits(hb_bitstream_t *bs,
+                                uint32_t num_bits);
+
+uint32_t hb_bitstream_get_bits(hb_bitstream_t *bs,
+                               uint32_t num_bits);
+
+void hb_bitstream_skip_bytes(hb_bitstream_t *bs,
+                             uint32_t num_bytes);
+
+void hb_bitstream_skip_bits(hb_bitstream_t *bs,
+                            uint32_t num_bits);
+
+uint32_t hb_bitstream_get_bit_position(hb_bitstream_t *bs);
+
+void hb_bitstream_set_bit_position(hb_bitstream_t *bs,
+                                   uint32_t bitPos);
+
+uint8_t * hb_bitstream_get_buffer(hb_bitstream_t *bs);
+
+uint32_t hb_bitstream_get_count_of_bytes(hb_bitstream_t *bs);
+
+uint32_t hb_bitstream_get_count_of_bits(hb_bitstream_t *bs);
+
+uint32_t hb_bitstream_get_count_of_used_bytes(hb_bitstream_t *bs);
+
+uint32_t hb_bitstream_get_remaining_bits(hb_bitstream_t *bs);
+
+#endif // HANDBRAKE_BITSTREAM_H

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1185,9 +1185,12 @@ struct hb_title_s
     int             color_matrix;
     int             color_range;
     int             chroma_location;
+
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t     coll;
     hb_dovi_conf_t  dovi;
+    int             hdr_10_plus;
+
     hb_rational_t   vrate;
     int             crop[4];
     int             loose_crop[4];

--- a/libhb/handbrake/hdr10plus.h
+++ b/libhb/handbrake/hdr10plus.h
@@ -1,0 +1,18 @@
+/* hdr10plus.h
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HANDBRAKE_HDR_10_PLUS_H
+#define HANDBRAKE_HDR_10_PLUS_H
+
+#include <stdint.h>
+#include "libavutil/hdr_dynamic_metadata.h"
+
+void hb_dynamic_hdr10_plus_to_itu_t_t35(const AVDynamicHDRPlus *s, uint8_t **buf_p, uint32_t *size);
+
+#endif // HANDBRAKE_HDR_10_PLUS_H

--- a/libhb/hdr10plus.c
+++ b/libhb/hdr10plus.c
@@ -1,0 +1,133 @@
+/* hdr10plus.c
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include <string.h>
+#include "handbrake/bitstream.h"
+#include "libavutil/hdr_dynamic_metadata.h"
+
+void hb_dynamic_hdr10_plus_to_itu_t_t35(const AVDynamicHDRPlus *s, uint8_t **buf_p, uint32_t *size)
+{
+    const uint8_t countryCode = 0xB5;
+    const uint16_t terminalProviderCode = 0x003C;
+    const uint16_t terminalProviderOrientedCode = 0x0001;
+    const uint8_t applicationIdentifier = 4;
+
+    uint8_t *buf = av_mallocz(2048);
+    hb_bitstream_t bs;
+
+    hb_bitstream_init(&bs, buf, 2048, 0);
+
+    hb_bitstream_put_bits(&bs, countryCode, 8);
+    hb_bitstream_put_bits(&bs, terminalProviderCode, 16);
+    hb_bitstream_put_bits(&bs, terminalProviderOrientedCode, 16);
+
+    hb_bitstream_put_bits(&bs, applicationIdentifier, 8);
+    hb_bitstream_put_bits(&bs, s->application_version, 8);
+    hb_bitstream_put_bits(&bs, s->num_windows, 2);
+
+    for (int w = 1; w < s->num_windows; w++)
+    {
+        const AVHDRPlusColorTransformParams *params = &s->params[w];
+
+        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
+
+        hb_bitstream_put_bits(&bs, params->center_of_ellipse_x, 16);
+        hb_bitstream_put_bits(&bs, params->center_of_ellipse_y, 16);
+        hb_bitstream_put_bits(&bs, params->rotation_angle, 8);
+        hb_bitstream_put_bits(&bs, params->semimajor_axis_internal_ellipse, 16);
+        hb_bitstream_put_bits(&bs, params->semimajor_axis_external_ellipse, 16);
+        hb_bitstream_put_bits(&bs, params->semiminor_axis_external_ellipse, 16);
+        hb_bitstream_put_bits(&bs, params->overlap_process_option, 1);
+    }
+
+    hb_bitstream_put_bits(&bs, s->targeted_system_display_maximum_luminance.num, 27);
+    hb_bitstream_put_bits(&bs, s->targeted_system_display_actual_peak_luminance_flag, 1);
+
+    if (s->targeted_system_display_actual_peak_luminance_flag)
+    {
+        hb_bitstream_put_bits(&bs, s->num_rows_targeted_system_display_actual_peak_luminance, 5);
+        hb_bitstream_put_bits(&bs, s->num_cols_targeted_system_display_actual_peak_luminance, 5);
+
+        for (int i = 0; i < s->num_rows_targeted_system_display_actual_peak_luminance; i++)
+        {
+            for (int j = 0; j < s->num_cols_targeted_system_display_actual_peak_luminance; j++)
+            {
+                hb_bitstream_put_bits(&bs, s->targeted_system_display_actual_peak_luminance[i][j].num, 4);
+            }
+        }
+    }
+
+    for (int w = 0; w < s->num_windows; w++)
+    {
+        const AVHDRPlusColorTransformParams *params = &s->params[w];
+
+        for (int i = 0; i < 3; i++)
+        {
+            hb_bitstream_put_bits(&bs, params->maxscl[i].num, 17);
+        }
+        hb_bitstream_put_bits(&bs, params->average_maxrgb.num, 17);
+        hb_bitstream_put_bits(&bs, params->num_distribution_maxrgb_percentiles, 4);
+
+        for (int i = 0; i < params->num_distribution_maxrgb_percentiles; i++)
+        {
+            hb_bitstream_put_bits(&bs, params->distribution_maxrgb[i].percentage, 7);
+            hb_bitstream_put_bits(&bs, params->distribution_maxrgb[i].percentile.num, 17);
+        }
+
+        hb_bitstream_put_bits(&bs, params->fraction_bright_pixels.num, 10);
+    }
+
+    hb_bitstream_put_bits(&bs, s->mastering_display_actual_peak_luminance_flag, 1);
+
+    if (s->mastering_display_actual_peak_luminance_flag)
+    {
+        hb_bitstream_put_bits(&bs, s->num_rows_mastering_display_actual_peak_luminance, 5);
+        hb_bitstream_put_bits(&bs, s->num_cols_mastering_display_actual_peak_luminance, 5);
+
+        for (int i = 0; i < s->num_rows_mastering_display_actual_peak_luminance; i++)
+        {
+            for (int j = 0; j < s->num_cols_mastering_display_actual_peak_luminance; j++)
+            {
+                hb_bitstream_put_bits(&bs, s->mastering_display_actual_peak_luminance[i][j].num, 4);
+            }
+        }
+    }
+
+    for (int w = 0; w < s->num_windows; w++)
+    {
+        const AVHDRPlusColorTransformParams *params = &s->params[w];
+
+        hb_bitstream_put_bits(&bs, params->tone_mapping_flag, 1);
+        if (params->tone_mapping_flag)
+        {
+            hb_bitstream_put_bits(&bs, params->knee_point_x.num, 12);
+            hb_bitstream_put_bits(&bs, params->knee_point_y.num, 12);
+
+            hb_bitstream_put_bits(&bs, params->num_bezier_curve_anchors, 4);
+
+            for (int i = 0; i < params->num_bezier_curve_anchors; i++)
+            {
+                hb_bitstream_put_bits(&bs, params->bezier_curve_anchors[i].num, 10);
+            }
+        }
+
+        hb_bitstream_put_bits(&bs, params->color_saturation_mapping_flag, 1);
+
+        if (params->color_saturation_mapping_flag)
+        {
+            hb_bitstream_put_bits(&bs, params->color_saturation_weight.num, 6);
+        }
+    }
+
+    *buf_p = buf;
+    *size = hb_bitstream_get_count_of_used_bytes(&bs);
+}

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1342,6 +1342,11 @@ skip_preview:
                    title->dovi.dv_bl_signal_compatibility_id);
         }
 
+        if (title->hdr_10_plus)
+        {
+            hb_log("scan: hdr10+ dynamic metadata found");
+        }
+
         if (title->video_decode_support != HB_DECODE_SUPPORT_SW)
         {
             hb_log("scan: supported video decoders:%s%s%s",


### PR DESCRIPTION
Here's come code I wrote one year ago I forgot about.

It adds yet another bare bones bitstream reader/writer, and converts the AVDynamicHDRPlus struct back to a SEI.
Needs to be tested on one actual HDR10 Plus hardware, which I don't own.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux