### PR TITLE
test: Fix --json progress output not being flushed

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -853,7 +853,7 @@ static void show_progress_json(hb_state_t * state)
     hb_value_free(&state_dict);
     fprintf(stdout, "Progress: %s\n", state_json);
     free(state_json);
-    fflush(stderr);
+    fflush(stdout);
 }
 
 static int HandleEvents(hb_handle_t * h, hb_dict_t *preset_dict)


### PR DESCRIPTION
**Description of Change:**

I noticed that `--json` was buffering the progress reports when it was run through a pipe. I was able to recreate the issue  on macOS 13 and Debian testing. The easy way to see it:

```
# This outputs nicely
HandBrakeCLI --scan -i /dev/cdrom -t 0 --json
# This buffers and spews a bunch of progresses ever few seconds:
HandBrakeCLI --scan -i /dev/cdrom -t 0 --json | cat
```

Poking around the code I saw that the `show_progress_json()` function was printing to `stdout` but flushing `stderr`. This PR changes it to flush `stdout` which fixes the symptom for me.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] ~~Ubuntu~~Debian Linux
