### PR TITLE
libhb: do not rely on a locale dependant way to convert floats to st…

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -11,6 +11,7 @@
 #include <time.h>
 #include <ctype.h>
 #include <sys/time.h>
+#include <locale.h>
 
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
@@ -5273,6 +5274,18 @@ int hb_subtitle_add_ssa_header(hb_subtitle_t *subtitle, const char *font,
     float shadow_size = fs / 36.0;
     float outline_size = fs / 30.0;
 
+    char *shadow_size_string = hb_strdup_printf("%.2f", shadow_size);
+    hb_str_from_locale(shadow_size_string);
+
+    char *outline_size_string = hb_strdup_printf("%.2f", outline_size);
+    hb_str_from_locale(outline_size_string);
+
+    if (shadow_size_string == NULL || outline_size_string == NULL)
+    {
+        hb_error("hb_subtitle_add_ssa_header: malloc failed");
+        return 0;
+    }
+
     // SRT subtitles are represented internally as SSA
     // Create an SSA header
     const char * ssa_header =
@@ -5287,9 +5300,13 @@ int hb_subtitle_add_ssa_header(hb_subtitle_t *subtitle, const char *font,
         "\r\n"
         "[V4+ Styles]\r\n"
         "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\r\n"
-        "Style: Default,%s,%d,&H00FFFFFF,&H00FFFFFF,&H000F0F0F,&H000F0F0F,0,0,0,0,100,100,0,0.00,1,%.2f,%.2f,2,20,20,20,0\r\n";
+        "Style: Default,%s,%d,&H00FFFFFF,&H00FFFFFF,&H000F0F0F,&H000F0F0F,0,0,0,0,100,100,0,0.00,1,%s,%s,2,20,20,20,0\r\n";
 
-    subtitle->extradata = (uint8_t*)hb_strdup_printf(ssa_header, w, h, font, fs, outline_size, shadow_size);
+    subtitle->extradata = (uint8_t *)hb_strdup_printf(ssa_header, w, h, font, fs, outline_size_string, shadow_size_string);
+
+    free(shadow_size_string);
+    free(outline_size_string);
+
     if (subtitle->extradata == NULL)
     {
         hb_error("hb_subtitle_add_ssa_header: malloc failed");
@@ -5611,6 +5628,46 @@ void hb_metadata_rem_coverart( hb_metadata_t *metadata, int idx )
             free( art->data );
             free( art );
         }
+    }
+}
+
+// Copied from jansson strconv.c
+
+void hb_str_to_locale(char *str)
+{
+    const char *point;
+    char *pos;
+
+    point = localeconv()->decimal_point;
+    if (*point == '.')
+    {
+        // No conversion needed
+        return;
+    }
+
+    pos = strchr(str, '.');
+    if (pos)
+    {
+        *pos = *point;
+    }
+}
+
+void hb_str_from_locale(char *str)
+{
+    const char *point;
+    char *pos;
+
+    point = localeconv()->decimal_point;
+    if (*point == '.')
+    {
+        // No conversion needed
+        return;
+    }
+
+    pos = strchr(str, *point);
+    if (pos)
+    {
+        *pos = '.';
     }
 }
 

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1534,6 +1534,9 @@ typedef void hb_error_handler_t( const char *errmsg );
 
 extern void hb_register_error_handler( hb_error_handler_t * handler );
 
+void hb_str_to_locale(char *buffer);
+void hb_str_from_locale(char *buffer);
+
 char * hb_strdup_vaprintf( const char * fmt, va_list args );
 char * hb_strdup_printf(const char *fmt, ...) HB_WPRINTF(1, 2);
 char * hb_strncat_dup( const char * s1, const char * s2, size_t n );


### PR DESCRIPTION
…rings.

Unfortunately I had introduce a float to char conversion that used a different decimal separator depending on the current set locale, leading to this issue: https://forum.handbrake.fr/viewtopic.php?t=42849
If someone with a better C knowledge can suggest a better way, or if this is good enough.

**Test on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux