### PR TITLE
Linux: Show HDR information in source summary

### DIFF
--- a/gtk/po/af.po
+++ b/gtk/po/af.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Gideon Wentink <gjwentink@gmail.com>, 2017\n"
 "Language-Team: Afrikaans (https://www.transifex.com/HandBrakeProject/"
@@ -104,8 +104,8 @@ msgstr "_Voorinstellings"
 msgid "Set De_fault"
 msgstr "Stel As _Verstek"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Bewaar"
 
@@ -113,7 +113,7 @@ msgstr "_Bewaar"
 msgid "Save _As"
 msgstr "Bewaar _As"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Hernoem"
 
@@ -163,7 +163,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Ingebrand</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Verstek</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -362,7 +362,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Begin Enkodering"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Begin"
@@ -381,7 +381,7 @@ msgstr "Wag"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -401,8 +401,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Wysig"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Voorinstelling:"
 
@@ -410,7 +410,7 @@ msgstr "Voorinstelling:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titel:"
 
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Opsomming"
 
@@ -517,11 +517,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Kies Videobron"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Open Bron"
 
@@ -553,7 +553,7 @@ msgstr "Voorskou"
 msgid "Show Queue"
 msgstr "Toon Wagry"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Wagry"
 
@@ -576,15 +576,15 @@ msgstr "<b>Bron:</b>"
 msgid "None"
 msgstr "Geen"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Skandeer Tans …"
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titel:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -594,52 +594,52 @@ msgstr ""
 "Die langste titel word by verstek gekies.\n"
 "Dit is gewoonlik die hooftitel van ’n DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Kies die gewenste hoek vir enkodering vir multihoek-DVD’s."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Omvang:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Omvang van titel vir enkodering. Kan hoofstukke, sekondes of rame wees."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Stel die eerste hoofstuk vir enkodering."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Stel die laaste hoofstuk vir enkodering."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Voorinstelling:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Kies Voorinstelling"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Gewysig</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Herlaai"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -647,177 +647,177 @@ msgstr ""
 "Herlaai die instellings vir die gekose voorinstelling.\n"
 "Wysigings sal weggegooi word."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Bewaar Nuwe Voorinstelling"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Bewaar die huidige instelling as ’n nuwe Voorinstelling."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formaat"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formaat vir muks van geënkodeerde snitte."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G-ondersteuning"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Voeg iPod Atom wat deur sommige ouer iPods benodig word toe."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Duur:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Snitte:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filters:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Grootte:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Roteer die video kloksgewys in 90º-hoeveelhede."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Linkersnoei"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Bosnoei"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Ondersnoei"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Regtersnoei"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -827,11 +827,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -840,11 +840,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -852,11 +852,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -866,7 +866,7 @@ msgstr ""
 "Die ware vertoondimensies sal verskil indien die aspekverhouding nie 1:1 is "
 "nie."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -876,84 +876,84 @@ msgstr ""
 "Die ware vertoondimensies sal verskil indien die aspekverhouding nie 1:1 is "
 "nie."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Outomaties"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensies"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -961,18 +961,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Interlinieerbespeuring:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -984,7 +984,7 @@ msgstr ""
 "Indien ’n deïnterlinieerfilter geaktiveer is sal slegs rame wat\n"
 "deur hierdie filter opgespoor word, geïnterlinieer word."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -996,11 +996,11 @@ msgstr ""
 "Modus:Ruimtelik Metriek:Beweging Dors:Ruimtelik Dors:Masker\n"
 "Filtermodus: Blok Dors: Blok Wydte: Blok Hoogte"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deïnterlinieer:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1012,7 +1012,7 @@ msgstr ""
 "Die ontsiffilter ondersteun ’n verskeidenheid van interpolasie-algoritmes.\n"
 "Die deïnterlinieerfilter is ’n klassieke YADIF-deïnterlinieerder.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1026,39 +1026,39 @@ msgstr ""
 "Die ontsiffilter ondersteun ’n verskeideinheid van interpolasie-algoritmes.\n"
 "Die deïnterlinieerfilter is ’n klassieke YADIF-deïnterlinieerder.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1066,7 +1066,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1074,78 +1074,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filters"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Video-enkodeerder:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Beskikbare video-enkodeerders."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Raamtempo:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1157,19 +1157,19 @@ msgstr ""
 "‘Selfde as bron’ word aanbeveel. Indien u bronvideo ’n\n"
 "veranderlike raamtempo het sal ‘Selfde as bron’ dit bewaar."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Konstante Raamtempo"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Aktiveer konstante raamtempo-afvoer."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1177,11 +1177,11 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1191,7 +1191,7 @@ msgstr ""
 "\n"
 "VFR is onversoenbaar met sommige spelers."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1207,15 +1207,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Konstante Kwaliteit"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bistempo (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1232,11 +1232,11 @@ msgstr ""
 "vbv-bufgrootte en -makstempo-instellings indien u onmiddellike bistempo moet "
 "beperk."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2-Deurloopenkodering"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1251,18 +1251,18 @@ msgstr ""
 "oor die video opgegaar. In die tweede deurloop word daardie statiestiek\n"
 "gebruik om besluite oor bistempotoewysings te maak."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Jaag 1ste Deurloop Aan"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Gebruik instellings wat sake bespoedig gedurende die 1ste deurloop van ’n 2-"
 "deurloopenkodering."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1274,7 +1274,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1283,22 +1283,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1315,33 +1315,33 @@ msgstr ""
 "nie,\n"
 "het hierdie instelling nie baie waarde hier nie."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profiel:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Vlak:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Nog Instellings:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1351,193 +1351,193 @@ msgstr ""
 "\n"
 "Dubbelpuntgeskeide lys van enkodeerderopsies."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Voeg Toe"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Voeg nuwe oudio-instellings by die lys"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Voeg Alle Toe"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Voeg alle oudiosnitte by die lys"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Snitlys"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Kies welke oudiosnitte van die bronmedia gebruik word."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Verwyder"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Beskikbare Tale"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Gekose Tale"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Gebruik slegs eerste enkodeerder vir sekondêre oudio"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Outodeurgang:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Deurgangterugval"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1545,75 +1545,75 @@ msgstr ""
 "Stel die oudiokodek vir enkodering wanneer geen geskikte snit vir "
 "oudiodeurgang gevind kan word nie."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Oudioënkodeerinstellings:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "Elke gekose bronsnit sal met alle gekose enkodeerders geënkodeer word"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Enkodeerder"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bistempo/Kwaliteit"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Voorbeeldtempo"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Wins"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DOS"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Snitseleksie"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Oudio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Voeg nuwe onderskrifinstellings by die lys"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Voeg alle onderskrifsnitte by die lys"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Kies welke onderskrifsnitte van die bronmedia gebruik word."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1630,15 +1630,15 @@ msgstr ""
 "Die eerste taal in hierdie lys is u voorkeurtaal en sal gebruik word om\n"
 "onderskrifseleksie te bepaal wanneer daar vreemde oudio is."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Voeg Vreemdeoudioskanderingsdeurloop Toe"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1648,11 +1648,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Voeg onderskrifsnit toe indien verstekoudio vreemd is"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1660,21 +1660,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1684,15 +1684,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD-onderskrifte"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1703,11 +1703,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray-onderskrifte"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1718,7 +1718,7 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1726,7 +1726,7 @@ msgstr ""
 "<small>* Slegs een van die bostaande onderskrifbrandopsies sal toegepas "
 "word, met ’n aanvang bo-aan.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1734,112 +1734,112 @@ msgstr ""
 "Slegs een onderskrifsnit kan gebrand word! Die eerste gekose een wen omdat "
 "daar botsing kan wees."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Onderskrifte"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Hoofstukmerkers"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Plaas hoofstukmerkers in die afvoerlêer."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Hoofstukke"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Hoofstukke"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Duur"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titel"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Hoofstukke"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Akteurs"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regisseur:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Vrystellingsdatum:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Kommentaar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genre:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Beskrywing:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Storielyn:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Merkies"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Bewaar As:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Bestemminglêernaam vir u enkodering."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Na:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Bestemminggids vir u enkodering."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Bestemminggids"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Voeg _Meerdere Toe"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1847,74 +1847,74 @@ msgstr "Voeg _Meerdere Toe"
 msgid "Cancel"
 msgstr "Kanselleer"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Kies Alles"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Merk alle titels om tot die wagry toe te voeg"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Bestemminglêers reg. Geen duplikate gespeur nie."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Voorkeure"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Soek outomaties na bywerkings"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Gebruik outomatiesebenoeming (gebruik aangepaste bronnaam)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Outobenoemingsjabloon"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Gebruik iPod/iTunes-vriendelike (.m4v) lêeruitbreiding vir MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Aantal voorskoue"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -1923,52 +1923,52 @@ msgstr ""
 "Voltooide take bly by verstek in die wagry en word as voltooi gemerk.\n"
 "Merk dit indien die wagry homself moet opruim deur voltooide take te skrap."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Algemeen"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1982,63 +1982,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Laat enkodering wag indien skyfspasie onder limiet val"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Plaas individuele enkodeerlogs in dieselfde ligging as rolprent"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Skandeer DVD outomaties wanneer gelaai"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Skandeer die DVD wanneer ’n nuwe skyf gelaai word"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2047,185 +2047,185 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Gevorderd"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Ontsteurvoorinstelling:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Hernoem Voorinstelling</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Naam:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "Beskrywing</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Bewaar Nuwe Voorinstelling"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Stel die kategorie waaronder hierdie voorinstelling vertoon sal word."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Kategorienaam:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Voorinstellingnaam:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Verstekvoorinstelling"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Kies voorskouraampies."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Duur:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Toon Snoei"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Toon Besnoeide area van die voorskou"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Onderskrifte"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Aktiveer instellings om ’n SRT-onderskriflêer in te voer"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Ingebedde Onderskriflys"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Aktiveer instellings om ingebedde onderskrifte te kies"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Bronsnit"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lys van onderskrifsnitte beskikbaar op u bron."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Snitnaam:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Taal"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Karakterkode"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Lêer:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2233,7 +2233,7 @@ msgstr ""
 "Stel die taal van hierdie onderskrif.\n"
 "Hierdie waarde sal deur spelers in onderskrifkieslyste gebruik word."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2242,27 +2242,27 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Kies die SRT-lêer vir invoer"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Slegs Gedwonge Onderskrifte"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Brand in op video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2270,34 +2270,34 @@ msgstr ""
 "Verbeeld die onderskrif oor die video.\n"
 "Die onderskrif sal deel van die video wees en  kan nie afgeskakel word nie"
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Stel Versteksnit"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lys van oudiosnitte beskikbaar op u bron."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Meng"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Voorbeeldtempo"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2315,50 +2315,50 @@ msgstr ""
 "laat DOS u toe om die omvang ‘saam te pers’ deur harge klank sagter en sagte "
 "klank harder te maak."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Stel die oudiokodek om hierdie snit mee te enkodeer."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bistempo"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Aktiveer bistempo-instelling"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kwaliteit"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Aktiveer kwaliteitinstelling"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Stel die bistempo vir enkodering van hierdie snit."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 "<b>Kwaliteit:</b> Verstel die afvoerkwaliteit vir ondersteunde afvoerkodeks."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Stel die voorbeeldtempo van die afvoeroudiosnit."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2367,41 +2367,41 @@ msgstr ""
 "afvoeroudiosnit."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Af"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Slaan Hierdie Weergawe Oor"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Herinner My Later"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>’n Nuwe weergawe van HandBrake is beskikbaar!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx is nou beskikbaar (u het yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Vrystellingsnotas</b>"
 
@@ -2545,7 +2545,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Skandeer Tans …"
 
@@ -2558,92 +2558,121 @@ msgstr "Staak Skandering"
 msgid "Single Title"
 msgstr "Open Enkele _Titel"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DOS"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DOS"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Oudio"
 msgstr[1] "Oudio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Onderskrifte"
 msgstr[1] "Onderskrifte"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "Vreemde Oudio-onderskrifsnit"
 msgstr[1] "Vreemde Oudio-onderskrifsnit"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Geen titel gevind"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nuwe Video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2654,132 +2683,132 @@ msgstr ""
 "\n"
 "%s in %d sekondes …"
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sU rolprent gaan verlore indien u nie enkodering voortsit nie."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Kanselleer Huidige en Stop"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Kanselleer Huidige, Begin Volgende"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Eindig Huidige, Stop dan"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Sit Enkodering Voort"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "Taak %d van %d,"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "deurloop %d (onderskrifskandering) van %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "deurloop %d van %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Enkodering: %s%s%.2f %% (%.2f fps, gem %.2f fps, Tyd %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Enkodering: %s%s%.2f %% (Tyd %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Enkodering: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Skandeer titel %d van %d…"
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Skandeer titel %d van %d voorskou %d…"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Hangend"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Enkodering Afgehandel!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Enkodering Gekanselleer"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Enkodering het Misluk."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Muksing: Dit kan ’n ruk duur…"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s%s is nou beskikbaar (u het %s%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Enkodering Voltooid"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Sit daardie skemerkelkie neer, u HandBrake-wagry is klaar!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "U enkodering is klaar."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "HandBrake word Afgesluit"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/bg.po
+++ b/gtk/po/bg.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: inncharge, 2022\n"
 "Language-Team: Bulgarian (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_Шаблони"
 msgid "Set De_fault"
 msgstr "Избери по_подразбиране"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Запази"
 
@@ -114,7 +114,7 @@ msgstr "_Запази"
 msgid "Save _As"
 msgstr "Запази _като"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Преименувай"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Вграден</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>По подразбиране</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -356,7 +356,7 @@ msgstr "0 чакащи задачи"
 msgid "Start Encoding"
 msgstr "Започни кодиране"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Начало"
@@ -375,7 +375,7 @@ msgstr "Пауза"
 msgid "Options"
 msgstr "Опции"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr " При завършване:"
 
@@ -395,8 +395,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Редактирай"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Шаблон:"
 
@@ -404,7 +404,7 @@ msgstr "Шаблон:"
 msgid "Source:"
 msgstr "Източник:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Заглавие:"
 
@@ -428,7 +428,7 @@ msgstr "Аудио:"
 msgid "Subtitles:"
 msgstr "Субтитри:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Обобщение"
 
@@ -522,11 +522,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Избери видео източник"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Отвори източник"
 
@@ -558,7 +558,7 @@ msgstr "Визуализация"
 msgid "Show Queue"
 msgstr "Покажи опашка"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Опашка"
 
@@ -581,15 +581,15 @@ msgstr "<b>Източник:</b>"
 msgid "None"
 msgstr "Няма"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Сканиране..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Заглавие:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -599,52 +599,52 @@ msgstr ""
 "По подразбиране се избира най-дългото заглавие.\n"
 "Това най-често е главното заглавие на DVD диска."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Ъгъл:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "За многоъгълни DVD дискове, изберете желания ъгъл за кодиране."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Интервал:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Интервал от заглавието за кодиране. Може да е в глави, секунди или кадри."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Наглася първата глава за кодиране."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Наглася последната глава за кодиране."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Шаблон:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Избери шаблон"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Променено</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Презареди"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -652,27 +652,27 @@ msgstr ""
 "Презареди настройките за текущо избрания шаблон.\n"
 "Промените няма да бъдат запазени."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Запази нов шаблон"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Запази настоящите настройки в нов шаблон."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Формат:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Формат за мултиплексиране на кодираните пътечки."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Оптимизирано за уеб"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -681,11 +681,11 @@ msgstr ""
 "Това позволява на плеъра да възпроизвежда преди да е изтеглен целия файл "
 "докрай."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Подравняване на Аудио/Видео началото"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -695,142 +695,142 @@ msgstr ""
 "празни кадри или пропуска кадри. Може да подобри аудио/видео синхронизацията "
 "за счупени плеъри, които не уважават MP4 списъците с отместване (edit lists)."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Поддръжка на iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Добавя нужния за някои стари iPod устройства, iPod Atom"
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Подаване на общи метаданни"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Копира метаданните от източника в изхода."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Продължителност:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "чч:мм:сс"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Пътечки:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Филтри:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Размер:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Размер в хранилище:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Размер на екран:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr " Съотношение на страните:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Размери на източник</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Обръщане:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Хоризонтално  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Обърни видеото хоризонтално"
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Завъртане:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 "Завъртане на видеото по посока на часовниковата стрелка на 90 градусови "
 "стъпки."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Изрязване:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Как се прилагат настройките за изрязване."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Изрязване вляво"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Изрязване отгоре"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Изрязване отдолу"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Изрязване вдясно"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Ориентация и изрязване</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Лимит на разделителна способност:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Лимити на разделителна способност за често срещани видео формти."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Максимален размер:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Това е максималната ширина, с която видеото ще бъде запазено."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Това е максималната дължина, с която видеото ще бъде запазено."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Анаморфотен:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -849,11 +849,11 @@ msgstr ""
 "   Персонализирано - Въвежда се съотношение на пикселите по избор. </tt></"
 "small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Съотношение на пикселите:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -866,11 +866,11 @@ msgstr ""
 "правоъгълни форми.\n"
 "Плеърите ще мащабират изображението да получат желаното съотношение."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -882,11 +882,11 @@ msgstr ""
 "правоъгълни форми.\n"
 "Плеърите ще мащабират изображението да получат желаното съотношение."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Мащабиран размер:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -896,7 +896,7 @@ msgstr ""
 "Истинските размери на дисплея ще се различават, ако съотношението на "
 "размерите на пикселите не е 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -906,88 +906,88 @@ msgstr ""
 "Истинските размери на дисплея ще се различават, ако съотношението на "
 "размерите на пикселите не е 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Оптимален размер"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 "Използвай най-високата разделителна способност, позволена от настройките по-"
 "горе."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Позволи преоразмеряване нагоре"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Ако не е избрано, оразмерените размери ще бъдат ограничени до размерите на "
 "източника."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Разделителна способност и мащабиране</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Запълни:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Добави рамка около видеото"
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Запълване отляво"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Запълване отгоре"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Запълване отдолу"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Запълване отдясно"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Цвят:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Цвят на добавената рамка около видеото."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Рамки</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Промяната на размера на екрана ще разтегне видеото."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Финални размери</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Размери"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Обратно кадриране:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -999,7 +999,7 @@ msgstr ""
 "Кадрирането е процес, който коригира кадровите честоти на филм, който е "
 "24fps, към кадрови честоти на NTSC видео, което е 30fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1009,11 +1009,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Засичане на презредов образ:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1025,7 +1025,7 @@ msgstr ""
 "Ако е включен филтър за изглаждане на презредов образ, само кадрите, които "
 "този филтър намира за презредови, ще бъдат изгладени."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1037,11 +1037,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Изглаждане на презредов образ:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1055,7 +1055,7 @@ msgstr ""
 "интерполационни алгоритми.\n"
 "Филтърът за изглаждане на презредов образ е класически YADIF филтър.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1071,11 +1071,11 @@ msgstr ""
 "интерполационни алгоритми.\n"
 "Филтърът за изглаждане на презредов образ е класически YADIF филтър.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Филтър за поправяне на макроблокове:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1084,12 +1084,12 @@ msgstr ""
 "несъвършенства при компресиране.\n"
 "Ако източникът ви има макроблокове, този филтър може да ги изчисти."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Настройка:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1099,7 +1099,7 @@ msgstr ""
 "несъвършенства при компресиране.\n"
 "Ако източникът ви има макроблокове, този филтър може да ги изчисти."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1110,11 +1110,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Филтър за премахване на шум:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1128,7 +1128,7 @@ msgstr ""
 "Използването на този филтър върху подобни източници може да доведе до по-"
 "малки размери на файловете."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1143,7 +1143,7 @@ msgstr ""
 "Използването на този филтър върху подобни източници може да доведе до по-"
 "малки размери на файловете."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1154,11 +1154,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Филтър за изглаждане на наситеността:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1168,7 +1168,7 @@ msgstr ""
 "Съдържание от аналогови източници с по-ниска резолюция може да има полза от "
 "този филтър."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1179,11 +1179,11 @@ msgstr ""
 "Съдържание от аналогови източници с по-ниска резолюция може да има полза от "
 "този филтър."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Филтър за изостряне:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1191,7 +1191,7 @@ msgstr ""
 "Филтърът за изостряне подчертава ръбове и други\n"
 "високочестотни компоненти във видеото."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1200,39 +1200,39 @@ msgstr ""
 "Филтърът за изостряне подчертава ръбове и други\n"
 "високочестотни компоненти във видеото."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Цветово пространство:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Преобразувай цветовото пространство на източника."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Сива скала"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Ако е включено, премахни цветните компоненти от видеото."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Филтри"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Видео енкодер:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Налични видео енкодери."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Кадрова честота:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1244,19 +1244,19 @@ msgstr ""
 "\"Същата като източника\" е препоръчителна. Ако източника има променлива "
 "кадрова честота, 'Същата като източника' ще я запази."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr " Постоянна кадрова честота"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Наглася постоянна кадрова честота на изхода."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Максимална кадрова честота (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1268,11 +1268,11 @@ msgstr ""
 "\n"
 "ПКР не е съвместима с някои плеъри."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Променлива кадрова честота"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1282,7 +1282,7 @@ msgstr ""
 "\n"
 "ПКЧ не е съвместима с някои плеъри."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1311,15 +1311,15 @@ msgstr ""
 "Скалите на FFMpeg и Theora са по-линейни.\n"
 "Тези енкодери нямат режим без никакви загуби."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Постоянно качество:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Побитова скорост (кб/с):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1337,11 +1337,11 @@ msgstr ""
 "ограничите моментната побитова скорост, погледнете на x264 vbv-bufsize и vbv-"
 "maxrate настройките."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Кодиране с два цикъла"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1358,18 +1358,18 @@ msgstr ""
 "използва\n"
 "да се вземат решения за разпределение на побитовата скорост."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Турбо първи цикъл"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "По време на първия цикъл от кодиране с два цикъла използвай настройки, които "
 "да го забързат."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1389,7 +1389,7 @@ msgstr ""
 "понесете, защото с по-бавни настройки се получават по-добро качество или по-"
 "малки файлове."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1403,11 +1403,11 @@ msgstr ""
 "или да зададе характеристики за изходния файл. Промените ще се приложат\n"
 "след шаблона, но преди всички други параметри."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Бързо декодиране"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1418,11 +1418,11 @@ msgstr ""
 "Избери тази опция, ако устройството ти не успява да възпроизведе изхода "
 "(пропуснати кадри)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Нулево изчакване"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1439,11 +1439,11 @@ msgstr ""
 "Понеже HandBrake не е подходящ за излъчване на предавания на живо,\n"
 "тази настройка няма голяма стойност тук."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Профил:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1453,11 +1453,11 @@ msgstr ""
 "\n"
 "Презаписва всички останали настройки."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Ниво:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1467,11 +1467,11 @@ msgstr ""
 "\n"
 "Презаписва всички останали настройки."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Още настройки:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1481,45 +1481,45 @@ msgstr ""
 "\n"
 "Списък опции за енкодера разделени с точка и запетая."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Видео"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Добави"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Добави нови аудио настройки в списъка"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Добави всички"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Добави всички аудио пътечки в списъка"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Презареди всички аудио настройки от тези по подразбиране"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Списък с пътечки"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Поведение на селекция:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Избери кои аудио пътечки от медийния източник да бъдат използвани."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1529,23 +1529,23 @@ msgstr ""
 "Пътечките, пасващи на тези езици, ще бъдат избрани, използвайки избраното "
 "поведение на селекция."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Премахни"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Налични езици"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Избрани езици"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Използвай само първия енкодер за второстепенно аудио"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1555,15 +1555,15 @@ msgstr ""
 "Всички други второстепенни изходни аудио пътечки ще бъдат кодирани само с "
 "първия енкодер."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Автоматично подаване:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1573,11 +1573,11 @@ msgstr ""
 "Това позволява подаване на MP2 да бъде избрано когато автоматично подаване е "
 "включено."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1587,11 +1587,11 @@ msgstr ""
 "Това позволява подаване на MP3 да бъде избрано когато автоматично подаване е "
 "включено."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1601,11 +1601,11 @@ msgstr ""
 "Това позволява подаване на AC-3 да бъде избрано когато автоматично подаване "
 "е включено."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1615,11 +1615,11 @@ msgstr ""
 "Това позволява подаване на ЕAC-3 да бъде избрано когато автоматично подаване "
 "е включено."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1629,11 +1629,11 @@ msgstr ""
 "Това позволява подаване на DTS да бъде избрано когато автоматично подаване е "
 "включено."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1643,11 +1643,11 @@ msgstr ""
 "Това позволява подаване на DTS-HD да бъде избрано когато автоматично "
 "подаване е включено."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1657,11 +1657,11 @@ msgstr ""
 "Това позволява подаване на TrueHD да бъде избрано когато автоматично "
 "подаване е включено."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1671,11 +1671,11 @@ msgstr ""
 "Това позволява подаване на FLAC да бъде избрано когато автоматично подаване "
 "е включено."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1685,11 +1685,11 @@ msgstr ""
 "Това позволява подаване на AAC да бъде избрано когато автоматично подаване е "
 "включено."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1699,11 +1699,11 @@ msgstr ""
 "Това позволява подаване на Opus да бъде избрано когато автоматично подаване "
 "е включено."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Резерва при подаване:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1711,60 +1711,60 @@ msgstr ""
 "Изберете аудио кодека, с който ще се кодира, когато не е налична подходяща "
 "пътечка за подаване на аудио."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Настройки на аудио енкодера:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "Всяка пътечка от източника ще бъде кодирана с избраните енкодери."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Енкодер"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Побитова скорост/Качество"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Смесване"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Честота на дискретизация"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Усилване"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Избор на пътечки"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Аудио"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Добави нови настройки за субтитри в списъка"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Добави всички пътечки за субтитри в списъка"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr " Сканиране за чуждо аудио"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1774,16 +1774,16 @@ msgstr ""
 "потенциални субтитри, които да дадат субтитри на\n"
 "чуждоезични сегменти от аудиото."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Презареди всички настройки за субтитри от тези по подразбиране"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 "Избери кои пътечки за субтитри от медийния източник да бъдат използвани."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1801,15 +1801,15 @@ msgstr ""
 "използван\n"
 "за определяне на настройки за селекция субтитри, когато няма чуждо аудио."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Предпочитан език: Няма"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Добави цикъл на сканиране за чуждо аудио"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1825,11 +1825,11 @@ msgstr ""
 "\n"
 "Тази опция изисква да бъде зададен език в списъка на избрани езици."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Добави пътечка за субтитри, ако аудиото по подразбиране е чуждо"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1841,11 +1841,11 @@ msgstr ""
 "\n"
 "Тази настройка изисква език да е избран в списъка \"Избрани езици\"."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Добави затворени надписи, когато са налични"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1853,11 +1853,11 @@ msgstr ""
 "Затворените надписи са текстови субтитри, които могат да се добавят във "
 "всеки контейнер като пътечка за субтитри."
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Поведение при вграждане*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1873,15 +1873,15 @@ msgstr ""
 "Само една пътечка за субтитри може да се вгради! Понеже може да има "
 "конфликти, само първата се вгражда."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Вграждане за неспособни плеъри*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD субтитри"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1899,11 +1899,11 @@ msgstr ""
 "Само една пътечка за субтири може да се вгради! Понеже може да има "
 "конфликти, само първата се вгражда."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray субтитри"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1921,7 +1921,7 @@ msgstr ""
 "Само една пътечка за субтири може да се вгради! Понеже може да има "
 "конфликти, само първата се вгражда."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1929,7 +1929,7 @@ msgstr ""
 "<small>* Само една от по-горните пътечки с вграждане на субтитри ще се "
 "приложи, започвайки от най-горната.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1937,111 +1937,111 @@ msgstr ""
 "Само една пътечка за субтитри може да се вгради! Понеже могат да се случат "
 "конфликти, първата се избира."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Субтитри"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Маркери на глави"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Добави маркери на глави в изходния файл."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Глави"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Глави"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Индекс"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Продължителност"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Заглавие"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Глави"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Актьори:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Режисьор:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Дата на излизане:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Коментари:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Жанр:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Описание:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Сюжет:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Тагове"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Запиши като:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Изходно име на файла за кодирането."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Към:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Изходна директория за кодирането."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Изходна директория"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr "Добави няколко заглавия"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2049,52 +2049,52 @@ msgstr "Добави няколко заглавия"
 msgid "Cancel"
 msgstr "Отмени"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Избери всички"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Маркирай всички заглавия за добавяне на опашката"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Изчисти всички"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Размаркирай всички заглавия"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Изходни файловете са наред. Не са засечени дубликати."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Настройки"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Автоматично проверявай за актуализации"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Действие по подразбиране когато всички кодирания завършат"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Използване на автоматично именуване (използва променено име на източника)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "Създава файл с изходно име от името на източника или етикета на дяла"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Шаблон за автоматично именуване"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2104,25 +2104,25 @@ msgstr ""
 "Налични опции: {source-path} {source} {title}  {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 "Използване на файлово разширение (.m4v) подходящо за iPod/iTunes "
 "възпроизвеждане на MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Брой визуализации"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Филтриране на кратки DVD и Blu-ray заглавия (секунди)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Изчисти завършените елементи на опашката след завършване на кодирането"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2133,52 +2133,52 @@ msgstr ""
 "Изберете това, ако искате опашката сама да се разчиства, като изтрива "
 "завршените задачи."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr " Основни"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr "Избор на персонализирана директория за временни файлове на Handbrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2205,64 +2205,64 @@ msgstr ""
 "памет и може да е твърде малка за неща като файлът за информация на кодиране "
 "в два цикъла."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Временна директория"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Постоянно качество дробна грануларност"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Използване на dvdnav (вместо libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Следене на свободното пространство в изходния диск"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Паузиране на кодирането ако дисковото пространства падне под дадена граница"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Ограничение в МБ"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Сложи индивидуални дневници в същото място като филма"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Ниво на подробност на дневника на дейностите:"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Дълголетие на дневника на дейностите"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Смаляване на висококачествени визуализации"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Автоматично сканирай DVD, когато бъде заредено"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Сканира DVD-то, когато нов диск бъде зареден"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Размер на шрифта в прозореца на дейностите"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Използвай еднакви настройки за всички заглавия в група"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2276,11 +2276,11 @@ msgstr ""
 "Махнете отметката, ако искате да позволите настройките на всяко заглавие да "
 "бъдат променяни независимо."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr "Покажи визуализация в раздела Обобщение"
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
@@ -2288,75 +2288,75 @@ msgstr ""
 "Махнете отметката, ако искате да скриете визуализацията в раздела Обобщение "
 "за допълнителна поверителност."
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Позволи корекции"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Позволи HandBrake For Dummies"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Разширени"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr "Преименувай шаблон"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Преименувай шаблон</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Име:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Описание</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr "Запази шаблон"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Категория:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Избоерете категория, в която този шаблон ще се показва."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Име на категория:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Име на шаблон:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Шаблон по подразбиране"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Направи това шаблона по подразбиране, когато Handbrake се пусне"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Размери</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrake визуализация"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Избор на кадрите за визуализация."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2364,77 +2364,77 @@ msgstr ""
 "Вграждане и възпроизвеждане на кратка част от видеото, започвайки от "
 "текущото място на визуализацията."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr "Цъкни, за да включиш режим на пълен екран"
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Продължителност:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Нагласяне на продължителността на визуализацията в реално време."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Покажи изрязване"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Покажи изрязаната част на визуализацията"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Разделителната способност на източника"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 "Върни прозореца за визуализация към разделителната способност на видеото "
 "източник"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr "Редактирай субтитри"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Импортирай SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Позволи на настройките да импортират файл за субтитри тип SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Импортирай SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Позволи на настройките да импортират файл за субтитри тип SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Списък с вградени субтитри"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Позволи на настройките да избират вградени субтитри"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Пътечка източник"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Списък с пътечки за субтитри, налични от Вашия източник."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Име на пътечка:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2444,23 +2444,23 @@ msgstr ""
 "\n"
 "Плеърите може да го използват в списъка за избор на субтитри."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Език"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Кодиращ модел"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Файл:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Отместване (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2468,7 +2468,7 @@ msgstr ""
 "Задайте езика на субтитрите.\n"
 "Тази стойност ще се ползва от плеърите в менютата за субтитри."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2482,27 +2482,27 @@ msgstr ""
 "Преобразуваме кодиращия модел към UTF-8.\n"
 "Кодиращият модел на източника е нужен за извршването на това преобразуване."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Изберете SRT файла за импортиране."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Импортирай файл"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "Настройване на отместването в милисекунди между видео и SRT времената."
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Само принудителни субтитри"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Вграждане във видео"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2510,19 +2510,19 @@ msgstr ""
 "Рендирай субтитрите върху видеото.\n"
 "Субтитрите ще бъдат част от видеото и няма да могат да бъдат скрити."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Задай пътечка по подразбиране"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr "Редактирай аудио пътечка"
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Списък с аудио пътечки, налични от Вашия източник."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2532,15 +2532,15 @@ msgstr ""
 "\n"
 "Плеърите може да го използват в списъка за избор на аудио."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Микс"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Честота на дискретизация"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2558,31 +2558,31 @@ msgstr ""
 "DRC позволява да 'компресирате' обхвата, като правите шумните звуци по-тихи "
 "и тихите по-шумни."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Задайте аудио кодека, с който ще се кодира на тази пътечка."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Побитова честота"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Включване на настройки за побитова честота"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Качество"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Включване на настройки за качество"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Задайте побитовата честота, с която ще се кодира на тази пътечка."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2590,19 +2590,19 @@ msgstr ""
 "<b>Качество:</b> За изходни кодеци, които го поддържат. Настройва качеството "
 "на изходния файл."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Наглася смесването на изходната аудио пътечка."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Наглася честотата на дискретизация на изходната аудио пътечка."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2611,40 +2611,40 @@ msgstr ""
 "пътечка."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Изключено"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr "Актуализатор на HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Прескочи тази версия"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Напомни ми по-късно"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Налична е нова версия на HandBrake!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx сега е наличен (Вие имате yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Бележки по новата версия</b>"
 
@@ -2789,7 +2789,7 @@ msgstr "Засечени DVD устройства:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Сканиране ..."
 
@@ -2802,90 +2802,119 @@ msgstr "Спри сканирането"
 msgid "Single Title"
 msgstr "Отвори едно _заглавие"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr "FPS"
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Аудио пътечка"
 msgstr[1] "Аудио пътечки"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Пътечка за субтитри"
 msgstr[1] "Пътечки за субтитри"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr "CFR"
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr "PFR"
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr "VFR"
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] "+ още %d аудио пътечка"
 msgstr[1] "+ още %d аудио пътечки"
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Само принудително"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", вграден"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", по подразбиране"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "+ още %d пътечка за субтитри"
 msgstr[1] "+ още %dпътечки за субтитри"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr "хранилище"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr "екран"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr "Съотношение на пикселите:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr "Съотношение на страните на екрана"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Не е открито заглавие"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Ново видео"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2896,132 +2925,132 @@ msgstr ""
 "\n"
 "%s в %d секунди ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%s Филмът Ви ще бъде загубен, ако не продължите кодирането."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Отмени настоящо и спри"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Отмени настоящо, започни следващо"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Завърши настоящо и спри"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Продължи кодирането"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d чакащо кодиране"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d чакащи кодирания"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "задача %d от %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "цикъл %d (сканиране на субтитри) от %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "цикъл %d от %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Кодиране: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dч%02dм%02dс)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Кодиране: %s%s%.2f %% (ETA %02dч%02dм%02dс)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Кодиране: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Търсене на начално време,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Сканиране на заглавие %d от %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Сканиране на заглавие %d от %d визуализация %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "На пауза"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Кодирането е готово!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Кодирането е отменено."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Кодирането се провали."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Мултиплексиране: Може да отнеме известно време..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s сега е наличен (Вие имате %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Кодирането завърши"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Оставете коктейла, Вашата опашка в HandBrake е готова!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Кодирането ви е завършено."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Изход от HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Заспиване на компютъра"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Изключване на компютъра"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 #, fuzzy
 msgid "All Files"

--- a/gtk/po/ca.po
+++ b/gtk/po/ca.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Pere Orga <pere@orga.cat>, 2022\n"
 "Language-Team: Catalan (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "Valors _predefinits"
 msgid "Set De_fault"
 msgstr "Estableix per _defecte"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "De_sa"
 
@@ -114,7 +114,7 @@ msgstr "De_sa"
 msgid "Save _As"
 msgstr "_Anomena i desa"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Canvia el nom"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Enregistrat</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Predeterminat</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -364,7 +364,7 @@ msgstr "0 tasques pendents"
 msgid "Start Encoding"
 msgstr "Inicia la codificació"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Inicia"
@@ -383,7 +383,7 @@ msgstr "Pausa"
 msgid "Options"
 msgstr "Opcions"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "En acabar:"
 
@@ -404,8 +404,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Edita"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Valors predefinits:"
 
@@ -413,7 +413,7 @@ msgstr "Valors predefinits:"
 msgid "Source:"
 msgstr "Origen:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Títol:"
 
@@ -437,7 +437,7 @@ msgstr "Àudio:"
 msgid "Subtitles:"
 msgstr "Subtítols:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Resum"
 
@@ -532,11 +532,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Trieu l'origen del vídeo"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Obre l'origen"
 
@@ -568,7 +568,7 @@ msgstr "Previsualitza"
 msgid "Show Queue"
 msgstr "Mostra la cua"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Cua"
 
@@ -591,15 +591,15 @@ msgstr "<b>Origen:</b>"
 msgid "None"
 msgstr "Cap"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "S'està escanejant..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Títol:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -609,52 +609,52 @@ msgstr ""
 "Per defecte es tria el títol més llarg.\n"
 "En un DVD, aquest és sovint el títol principal."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angle:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Per a DVDs multiangle, seleccioneu l'angle desitjat a codificar."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Interval:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Interval del títol a codificar. Poden ser capítols, segons o fotogrames."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Set the first chapter to encode."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Set the last chapter to encode."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Valors predefinit:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Trieu uns valors predefinits"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modificat</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Torna a carregar"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -662,27 +662,27 @@ msgstr ""
 "Torna a carregar els paràmetres dels valors predefinits seleccionats.\n"
 "Es descartaran les modificacions."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Desa els nous valors predefinits"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Desa la configuració actual a un valor predefinit nou."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format de les pistes codificades a multiplexar."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimitzada pel web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -691,11 +691,11 @@ msgstr ""
 "Això fa que un reproductor pugui iniciar la reproducció abans de baixar tot "
 "el fitxer."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Alinea l'inici A/V"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -707,140 +707,140 @@ msgstr ""
 "sincronització de l'àudio i del vídeo en reproductors mal fets que no fan "
 "cas a les llistes d'edició MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Compatible amb l'iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Afegeix l'iPod Atom que necessiten alguns iPods més antics."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Metadades comunes del pas directe («passthru»)"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Copia les metadades de l'origen a la sortida."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Durada:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Pistes:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtres:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Mida:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Mida de l'emmagatzematge:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Mida de la pantalla:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Relació d'aspecte:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Dimensions de l'origen</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Capgirament:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Horitzontal ⇌"
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Inverteix el vídeo horitzontalment."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Rotació:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Gira el vídeo en sentit horari en increments de 90 graus."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Escapçat:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Com aplicar la configuració de l'escapçat."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Escapça a l'esquerra"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Escapça a dalt"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Escapça a baix"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Escapça a la dreta"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientació i escapçament</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Límit de resolució:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Límits de resolució per als formats de vídeo comuns."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Mida màxima:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Aquesta és l'amplada màxima a la qual s'emmagatzemarà el vídeo."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Aquesta és l'alçada màxima a la qual s'emmagatzemarà el vídeo."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamòrfic:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -856,11 +856,11 @@ msgstr ""
 "    Cap - Força la relació d'aspecte del píxel a 1:1.\n"
 "    Personalitzat - Introduïu una relació d'aspecte del píxel.</tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspecte del píxel:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -875,11 +875,11 @@ msgstr ""
 "Els reproductors escalaran la imatge per tal d'aconseguir l'aspecte "
 "especificat."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -892,11 +892,11 @@ msgstr ""
 "Els reproductors escalaran la imatge per tal d'aconseguir l'aspecte "
 "especificat."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Mida de l'escalat:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -906,7 +906,7 @@ msgstr ""
 "Les dimensions reals a visualitzar diferiran si la relació d'aspecte del "
 "píxel no és 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -916,86 +916,86 @@ msgstr ""
 "Les dimensions reals a visualitzar diferiran si la relació d'aspecte del "
 "píxel no és 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Mida òptima"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Usa la resolució més alta permesa per la configuració anterior."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Permet augmentar l'escalat"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Si no està habilitat, les dimensions escalades es limitaran a les dimensions "
 "d'origen."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Resolució i escalat</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Omple:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Afegeix una vora al voltant del vídeo."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Botó esquerre"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Botó superior"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Botó inferior"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Botó dret"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Color:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "El color de la vora afegit al voltant del vídeo."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Vores</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Canviar la mida de la pantalla estirarà el vídeo."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automàtic"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Dimensions finals</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1007,7 +1007,7 @@ msgstr ""
 "El telecining és un procés que ajusta la velocitat dels fotogrames de la "
 "pel·lícula de 24 fps a la velocitat de fotogrames de vídeo NTSC, de 30 fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1017,11 +1017,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Detecció de l'entrellaçat:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1033,7 +1033,7 @@ msgstr ""
 "Si s'habilita un filtre de desentrellaçat, només els fotogrames\n"
 "entrellaçats que trobi aquest filtre es desentrellaçaran."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1045,11 +1045,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Desentrellaçat:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1061,7 +1061,7 @@ msgstr ""
 "El filtre decomb suporta una varietat d'algorismes d'interpolació.\n"
 "El filtre de desentrellaçat és un desentrellaçador YADIF clàssic.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1075,11 +1075,11 @@ msgstr ""
 "El filtre decomb suporta una varietat d'algorismes d'interpolació.\n"
 "El filtre de desentrellaçat és un desentrellaçador YADIF clàssic.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtre Deblock:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1087,12 +1087,12 @@ msgstr ""
 "El filtre Deblock esborra els artefactes de compressió més típics.\n"
 "Si l'origen té blocs de compressió, aquest filtre pot ajudar a netejar-los."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Ajusta:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1101,7 +1101,7 @@ msgstr ""
 "El filtre Deblock esborra els artefactes de compressió més típics.\n"
 "Si l'origen té blocs de compressió, aquest filtre pot ajudar a netejar-los."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1112,11 +1112,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtre per treure el soroll:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1129,7 +1129,7 @@ msgstr ""
 "de comprimir.\n"
 "L'ús d'aquest filtre en aquests origens pot generar fitxer més petits."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1143,7 +1143,7 @@ msgstr ""
 "de comprimir.\n"
 "L'ús d'aquest filtre en aquests origens pot generar fitxer més petits."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1154,11 +1154,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Filtre de suavització de la crominància:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1168,7 +1168,7 @@ msgstr ""
 "El contingut d'un origen analògic de baixa resolució podria beneficiar-se "
 "d'aquest filtre."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1179,11 +1179,11 @@ msgstr ""
 "El contingut d'un origen analògic de baixa resolució podria beneficiar-se "
 "d'aquest filtre."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtre de nitidesa:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1191,7 +1191,7 @@ msgstr ""
 "El filtre de nitidesa millora les vores i altres\n"
 "components d'alta freqüència al vídeo."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1200,39 +1200,39 @@ msgstr ""
 "El filtre de nitidesa millora les vores i altres\n"
 "components d'alta freqüència al vídeo."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Espai de color:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Tradueix l'espai de color de l'origen."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Escala de grisos"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Si és actiu, filtra els components de color del vídeo."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codificador de vídeo:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codificadors de vídeo disponibles."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Velocitat dels fotogrames:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1244,19 +1244,19 @@ msgstr ""
 "Es recomana posar «igual que l'origen». Si el vídeo d'origen té\n"
 "una freqüència de fotogrames variable, «igual que l'origen» la mantindrà."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Velocitat dels fotogrames constant"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Fa que la velocitat dels fotogrames de la sortida sigui constant."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Velocitat dels fotogrames màxima (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1268,11 +1268,11 @@ msgstr ""
 "\n"
 "VFR no és compatible amb alguns reproductors."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Velocitat dels fotogrames variable"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1282,7 +1282,7 @@ msgstr ""
 "\n"
 "VFR no és compatible amb alguns reproductors."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1314,15 +1314,15 @@ msgstr ""
 "L'escala de FFmpeg i Theora és més lineal.\n"
 "Aquests codificadors no tenen un mode sense pèrdua."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualitat constant:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Taxa de bits (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1341,11 +1341,11 @@ msgstr ""
 "limitar la velocitat de bits instantània, mireu els paràmetres vbv-bufsize i "
 "vbv-maxrate de x264."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Codificació en 2 passades"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1361,18 +1361,18 @@ msgstr ""
 "s'utilitzen aquestes estadístiques per prendre decisions d'assignació de "
 "taxa de bits."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Primera passada en mode turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Durant la primera passada d'una codificació de 2 passades, utilitza "
 "paràmetres que ho facin anar més ràpid."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1393,7 +1393,7 @@ msgstr ""
 "ja que\n"
 "configuració més lenta donarà lloc a fitxers de millor qualitat o més petits."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1408,11 +1408,11 @@ msgstr ""
 "característiques del fitxer de sortida. Els canvis s'aplicaran després dels\n"
 "valors predefinits, però abans de tots els altres paràmetres."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Descodificació ràpida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1423,11 +1423,11 @@ msgstr ""
 "Establiu-ho si el dispositiu té dificultats per reproduir el vídeo (si ha de "
 "descartar fotogrames)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latència zero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1444,11 +1444,11 @@ msgstr ""
 "Com que el HandBrake no és adequat per a la transmissió en directe,\n"
 "aquest paràmetre no serveix de gaire aquí."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1458,11 +1458,11 @@ msgstr ""
 "\n"
 "Això sobreescriu la resta de paràmetres."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nivell:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1472,11 +1472,11 @@ msgstr ""
 "\n"
 "Això sobreescriu la resta de paràmetres."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Més paràmetres:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1486,46 +1486,46 @@ msgstr ""
 "\n"
 "Llista de les opcions del codificador, separades per dos punts."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Vídeo"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Afegeix"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Afegeix una nova configuració d'àudio a la llista"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Afegeix-ho tot"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Afegeix totes les pistes d'àudio a la llista"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 "Torna a carregar tots els paràmetres d'àudio dels valors predeterminats"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Llista de pistes"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Comportament de la selecció:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Trieu quines pistes d'àudio s'utilitzaran en el mitjà d'origen."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1535,23 +1535,23 @@ msgstr ""
 "Les pistes que coincideixin amb aquestes llengües se seleccionaran "
 "utilitzant el comportament de selecció escollit."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Suprimeix"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Idiomes disponibles"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Idiomes seleccionats"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Utilitza només el primer codificador per a l'àudio secundari"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1562,15 +1562,15 @@ msgstr ""
 "Totes les altres pistes de sortida d'àudio secundàries es codificaran només "
 "amb el primer codificador."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Pas directe automàtic:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1580,11 +1580,11 @@ msgstr ""
 "Permet seleccionar el pas directe de MP2 quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1594,11 +1594,11 @@ msgstr ""
 "Permet seleccionar el pas directe de MP3 quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1608,11 +1608,11 @@ msgstr ""
 "Permet seleccionar el pas directe de AC-3 quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1622,11 +1622,11 @@ msgstr ""
 "Permet seleccionar el pas directe d'EAC-3 quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1636,11 +1636,11 @@ msgstr ""
 "Permet seleccionar el pas directe de DTS quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1650,11 +1650,11 @@ msgstr ""
 "Permet seleccionar el pas directe de DTS-HD quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1664,11 +1664,11 @@ msgstr ""
 "Permet seleccionar el pas directe de TrueHD quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1678,11 +1678,11 @@ msgstr ""
 "Permet seleccionar el pas directe de FLAC quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1692,11 +1692,11 @@ msgstr ""
 "Permet seleccionar el pas directe d'AAC quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1706,11 +1706,11 @@ msgstr ""
 "Permet seleccionar el pas directe d'Opus quan el mode de pas directe "
 "automàtic és actiu."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Alternativa al pas directe:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1718,62 +1718,62 @@ msgstr ""
 "Estableix el còdec d'àudio amb el qual codificar quan no es pot trobar una "
 "pista adequada per al pas directe d'àudio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Configuració del codificador d'àudio:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Cada pista d'origen seleccionada es codificarà amb tots els codificadors "
 "seleccionats"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codificador"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Taxa de bits/Qualitat"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mescla"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Freqüència de mostreig"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Guany"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Selecció de pistes"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Àudio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Afegeix una nova configuració de subtítols a la llista"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Afegeix totes les pistes de subtítols a la llista"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Explora l'àudio estranger"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1783,16 +1783,16 @@ msgstr ""
 "cerca candidats de subtítols per als segments\n"
 "d'àudio que estan en una llengua estrangera."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 "Torna a carregar tots els paràmetres de subtítols dels valors predeterminats"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Trieu quines pistes de subtítols s'utilitzaran."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1812,15 +1812,15 @@ msgstr ""
 "per a determinar la configuració de la selecció de subtítols quan hi ha un "
 "àudio estranger."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Idioma preferit: cap"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Afegeix una passada d'exploració d'àudio estranger"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1837,11 +1837,11 @@ msgstr ""
 "Aquesta opció requereix que s'estableixi una llengua a la llista d'idiomes "
 "seleccionats."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Afegeix una pista de subtítols si l'àudio predeterminat és estranger"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1854,11 +1854,11 @@ msgstr ""
 "Aquesta opció requereix que s'estableixi un idioma a la llista d'idiomes "
 "seleccionats."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Afegeix subtítols Closed Caption quan estiguin disponibles"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1866,11 +1866,11 @@ msgstr ""
 "Els subtítols de text Closed Caption es poden afegir a qualsevol contenidor "
 "com a pista de subtítols opcional"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Comportament de l'enregistrament*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1886,15 +1886,15 @@ msgstr ""
 "Només es pot enregistrar una pista de subtítols. Com que poden produir-se "
 "conflictes, es triarà la primera."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Enregistrament per a reproductors deficients*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD Subtitles"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1912,11 +1912,11 @@ msgstr ""
 "Només es pot enregistrar una pista de subtítols. Com que poden produir-se "
 "conflictes, es triarà la primera."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray Subtitles"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1934,7 +1934,7 @@ msgstr ""
 "Només es pot enregistrar una pista de subtítols. Com que poden produir-se "
 "conflictes, es triarà la primera."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1942,7 +1942,7 @@ msgstr ""
 "<small>* Només s'aplicarà una de les opcions d'enregistrament de subtítols "
 "anteriors, començant pel principi.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1950,112 +1950,112 @@ msgstr ""
 "Només es pot enregistrar una pista de subtítols. Com que poden produir-se "
 "conflictes, es triarà la primera."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Subtítols"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcadors de capítol"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Afegeix marcadors de capítol al fitxer de sortida."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capítols"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capítols"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Índex"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Durada"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Títol"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capítols"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Actors:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Director:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Data de publicació:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Comentari:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Gènere:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Descripció:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Gràfic:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etiquetes"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Anomena i desa:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nom del fitxer de destinació per la codificació."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>A:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Directori de destinació per a la codificació."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Directori de destinació"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Afegeix-ne _múltiples"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2063,54 +2063,54 @@ msgstr "Afegeix-ne _múltiples"
 msgid "Cancel"
 msgstr "Cancel·la"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Selecciona-ho tot"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marca tots els títols per afegir a la cua"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Neteja-ho tot"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Desmarca tots els títols"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 "Els fitxers de destinació són correctes.  No s'ha detectat cap duplicat."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferències"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Comprova automàticament si hi ha actualitzacions"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Acció per defecte quan totes les codificacions s'hagin completat"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Usa el nom automàtic (usa el nom de l'origen modificat)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 "Crea el nom del fitxer de destinació a partir del nom del fitxer d'origen o "
 "l'etiqueta del volum"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Plantilla del nom automàtic"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2120,23 +2120,23 @@ msgstr ""
 "Opcions disponibles: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Usa l'extensió d'iPod/iTunes (.m4v) per els fitxers MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Nombre de previsualitzacions"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtra els títols curts de DVD i Blu-ray (segons)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Neteja els elements de cua completats en acabar la codificació"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2147,53 +2147,53 @@ msgstr ""
 "Marqueu-ho si voleu que la cua es netegi ella sola, suprimint les tasques "
 "completades."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "General"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 "Estableix un directori personalitzat per als fitxers temporals del HandBrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2220,65 +2220,65 @@ msgstr ""
 "física i pot ser massa petita per a coses com el fitxer d'estadístiques de 2 "
 "passades."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Directori temporal"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Granularitat fraccional de qualitat constant"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Usa dvdnav (en comptes de de libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Fes un seguiment de l'espai lliure al disc"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Pausa la codificació si l'espai lliure al disc cau per sota del límit"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Límit de MB"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Col·loca els registres individuals de les codificacions en la mateixa "
 "ubicació que la pel·lícula"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Nivell de detall del registre d'activitat"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Longevitat del registre d'activitats"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Fes la previsualització d'alta definició més petita"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Explora automàticament el DVD quan es carregui"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Explora el DVD cada vegada que es carregui un disc"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Mida de la lletra de la finestra d'activitat"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Utilitza la mateixa configuració per a tots els títols d'un lot"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2292,89 +2292,89 @@ msgstr ""
 "Desmarqueu aquesta opció si voleu permetre canviar la configuració de cada "
 "títol de forma independent."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Permet retocs"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Permet el HandBrake For Dummies"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avançat"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Valors predefinits del filtre per treure el soroll:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Canvia el nom dels predefinits</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nom:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descripció</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Desa els nous valors predefinits"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categoria:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Estableix la categoria on es mostraran els predefinits."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nom de la categoria:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nom dels valors predefinits:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Valors predefinits predeterminats"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 "Fes que aquest siguin els valors predefinits predeterminats quan s'iniciï el "
 "HandBrake"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensions</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Previsualització del HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Seleccioneu els fotogrames de previsualització."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2382,76 +2382,76 @@ msgstr ""
 "Codifica i reprodueix una seqüència curta de vídeo a partir de la posició "
 "actual de la vista prèvia."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Durada:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Estableix la durada de la vista prèvia en segons."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Mostra l'escapçat"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Mostra l'àrea retallada de la vista prèvia"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Resolució d'origen"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Reinicia la finestra de vista prèvia a la resolució del vídeo d'origen"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Subtítols"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importa SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Activa la configuració per importar un fitxer de subtítols SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importa SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Activa la configuració per a importar un fitxer de subtítols SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Llista de subtítols incrustats"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Activa la configuració per a seleccionar uns subtítols incrustats"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Pista d'origen"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Llista de pistes de subtítols disponibles a l'origen."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nom de la pista:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2461,23 +2461,23 @@ msgstr ""
 "\n"
 "Els reproductors poden utilitzar això a la llista de selecció de subtítols."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Idioma"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Codi de caràcters"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fitxer:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Desplaçament (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2485,7 +2485,7 @@ msgstr ""
 "Estableix la llengua d'aquest subtítol.\n"
 "Aquest valor serà utilitzat pels reproductors en els menús dels subtítols."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2501,29 +2501,29 @@ msgstr ""
 "El codi de caràcters de l'origen és necessari per a realitzar aquesta "
 "traducció."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Seleccioneu el fitxer SRT a importar."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importa un fitxer"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Ajusta el desplaçament en mil·lisegons entre les marques horàries del vídeo "
 "i del SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Només subtítols forçats"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Enregistra al vídeo"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2531,19 +2531,19 @@ msgstr ""
 "Renderitza el subtítol sobre el vídeo.\n"
 "El subtítol formarà part del vídeo i no es podrà desactivar."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Estableix la pista per defecte"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Llista de pistes d'àudio disponibles a l'origen."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2553,15 +2553,15 @@ msgstr ""
 "\n"
 "Els reproductors poden utilitzar això a la llista de selecció d'àudio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mescla"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Freqüència de mostreig"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2579,31 +2579,31 @@ msgstr ""
 "el DRC permet «comprimir» l'interval fent que els sons forts siguin més "
 "suaus i els suaus més forts."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Estableix el còdec d'àudio per a codificar aquesta pista."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Taxa de bits"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Activa la configuració de la taxa de bits"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualitat"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Habilita la configuració de qualitat"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Estableix la taxa de bits amb la qual codificar aquesta pista."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2611,19 +2611,19 @@ msgstr ""
 "<b>Qualitat:</b> Per als còdecs de sortida que ho admeten, ajusteu la "
 "qualitat de la sortida."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Estableix la mescla de la pista d'àudio de sortida."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Estableix la freqüència de mostreig de la pista d'àudio de sortida."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2632,41 +2632,41 @@ msgstr ""
 "de sortida."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Desactivat"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Omet aquesta versió"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Recordeu-m'ho més tard"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Hi ha disponible una nova versió de HandBrake.</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "El HandBrake xxx està disponible (teniu yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Notes de llançament</b>"
 
@@ -2812,7 +2812,7 @@ msgstr "Dispositius DVD detectats:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "S'està escanejant..."
 
@@ -2825,96 +2825,125 @@ msgstr "Atura l'escaneig"
 msgid "Single Title"
 msgstr "Obre un sol _títol"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Àudio"
 msgstr[1] "Àudio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Subtítols"
 msgstr[1] "Subtítols"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", només forçats"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", enregistrat"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", predeterminat"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "Pista de subtítols d'àudio extern"
 msgstr[1] "Pista de subtítols d'àudio extern"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 #, fuzzy
 msgid "storage"
 msgstr "Mida de l'emmagatzematge:"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 #, fuzzy
 msgid "display"
 msgstr "Mida de la pantalla:"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Relació d'aspecte:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "Relació d'aspecte:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "No s'ha trobat cap títol"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nou vídeo"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2925,134 +2954,134 @@ msgstr ""
 "\n"
 "%s en %d segons..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sLa vostra pel·lícula es perdrà si no continueu codificant."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Cancel·la l'actual i atura"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Cancel·la l'actual, comença el següent"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Finalitza l'actual, després atura"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continua codificant"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d codificació pendent"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d codificacions pendents"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "tasca %d de %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "passada %d (exploració de subtítols) de %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "passada %d de %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Codificació: %s%s%.2f %% (%.2f fps, %.2f fps de mitjana, %02dh%02dm%02ds "
 "esperat)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Codificació: %s%s%.2f %% (%02dh%02dm%02ds esperat)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Codificació: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "S'està cercant el temps d'inici, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "S'està escanejant el títol %d de %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "S'està escanejant el títol %d de %d, de la vista prèvia %d…"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "En pausa"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Ha finalitzat la codificació."
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "S'ha cancel·lat la codificació."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Ha fallat la codificació."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Multiplexant: pot trigar una estona..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "El HandBrake %s/%s ja està disponible (teniu %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "S'ha completat la codificació"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "La cua del HandBrake s'ha completat."
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "S'ha completat la codificació."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "S'està sortint del HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "S'està posant l'ordinador a dormir"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "S'està aturant l'ordinador"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/co.po
+++ b/gtk/po/co.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Patriccollu di Santa Maria è Sichè <Patrick.Santa-"
 "Maria@laposte.net>, 2022\n"
@@ -105,8 +105,8 @@ msgstr "_Prerigature"
 msgid "Set De_fault"
 msgstr "_Sceglie predefinitu"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Arregistrà"
 
@@ -114,7 +114,7 @@ msgstr "_Arregistrà"
 msgid "Save _As"
 msgstr "Arregistrà cù u _nome"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Rinumà"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Intarsiati</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Predefinitu</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -358,7 +358,7 @@ msgstr "0 travagli in attesa"
 msgid "Start Encoding"
 msgstr "Principià a cudificazione"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Principià"
@@ -377,7 +377,7 @@ msgstr "Pausa"
 msgid "Options"
 msgstr "Ozzioni"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Quandu hè compiu :"
 
@@ -397,8 +397,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Mudificà"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Prerigatura :"
 
@@ -406,7 +406,7 @@ msgstr "Prerigatura :"
 msgid "Source:"
 msgstr "Fonte :"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titulu :"
 
@@ -430,7 +430,7 @@ msgstr "Audio :"
 msgid "Subtitles:"
 msgstr "Sottutituli :"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Riassuntu"
 
@@ -525,11 +525,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Sceglie a video di fonte"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Apre a fonte"
 
@@ -561,7 +561,7 @@ msgstr "Fighjulata"
 msgid "Show Queue"
 msgstr "Affissà a fila d’attesa"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Fila d’attesa"
 
@@ -584,15 +584,15 @@ msgstr "<b>Fonte :</b>"
 msgid "None"
 msgstr "Nisunu"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Verificazione…"
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titulu :</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -602,53 +602,53 @@ msgstr ""
 "Osinnò, u titulu u più longu hè sceltu.\n"
 "Ghjè aspessu u titulu d’un DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angulu :</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Per i DVD cù anguli multiple, selezziunate l’anguli à cudificà."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Stesa :</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Stesa di u titulu à cudificà. Si pò agisce di capituli, di seconde, o di "
 "fiure."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Definisce u primu capitulu à cudificà."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Definisce l’ultimu capitulu à cudificà."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Prerigatura :</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Sceglie a prerigatura"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Mudificata</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Ricaricà"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -656,27 +656,27 @@ msgstr ""
 "Ricaricà e preferenze per a prerigatura attualmente selezziunata.\n"
 "I cambiamenti seranu persi."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Arregistrà a nova prerigatura"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Arregistrà e preferenze attuale in una nova prerigatura."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Furmatu :"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Furmatu ver di e traccie cudificate in mux."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Megliuratu per u Web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -686,11 +686,11 @@ msgstr ""
 "Què permette à u lettore di principià a lettura nanzu a fine di u "
 "scaricamentu."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Alineà u principiu di l’audio/video"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -701,140 +701,140 @@ msgstr ""
 "sincrunizazione audio/video per i lettori disfunziunendu chì ùn\n"
 "rispettanu micca e liste di mudificazioni MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Ghjestione di l’iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Aghjunghje l’iPod Atom richiestu per certi iPod anziani."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Cunservazione di i metadati cumuni"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Cupià i metadati da a fonte ver di a destinazione."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Durata :"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "oo:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Traccie :"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtri :"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Dimensione :"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Dimensione d’allucamentu :"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Dimensione d’affissera :"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Prupurzioni :"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Dimensioni di a fonte</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Rivultamentu :"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Orizuntale  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Rivultà orizuntalmente a video."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Rutazione :"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Rutazione di u filmu di 90 gradi in u sensu orariu."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Inquadratura :"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Cumu appiecà e preferenze d’inquadratura."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Runzicatura à manca"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Runzicatura insù"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Runzicatura inghjò"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Runzicatura à dritta"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientazione è inquadratura</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Cunfina di risuluzione :"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Cunfine di risuluzione per i furmati cumuni di video."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Dimensione massima :"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Ghjè a larghezza massima cù quella a video serà arregistrata."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Ghjè l’altezza massima cù quella a video serà arregistrata."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorficu :"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -851,11 +851,11 @@ msgstr ""
 "    Persunalizatu    - Stampittà un raportu larghezza/altezza di pixel.</"
 "tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspettu di fiura (pixel) :"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -871,11 +871,11 @@ msgstr ""
 "I lettori cambieranu e dimensioni di a fiura per currisponde à l’aspettu "
 "specificatu."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -889,11 +889,11 @@ msgstr ""
 "I lettori cambieranu e dimensioni di a fiura per currisponde à l’aspettu "
 "specificatu."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Dimensione à a scala :"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -903,7 +903,7 @@ msgstr ""
 "E vere dimensioni d’affisera seranu sfarente s’è u raportu larghezza/altezza "
 "ùn hè micca 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -913,86 +913,86 @@ msgstr ""
 "E vere dimensioni d’affisera seranu sfarente s’è u raportu larghezza/altezza "
 "ùn hè micca 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Dimensione ottimale"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Impiegà a risuluzione a più alta permessa da e preferenze insù."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Permette a culata in gamma"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "S’è l’ozzione hè disattivata, e dimensioni à a scala seranu cunfinate à "
 "quelle di a fonte."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Risuluzione è messa à a scala</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Riempiimentu :"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Aghjunghje un bordu à u giru di a video."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Riempiimentu à manca"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Riempiimentu à u principiu"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Riempiimentu à a fine"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Riempiimentu à diritta"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Culore :"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Culore di u bordu aghjuntu à u giru di a video."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Bordi</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "U cambiamentu di dimensione di l’affissera stinzerà a video."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Autumaticu"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Dimensioni finale</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensioni"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelesinema :"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1005,7 +1005,7 @@ msgstr ""
 "U telesinema hè u prucessu chì adatteghja a cadenza di fiura di filmi di 24 "
 "fps ver di quella di e video NTSC à 30 fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1015,11 +1015,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Avventata di l’intricciamentu :"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1031,7 +1031,7 @@ msgstr ""
 "S’è un filtru di disintricciamentu hè attivatu, solu e fiure scuperte da stu "
 "filtru cum’è essendu intricciate seranu disintricciate."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1043,11 +1043,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Disintricciamentu :"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1059,7 +1059,7 @@ msgstr ""
 "U filtru di dipettinera accetta cudificazioni numerose d’interpolazione.\n"
 "U filtru di disintricciament hè un disintricciatore YADIF classicu.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1073,11 +1073,11 @@ msgstr ""
 "U filtru di dipettinera accetta cudificazioni numerose d’interpolazione.\n"
 "U filtru di disintricciament hè un disintricciatore YADIF classicu.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtru di sblucchime :"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1087,12 +1087,12 @@ msgstr ""
 "S’è a vostra fonte fà vede certi effetti parassiti di bloccu, stu filtru pò "
 "aiutà à nettalli."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Rigatura :"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1103,7 +1103,7 @@ msgstr ""
 "S’è a vostra fonte fà vede certi effetti parassiti di bloccu, stu filtru pò "
 "aiutà à nettalli."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1114,11 +1114,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtru di riduzzione di trostu :"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1132,7 +1132,7 @@ msgstr ""
 "L’impiegu di stu filtru nant’à quelle fonti permette di riduce a dimensione "
 "di i schedarii."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1147,7 +1147,7 @@ msgstr ""
 "L’impiegu di stu filtru nant’à quelle fonti permette di riduce a dimensione "
 "di i schedarii."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1158,11 +1158,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Filtru d’allisciata cromatica :"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1171,7 +1171,7 @@ msgstr ""
 "culore.\n"
 "E fonti analogichi di risuluzione debule ponu prufittà di stu filtru."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1181,11 +1181,11 @@ msgstr ""
 "culore.\n"
 "E fonti analogichi di risuluzione debule ponu prufittà di stu filtru."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtru d’arrutata :"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1193,7 +1193,7 @@ msgstr ""
 "U filtru d’arrutata amendeghja i bordi è\n"
 "l’altri cumpunenti d’alta frequenza in u filmu."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1202,39 +1202,39 @@ msgstr ""
 "U filtru d’arrutata amendeghja i bordi è\n"
 "l’altri cumpunenti d’alta frequenza in u filmu."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Spaziu culorimetricu :"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Cunvertisce u spaziu culorimetricu di a fonte."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Scala di grisgiu"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Attivà st’ozzione per filtrà i cumpunenti di culore di u filmu."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Cudificatore video :"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Cudificatori video dispunibule."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Frequenza di fiure :"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1246,19 +1246,19 @@ msgstr ""
 "« Listessa chì a fonte » hè ricumandatu. S’è a vostra video di fonte hà una "
 "frequenza di fiure variabile, st’ozzione a preserverà."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Frequenza di fiure custente"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Attiveghja una frequenza di fiure custente in esciuta."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Frequenza di fiure di cresta (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1270,11 +1270,11 @@ msgstr ""
 "\n"
 "VFR ùn hè micca cumpatibile cù certi lettori."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Frequenza di fiure variabile (VFR)"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1284,7 +1284,7 @@ msgstr ""
 "\n"
 "VFR ùn hè micca cumpatibile cù certi lettori."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1313,15 +1313,15 @@ msgstr ""
 "A scala di FFMpeg è Theora hè più lineare.\n"
 "Sti cudificatori ùn anu micca di modu senza perdita."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualità custente :"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Flussu binariu (kbps) :    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1339,11 +1339,11 @@ msgstr ""
 "di limità u flussu istantaneu, fighjate e preferenze vbv-bufsize è vbv-"
 "maxrate di u x264."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Cudificazione à 2 passi"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1359,18 +1359,18 @@ msgstr ""
 "fà\n"
 "a scelta di l’allucamentu di u flussu."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Primu passu Turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Durante u primu passu d’una cudificazione à 2 passi, impiegate preferenze "
 "chì acceleranu u trattamentu."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1391,7 +1391,7 @@ msgstr ""
 "vo siate capace d’accettà, perchè preferenze più lente vi danu una\n"
 "più bella qualità o schedarii più chjuchi."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1405,11 +1405,11 @@ msgstr ""
 "o di e caratteristiche definite di u schedariu d’esciuta.  I cambiamenti\n"
 "seranu appiecati dopu a prerigatura ma nanzu tutti l’altre preferenze."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Discudificazione rapida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1420,11 +1420,11 @@ msgstr ""
 "Attivate st’ozzione s’è u vostru apparechju ùn leghje micca bè u schedariu "
 "d’esciuta (perdita di fiure)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Cumportu d’attesa à zeru"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1441,11 +1441,11 @@ msgstr ""
 "Cum’è HandBrake ùn hè micca adattatu à a diffusione da flussi\n"
 "in direttu, st’ozzione hè di pocu valore quì."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Prufilu :"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1455,11 +1455,11 @@ msgstr ""
 "\n"
 "Supraneghja tutte l’altre preferenze."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Livellu :"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1469,11 +1469,11 @@ msgstr ""
 "\n"
 "Supraneghja tutte l’altre preferenze."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Altre preferenze :"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1483,45 +1483,45 @@ msgstr ""
 "\n"
 "Lista d’ozzioni di u cudificatore staccate da dui punti."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Aghjunghje"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Aghjunghje nove preferenze audio à a lista"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Tuttu aghjunghje"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Aghjunghje tutte e traccie audio à a lista"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Ricaricà tutte e predefinizioni di e preferenze audio"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Lista di e traccie"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Cumpurtamentu di a selezzione :"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Sciglite in u media di fonte chì traccie audio à impiegà."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1531,23 +1531,23 @@ msgstr ""
 "E traccie currispundente à ste lingue seranu selezziunate secondu à u "
 "cumpurtamentu di selezzione."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Caccià"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Lingue dispunibule"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Lingue selezziunate"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Impiegà solu u primu cudificatore per a traccia audio secundaria"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1558,15 +1558,15 @@ msgstr ""
 "Tutte l’altre traccie audio secundarie d’esciuta seranu cudificate solu cù u "
 "primu cudificatore."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Ricopia autumatica :"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1577,11 +1577,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia MP2 quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1592,11 +1592,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia MP3 quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1607,11 +1607,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia AC-3 quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1622,11 +1622,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia EAC-3 quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1637,11 +1637,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia DTS quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1652,11 +1652,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia DTS-HD quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1667,11 +1667,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia TrueHD quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1682,11 +1682,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia FLAC quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1697,11 +1697,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia AAC quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1712,11 +1712,11 @@ msgstr ""
 "Què permette di selezziunà a ricopia Opus quandu l’ozzione di ricopia "
 "autumatica hè attivata."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "In casu di fiascu di a ricopia :"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1724,62 +1724,62 @@ msgstr ""
 "Definisce u cudecu audio à impiegà per a cudificazione quandu ùn si pò truvà "
 "una traccia cumpatibile per a ricopia audio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Preferenze di cudificazione audio :</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Ogni traccia di fonte selezziunata serà cudificata cù tutti i cudificatori "
 "selezziunati"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Cudificatore"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Flussu binariu/Qualità"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mischiera"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Frequenza di campiunariu"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Guadagnu"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Selezzione di traccia"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Aghjunghje nove preferenze di sottutitulu à a lista"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Aghjunghje tutte e traccie di sottutitulu à a lista"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Analisa di traccia audio straniera"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1789,15 +1789,15 @@ msgstr ""
 "cudificazione per circà sottutituli chì\n"
 "currispondenu à una scena in lingua straniera."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Ricaricà tutte e predefinizioni di e preferenze di sottutitulu"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Sciglite in u media di fonte chì traccie di sottutitulu à impiegà."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1816,15 +1816,15 @@ msgstr ""
 "minà e preferenze di selezzione di sottutitulu quandu ci hè audio in lingua "
 "straniera."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Lingua preferita : Nisuna"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Aghjunghje un passu d’analisa di traccia audio straniera"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1841,13 +1841,13 @@ msgstr ""
 "St'ozzione richiede chì una lingua sia definita in a lista di e lingue "
 "selezziunate."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 "Aghjunghje una traccia di sottutitulu s’è a lingua predefinita di l’audio hè "
 "straniera"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1860,11 +1860,11 @@ msgstr ""
 "St'ozzione richiede chì una lingua sia definita in a lista di e lingue "
 "selezziunate."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Aghjunghje e legende chjose (CC) s’elle sò dispunibule"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1872,11 +1872,11 @@ msgstr ""
 "E legende chjose sò sottutituli di testu chì ponu esse aghjunti à tuttu "
 "furmatu di cuntenidore tale una traccia di sottutituli incavalcati"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Cumpurtamentu d’intarsiatura* :"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1892,15 +1892,15 @@ msgstr ""
 "Solu una traccia di sottutitulu pò esse intarsiata ! In casu di cunflittu, "
 "ghjè a prima scelta chì supraneghja."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Intarsiatura per i lettori deficienti* :"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Sottutituli DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1918,11 +1918,11 @@ msgstr ""
 "Solu una traccia di sottutitulu pò esse intarsiata ! In casu di cunflittu, "
 "ghjè a prima scelta chì supraneghja."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Sottutituli Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1940,7 +1940,7 @@ msgstr ""
 "Solu una traccia di sottutitulu pò esse intarsiata ! In casu di cunflittu, "
 "ghjè a prima scelta chì supraneghja."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1948,7 +1948,7 @@ msgstr ""
 "<small>* Sola una di st’ozzioni d’intarsiatura di sottutitulu insù serà "
 "appiecata, principiendu da l’altu.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1956,111 +1956,111 @@ msgstr ""
 "Solu una traccia di sottutitulu pò esse intarsiata ! In casu di cunflittu, "
 "ghjè a prima scelta chì supraneghja."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Sottutituli"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcatori di capitulu"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Aghjunghje marcatori di capitulu à u schedariu d’esciuta."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capituli"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capituli"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Indice"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Durata"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titulu"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capituli"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Attori :"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Direttore :"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Data d’esciuta :"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Cummentu :"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Generu :"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Discrizzione :"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Scenariu :"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etichette"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Arregistrà cum’è :</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nome di schedariu di destinazione per a vostra cudificazione."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>In :</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Cartulare di destinazione per a vostra cudificazione."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Cartulare di destinazione"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr "Aghjunghje parechji tituli"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2068,53 +2068,53 @@ msgstr "Aghjunghje parechji tituli"
 msgid "Cancel"
 msgstr "Abbandunà"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Tuttu selezziunà"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marcà tutti i tituli per esse aghjunti à a fila d’attesa"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Tuttu viutà"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Caccià e marche da tutti i tituli"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "I schedarii di destinazione sò valevule.  Nisunu duppione trovu."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Cuntrollà autumaticamente i rinnovi"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Azzione predefinita quandu tutte e cudificazioni sò compie"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Impiegà a scelta autumatica di u nome (cù un nome di fonte mudificatu)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 "Creà u nome di u schedariu di destinazione da quellu di a fonte o da u nome "
 "di vulume"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Mudellu di a scelta autumatica di u nome"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2124,26 +2124,26 @@ msgstr ""
 "Ozzioni dispunibule : {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 "Impiegà un’estensione di schedariu cumpatibile iPod/iTunes (.m4v) per i MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Numeru di fighjulate"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtrazione di i tituli corti di DVD è Blu-ray (seconde)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 "Squassà l’elementi compii di a fila d’attesa quandu una cudificazione si "
 "pianta"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2154,53 +2154,53 @@ msgstr ""
 "Attivà st’ozzione per chì a fila d’attesa si vioti autumaticamente cacciendu "
 "i travagli compii."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Generale"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 "Definisce un cartulare persunalizatu per i schedarii timpurarii d’HandBrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2227,68 +2227,68 @@ msgstr ""
 "è què puderia esse troppu chjuca per certi schedarii cum’è quellu schedariu "
 "di statistiche d’una cudificazione à 2 passi."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Cartulare timpurariu"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Granularità frazziunale di qualità custente"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Impiegà dvdnav (piuttostu chì libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Cuttighjà u spaziu liberu di u discu di destinazione"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Interrompe a cudificazione s’è u spaziu liberu di u discu fala sottu una "
 "limita"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Limita in Mo"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Piazzà i ghjurnali di messaghji di cudificazione in u listessu locu chì u "
 "filmu"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Livellu di verbusità di u ghjurnale d’attività"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Durata di vita di u ghjurnale d’attività"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Riduce l’alta definizione di e fighjulate"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Analizà autumaticamente u DVD à u so caricamentu"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Analisa di u DVD quandu un discu hè caricatu"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Dimensione di a grafia di a finestra d’attività"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 "Impiegà e listesse preferenze per tutti i tituli in un trattamentu da lottu"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2302,11 +2302,11 @@ msgstr ""
 "Disattivatela per permette u cambiamentu di e preferenze d’ogni titulu "
 "indipendentemente."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr "Affissà e fighjulate nant’à l’unghjetta Riassuntu"
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
@@ -2314,75 +2314,75 @@ msgstr ""
 "Disattivate st’ozzione s’è vo vulete piattà e fighjulate di e video nant’à "
 "l’unghjetta Riassuntu per raghjoni di cunfidenzialità."
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Permette l’adattazioni"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Permette HandBrake per i principianti"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Espertu"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr "Rinuminà a prerigatura"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Prerigatura di cambiamentu di nome</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nome :"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Discrizzione</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr "Arregistrà a prerigatura"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categuria :"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Definisce a categuria sottu quella sta prerigatura serà affissata."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nome di a categuria :"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nome di a prerigatura :"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Prerigatura predefinita"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Definisce sta prerigatura cum’è predefinita quandu HandBrake si lancia"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensioni</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Fighjulata HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Selezziunà e sequenze di a fighjulata."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2390,75 +2390,75 @@ msgstr ""
 "Cudificà è leghje una corta sequenza di video principiendu à a pusizione "
 "attuale di fighjulata."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr "Cliccu per attivà o disattivà u modu di screnu sanu"
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Durata :</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Definisce a durata in seconde di a fighjulata diretta."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Affissà a runzicatura"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Affissà l’area di runzicatura nant’à a fighjulata"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Risuluzione di a fonte"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Reinizià a finestra di fighjulata à a risuluzione di a video di fonte"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr "Mudificà i sottutituli"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Impurtà SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Attivà e preferenze per l’impurtazione di schedarii di sottutitulu SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Impurtà SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Attivà e preferenze per l’impurtazione di schedarii di sottutitulu SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Lista di i sottutituli incurpurati"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Attivà e preferenze per selezziunà i sottutituli incurpurati"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Traccia di fonte"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lista di e traccie di sottutitulu dispunibule per a vostra fonte."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nome di a traccia :"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2468,23 +2468,23 @@ msgstr ""
 "\n"
 "I lettori ponu impiegallu in a lista di selezzione di sottutitulu."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Lingua"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Codice di caratteru"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Schedariu :"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Staccamentu (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2492,7 +2492,7 @@ msgstr ""
 "Definisce a lingua di stu sottutitulu.\n"
 "Stu valore serà impiegatu da i lettori in u listinu di i sottutituli."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2507,28 +2507,28 @@ msgstr ""
 "Traducemu u codice di caratteru in UTF-8.\n"
 "Avemu bisognu di u codice di caratteru di a fonte per fà sta traduzzione."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Selezziunà u schedariu SRT à impurtà."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Impurtà u schedariu"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Adattà u staccamentu in milliseconde trà e stampiglie di video è di SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Solu sottutituli sfurzati"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Intarsià in a video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2536,19 +2536,19 @@ msgstr ""
 "Affissà i sottutituli sopra a video.\n"
 "I sottutituli facenu parte di a video è ùn pudenu micca esse disattivati."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Sceglie a traccia predefinita"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr "Mudificà a traccia audio"
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lista di e traccie di sottutitulu dispunibule per a vostra fonte."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2558,15 +2558,15 @@ msgstr ""
 "\n"
 "I lettori ponu impiegallu in a lista di selezzione audio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mischju"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Frequenza di campiunariu"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2584,31 +2584,31 @@ msgstr ""
 "vi permette di « cumprime » a stesa addulciscendu i soni forti è rinfurzendu "
 "i soni debule."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Definisce u cudecu audio per cudificà sta traccia."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Flussu binariu"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Attivà a preferenza di flussu binariu"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualità"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Attivà a preferenza di qualità"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Definisce u flussu binariu per cudificà sta traccia."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2616,19 +2616,19 @@ msgstr ""
 "<b>Qualità :</b> Per i cudechi d’esciuta chì l’accettanu, què permette "
 "d’accumudà a qualità di l’esciuta."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Definisce a mischiera di a traccia audio d’esciuta."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Definisce a frequenza di campiunariu di a traccia audio d’esciuta."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2637,40 +2637,40 @@ msgstr ""
 "a traccia audio d’esciuta."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0 dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Nò"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr "Rinnuvadore d’HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Ignurà sta versione"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Rammintatemi un altra volta"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Una nova versione d’HandBrake hè dispunibule !</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx hè dispunibule avà (avete yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Annutazioni di versione</b>"
 
@@ -2816,7 +2816,7 @@ msgstr "Lettori DVD scuperti :"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Esplurazione…"
 
@@ -2829,90 +2829,119 @@ msgstr "Piantà l’esplurazione"
 msgid "Single Title"
 msgstr "Apre u _titulu solu"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr "FPS"
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Traccia audio"
 msgstr[1] "Traccie audio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Traccia di sottutitulu"
 msgstr[1] "Traccie di sottutitulu"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr "CFR"
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr "PFR"
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr "VFR"
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] "+ %d traccia audio di più"
 msgstr[1] "+ %d traccie audio di più"
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", sfurzatu solu"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", Intarsiatu"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", predefinitu"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "+ %d traccia di sottutitulu di più"
 msgstr[1] "+ %d traccie di sottutitulu di più"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr "allucamentu"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr "affissera"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr "Prupurzioni di pixel"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr "Prupurzioni d’affissera"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nisunu titulu trovu"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nova video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2923,134 +2952,134 @@ msgstr ""
 "\n"
 "%s in %d seconde…"
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 "%sU vostru filmu serà persu s’è vo ùn cuntinuate micca a cudificazione."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Abbandunà l’attuale è piantà"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Abbandunà l’attuale, principià u seguente"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Compie l’attuale eppò piantà"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Cuntinuà a cudificazione"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d cudificazione in attesa"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d cudificazioni in attesa"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "travagliu %d nant’à %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "passu %d (analisa di i sottutituli) nant’à %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "passu %d nant’à %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Cudificazione : %s%s%.2f %% (%.2f fps, mez. %.2f fps, tras. %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Cudificazione : %s%s%.2f %% (tras. %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Cudificazione : %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Ricerca di l’ora di principiu, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Esplurazione di u titulu %d nant’à %d…"
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Esplurazione di u titulu %d nant’à %d fighjulata %d…"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Cudificazione compia !"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Cudificazione abbandunata."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Cudificazione fiascata."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Mischiu multiple : Què pò piglià qualchì tempu…"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s hè dispunibule avà (avete %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Cudificazione compia"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Punite stu bichjeru ; A vostra fila d’attesa HandBrake hè compia !"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "A vostra cudificazione hè compia."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Esciuta d’Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Messa in veghja di l’urdinatore"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Piantata di l’urdinatore"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 #, fuzzy
 msgid "All Files"

--- a/gtk/po/cs.po
+++ b/gtk/po/cs.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Stanislav Horáček <stanislav.horacek@gmail.com>, 2022\n"
 "Language-Team: Czech (https://www.transifex.com/HandBrakeProject/teams/92423/"
@@ -106,8 +106,8 @@ msgstr "_Přednastavení"
 msgid "Set De_fault"
 msgstr "Nastavit _výchozí"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Uložit"
 
@@ -115,7 +115,7 @@ msgstr "_Uložit"
 msgid "Save _As"
 msgstr "Uložit _jako"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Přejmenovat"
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Vloženo</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Výchozí</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -364,7 +364,7 @@ msgstr "0 čekajících úkolů"
 msgid "Start Encoding"
 msgstr "Spustit kódování"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Spustit"
@@ -383,7 +383,7 @@ msgstr "Pozastavit"
 msgid "Options"
 msgstr "Možnosti"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Při dokončení:"
 
@@ -404,8 +404,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Upravit"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Přednastavení:"
 
@@ -413,7 +413,7 @@ msgstr "Přednastavení:"
 msgid "Source:"
 msgstr "Zdroj:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Název:"
 
@@ -437,7 +437,7 @@ msgstr "Audio:"
 msgid "Subtitles:"
 msgstr "Titulky:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Shrnutí"
 
@@ -519,11 +519,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Vybrat zdroj obrazu"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Otevřít zdroj"
 
@@ -555,7 +555,7 @@ msgstr "Náhled"
 msgid "Show Queue"
 msgstr "Ukázat řadu"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Řada"
 
@@ -578,15 +578,15 @@ msgstr "<b>Zdroj:</b>"
 msgid "None"
 msgstr "Žádný"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Prohledává se..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Název:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -596,52 +596,52 @@ msgstr ""
 "Ve výchozím nastavení je vybrán nejdelší titul.\n"
 "To je často hlavní titul DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Úhel:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Pro víceúhlová DVD, vyberte požadovaný úhel k zakódování."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Rozsah:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Rozsah titulu k zakódování. Můžou to být kapitoly, sekundy nebo snímky."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Nastavit první kapitolu k zakódování."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Nastavit poslední kapitolu k zakódování."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Přednastavení:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Vybra přednastavení"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Změněno</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Nahrát znovu"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -649,27 +649,27 @@ msgstr ""
 "Nahrát znovu nastavení pro nyní vybrané přednastavení.\n"
 "Změny budou zahozeny."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Uložit nové přednastavení"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Uložit nynější nastavení do nového přednastavení"
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formát:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formátovat do mux zakódovaných stop."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Vyladěno pro internet"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -678,151 +678,151 @@ msgstr ""
 "To přehrávači umožní začít přehrávat před dokončením stahování celého "
 "souboru."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Zarovnat začátek zvuku/obrazu"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Podpora pro iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Přidat iPod Atom, jenž je potřeba některými staršími zařízeními iPod."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Doba trvání:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Stopy:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtry:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Velikost:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Poměr stran:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Rozměry zdroje</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Překlopení:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Vodorovné  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Překlopit video vodorovně."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Otočení:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Otáčet obraz po směru hodinových ručiček v 90° krocích."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Oříznutí:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Jak použít oříznutí."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Oříznutí vlevo"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Oříznutí nahoře"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Oříznutí dole"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Oříznutí vpravo"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientace a oříznutí</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Limit rozlišení:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Limity rozlišení pro běžné formáty videa."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Maximální velikost:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Jedná se o maximální šířku, s níž bude video uloženo."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Jedná se o maximální výšku, s níž bude video uloženo."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Pokřivené:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -832,11 +832,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Strana obrazového bodu:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -850,11 +850,11 @@ msgstr ""
 "tvary.\n"
 "Přehrávače změní velikost obrázku tak, aby dosáhly stanovené stránky."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -866,11 +866,11 @@ msgstr ""
 "obdélníkové tvary.\n"
 "Přehrávače změní velikost obrázku tak, aby dosáhly stanovené stránky."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Škálovaná velikost:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -880,7 +880,7 @@ msgstr ""
 "Skutečné rozměry zobrazení se budou lišit, pokud poměr strany\n"
 "obrazového bodu není 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -890,84 +890,84 @@ msgstr ""
 "Skutečné rozměry zobrazení se budou lišit, pokud poměr strany\n"
 "obrazového bodu není 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Optimální velikost"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Použít nejvyšší rozlišení povolené ve výše uvedeném nastavení."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr "Není-li povoleno, škálované rozměry budou omezeny rozměry zdroje."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Rozlišení a škálování</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Výplň:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Přidat ohraničení okolo videa."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Levý okraj"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Horní okraj"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Dolní okraj"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Pravý okraj"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Barva:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Barva ohraničení okolo videa."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Ohraničení</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automaticky"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Výsledné rozměry</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Rozměry"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Odstranit filmové snímání:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -981,7 +981,7 @@ msgstr ""
 "jsou 24 snímků za sekundu (SZS) na rychlosti snímkování obrazu NTSC, které "
 "jsou 30 SZS."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -991,11 +991,11 @@ msgstr ""
 "    \n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Zjištění prokládání:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1008,7 +1008,7 @@ msgstr ""
 "je prokládání odstraněno jen u snímků k proložení\n"
 "nalezených tímto filtrem."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1020,11 +1020,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Odstranění prokládání:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1036,7 +1036,7 @@ msgstr ""
 "Filtr na odstranění hřebenu podporuje celou řadu interpolačních algoritmů.\n"
 "Filtr na odstranění prokládání je klasický odstraňovač prokládání YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1051,11 +1051,11 @@ msgstr ""
 "Filtr na odstranění hřebenu podporuje celou řadu interpolačních algoritmů.\n"
 "Filtr na odstranění prokládání je klasický odstraňovač prokládání YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1064,12 +1064,12 @@ msgstr ""
 "Pokud se u vašeho zdroje projevuje blokovitost, tento filtr může pomoci s "
 "jejím odstraněním."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Naladění:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1079,18 +1079,18 @@ msgstr ""
 "Pokud se u vašeho zdroje projevuje blokovitost, tento filtr může pomoci s "
 "jejím odstraněním."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtr pro odstranění šumu:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1102,7 +1102,7 @@ msgstr ""
 "Zrnitost filmu a jiné typy vysokokmitočtového šumu je obtížné zkomprimovat.\n"
 "Použití tohoto filtru na tyto zdroje může vést k menším velikostem souborů."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1115,7 +1115,7 @@ msgstr ""
 "Zrnitost filmu a jiné typy vysokokmitočtového šumu je obtížné zkomprimovat.\n"
 "Použití tohoto filtru na tyto zdroje může vést k menším velikostem souborů."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1126,34 +1126,34 @@ msgstr ""
 "    \n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtr přiostření:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 "Ostřící filtrování vylepšuje okraje a další vysokokmitočtové složky v obrazu."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1161,39 +1161,39 @@ msgid ""
 msgstr ""
 "Ostřící filtrování vylepšuje okraje a další vysokokmitočtové složky v obrazu."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Odstíny šedi"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Je-li povoleno, filtrovat složky barvy mimo obraz."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Kodér obrazu:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Dostupné kodéry obrazu."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Rychlost snímkování:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1205,19 +1205,19 @@ msgstr ""
 "Doporučena je stejná, jakou má zdroj. Pokud má zdroj obrazu\n"
 "proměnlivou rychlost snímkování, volba Stejné jako zdroj ji zachová."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Stálá rychlost snímkování"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Povolí výstup se stálou rychlostí snímkování."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Nejvyšší rychlost snímkování (PromRS)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1228,11 +1228,11 @@ msgstr ""
 "rychlostí určenou nastavením rychlosti snímkování.\n"
 "Proměnlivá rychlost snímkování (PromRS) se neslučuje s některými přehrávači."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Proměnlivá rychlost snímkování"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1241,7 +1241,7 @@ msgstr ""
 "Povolí výstup s proměnlivou rychlostí snímkování.\n"
 "Proměnlivá rychlost snímkování (PromRS) se neslučuje s některými přehrávači."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1269,15 +1269,15 @@ msgstr ""
 "Měřítko u FFMpeg a Theory je více lineární.\n"
 "Tyto kodéry nemají bezztrátový režim."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Stálá jakost:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Datový tok (kb/s):  "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1294,11 +1294,11 @@ msgstr ""
 "Pokud okamžitý datový tok  potřebujete omezit, podívejte se na nastavení "
 "x264 vbv-bufsize a vbv-maxrate."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Dvouprůchodové kódování"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1313,18 +1313,18 @@ msgstr ""
 "shromažďovány statistiky o obrazu. Při druhém průchodu jsou tyto\n"
 "statistiky použity při rozhodování o rozvržení datového toku."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Rychlý první průchod"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Během prvního průchodu dvouprůchodového kódování použít nastavení, která "
 "věci dál urychlí."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1336,7 +1336,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1350,11 +1350,11 @@ msgstr ""
 "znaky výstupního souboru. Změny se použijí po přednastavení,\n"
 "ale přede všemi ostatními parametry."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Rychlé dekódování"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1365,11 +1365,11 @@ msgstr ""
 "Nastavte, pokud se vaše zařízení potýká s přehráváním výstupu (zahozené "
 "snímky)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Nulová prodleva"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1385,11 +1385,11 @@ msgstr ""
 "Protože HandBrake není vhodný pro přenos živých proudů,\n"
 "má toto nastavení zde malý význam."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1399,11 +1399,11 @@ msgstr ""
 "\n"
 "Potlačí všechna ostatní nastavení."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Úroveň:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1413,11 +1413,11 @@ msgstr ""
 "\n"
 "Potlačí všechna ostatní nastavení."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Další nastavení:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1427,193 +1427,193 @@ msgstr ""
 "\n"
 "Dvojtečkou oddělený seznam voleb pro kodér."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Obraz"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Přidat"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Přidat nové nastavení zvuku do seznamu"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Přidat vše"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Přidat všechny zvukové stopy do seznamu"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Nahrát znovu všechna nastavení zvuku z výchozích hodnot"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Seznam stop:"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Chování při výběru:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Vyberte, které zvukové stopy ze zdrojového nosiče záznamu se použijí."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Odstranit"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Dostupné jazyky"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Vybrané jazyky"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Použít pouze první kodér pro doplňkový zvuk"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Automatický průchod:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Nouzový passthru:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1621,77 +1621,77 @@ msgstr ""
 "Nastavit zvukový kodek, který se má použít při kódování, když nelze najít "
 "vhodnou stopu pro \"audio passthru\"."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Nastavení kódování zvuku:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Každá vybraná zdrojová stopa bude zakódována pomocí všech vybraných kodérů."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Kodér"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Datový tok/Jakost"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Závěrečné smíchání"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Vzorkovací kmitočet"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Zesílení"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Výběr stopy"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Zvuk"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Přidat nastavení pro nové titulky do seznamu"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Přidat všechny titulkové stopy do seznamu"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Prohlédnutí zvuku v cizím jazyce"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Nahrát znovu všechna nastavení titulků z výchozích hodnot"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 "Vyberte, které titulkové stopy ze zdrojového nosiče záznamu se použijí."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1708,15 +1708,15 @@ msgstr ""
 "První jazyk v tomto seznamu je vámi upřednostňovaný jazyk a použije se\n"
 "pro určení nastavení výběru titulků, když je dostupný cizí jazyk. "
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Upřednostňovaný jazyk: Žádný"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1726,11 +1726,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Přidat stopu titulků, pokud je výchozí zvuk v cizím jazyce"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1738,11 +1738,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Přidat skryté titulky, když jsou dostupné"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1750,11 +1750,11 @@ msgstr ""
 "Skryté titulky jsou textové titulky, které lze přidat do kteréhokoli "
 "kontejneru jako měkkou titulkovou stopu"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Chování zahořování*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1764,15 +1764,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Zahořování pro nedostatečné přehrávače*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Titulky DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1783,11 +1783,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Titulky Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1798,7 +1798,7 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1806,7 +1806,7 @@ msgstr ""
 "<small>* Pouze jedna z voleb pro vypálení titulků výše se použije, počínaje "
 "tou, co je nahoře.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1814,112 +1814,112 @@ msgstr ""
 "Do obrazu může být vypálena jen jedna titulková stopa! Aby nedošlo ke "
 "konfliktu, nejdříve vybraná stopa vyhrává."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Titulky"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Značky kapitol"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Přidat značky kapitol do výstupního souboru."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Číslo"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Doba trvání"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Název"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Herci:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Režisér:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Datum vydání:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Poznámka:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Žánr:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Popis:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Zápletka:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Značky"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Uložit jako:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Cílový souborový název pro zakódovaný soubor."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Do:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Cílový adresář pro zakódovaný soubor."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Cílový adresář"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Přidat _více"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1927,76 +1927,76 @@ msgstr "Přidat _více"
 msgid "Cancel"
 msgstr "Zrušit"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Vybrat vše"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Označit všechny názvy pro přidání do řady"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Vyprázdnit vše"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Odznačit všechny názvy"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 "Cílové soubory jsou v pořádku. Nebylo zjištěno, že by byly některé soubory "
 "dvakrát."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Nastavení"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automaticky ověřit dostupnost aktualizací"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Použít automatické pojmenovávání (používá změněný název zdroje)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Pojmenovat předlohu automaticky"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Použít souborovou příponu iPod/iTunes friendly (.m4v) pro MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Počet náhledů"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2006,52 +2006,52 @@ msgstr ""
 "hotové.\n"
 "Zaškrtněte, pokud chcete řadu uklidit sami, tím že smažete hotové úkoly."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Obecné"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2065,63 +2065,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Nepatrná zrnitost při stálé kvalitě"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Použít dvdnav (namísto libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Sledovat volné místo na cílovém disku"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Pozastavit kódování, pokud volné místo na disku klesne pod mez"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Omezení MB"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Dát jednotlivé záznamy o kódování do stejného umístění, kde je film"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Úroveň podrobnosti zápisu o činnosti"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Délka života zápisu o činnosti"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Zmenšit rozlišení náhledů ve vysokém rozlišení"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Automaticky prohledat DVD při nahrání"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Při nahrání disku prohlédne DVD"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Velikost písma okna činností"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Použít stejná nastavení pro všechny názvy v dávkovém zpracování"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2130,186 +2130,186 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Povolit vyladění"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Povolit HandBrake pro natvrdlé"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Přednastavení pro odstranění šumu:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Přejmenovat přednastavení</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Název:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Popis</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Uložit nové přednastavení"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Nastavit kategorii, pod níž se bude ukazovat toto přednastavení."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Název kategorie:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Název přednastavení:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Výchozí přednastavení"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Učinit výchozím přednastavením při spuštění HandBrake"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Náhled HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Vybrat náhledové snímky."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 "Zakódovat a přehrát krátký úryvek obrazu počínaje nynějším místem náhledu."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Doba trvání</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Nastavit dobu trvání živého náhledu v sekundách."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Ukázat oříznutí"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Ukázat oříznutou oblast v náhledu"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Rozlišení zdroje"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Nastavit náhledové okno znovu na rozlišení zdrojového záznamu"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Titulky"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Zavést SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Povolit nastavení pro zavedení souboru s titulky SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Vložený seznam titulků"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Povolit nastavení pro vybrání vložených titulků"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Zdrojová stopa"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Seznam stop s titulky dostupných ze zdroje."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Název stopy:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Jazyk"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Kód znaku"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Soubor:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Posun (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2317,7 +2317,7 @@ msgstr ""
 "Nastavit jazyk těchto titulků.\n"
 "Tato hodnota bude používána přehrávači v nabídkách s titulky."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2331,29 +2331,29 @@ msgstr ""
 "Znakovou sadu překládáme do UTF-8.\n"
 "Znakový kód zdroje je potřeba za účelem provedení tohoto překódování znaků."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Vybrat soubor titulků SRT k zavedení."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Upravit posun v milisekundách mezi časovými razítky obrazu a souborem "
 "titulků SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Pouze vynuceno titulky"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Vypálit do obrazu"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2361,19 +2361,19 @@ msgstr ""
 "Vložit titulky do obrazu.\n"
 "Titulky budou součástí obrazu a nepůjde je zakázat."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Nastavit výchozí stopu"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Seznam zvukových stop dostupných ze zdroje."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2383,15 +2383,15 @@ msgstr ""
 "\n"
 "Tento mohou použít přehrávače v seznamu pro výběr zvuku."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Smíchání"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Vzorkovací kmitočet"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2410,50 +2410,50 @@ msgstr ""
 "'stlačit' rozsah tím, že udělá hlasité oblasti slabšími a slabé\n"
 "oblasti hlasitějšími."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Nastavit zvukový kodek, kterým se má tato stopa zakódovat."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Datový tok"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Povolit nastavení datového toku"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Jakost"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Povolit nastavení jakosti"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Nastavit datový tok, ve kterém se má tato stopa zakódovat."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 "<b>Kvalita:</b> Upravit jakost výstupu u výstupních kodeků, jež to podporují."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Nastavit finální mixáž výstupní zvukové stopy."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Nastavit vzorkovací kmitočet výstupní zvukové stopy."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2462,41 +2462,41 @@ msgstr ""
 "Upravit zesílení nebo zeslabení výstupní zvukové stopy."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0 dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Vypnuto"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Přeskočit tuto verzi"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Připomenout později"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Je dostupná nová verze HandBrake!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx je nyní dostupný (máte yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Poznámky k vydání</b>"
 
@@ -2641,7 +2641,7 @@ msgstr "Zjištěná zařízení DVD:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Prohledává se..."
 
@@ -2654,11 +2654,40 @@ msgstr "Zastavit prohledávání"
 msgid "Single Title"
 msgstr "Otevřít jeden _titul"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2667,7 +2696,7 @@ msgstr[1] "Zvuk"
 msgstr[2] "Zvuk"
 msgstr[3] "Zvuk"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2676,19 +2705,19 @@ msgstr[1] "Titulky"
 msgstr[2] "Titulky"
 msgstr[3] "Titulky"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2697,22 +2726,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2721,35 +2750,35 @@ msgstr[1] "Stopa titulků k cizímu zvuku"
 msgstr[2] "Stopa titulků k cizímu zvuku"
 msgstr[3] "Stopa titulků k cizímu zvuku"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Poměr stran:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "Poměr stran:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nenalezen žádný název"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nový obraz"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2760,134 +2789,134 @@ msgstr ""
 "\n"
 "%s za %d sekund..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%s Film bude ztracen, pokud nebudete pokračovat v kódování."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Zrušit nynější a zastavit"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Zrušit nynější, začít další"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Dokončit nynější, pak zastavit"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Pokračovat v kódování"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "úkol %d z %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "projití %d (jemné prohledání) z %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "projití %d z %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Kódování: %s%s%.2f %% (%.2f snímků za sekundu (SZS), avg %.2f SZS, ETA %02d "
 "h%02d m%02d s)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Kódování: %s%s%.2f %% (ETA %02d h%02d m%02d s)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Kódování: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Hledá se čas začátku,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Prohledává se %d z %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Prohledává se název %d z %d náhledu %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pozastaveno"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Zakódování dokončeno!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Zakódování zrušeno!"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Zakódování selhalo."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Mux: To může chvíli trvat..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s je nyní dostupný (máte %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Zakódování hotovo"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Položte si tu šťávu. Řada v HandBrake je hotova!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Zakódování je hotovo."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Ukončuje se Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Uspává se počítač"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Vypíná se počítač"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/da.po
+++ b/gtk/po/da.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: HandBrake-0.10\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2014-11-28 14:44+0000\n"
 "Last-Translator: VictorR2007 <victorr2007@yandex.ru>\n"
 "Language-Team: Danish (http://www.transifex.com/projects/p/handbrake/"
@@ -106,8 +106,8 @@ msgstr ""
 msgid "Set De_fault"
 msgstr "_Gør standard"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr ""
 
@@ -115,7 +115,7 @@ msgstr ""
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Indbrændt</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Standard</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -353,7 +353,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Start konvertering"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr ""
@@ -372,7 +372,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -390,8 +390,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Source:"
 msgstr "K_ilde"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -426,7 +426,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Opsummering"
 
@@ -509,11 +509,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Vælg videokilde"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 #, fuzzy
 msgid "Open Source"
 msgstr "K_ilde"
@@ -549,7 +549,7 @@ msgstr ""
 msgid "Show Queue"
 msgstr "Vis kø"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Kø"
 
@@ -572,252 +572,252 @@ msgstr "<b>Kilde:</b>"
 msgid "None"
 msgstr "Ingen"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 #, fuzzy
 msgid "<b>Title:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 #, fuzzy
 msgid "<b>Angle:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Ved multivinkel-DVDer, vælg den ønskede vinkel der skal konverteres."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 #, fuzzy
 msgid "<b>Range:</b>"
 msgstr "<b>Skalering</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Område af titlen der skal konverteres. Kan være kapitler, sekunder, eller "
 "frames."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Vælg det første kapitel der skal konverteres."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Vælg det sidste kapitel der skal konverteres."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 #, fuzzy
 msgid "<b>Preset:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format til de konverterede spor."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web-optimeret"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G-understøttelse"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Tilføj iPod-Atom der kræves af nogle ældre iPods."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Varighed:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 #, fuzzy
 msgid "Aspect Ratio:"
 msgstr "Billedforhold:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 #, fuzzy
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 #, fuzzy
 msgid "Rotation:"
 msgstr "Varighed:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 #, fuzzy
 msgid "Cropping:"
 msgstr "Beskær:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorft:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -827,11 +827,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -840,11 +840,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -852,108 +852,108 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 #, fuzzy
 msgid "Scaled Size:"
 msgstr "Skaleringsdimensioner:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 #, fuzzy
 msgid "Optimal Size"
 msgstr "Optimal til kilde:"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 #, fuzzy
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Skalering</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 #, fuzzy
 msgid "<b>Borders</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 #, fuzzy
 msgid "<b>Final Dimensions</b>"
 msgstr "Skaleringsdimensioner:"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 #, fuzzy
 msgid "Dimensions"
 msgstr "Dimensioner:"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -961,18 +961,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -980,7 +980,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -988,11 +988,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1000,7 +1000,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -1009,39 +1009,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1049,7 +1049,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1057,78 +1057,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Video-encoder:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Tilgængelige video-encodere."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Framerate:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1136,19 +1136,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Konstant framerate"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Top-framerate (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1156,18 +1156,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Variabel framerate"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1183,15 +1183,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1202,11 +1202,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1216,16 +1216,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1237,7 +1237,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1246,22 +1246,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1271,300 +1271,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1575,15 +1575,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1593,11 +1593,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1605,21 +1605,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1629,15 +1629,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1648,11 +1648,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1663,123 +1663,123 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 #, fuzzy
 msgid "<b>Save As:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Destinationsfilnavn til din konverterede fil."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 #, fuzzy
 msgid "<b>To:</b>"
 msgstr "<b>Kilde:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Destinationsmappe til din konverterede fil."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Destinationsmappe"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1787,127 +1787,127 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 #, fuzzy
 msgid "Create destination filename from source filename or volume label"
 msgstr "Destinationsfilnavn til din konverterede fil."
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1921,65 +1921,65 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 #, fuzzy
 msgid "Temp Directory"
 msgstr "Destinationsmappe"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 #, fuzzy
 msgid "Activity Window Font Size"
 msgstr "_Aktivitetsvindue"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1988,191 +1988,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr ""
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr ""
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 #, fuzzy
 msgid "<b>Dimensions</b>"
 msgstr "Dimensioner:"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 #, fuzzy
 msgid "HandBrake Preview"
 msgstr "HandBrake kort forklaret"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 #, fuzzy
 msgid "Import SSA"
 msgstr "_Importér"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fil:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2181,61 +2181,61 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 #, fuzzy
 msgid "Import File"
 msgstr "_Importér"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2246,89 +2246,89 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Fra"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2463,7 +2463,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2476,92 +2476,119 @@ msgstr ""
 msgid "Single Title"
 msgstr "_Enkel titel"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 #, fuzzy
 msgid ", Forced Only"
 msgstr "<b>Kun tvungen</b>"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 #, fuzzy
 msgid ", Default"
 msgstr "_Gør standard"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2569,132 +2596,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/de.po
+++ b/gtk/po/de.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Nomis101 <Nomis101@web.de>, 2022\n"
 "Language-Team: German (https://www.transifex.com/HandBrakeProject/"
@@ -104,8 +104,8 @@ msgstr "Voreinstellungen"
 msgid "Set De_fault"
 msgstr "Setze Standard"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Speichern"
 
@@ -113,7 +113,7 @@ msgstr "_Speichern"
 msgid "Save _As"
 msgstr "Speichern _als"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Umbenennen"
 
@@ -162,7 +162,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Eingebrannt</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Standard</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -351,7 +351,7 @@ msgstr "0 Aufgaben anstehend"
 msgid "Start Encoding"
 msgstr "Encodierung starten"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Start"
@@ -370,7 +370,7 @@ msgstr "Pause"
 msgid "Options"
 msgstr "Einstellungen"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Wenn fertig:"
 
@@ -391,8 +391,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Voreinstellung:"
 
@@ -400,7 +400,7 @@ msgstr "Voreinstellung:"
 msgid "Source:"
 msgstr "Quelle:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titel:"
 
@@ -424,7 +424,7 @@ msgstr "Audio:"
 msgid "Subtitles:"
 msgstr "Untertitel:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Übersicht"
 
@@ -523,11 +523,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Videoquelldatei auswählen"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Quelle öffnen"
 
@@ -559,7 +559,7 @@ msgstr "Vorschau"
 msgid "Show Queue"
 msgstr "Warteschlange anzeigen"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Warteschlange"
 
@@ -582,15 +582,15 @@ msgstr "<b>Quelle:</b>"
 msgid "None"
 msgstr "Nichts"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Überprüfen …"
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titel:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -600,53 +600,53 @@ msgstr ""
 "Standardmäßig wird der längste Titel ausgewählt.\n"
 "Dies ist oft der Feature-Titel einer DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Winkel:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Wähle für DVD's mit mehreren Blickwinkeln den gewünschten aus."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Bereich:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Dauer des Titels zum encodieren. Kann in Kapitel, Sekunden oder Einzelbilder "
 "angegeben werden."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Das erste Kapitel zum Encodieren festlegen."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Das letzte Kapitel zum Encodieren festlegen."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Voreinstellung:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Voreinstellung auswählen"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Geändert</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Neu laden"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -654,27 +654,27 @@ msgstr ""
 "Lade die Einstellungen für die aktuell ausgewählte Voreinstellung neu.\n"
 "Änderungen werden verworfen."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Neue Voreinstellung speichern"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Speichere die aktuellen Einstellungen in einer neuen Voreinstellung."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format in das die Spuren gemultiplext werden."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web-optimiert"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -684,11 +684,11 @@ msgstr ""
 "Abspielen übers Internet ermöglicht wird ohne den gesamten Film "
 "herunterladen zu müssen."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "A/V synchron"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -700,140 +700,140 @@ msgstr ""
 "bei manchen defekten Abspielgeräten verbessern, die keine \n"
 "MP4-Bearbeitungslisten berücksichtigen."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G-Unterstützung"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Das von einigen älteren iPods benötigte iPod-Atom hinzufügen."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Metadaten-Passthru"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Kopiert die Metadaten der Quelldatei in die Ausgabedatei."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Dauer:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Spuren:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filter:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Größe:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Bildgröße:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Anzeigegröße:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Bildformat:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Quellbildgröße</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Spiegeln:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Horizontal  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Video horizontal spiegeln."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Drehung:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Rotiere das Video im Uhrzeigersinn in 90 Grad-Schritten."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Beschneiden:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Wie Beschnitteinstellungen angewendet werden."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Links beschneiden"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Oben beschneiden"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Unten beschneiden"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Rechts beschneiden"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Ausrichtung &amp; Beschnitt</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Auflösungslimit:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Auflösungsgrenzen für gängige Videoformate."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Maximale Größe:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Dies ist die maximale Breite, in der das Video gespeichert wird."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Dies ist die maximale Höhe, in der das Video gespeichert wird."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorph:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -849,11 +849,11 @@ msgstr ""
 "Keine - Erzwingt ein Pixel-Seitenverhältnis von 1:1.\n"
 "Benutzerdefiniert - Benutzerdefiniertes Pixel-Seitenverhältnis.</tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Pixel-Bildformat:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -868,11 +868,11 @@ msgstr ""
 "Abspieler skalieren dann wieder das Bild um den spezifizierten Wert zu "
 "erreichen."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -885,11 +885,11 @@ msgstr ""
 "Abspieler skalieren dann wieder das Bild um den spezifizierten Wert zu "
 "erreichen."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Skalierte Größe:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -898,7 +898,7 @@ msgstr ""
 "Dies ist die Breite mit dem das Video gespeichert wird.\n"
 "Die Anzeigegröße variiert, falls das Pixel-Bildformat ungleich 1:1 ist."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -907,86 +907,86 @@ msgstr ""
 "Dies ist die Höhe mit dem das Video gespeichert wird.\n"
 "Die Anzeigegröße variiert, falls das Pixel-Bildformat ungleich 1:1 ist."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Optimale Größe"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Verwende höchste durch obige Einstellungen erlaubte Auflösung"
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Hochskalieren zulassen"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Wenn diese Option nicht aktiviert ist, werden die skalierten Bildgrößen auf "
 "die Quellbildgröße beschränkt."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Auflösung &amp; Skalierung</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Füllen:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Einen Rand um das Video hinzufügen"
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Links füllen"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Oben füllen"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Unten füllen"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Rechts füllen"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Farbe:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Farbe des Randes um das Video."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Ränder</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Wenn Sie die Anzeigegröße ändern, wird das Video gestreckt."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Finale Bildgröße</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensionen"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -999,7 +999,7 @@ msgstr ""
 "Telecining ist ein Prozess um Filme mit einer Bildfrequenz von 24 BpS in "
 "NTSC mit einer Bildfrequenz von 30 BpS zu konvertieren."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1009,11 +1009,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Interlace-Erkennung:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1025,7 +1025,7 @@ msgstr ""
 "Falls ein Deinterlace-Filter aktiviert ist, werden nur Einzelbilder die von "
 "diesem Filter als Interlaced erkannt werden deinterlaced."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1037,11 +1037,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deinterlace:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1053,7 +1053,7 @@ msgstr ""
 "Der Decomb-Filter unterstützt eine Vielzahl an Interpolationsalgorithmen.\n"
 "Der Deinterlace-Filter ist ein klassischer YADIF-Deinterlacer.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1067,11 +1067,11 @@ msgstr ""
 "Der Decomb-Filter unterstützt eine Vielzahl an Interpolationsalgorithmen.\n"
 "Der Deinterlace-Filter ist ein klassischer YADIF-Deinterlacer.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Deblock-Filter:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1079,12 +1079,12 @@ msgstr ""
 "Der Deblockfilter entfernt die bekannte Form der Kompressionsartefakte.\n"
 "Wenn die Quelle Blockartefakte zeigt, könnte der Filter hilfreich sein."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Abstimmung:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1093,7 +1093,7 @@ msgstr ""
 "Der Deblockfilter entfernt die bekannte Form der Kompressionsartefakte.\n"
 "Wenn die Quelle Blockartefakte zeigt, könnte der Filter hilfreich sein."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1104,11 +1104,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Entrauschfilter:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1122,7 +1122,7 @@ msgstr ""
 "Durch Benutzung dieses Filters auf solche Quellen, können die resultierenden "
 "Dateien kleiner werden."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1137,7 +1137,7 @@ msgstr ""
 "Durch Benutzung dieses Filters auf solche Quellen, können die resultierenden "
 "Dateien kleiner werden."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1148,11 +1148,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Chroma-Glättung:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1161,7 +1161,7 @@ msgstr ""
 "Bei analogen Quellen mit geringerer Auflösung kann dieser Filter von Vorteil "
 "sein."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1171,11 +1171,11 @@ msgstr ""
 "Bei analogen Quellen mit geringerer Auflösung kann dieser Filter von Vorteil "
 "sein."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Schärfefilter:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1183,7 +1183,7 @@ msgstr ""
 "Schärfefilter hebt Kanten und andere \n"
 "hochfrequente Komponenten im Video hervor."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1192,39 +1192,39 @@ msgstr ""
 "Schärfefilter hebt Kanten und andere \n"
 "hochfrequente Komponenten im Video hervor."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Farbraum:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Den Farbraum der Quelle übersetzen."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Graustufen"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Filtert Farbkomponenten aus dem Video, falls aktiviert."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filter"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Videoencoder:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Verfügbare Videoencoder."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Bildfrequenz:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1236,19 +1236,19 @@ msgstr ""
 "„Wie die Quelle“ ist empfohlen. Falls das Quellvideo eine\n"
 "variable Bildfrequenz hat, wird diese Einstellung diese beibehalten."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Konstante Bildfrequenz:"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Aktiviert eine konstante Bildfrequenz der Ausgabe"
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Maximale Bildfrequenz (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1260,11 +1260,11 @@ msgstr ""
 "\n"
 "VFR ist nicht kompatibel mit manchen Abspielern."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Variable Bildfrequenz:"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1273,7 +1273,7 @@ msgstr ""
 "Aktiviert variable Bildfrequenz.\n"
 "VFR ist mit manchen Abspielern nicht kompatibel."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1301,15 +1301,15 @@ msgstr ""
 "FFmpeg's und Theora's Skalen sind eher linear.\n"
 "Diese Encoder haben keinen verlustfreien Modus."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Konstante Qualität:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bitrate (kbps):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1327,11 +1327,11 @@ msgstr ""
 "Falls die Bitrate unbedingt eingehalten werden muss, kann x264's vbv-bufsize "
 "und vbv-maxrate verwendet werden."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Encodierung in zwei Durchgängen"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1347,18 +1347,18 @@ msgstr ""
 "Im zweiten Durchgang werden diese Statistiken verwendet, um Entscheidungen "
 "über die Zuweisungen der Bitrate zu treffen."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Ersten Durchgang beschleunigen"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Verwende während des ersten Durchgangs einer Encodierung in zwei Durchgängen "
 "Einstellungen um die Verarbeitung zu beschleunigen. "
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1379,7 +1379,7 @@ msgstr ""
 "die vertretbar ist, da langsamere\n"
 "Einstellungen zu einer besseren Qualität oder kleineren Dateien führen."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1393,11 +1393,11 @@ msgstr ""
 "Diese Veränderungen werden nach den Voreinstellungen gemacht, aber vor allen "
 "anderen Parametern."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Schnelle Decodierung"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1408,11 +1408,11 @@ msgstr ""
 "Nützlich bei leistungsschwachen Abspielgeräten, bei denen das Video sonst "
 "nicht ruckelfrei läuft."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Keine Latenz"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1426,11 +1426,11 @@ msgstr ""
 "Da HandBrake jedoch nicht für Livestreams nützlich ist, bringt diese "
 "Einstellung wenig."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1440,11 +1440,11 @@ msgstr ""
 "\n"
 "Überschreibt alle anderen Einstellungen."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Level:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1454,11 +1454,11 @@ msgstr ""
 "\n"
 "Überschreibt alle anderen Einstellungen."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Mehr Einstellungen:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1468,45 +1468,45 @@ msgstr ""
 "\n"
 "Liste von Kodiereroptionen, getrennt durch Doppelpunkte."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Hinzufügen"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Füge neue Audioeinstellungen der Liste hinzu"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Alle hinzufügen"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Füge alle Tonspuren der Liste hinzu"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Lade alle Audioeinstellungen vom Standard neu"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Spurliste"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Auswahlverhalten:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Wähle die zu verwendenen Tonspuren aus der Quelldatei aus."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1516,23 +1516,23 @@ msgstr ""
 "Spuren, die diesen Sprachen entsprechen, werden mit dem gewählten "
 "Auswahlverhalten ausgewählt."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Entfernen"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Verfügbare Sprachen"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Ausgewählte Sprachen"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Nur ersten Encoder für sekundäres Audio verwenden"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1542,15 +1542,15 @@ msgstr ""
 "Alle anderen sekundären Audioausgangsspuren werden nur mit dem ersten "
 "Encoder kodiert."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Automatisches Passthru:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1560,11 +1560,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von MP2-Passthru, wenn die automatische Passthru-"
 "Auswahl aktiviert ist."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1574,11 +1574,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von MP3-Passthru, wenn die automatische Passthru-"
 "Auswahl aktiviert ist."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1588,11 +1588,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von AC-3-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1602,11 +1602,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von EAC-3-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1616,11 +1616,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von DTS-Passthru, wenn die automatische Passthru-"
 "Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1630,11 +1630,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von DTS-HD-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1644,11 +1644,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von TrueHD-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1658,11 +1658,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von FLAC-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1672,11 +1672,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von AAC-Passthru, wenn die automatische Passthru-"
 "Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1686,11 +1686,11 @@ msgstr ""
 "Dies ermöglicht die Auswahl von Opus-Passthru, wenn die automatische "
 "Passthru-Auswahl aktiviert ist."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Passthru-Fallback:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1698,61 +1698,61 @@ msgstr ""
 "Setzt einen Audiocodec falls eine geeignete Audio Spur bei Audio-Passthru "
 "nicht gefunden wurde."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Audioencoder-Einstellungen:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Jede ausgewählte Quellspur wird mit allen ausgewählten Encodern kodiert."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Encoder:"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bitrate/Qualität"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Abmischung"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Abtastrate"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Verstärkung"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Spurauswahl"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Füge neue Untertitel-Einstellungen der Liste hinzu"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Füge alle Untertitelspuren der Liste hinzu"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Fremdsprachentonsuche"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1762,15 +1762,15 @@ msgstr ""
 "nach Untertitelkandidaten sucht, die Untertitel für\n"
 "Segmente des Tons, die in einer Fremdsprache sind, untertiteln."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Lade alle Untertiteleinstellungen von den Standardeinstellungen neu"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Wähle die zu verwendenden Untertitelspuren der Quelldatei aus"
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1790,15 +1790,15 @@ msgstr ""
 "zum Bestimmen der Einstellungen für die Untertitelauswahl bei "
 "Fremdsprachenton."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Bevorzugte Sprache: Keine"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Fremdsprachentonsuche hinzufügen"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1815,12 +1815,12 @@ msgstr ""
 "Für diese Option muss eine Sprache in der Liste Ausgewählte Sprachen "
 "eingestellt sein."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 "Füge eine Untertitelspur hinzu falls die Standardspur fremdsprachig ist"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1833,11 +1833,11 @@ msgstr ""
 "Für diese Option muss eine Sprache in der Liste Ausgewählte Sprachen "
 "eingestellt sein."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Closed Captions hinzufügen falls verfügbar"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1845,11 +1845,11 @@ msgstr ""
 "Closed Captions sind Untertitel welche jedem beliebigen Container "
 "hinzugefügt werden können."
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Einbrennverhalten*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1865,15 +1865,15 @@ msgstr ""
 "Es kann nur eine Untertitelspur eingebrannt werden! Da es zu Konflikten "
 "kommen kann, wird die zuerst gewählte bevorzugt."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Einbrennen für fehlerhafte Abspieler*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD-Untertitel"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1891,11 +1891,11 @@ msgstr ""
 "Es kann nur eine Untertitelspur eingebrannt werden! Da es zu Konflikten "
 "kommen kann, wird die zuerst gewählte bevorzugt."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray-Untertitel"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1913,7 +1913,7 @@ msgstr ""
 "Es kann nur eine Untertitelspur eingebrannt werden! Da es zu Konflikten "
 "kommen kann, wird die zuerst gewählte bevorzugt."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1921,7 +1921,7 @@ msgstr ""
 "<small>* Nur eine der oben angegebenen Untertiteleinbrennoptionen wird "
 "angewendet, beginnend mit der ersten.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1929,111 +1929,111 @@ msgstr ""
 "Nur eine Untertitelspur kann eingebrannt werden! Wenn Konflikte auftreten, "
 "wird nur die Erste verwendet."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Untertitel"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Kapitelmarkierungen"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Füge Kapitel Markierungen der Ausgabedatei hinzu."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Kapitel"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Kapitel"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Index"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Dauer"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titel"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Kapitel"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Schauspieler:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regisseur:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Erscheinungsdatum:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Kommentar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genre:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Beschreibung:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Handlung:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Tags"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Speichern als:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Dateiname für die Ausgabe."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>In:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Speicherort für das encodierte Video."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Speicherort"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr "Mehrere Titel hinzufügen"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2041,52 +2041,52 @@ msgstr "Mehrere Titel hinzufügen"
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Alle auswählen"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Markiere alle Titel zum Hinzufügen zur Warteschlange"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Alles löschen"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Alle Titel demarkieren"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Ausgabedateien Ok. Keine Duplikate erkannt."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Einstellungen"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automatisch nach Updates suchen"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Standardaktion wenn alle Enkodierungen abgeschlossen sind"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Verwende automatische Benennung (verwendet modifizierten Quelldateinamen)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "Zieldateiname aus Quelldateiname oder Datenträgerbezeichnung erzeugen"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Template für die automatische Benennung"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2096,25 +2096,25 @@ msgstr ""
 "Verfügbare Optionen: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Verwende iPod/iTunes freundliche (.m4v) Dateiendungen für MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Anzahl der Vorschauen"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Kurze DVD- und Blu-ray-Titel entfernen (Sekunden)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 "Löschen abgeschlossener Warteschlangenelemente nach Abschluss einer "
 "Encodierung"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2124,54 +2124,54 @@ msgstr ""
 "werden als solche markiert. Aktiviere diese Option, falls abgeschlossene "
 "Aufgaben aus der Warteschlange entfernt werden sollen."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Allgemein"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 "Festlegen eines benutzerdefinierten Verzeichnisses für temporäre Handbrake-"
 "Dateien"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2197,66 +2197,66 @@ msgstr ""
 "Verzeichnisses in einer Flatpak-Sandbox beträgt 1/2 des physischen Speichers "
 "und kann für Dinge wie die 2-Pass-Statistikdatei zu klein sein."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Temp Verzeichnis"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Schrittweite für den Faktor der konstanten Qualität"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Verwende dvdnav (anstatt libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Überwache den freien Speicherplatz auf dem Zielmedium"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Pausiere die Kodierung falls der freie Speicherplatz unter das Limit fällt"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB-Limit"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Speichere individuelle Kodierungsprotokolle an selbem Speicherort wie das "
 "Video"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Aktivitätsprotokoll-Ausführlichkeitsstufe"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Aktivitätsprotokoll-Speicherdauer"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Skaliere High Definition-Vorschau herunter"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Überprüfe DVD beim Laden automatisch"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Überprüft eine DVD wenn eine neue Disc geladen wird"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Schriftgröße des Aktivitätsfensters"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Verwende dieselben Einstellungen für alle Titel in einem Batch"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2270,11 +2270,11 @@ msgstr ""
 "Deaktiviere diese Option, falls für jeden Titel eigene Einstellungen "
 "festgelegt werden sollen."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr "Vorschaubild im Tab 'Übersicht' zeigen"
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
@@ -2282,76 +2282,76 @@ msgstr ""
 "Deaktivieren Sie diese Option, wenn Sie das Videovorschaubild auf der "
 "Registerkarte 'Übersicht' aus Datenschutzgründen ausblenden möchten."
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Erlaube Optimierungen"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Erlaube HandBrake für Dummies"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Erweitert"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr "Voreinstellung umbenennen"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Voreinstellung umbenennen</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Name:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Beschreibung</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr "Voreinstellung speichern"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategorie:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 "Wähle die Kategorie unter der diese Voreinstellung angezeigt werden soll."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Kategoriename:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Voreinstellungsname:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Standard-Voreinstellung"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Setze dies als Standard-Voreinstellung wenn HandBrake startet"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Bildgröße</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrake Vorschau"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Wähle Einzelbilder für die Vorschau aus."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2359,75 +2359,75 @@ msgstr ""
 "Encodiere und spiele eine kurze Sequenz des Videos ab, beginnend mit der "
 "aktuellen Vorschauposition."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr "Klicken um Bildschirmmodus umzuschalten"
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Dauer:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Setze die Dauer der Live-Vorschau in Sekunden."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Zeige Beschnitt"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Zeige beschnittene Teile der Vorschau"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Quelldatei-Auflösung"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Setze das Vorschaufenster auf die Auflösung der Quelldatei zurück"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr "Untertitel bearbeiten"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importiere SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Aktiviere Einstellung zum Import einer SRT Untertiteldatei"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "SSA importieren"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Einstellungen zum Import von SSA-Untertiteln aktivieren"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Eingebettete Untertitelliste"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Aktiviere Einstellung zum Selektieren von eingebetteten Untertiteln"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Quelldateispur"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Liste der verfügbaren Untertitelspuren der Quelldatei."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Spurname:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2437,23 +2437,23 @@ msgstr ""
 "\n"
 "Wiedergabegeräte können dies in der Untertitel-Auswahlliste verwenden."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Sprache"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Character Code"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Datei:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Versatz (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2461,7 +2461,7 @@ msgstr ""
 "Setz die Sprache des Untertitels.\n"
 "Dieser Wert wird von Abspielern in Untertitelmenüs verwendet."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2475,28 +2475,28 @@ msgstr ""
 "Wir übersetzen das Character Set zu UTF-8.\n"
 "Das Character Set der Quelle wird für diese Operation benötigt."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Wähle die zu importierende SRT-Datei."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Datei importieren"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Einstellen des Versatz in Millisekunden zwischen Video- und SRT-Zeitstempel"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Nur erzwungene Untertitel"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Ins Video brennen"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2504,19 +2504,19 @@ msgstr ""
 "Render den Untertitel über dem Video.\n"
 "Der Untertitel wird Teil des Videos und kann nicht deaktiviert werden."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Setze Standardspur"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr "Tonspuren bearbeiten"
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Liste von verfügbaren Tonspuren der Quelldatei."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2526,15 +2526,15 @@ msgstr ""
 "\n"
 "Abspieler können dies in der Tonauswahlliste verwenden."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mischung"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Abtastrate"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2552,31 +2552,31 @@ msgstr ""
 "erlaubt DRC diesen Umfang zu komprimieren indem laute Geräusche\n"
 "leiser und leise Geräusche lauter gemacht werden."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Setze den Audiocodec mit dem diese Spur kodiert werden soll."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Aktiviere Einstellungen für die Bitrate"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualität"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Aktiviere Einstellungen für die Qualität"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Setz die Bitrate für diese Spur."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2584,19 +2584,19 @@ msgstr ""
 "<b>Qualität:</b> Verändere die Qualität der Ausgabe für Codecs die es "
 "unterstützen."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Lege die Abmischung der Ausgabetonspur fest."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Lege die Abtastrate der Ausgabetonspur fest."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2605,40 +2605,40 @@ msgstr ""
 "Tonspur ein."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Aus"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr "HandBrake-Updater"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Diese Version überspringen"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Erinnere mich später"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Eine neue Version von HandBrake ist verfügbar!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx ist jetzt verfügbar (installierte Version ist yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Versionshinweise</b>"
 
@@ -2783,7 +2783,7 @@ msgstr "Erkannte DVD-Geräte:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Überprüfen …"
 
@@ -2796,90 +2796,119 @@ msgstr "Überprüfen stoppen"
 msgid "Single Title"
 msgstr "Öffne _Einzeldatei"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr "BpS"
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Tonspuren"
 msgstr[1] "Tonspuren"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Untertitelspuren"
 msgstr[1] "Untertitelspuren"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr "CFR"
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr "PFR"
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr "VFR"
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] "+ %d zusätzliche Tonspuren"
 msgstr[1] "+ %d zusätzliche Tonspuren"
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", nur erzwungene"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", eingebrannt"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Standard"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "+ %d zusätzliche Untertitelspuren"
 msgstr[1] "+ %d zusätzliche Untertitelspuren"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr "quelle"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr "anzeige"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr "Pixel-Seitenverhältnis"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr "Bildseitenverhältnis"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Kein Titel gefunden"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Neues Video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2890,133 +2919,133 @@ msgstr ""
 "\n"
 "%s in %d Sekunden …"
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 "%s Der Film geht verloren falls nicht mit dem Encodieren fortgefahren wird."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Momentanes abbrechen und stoppen"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Breche aktuelle Aufgabe ab, starte nächsten"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Momentanes fertigstellen, dann stoppen"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Encodieren fortsetzen"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d Encodierung ausstehend"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d Encodierungen ausstehend"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "Aufgabe %d von %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "Durchgang %d (Untertitelüberprüfung) von %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "Durchgang %d von %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Encodierung: %s%s%.2f %% (%.2f BpS, avg %.2f BpS, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Encodierung: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Encodierung: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Suche Startzeit,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Überprüfe Titel %d von %d …"
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Überprüfe Titel %d von %d Vorschau %d …"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pausiert"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Encodierung abgeschlossen!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Encodierung abgebrochen."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Encodierung fehlgeschlagen."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Multiplexen: Dies kann eine Weile dauern …"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s ist nun verfügbar (aktuell %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Encodierung abgeschlossen"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Stellen Sie den Cocktail ab, die HandBrake-Warteschlange ist fertig!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Die Encodierung ist abgeschlossen."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "HandBrake wird geschlossen"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Versetze Computer in Ruhezustand"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Fahre den Computer herunter"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 #, fuzzy
 msgid "All Files"

--- a/gtk/po/es.po
+++ b/gtk/po/es.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Casper, 2022\n"
 "Language-Team: Spanish (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_Preajustes"
 msgid "Set De_fault"
 msgstr "Establecer _por defecto"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Guardar"
 
@@ -114,7 +114,7 @@ msgstr "_Guardar"
 msgid "Save _As"
 msgstr "Guardar _como"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Renombrar"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Incrustado en</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Por defecto</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -357,7 +357,7 @@ msgstr "0 trabajos pendientes"
 msgid "Start Encoding"
 msgstr "Iniciar Codificacion"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Iniciar"
@@ -376,7 +376,7 @@ msgstr "Pausa"
 msgid "Options"
 msgstr "Opciones"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Cuando termine:"
 
@@ -396,8 +396,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Editar"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Preset:"
 
@@ -405,7 +405,7 @@ msgstr "Preset:"
 msgid "Source:"
 msgstr "Origen:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titulo:"
 
@@ -429,7 +429,7 @@ msgstr "Audio:"
 msgid "Subtitles:"
 msgstr "Subtitulos:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Resumen"
 
@@ -522,11 +522,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Escoja fuente de video"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Abrir Fuente"
 
@@ -558,7 +558,7 @@ msgstr "Vista previa"
 msgid "Show Queue"
 msgstr "Mostrar Cola"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Cola"
 
@@ -581,15 +581,15 @@ msgstr "<b>Fuente:</b>"
 msgid "None"
 msgstr "Ninguno"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Escaneando..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titulo</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -599,53 +599,53 @@ msgstr ""
 "Por defecto se elige el título más largo.\n"
 "Este es a menudo el título de la característica de un DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angulo:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 "Para DVD de múltiples ángulos, seleccione el ángulo deseado para codificar."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Rango:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Rango de título a codificar. Pueden ser capítulos, segundos, o fotogramas."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Establece el primer capítulo a codificar."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Establecer el último capítulo a codificar."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Preset:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Elegir preset"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modificado</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Recargar"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -653,27 +653,27 @@ msgstr ""
 "Recarga la configuración del preajuste seleccionado actualmente.\n"
 "Las modificaciones serán descartadas."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Guardar Nuevo Preajuste"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Guarda la configuración actual en un nuevo Preajuste."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formato:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Selecciona el formato contenedor de las pistas codificadas."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimizado web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -682,11 +682,11 @@ msgstr ""
 "Esto permite que un reproductor inicie la reproducción antes de descargar "
 "todo el archivo."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Alinear A/V Iniciar"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -698,140 +698,140 @@ msgstr ""
 "Sincronización para reproductores rotos que no cumplen con las listas de "
 "edición de MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Soporte para iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Agrega el iPod Atom que necesitan algunos iPods más antiguos."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Pasar a través de metadatos comunes"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Copiar los metadatos de la fuente a la salida."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Duracion:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Pistas:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtros:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Tamaño:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Tamaño de almacenamiento:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Tamaño de la Pantalla:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Relación de aspecto:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Dimensiones de Origen</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Volteando:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Horizontal ⇌"
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Voltear el video horizontalmente."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Rotación:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Gire el video hacia la derecha en incrementos de 90 grados."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Recortando:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Cómo aplicar la configuración de recorte."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Recorte Izquierdo"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Recorte Arriba"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Recorte Abajo"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Recorte Derecho"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientación y Recorte</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Límite de resolución:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Límites de resolución para formatos de video comunes."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Tamaño máximo:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Este es el ancho máximo en el que se almacenará el video."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Esta es la altura máxima a la que se almacenará el video."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamórfico:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -848,11 +848,11 @@ msgstr ""
 "  Personalizado   - Ingrese una relación de aspecto de píxeles personalizado."
 "</tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspecto del píxel:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -866,11 +866,11 @@ msgstr ""
 "formas rectangulares.\n"
 "Los reproductores escalarán la imagen para lograr el aspecto especificado."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -882,11 +882,11 @@ msgstr ""
 "formas rectangulares.\n"
 "Los reproductores escalarán la imagen para lograr el aspecto especificado."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Tamaño escalado:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -896,7 +896,7 @@ msgstr ""
 "Las dimensiones de visualización reales diferirán si la relación de aspecto "
 "de píxeles no es 1: 1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -906,86 +906,86 @@ msgstr ""
 "Las dimensiones de visualización reales diferirán si la relación de aspecto "
 "de píxeles no es 1: 1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Tamaño óptimo"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Usar la resolución más alta permitida por la configuración anterior."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Permitir escalado"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Si no está habilitado, las dimensiones escaladas se limitarán a las "
 "dimensiones de la fuente."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Resolución y Escalada</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Rellenar:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Añadir un borde alrededor del video."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Relleno izquierdo"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Relleno arriba"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Relleno abajo"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Relleno derecho"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Color:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Color del borde añadido alrededor del vídeo."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Bordes</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Cambiar el tamaño de la pantalla estirará el vídeo."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatico"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Dimensiones finales</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensiones"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Destelecinado:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -998,7 +998,7 @@ msgstr ""
 "Telecinado es un proceso que ajusta las tasas de cuadros de la película que "
 "son de 24 fps a las tasas de cuadros de video NTSC que son de 30 fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1008,11 +1008,11 @@ msgstr ""
 "\n"
 "JunkLeft: JunkRight: JunkTop: JunkBottom: StrictBreaks: MetricPlane: Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Detección de entrelazado:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1024,7 +1024,7 @@ msgstr ""
 "Si se habilita un filtro de desentrelazado, solo se desentrelazarán los \n"
 "cuadros que este filtro encuentre entrelazado."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1037,11 +1037,11 @@ msgstr ""
 "filtro de máscara:\n"
 "Trilla del bloque: Ancho del bloque: Altura del bloque"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Desentrelazado:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1053,7 +1053,7 @@ msgstr ""
 "El filtro de despeinado admite una variedad de algoritmos de interpolación.\n"
 "El filtro de desentrelazado es un desentrelazador clásico de YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1067,11 +1067,11 @@ msgstr ""
 "El filtro de despeinado admite una variedad de algoritmos de interpolación.\n"
 "El filtro de desentrelazado es un desentrelazador clásico de YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtro de Desbloqueo:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1079,12 +1079,12 @@ msgstr ""
 "El filtro de desbloqueo elimina un tipo común de artefacto de compresión.\n"
 "Si su fuente muestra \"bloqueo\", este filtro puede ayudar a limpiarlo."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Afinar:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1093,7 +1093,7 @@ msgstr ""
 "El filtro de desbloqueo elimina un tipo común de artefacto de compresión.\n"
 "Si su fuente muestra \"bloqueo\", este filtro puede ayudar a limpiarlo."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1104,11 +1104,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtro Denoise:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1121,7 +1121,7 @@ msgstr ""
 "El uso de este filtro en dichas fuentes puede resultar en tamaños de archivo "
 "más pequeños."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1135,7 +1135,7 @@ msgstr ""
 "El uso de este filtro en dichas fuentes puede resultar en tamaños de archivo "
 "más pequeños."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1146,11 +1146,11 @@ msgstr ""
 "\n"
 "SpatialLuma: SpatialChroma: TemporalLuma: TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Filtro suave de croma:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1159,7 +1159,7 @@ msgstr ""
 "El contenido de fuente analógica de menor resolución puede beneficiarse de "
 "este filtro."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1169,11 +1169,11 @@ msgstr ""
 "El contenido de fuente analógica de menor resolución puede beneficiarse de "
 "este filtro."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtro Afilar:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1181,7 +1181,7 @@ msgstr ""
 "El filtro de nitidez mejora los bordes y otros \n"
 "componentes de alta frecuencia en el video."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1190,39 +1190,39 @@ msgstr ""
 "El filtro de nitidez mejora los bordes y otros \n"
 "componentes de alta frecuencia en el video."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Espacio de color:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Traduce el espacio de colores de la fuente."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Escala de grises"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Si está habilitado, elimina los componentes de color del video."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codificador de video:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codificadores de video disponibles."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Tasa de Fotogramas:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1234,19 +1234,19 @@ msgstr ""
 "Se recomienda \"Igual que la fuente\". Si su fuente de video tiene\n"
 "una tasa de fotogramas variable, 'Igual que la fuente' la conservará."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Velocidad de Fotograma constante"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Selecciona una Tasa de fotogramas constante."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Velocidad de Fotograma variable (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1258,11 +1258,11 @@ msgstr ""
 "\n"
 "VFR no es compatible con algunos reproductores."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Tasa de fotogramas variable"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1272,7 +1272,7 @@ msgstr ""
 "\n"
 "No es compatible con algunos reproductores."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1303,15 +1303,15 @@ msgstr ""
 "La escala de FFMpeg y Theora es más lineal.\n"
 "Estos codificadores no tienen un modo sin pérdidas."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Calidad constante:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Tasa de bits (kbps): "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1330,11 +1330,11 @@ msgstr ""
 "limitar la tasa de bits instantánea, consulte las configuraciones vbv-"
 "bufsize y vbv-maxrate de x264."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Codificación en 2 pasadas"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1350,18 +1350,18 @@ msgstr ""
 "segunda pasada, se usan esas estadísticas.\n"
 "para tomar decisiones de asignación de bits."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Primera pasada rapida"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Aplica ajustes que aceleran la primera pasada de la codificación en dos "
 "pasadas."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1382,7 +1382,7 @@ msgstr ""
 "La configuración dará como resultado archivos de mejor calidad o más "
 "pequeños."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1398,11 +1398,11 @@ msgstr ""
 "después\n"
 "del preajuste, pero antes de todos los demás parámetros."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Decodificación rápida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1413,11 +1413,11 @@ msgstr ""
 "Configúralo si tu dispositivo está teniendo problemas para reproducir la "
 "salida (fotogramas eliminados)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latencia cero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1434,11 +1434,11 @@ msgstr ""
 "Dado que HandBrake no es adecuado para transmisiones en vivo,\n"
 "Esta configuración es de poco valor aquí."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1448,11 +1448,11 @@ msgstr ""
 "\n"
 "Anula todos los demás Ajustes."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nivel:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1462,11 +1462,11 @@ msgstr ""
 "\n"
 "Anula todos los demás Ajustes."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Mas ajustes:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1476,45 +1476,45 @@ msgstr ""
 "\n"
 "Lista separada por dos puntos de las opciones de codificador."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Añadir"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Añadir nuevos ajustes de audio a la lista"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Añadir todo"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Añadir todas las pistas de audio a la lista"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Recargar las pistas de audio por defecto"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Lista de Pistas"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Modo de selección:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Seleccione qué pistas de audio de la fuente se usaran."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1524,23 +1524,23 @@ msgstr ""
 "Las pistas que coincidan con estos idiomas se seleccionarán usando el Modo "
 "de selección elegido."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Eliminar"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Idiomas disponibles"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Idiomas seleccionados"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Usar solo el primer codificador para audio secundario"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1551,15 +1551,15 @@ msgstr ""
 "Todas las demás pistas de salida de audio secundarias se codificarán solo "
 "con el primer codificador."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Copia directa automática:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1569,11 +1569,11 @@ msgstr ""
 "Esto permite seleccionar MP2 Passthru cuando se habilita la selección "
 "automática de Passthru."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1583,11 +1583,11 @@ msgstr ""
 "Esto permite seleccionar el passthru MP3 cuando la selección de passthru "
 "automática está habilitada."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1597,11 +1597,11 @@ msgstr ""
 "Esto permite seleccionar el paso a través AC-3 cuando la selección de paso "
 "automático está habilitada."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1611,11 +1611,11 @@ msgstr ""
 "Esto permite seleccionar el paso a través EAC-3 cuando la selección de paso "
 "automático está habilitada."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1625,11 +1625,11 @@ msgstr ""
 "Esto permite seleccionar DTS passthru cuando la selección de passthru "
 "automática está habilitada."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1639,11 +1639,11 @@ msgstr ""
 "Esto permite seleccionar el passthru DTS-HD cuando la selección de passthru "
 "automática está habilitada."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1653,11 +1653,11 @@ msgstr ""
 "Esto permite seleccionar el passthru TrueHD cuando la selección de passthru "
 "automática está habilitada."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1667,11 +1667,11 @@ msgstr ""
 "Esto permite seleccionar el passthru FLAC cuando la selección de passthru "
 "automática está habilitada."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1681,11 +1681,11 @@ msgstr ""
 "Esto permite seleccionar el paso a través de AAC cuando la selección de paso "
 "automático está habilitada."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1695,11 +1695,11 @@ msgstr ""
 "Esto permite seleccionar Opus PassThru cuando se habilita la selección "
 "automática de Passthru."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Codificador alternativo a la copia directa:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1707,62 +1707,62 @@ msgstr ""
 "Configure el códec de audio para que se codifique cuando no se pueda "
 "encontrar una pista adecuada para la transferencia de audio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Ajustes del codificador de Audio:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Cada pista de origen seleccionada se codificará con todos los codificadores "
 "seleccionados"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codificador"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Tasa de bits / Calidad"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mezcla"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Tasa de muestreo"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Ganancia"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Selección de pistas"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Añadir nuevos ajustes de subtítulos a la lista"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Añadir todas las pistas de subtítulos a la lista"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Escanear audio extranjero"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1772,15 +1772,15 @@ msgstr ""
 "candidatos a subtítulos que proporcionan subtítulos para\n"
 "segmentos del audio que están en un idioma extranjero."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Recargar todos los ajustes de subtítulos por defecto"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Seleccione que pistas de subtítulos de la fuente se usaran."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1798,15 +1798,15 @@ msgstr ""
 "determinar\n"
 "la configuración de selección de subtítulos cuando haya audio extranjero."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Idioma preferido: Ninguno"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Añadir pasada de escaneo de audio extranjero"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1823,11 +1823,11 @@ msgstr ""
 "Esta opción requiere que se establezca un idioma en la lista Idiomas "
 "seleccionados."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Añadir pista de subtítulos si el audio predeterminado es extranjero"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1840,11 +1840,11 @@ msgstr ""
 "Esta opción requiere que se establezca un idioma en la lista Idiomas "
 "seleccionados."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Añadir subtítulos incrustados cuando estén disponibles"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1852,11 +1852,11 @@ msgstr ""
 "Los subtítulos cerrados son subtítulos de texto que se pueden agregar a "
 "cualquier contenedor como una pista de subtítulos suave"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Modo de Incrustacion*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1872,15 +1872,15 @@ msgstr ""
 "¡Solo se puede grabar una pista de subtítulos! Dado que pueden ocurrir "
 "conflictos, el primero elegido gana."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Incrustacion para reproductores deficientes*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Subtitulos de DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1898,11 +1898,11 @@ msgstr ""
 "¡Solo se puede grabar una pista de subtítulos! Dado que pueden ocurrir "
 "conflictos, el primero elegido gana."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Subtitulos Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1920,7 +1920,7 @@ msgstr ""
 "¡Solo se puede grabar una pista de subtítulos! Dado que pueden ocurrir "
 "conflictos, el primero elegido gana."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1928,7 +1928,7 @@ msgstr ""
 "<small>* Solo se aplicará una de las opciones de incrustacion de subtítulos "
 "anteriores, comenzando por la primera</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1936,111 +1936,111 @@ msgstr ""
 "Sólo se puede incrustar una pista de subtítulos! Dado que los conflictos "
 "pueden ocurrir, el primero sera el elegido."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Subtitulos"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcadores de capítulos"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Añadir marcadores de capítulos al archivo de salida."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Indice"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Duración"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titulo"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Actores:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Director:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Fecha de lanzamiento:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Comentario:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genero:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Descripción:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Argumento:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etiquetas"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Guardar como:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nombre de archivo de destino para su codificación."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>En:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Directorio de destino para su codificación."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Directorio de destino"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr "Añadir Múltiples Títulos"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2048,54 +2048,54 @@ msgstr "Añadir Múltiples Títulos"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Seleccionar todo"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Añadir multiples títulos a la cola"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Limpiar todo"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Desmarcar todos los títulos"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Archivos de destino OK. No se detectaron duplicados."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferencias"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Buscar actualizaciones automáticamente"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Acción por defecto cuando se completan todas las codificaciones"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Asignar el nombre de archivo automáticamente (nombre original modificado)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 "Crear un nombre de archivo de destino a partir del nombre de archivo de "
 "origen o la etiqueta de volumen"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Plantilla para la asignación automática"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2105,25 +2105,25 @@ msgstr ""
 "Opciones disponibles: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Use la extensión de archivo compatible con iPod/iTunes (.m4v) para MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Número de vistas previas"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtrar títulos cortos de DVD y Blu-ray (segundos)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 "Borrar elementos de la cola de completados después de que se complete una "
 "codificación"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2134,53 +2134,53 @@ msgstr ""
 "Marque esto si desea que la cola se limpie eliminando los trabajos "
 "completados."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "General"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 "Establezca un directorio personalizado para archivos temporales de Handbrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2206,66 +2206,66 @@ msgstr ""
 "física y puede ser demasiado pequeño para cosas como el archivo de "
 "estadísticas de 2 pasos."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Directorio temporal"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Nivel de detalle en la escala de calidad constante"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Usar la biblioteca dvdnav (en lugar de libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Controlar el espacio libre en el disco de destino"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Detener la codificación si el espacio libre en el disco cae por debajo del "
 "límite"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB Limite"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Guardar los registros de codificación en la misma ubicación que la película"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Nivel de detalle de los registros de actividad"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Caducidad de los registros de actividad"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Reducir las vistas previas de alta definición"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Escanear automáticamente los DVD"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Escanea el DVD cada vez que se carga un nuevo disco"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Tamaño de fuente de la ventana de actividad"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Usar los mismos ajustes para todos los títulos en un lote"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2279,11 +2279,11 @@ msgstr ""
 "Desactive esta opción si desea permitir cambiar el ajuste de cada título de "
 "forma independiente."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr "Mostrar imagen de vista previa en la pestaña Resumen"
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
@@ -2291,76 +2291,76 @@ msgstr ""
 "Desmarque esto si desea ocultar la imagen de vista previa del video en la "
 "pestaña Resumen por razones de privacidad."
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Mostrar Ajustes"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Mostrar HandBrake para Dummies"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avanzado"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr "Renombrar Preajuste"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Renombrar Preajuste</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nombre:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descripcion</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr "Guardar Preajuste"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categoría:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 "Establece la categoría en la que se mostrará este ajuste preestablecido."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nombre de la categoría:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nombre del PreAjuste:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Preajuste por defecto"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Establecer el Preset como predeterminado cuando se inicie HandBrake"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensiones</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Vista previa de HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Seleccionar los fotogramas de vista previa."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2368,75 +2368,75 @@ msgstr ""
 "Codifique y reproduzca una secuencia corta de video a partir de la posición "
 "de vista previa actual."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr "Clic para alternar el modo de pantalla completa"
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Duracion:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Establecer la duración de la vista previa en vivo en segundos."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Mostrar Recorte"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Mostrar área recortada de la vista previa"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Resolucion original"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Restablecer ventana de vista previa a la resolución del video original"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr "Editar Subtitulos"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importar SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Habilitar configuraciones para importar un archivo de subtítulos SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importar SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Habilite la configuración para importar un archivo de subtítulos SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Lista de subtítulos incrustados"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Habilitar la configuración para seleccionar subtítulos incrustados"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Pista de la fuente"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lista de subtítulos disponibles de su fuente."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nombre de la pista:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2446,23 +2446,23 @@ msgstr ""
 "\n"
 "Los reproductores pueden usar esto en la lista de selección de subtítulos."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Idioma"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Código de caracteres"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Archivo:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Compensar (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2470,7 +2470,7 @@ msgstr ""
 "Establece el idioma de este subtítulo. Este valor será usado por los "
 "reproductores en los menús de subtítulos."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2485,29 +2485,29 @@ msgstr ""
 "el conjunto de caracteres a UTF-8. El código de caracteres de la fuente es "
 "necesario para realizar esta traducción."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Seleccione el archivo SRT a importar."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importar archivo"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Ajuste el desplazamiento en milisegundos entre las marcas de tiempo de video "
 "y SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Solo subtítulos forzados"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Incrustar en el video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2515,19 +2515,19 @@ msgstr ""
 "Renderiza el subtítulo sobre el video. \n"
 "El subtítulo será parte del video y no podrá ser deshabilitado."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Establecer pista por defecto"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr "Editar pista de audio"
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lista de pistas de audio disponibles de su fuente."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2537,15 +2537,15 @@ msgstr ""
 "\n"
 "Los reproductores pueden usar esto en la lista de selección de audio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mezcla"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Frecuencia de muestreo"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2563,31 +2563,31 @@ msgstr ""
 "DRC le permite \"comprimir\" el rango haciendo que los sonidos fuertes sean "
 "más suaves y los sonidos suaves más fuertes."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Ajuste el códec de audio para codificar esta pista."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Tasa de bits"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Habilitar ajustes de tasa de bits"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Calidad"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Habilitar ajustes de calidad"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Establezca la tasa de bits para codificar esta pista."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2595,19 +2595,19 @@ msgstr ""
 "<b>Calidad:</b>Para codecs de salida que lo soportan, ajuste la calidad de "
 "la salida."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Ajuste la mezcla de la pista de audio de salida."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Ajuste la frecuencia de muestreo de la pista de audio de salida."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2616,40 +2616,40 @@ msgstr ""
 "de audio de salida."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Desactivado"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr "Actualizador de HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Omitir esta versión"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Recordarme más tarde"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>¡Una nueva versión de HandBrake está disponible!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx ya está disponible (tienes yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Notas de lanzamiento</b>"
 
@@ -2795,7 +2795,7 @@ msgstr "Dispositivos de DVD detectados:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Escaneando ..."
 
@@ -2808,37 +2808,66 @@ msgstr "Parar escaneado"
 msgid "Single Title"
 msgstr "Abrir unico _titulo"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr "FPS"
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Pista de audio"
 msgstr[1] "Pistas de audio"
 msgstr[2] "Pistas de audio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Pista de subtitulo"
 msgstr[1] "Pistas de subtitulos"
 msgstr[2] "Pistas de subtitulos"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr "CFR"
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr "PFR"
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr "VFR"
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2846,22 +2875,22 @@ msgstr[0] "+ %d mas pista de audio"
 msgstr[1] "+ %d mas pistas de audio"
 msgstr[2] "+ %d mas pistas de audio"
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Solo forzado"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", Incrustado"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Por defecto"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2869,33 +2898,33 @@ msgstr[0] "+ %d mas pista de subtitulo"
 msgstr[1] "+ %d mas pistas de subtitulos"
 msgstr[2] "+ %d mas pistas de subtitulos"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr "almacenamiento"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr "pantalla"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr "Relación de aspecto del píxel:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr "Mostrar Relación de Aspecto"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Titulo no encontrado"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nuevo Vídeo"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2906,134 +2935,134 @@ msgstr ""
 "\n"
 "%sen%d segundos ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%ssu película se perderá si no sigues codificando."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Cancelar actual y detener"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Cancelar y Comenzar siguiente"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Finalizar y después detener"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Seguir codificando"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d codificacion pendiente"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d codificaciones pendientes"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "trabajo %d de %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "pasada %d(exploración de subtítulos) de %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "pasada %d de %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Codificando: %s%s%.2f%% (%.2f fps, avg %.2f fps,Tiempo restante "
 "%02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Codificando: %s%s%.2f%% (Tiempo restante %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Codificando: %s%s%.2f%%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Buscando la hora de inicio, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Escaneando titulo %d de %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Escaneando titulo %d de %d vista previa %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "¡Codificación Realizada!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Codificación Cancelada."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Ha fallado la codificación."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Muxing: Esto puede tomar un tiempo ..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s ya está disponible (tienes %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Codificación Completada"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Deja ese cóctel, ¡Codificacion de HandBrake finalizada!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Su codificación está completada."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Saliendo de Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Poner el equipo en reposo"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Apagando el equipo"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 #, fuzzy
 msgid "All Files"

--- a/gtk/po/eu.po
+++ b/gtk/po/eu.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Language-Team: Basque (https://www.transifex.com/HandBrakeProject/"
 "teams/92423/eu/)\n"
@@ -103,8 +103,8 @@ msgstr "Aurrezarpenak"
 msgid "Set De_fault"
 msgstr "Ezarri lehenetsia"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "Gorde"
 
@@ -112,7 +112,7 @@ msgstr "Gorde"
 msgid "Save _As"
 msgstr "Gorde honela"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "Berrizendatu"
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Txigorketa denbora</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -182,7 +182,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Lehenetsia</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -359,7 +359,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Hasi bihurtzen"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Hasi"
@@ -378,7 +378,7 @@ msgstr "Pausatu"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -396,8 +396,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Editatu"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Aurrezarpena"
 
@@ -405,7 +405,7 @@ msgstr "Aurrezarpena"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Izenburua:"
 
@@ -429,7 +429,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Laburpena"
 
@@ -512,11 +512,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Aukeratu bideo-iturburua"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Ireki iturburua"
 
@@ -548,7 +548,7 @@ msgstr "Aurre-ikuspena"
 msgid "Show Queue"
 msgstr "Erakutsi ilara"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Ilara"
 
@@ -571,15 +571,15 @@ msgstr "<b>Iturburua:</b>"
 msgid "None"
 msgstr "Bat ere ez"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Eskaneatzen..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Izenburua:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -589,51 +589,51 @@ msgstr ""
 "Besterik ezean titulurik luzeena aukeratuko da.\n"
 "DVDren jatorrizko izenburua izaten ohi da."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angelua:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Angelu-anitzeko DVDetan, aukeratu zein angelu nahi duzun bihurtu."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Tartea:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "Bihurtzeko tartea. Izan daitezke kapituluak, segundoak edo fotogramak."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Ezarri bihurketaren lehenengo kapitulua"
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Ezarri bihurketaren azkeneko kapitulua."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Aurrezarpena:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Aukeratu aurrezarpena"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Aldatua</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Birkargatu"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -641,27 +641,27 @@ msgstr ""
 "Birkargatu ezarpenak une honetan hautatutako aurrezapenetik.\n"
 "Aldaketak baztertuko dira."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Gorde aurre-ezarpen berria"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Uneko ezarpenak aurrezarpen berri moduan gorde."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formatua:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formateatu mux pista kodetuetarako."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Weberako optimizatua"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -670,11 +670,11 @@ msgstr ""
 "Horrela erreproduzigailuak erreprodukzioa has dezake fitxategi osoa "
 "deskargatu aurretik."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Lerrokatu A/V hasiera"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -686,140 +686,140 @@ msgstr ""
 "hobetu dezake MP4 editatzeko zerrendak errespetatzen ez dituzten "
 "erreproduzitzaileentzat."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G euskarria"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Gehitu iPod zahar batzuk behar dute iPod Atom."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Iraupena:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Pistak:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Iragaziak:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Tamaina:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Moztu ezkerretik"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Moztu goitik"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Moztu behetik"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Moztu eskuinetik"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfikoa:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -829,11 +829,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Pixel proportzioa"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -842,11 +842,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -854,11 +854,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -868,7 +868,7 @@ msgstr ""
 "Bistaratzeko uneko luze-zabalera ez dira berdinak izango baldin eta pixelen "
 "itxuraren proportzioa 1:1 ez bada."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -878,84 +878,84 @@ msgstr ""
 "Bistaratzeko uneko luze-zabalera ez dira berdinak izango baldin eta pixelen "
 "itxuraren proportzioa 1:1 ez bada."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Neurriak"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -963,18 +963,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -982,7 +982,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -990,11 +990,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1002,7 +1002,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -1011,39 +1011,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Tonua:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1051,7 +1051,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1059,78 +1059,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Grisen eskala"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Iragaziak:"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Bideo bihurtzailea:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Bideo bihurtzaile erabilgarriak."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Fotograma-ratioa"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1138,19 +1138,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Fotograma-ratio konstantea"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1158,18 +1158,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Fotograma-ratio aldagarria"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1185,15 +1185,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Kalitate konstantea"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bit-ratioa (kbps):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1204,11 +1204,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2 psaeko bihurketa"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1218,16 +1218,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1239,7 +1239,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1248,22 +1248,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Bihurketa azkarra"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latentzia zero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1273,300 +1273,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profila:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Maila:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Beste ezarpenak:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Bideoa"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Gehitu"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Gehitu audio ezarpen berriak zerrendara"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Gehitu dena"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Gehitu audio pista guztiak ilarara"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Birkargatu audio ezarpenak lehenetsitakotik"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Pisten zerrenda"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Hautaketaren portaera:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Aukeratu iturburuko zein audio pista erabili diren."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Kendu"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Hizkuntza erabilgarriak"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Hautatu hizkuntzak"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Erabili soilik lehenengo kodetzailea audio sekundariorako."
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Audio bihurketaren ezarpenak:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Bihurgailua"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bit ratioa/Kalitatea"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Pisten hautapena"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1577,15 +1577,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Hobetsitako hizkuntza: Bat ere ez"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1595,11 +1595,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1607,21 +1607,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1631,15 +1631,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD azpitituluak"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1650,11 +1650,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray azpitituluak"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1665,124 +1665,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Azpitituluak"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Kapitulu sortzialeak"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Gehitu kapitulu markatzaileak irteera-fitxategia."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Kapituluak"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Kapituluak"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Aurkibidea"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Iraupena"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Izenburua"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Kapituluak"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Aktoreak:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Zuzendaria:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Argitalpen data:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Iruzkina:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Generoa:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Deskripzioa:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etiketak"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Gorde honela:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Kodetzearen helburuaren fitxategi-izena"
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Hona:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Kodeketaren direktorio helburua"
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Helburuaren direktorioa"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Gehitu batzuk"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1790,127 +1790,127 @@ msgstr "Gehitu batzuk"
 msgid "Cancel"
 msgstr "Utzi"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Hautatu denak"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Markatu ilarara gehituko diren titulu guztiak"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Garbitu dena"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Desmarkatu titulu guztiak"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Helburuko fitxategiak ondo. Ez da bikoizketarik atzeman."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Hobespenak"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Bilatu eguneraketak automatikoki"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Erabili izendatze automatikoa (aldatutako iturburu izena erabiltzen du)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Auto-izendatzeko txantiloia"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Erabili iPod/iTunes-en gogoko (.m4v) fitxategi luzapena  MP4rako"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Aurrebisten kopurua"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Orokorra"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1924,63 +1924,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB muga"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1989,191 +1989,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Onartu doikuntzak"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Aurreratua"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Aurrezarpen lehenetsiak"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Berrizendatu aurrezarpenak</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Izena:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descripzioa</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Gorde aurre-ezarpen berria"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategoria:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Kategoriaren izena:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Aurrezarpenen izena:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Aurrezarpen lehenetsiak"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Iraupena:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Azpitituluak"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Inportatu SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "iturburu pista"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Pistaren izena:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Hizkuntza"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fitxategia:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2182,60 +2182,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2246,90 +2246,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bit ratioa:"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kalitatea"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2464,7 +2464,7 @@ msgstr "Antzeman diren DVD gailuak:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2477,93 +2477,122 @@ msgstr ""
 msgid "Single Title"
 msgstr "Ireki titulu sinplea"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Audio"
 msgstr[1] "Audio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Azpitituluak"
 msgstr[1] "Azpitituluak"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Pixel proportzioa"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2571,132 +2600,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/fi.po
+++ b/gtk/po/fi.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Tommi Nieminen <translator@legisign.org>, 2022\n"
 "Language-Team: Finnish (https://www.transifex.com/HandBrakeProject/"
@@ -107,8 +107,8 @@ msgstr "_Esiasetukset"
 msgid "Set De_fault"
 msgstr "Aseta _oletukseksi"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Tallenna"
 
@@ -116,7 +116,7 @@ msgstr "_Tallenna"
 msgid "Save _As"
 msgstr "Tallenna _nimellä"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Muuta nimeä"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Kuvaan poltettu</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Oletus</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -364,7 +364,7 @@ msgstr "0 odottavaa työtä"
 msgid "Start Encoding"
 msgstr "Aloita koodaus"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Aloita"
@@ -383,7 +383,7 @@ msgstr "Tauko"
 msgid "Options"
 msgstr "Valinnat"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Kun valmista:"
 
@@ -403,8 +403,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Muokkaa"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Esiasetus:"
 
@@ -412,7 +412,7 @@ msgstr "Esiasetus:"
 msgid "Source:"
 msgstr "Lähde:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Nimeke:"
 
@@ -436,7 +436,7 @@ msgstr "Ääni:"
 msgid "Subtitles:"
 msgstr "Tekstitys:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Yhteenveto"
 
@@ -529,11 +529,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Valitse videolähde"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Avaa lähde"
 
@@ -565,7 +565,7 @@ msgstr "Esikatselu"
 msgid "Show Queue"
 msgstr "Näytä jono"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Jono"
 
@@ -588,15 +588,15 @@ msgstr "<b>Lähde:</b>"
 msgid "None"
 msgstr "Ei mitään"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Tutkitaan…"
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Nimeke:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -606,51 +606,51 @@ msgstr ""
 "Oletuksena valitaan pisin nimeke.\n"
 "Sillä on usein DVD:n varsinainen sisältö."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Kulma:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Valitse useampikulmaisen DVD:n haluttu koodauskulma."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Alue:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "Koodattavien nimekkeiden alue. Voi olla lukuja, sekunteja tai kuvia."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Asettaa ensimmäisen koodattavan luvun."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Asettaa viimeisen koodattavan luvun."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Esiasetus:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Valitse esiasetus"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Muutettu</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Lataa uudelleen"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -658,27 +658,27 @@ msgstr ""
 "Lataa valitun esiasetuksen asetukset uudelleen.\n"
 "Muutokset hylätään."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Tallenna uusi esiasetus"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Tallenna nykyiset asetukset uudeksi esiasetukseksi."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Muoto:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Muoto johon enkoodatut raidat työstetään."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimoi verkkoa varten"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -687,11 +687,11 @@ msgstr ""
 "Tämä mahdollistaa toistimen aloittaa varsinainen toisto ennen kuin koko "
 "tiedosto on ladattu."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Tasaa äänen/videon alku"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -701,140 +701,140 @@ msgstr ""
 "kehyksiä tai jättämällä kehyksiä pois. Voi parantaa äänen ja kuvan\n"
 "tahdistusta toistimilla, jotka eivät kunnioita MP4-muokkausluetteloita."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G -tuki"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Lisää joidenkin vanhempien iPodien vaatima iPod Atom."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Kesto:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "tt:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Raidat:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Suodattimet:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Koko:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Kierrä videota myötäpäivään 90 asteen askelin."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Rajaus vasemmalta"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Rajaus ylhäältä"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Rajaus alhaalta"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Rajaus oikealta"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfinen:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -844,11 +844,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Kuvapistesuhde:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -861,11 +861,11 @@ msgstr ""
 "1:1-suhde tekee kuvapisteestä neliön, muut arvot nelikulmioita.\n"
 "Toistimet voivat skaalata kuvaa saavuttaakseen asetetun kuvasuhteen."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -878,11 +878,11 @@ msgstr ""
 "suorakulmaista laajaa kuvaa.\n"
 "Toistimet mitoittavat kuvan pyydetyn kuva-asetuksen saavuttamiseksi. "
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -891,7 +891,7 @@ msgstr ""
 "Tämä on kuvaleveys, jolla video tallennetaan.\n"
 "Todelliset näyttömitat eroavat, ellei kuvapistesuhde ole 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -900,84 +900,84 @@ msgstr ""
 "Tämä on kuvakorkeus, jolla video tallennetaan.\n"
 "Todellinen näyttömitta eroaa, ellei kuvapistesuhde ole 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automaattinen"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Mitat"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Vastatelekiini:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -990,7 +990,7 @@ msgstr ""
 "Muuntamisessa filmin 24 FPS kuvanopeus sovitetaan NTSC-videon 30 FPS "
 "kuvanopeuteen."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1001,11 +1001,11 @@ msgstr ""
 "RoskaVasemmalla:RoskaOikealla:RoskaYläosassa:Roskala-osassa:TiukatHajoitteet:"
 "MetrinenAla:Vastaavuus"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Lomituksen tunnistus:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1017,7 +1017,7 @@ msgstr ""
 "Jos lomituksenpoistosuodatin on käytössä, lomituksenpoistoa käytetään vain\n"
 "tämän suodattimen lomittuneiksi havaitsemiin kuviin."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1030,11 +1030,11 @@ msgstr ""
 "Suodatin Moodi:\n"
 "Sulku Puinti: Laatikon Leveys: Laatikon Korkeus"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Lomituksen poisto:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1046,7 +1046,7 @@ msgstr ""
 "Kampapoistosuodin tukee useita interpolaation algoritmejä.\n"
 "Lomituspoiston suodin on perinteinen YADIF-lomituspoisto.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1060,11 +1060,11 @@ msgstr ""
 "Kampapoistosuodin tukee useita interpolaation algoritmejä.\n"
 "Lomituspoiston suodin on perinteinen YADIF-lomituspoisto.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Laatikoinninvähennyssuodin:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1074,12 +1074,12 @@ msgstr ""
 "Mikäli lähdevideossa on 'laatikkomaisuuksia', tämä suodatin voi auttaa "
 "niiden putsaamisessa."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Säätö:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1090,7 +1090,7 @@ msgstr ""
 "Mikäli lähdevideossa on 'laatikkomaisuuksia', tämä suodatin voi auttaa "
 "niiden putsaamisessa."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1101,11 +1101,11 @@ msgstr ""
 "\n"
 "voima=heikko|kova:puinti=0-100:laatikkokoko=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Kohinanpoistosuodatin:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1118,7 +1118,7 @@ msgstr ""
 "Tätä suodatinta käyttämällä kyseisissä tilantessa voit saavuttaa pienemmän "
 "tiedostokoon."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1132,7 +1132,7 @@ msgstr ""
 "Tätä suodatinta käyttämällä kyseisissä tilantessa voit saavuttaa pienemmän "
 "tiedostokoon."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1143,27 +1143,27 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Terävöityssuodatin:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1171,7 +1171,7 @@ msgstr ""
 "Terävöityssuodatin korostaa reunoja ja videon\n"
 "muita korkeataajuuksisia komponentteja."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1180,39 +1180,39 @@ msgstr ""
 "Terävöityssuodatin korostaa reunoja ja videon\n"
 "muita korkeataajuuksisia komponentteja."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Harmaasävy"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Jos valittu, värit suodatetaan pois videosta."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Suodattimet"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Videokoodaus:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Saatavilla olevat videokoodaajat."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Kuvanopeus:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1224,19 +1224,19 @@ msgstr ""
 "”Sama kuin lähteessä” on suositeltu. Jos lähdevideon kuvanopeus\n"
 "on vaihteleva, ”Sama kuin lähteessä” säilyttää sen."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Vakiokuvanopeus"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Asettaa vakiokuvanopeuksisen tuloksen."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Huippukuvanopeus (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1248,11 +1248,11 @@ msgstr ""
 "\n"
 "VFR ei toimi kaikissa soittimissa."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Vaihteleva kuvanopeus"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1262,7 +1262,7 @@ msgstr ""
 "\n"
 "VFR ei toimi kaikissa soittimissa."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1290,15 +1290,15 @@ msgstr ""
 "FFMpegin ja Theoran asteikko on lineaarisempi, eikä näillä koodaajilla\n"
 "ole häviötöntä tilaa."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Vakiolaatu:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bittinopeus (kbps): "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1317,11 +1317,11 @@ msgstr ""
 "bittinopeutta pitää rajoittaa, ks. x264:n asetuksia vbv-bufsize ja vbv-"
 "maxrate."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2-vaihekoodaus"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1337,18 +1337,18 @@ msgstr ""
 "Toisessa vaiheessa tilastoja käytetään tehtäessä päätöksiä bittinopeuden\n"
 "osoittamisesta."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Nopea ensimmäinen vaihe"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Käytä 2-vaiheisen koodauksen ensi vaiheessa asetuksia, jotka nopeuttavat "
 "asioita."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1369,7 +1369,7 @@ msgstr ""
 "asetukset\n"
 "tuottavat yleensä parempilaatuisen videon ja pienemmän tiedoston."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1383,11 +1383,11 @@ msgstr ""
 "tulostiedoston ominaisuuksia. Muutokset otetaan käyttöön esiasetuksen\n"
 "jälkeen mutta ennen muita parametreja."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Koodauksen pikapurku"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1397,11 +1397,11 @@ msgstr ""
 "\n"
 "Käytä tätä, jos laitteella on toistovaikeuksia (kuvia jää välistä)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Nollalatenssi"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1417,11 +1417,11 @@ msgstr ""
 "Koska HandBrake ei sovellu suoratuostalähetyksiin, asetuksella ei ole\n"
 "todellista merkitystä."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profiili:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1431,11 +1431,11 @@ msgstr ""
 "\n"
 "Ohittaa kaikki muut asetukset."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Taso:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1445,11 +1445,11 @@ msgstr ""
 "\n"
 "Ohittaa kaikki muut asetukset."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Lisäasetukset:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1459,45 +1459,45 @@ msgstr ""
 "\n"
 "Puolipistein erotettu koodausvalitsinluettelo."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Lisää"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Lisää luetteloon uusi ääniasetus"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Lisää kaikki"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Lisää kaikki ääniraidat luetteloon"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Lataa kaikki ääniasetukset oletuksista"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Raitaluettelo"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Valinnan toiminta:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Valitse, mitä lähdetietovälineen ääniraitoja käytetään."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1506,23 +1506,23 @@ msgstr ""
 "Luo luettelo kielistä, joiden äänen haluat valita.\n"
 "Kieliä vastaavat raidat valitaan halutun valintatoiminnan mukaisesti."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Poista"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Käytettävissä olevat kielet"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Valitut kielet"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Käytä toissijaiseen ääneen vain ensimmäistä koodausta"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1531,26 +1531,26 @@ msgstr ""
 "Vain ensisijainen ääniraita koodataan koko koodausluettelolla.\n"
 "Toissijaiset äänitulosraidat koodataan vain ensimmäisellä koodauksista."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "AUtomaattinen läpivienti:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1560,11 +1560,11 @@ msgstr ""
 "Tällöin valitaan MP3-läpivienti, kun automaattinen läpiviennin valinta on "
 "käytössä."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1574,11 +1574,11 @@ msgstr ""
 "Tämä sallii valita AC-3-läpiviennin, kun automaattinen läpivienti on "
 "käytössä."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1588,11 +1588,11 @@ msgstr ""
 "Tämä sallii valita EAC-3-läpiviennin, kun automaattinen läpivienti on "
 "käytössä."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1601,11 +1601,11 @@ msgstr ""
 "Ota tämä käyttöön, jos toistolaite tukee DTS:ää.\n"
 "Tämä sallii valita DTS-läpiviennin, kun automaattinen läpivienti on käytössä."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1615,11 +1615,11 @@ msgstr ""
 "Tämä sallii valita DTS-HD-läpiviennin, kun automaattinen läpivienti on "
 "käytössä."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1629,11 +1629,11 @@ msgstr ""
 "Tämä sallii valita TrueHD-läpiviennin, kun automaattinen läpivienti on "
 "käytössä."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1643,11 +1643,11 @@ msgstr ""
 "Tämä sallii valita FLAC-läpiviennin, kun automaattinen läpivienti on "
 "käytössä."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1657,22 +1657,22 @@ msgstr ""
 "Tällöin valitaan AAC-läpivienti, kun automaattinen läpiviennin valinta on "
 "käytössä."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Varaläpivienti:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1680,60 +1680,60 @@ msgstr ""
 "Aseta, millä äänikoodekilla koodataan, kun ääniläpivientiä varten ei löydy "
 "sopivaa raitaa."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Äänikoodausasetukset:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "Kukin valittu lähderaita koodataan kaikilla valituilla koodauksilla."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Koodaaja"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bittinopeus/laatu"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Alasmiksaus"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Näytteenottotaajuus"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Äänenvoimakkuuden tasaus"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Raidan valinta"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Ääni"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Lisää luetteloon uusi tekstitysasetus"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Lisää luetteloon kaikki tekstitysraidat"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Vieraskielisen äänen tunnistus"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1743,15 +1743,15 @@ msgstr ""
 "ehdokkaita tekstityksiksi äänijaksoille, jotka sisältävät\n"
 "vieraskielistä puhetta."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Lataa kaikki tekstitysasetukset oletuksista uudelleen"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Valitse, mitä lähteen tekstitysraidoista käytetään."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1767,15 +1767,15 @@ msgstr ""
 "Luettelon ensimmäinen kieli on ”suosimasi” kieli, ja sitä käytetään\n"
 "määrittämään tekstitysvalinta-asetukset, kun ääni sisältää vierasta kieltä."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Suosittu kieli: Ei mitään"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Lisää vieraskielisenä äänen tunnistusvaihe"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1791,11 +1791,11 @@ msgstr ""
 "\n"
 "Valinta vaatii, että valittujen kielten luettelossa on asetettu kieli."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Lisää tekstitysraita, kun oletusäänen kieli on vieras"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1806,11 +1806,11 @@ msgstr ""
 "\n"
 "Valinta vaatii, että valittujen kielten luettelossa on asetettu kieli."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Lisää valittavissa oleva tekstitys, kun saatavilla"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1818,11 +1818,11 @@ msgstr ""
 "Valittavissa oleva tekstitys on tekstimuotoinen tekstitys, joka voidaan "
 "lisätä mihin tahansa säilöön ohjelmallisena tekstitysraitana."
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Toiminta kuvaan poltettaessa*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1838,15 +1838,15 @@ msgstr ""
 "Vain yksi tekstitysraita voidaan polttaa kuvaan! Ristiriitatilanteissa "
 "ensimmäinen valittu voittaa."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Kuvaan poltto puutteellisia toistimia varten*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD-tekstitykset"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1862,11 +1862,11 @@ msgstr ""
 "Vain yhden tekstitysraidan voi polttaa! Ristiriitatapauksissa ensimmäinen "
 "valittu voittaa."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Bluray-tekstitykset"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1883,7 +1883,7 @@ msgstr ""
 "Vain yhden tekstitysraidan voi polttaa! Ristiriitatapauksissa ensimmäinen "
 "valittu voittaa."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1891,7 +1891,7 @@ msgstr ""
 "<small>* Käytetään vain yhteen yllä olevista tekstitysvalinnoista ylhäältä "
 "alkaen.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1899,112 +1899,112 @@ msgstr ""
 "Vain yksi tekstitysraita poltetaan! Ristiriitatilanteissa voittaa "
 "ensimmäinen valittu."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Tekstitykset"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Lukumerkit"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Lisää tulostiedostoon lukumerkit."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Luvut"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Luvut"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Hakemisto"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Kesto"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Nimeke"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Luvut"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Näyttelijät:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Ohjaaja:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Julkaisupäivä:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Huomautus:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Tyylilaji:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Kuvaus:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Juoni:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Luokitukset"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Tallenna nimellä:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Koodauksen kohdetiedostonimi."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Kansioon:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Koodauksen kohdekansio."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Kohdekansio"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Lisää _useampia"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2012,51 +2012,51 @@ msgstr "Lisää _useampia"
 msgid "Cancel"
 msgstr "Peru"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Valitse kaikki"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Merkitse kaikki nimekkeet lisättäviksi jonoon"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Tyhjennä kaikki"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Poista kaikkien nimekkeiden valinta"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Kohdetiedostot ovat kunnossa. Kaksoiskappaleita ei havaittu."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Valinnat"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Tarkista päivitykset automaattisesti"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Aseta nimet automaattisesti (käyttää muokattuja lähdenimiä)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "Luo kohdetiedostonimi lähdetiedostonimestä tai taltion nimestä"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Automaattisen nimen malli"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2067,23 +2067,23 @@ msgstr ""
 "{esiasetus} {luvut} {päiväys} {aika} {luontipäivä} {luontiaika} {laatu} "
 "{bittinopeus}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Käytä MP4-tiedostoille iPod/iTunes-yhteensopivaa päätettä (.m4v)"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Esikatselujen määrä"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Suodata lyhyet DVD- ja Bluray-nimekkeet (sekunteina)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Poista valmistuneet työt jonosta koodauksen valmistuttua"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2093,52 +2093,52 @@ msgstr ""
 "valmiiksi.\n"
 "Valitse tämä, jos haluat poistaa jonosta valmistuneet työt automaattisesti."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Yleistä"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2152,63 +2152,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Käytä dvdnavia (libdvdreadin sijaan)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Valvo kohdekansion vapaata levytilaa"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Keskeytä koodaus, jos vapaan levytilan määrä putoaa alle rajan"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Mt-rajoitus"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Tallenna yksittäiset koodauslokit samaan kansioon kuin video"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Toimintalokin yksityiskohtaisuus"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Toimintalokin elinikä"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Skaalaa huippulaatuisia esikatseluja alaspäin"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Tutki syötetty DVD automaattisesti"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Tutkii DVD:n aina, kun uusi levy syötetään"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Toimintaikkunan fonttikoko"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Käytä erän kaikkiin nimekkeisiin samoja asetuksia"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2221,163 +2221,163 @@ msgstr ""
 "\n"
 "Poista valinta, jos haluat muuttaa yksitellen kunkin nimekkeen asetuksia."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Salli säädöt"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Salli HandBrake typeryksille"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Lisäasetukset"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Kohinanpoiston esiasetus:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Muuta esiasetuksen nimeä</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nimi:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Kuvaus</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Tallenna uusi esiasetus"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Luokka:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Aseta, missä luokassa tämän esiasetuksen tulisi näkyä."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Luokan nimi:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Esiasetuksen nimi:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Oletusesiasetus"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Tee tätä HandBraken käynnistyessä valittu oletusesiasetus"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Mitat</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBraken esikatselu"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Valitse esikatselukuvat."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 "Koodaa ja toista lyhyt videokatkelma alkaen esikatselun nykyisestä kohdasta."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Kesto:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Aseta sekunteina elävän esikatselun kesto."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Näytä rajaus"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Näytä esikatselussa rajausalue"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Lähteen tarkkuus"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Palauta esikatseluikkuna lähdevideon tarkkuuteen"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Tekstitykset"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Tuo SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Aseta SRT-tekstitystiedostojen tuonnin asetukset"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Tuo SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Aseta SSA-tekstitystiedoston tuontiasetukset"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Upotettu tekstitysluettelo"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Aseta upotettujen tekstitysten valinnan asetukset"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Lähderaita"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lähteessä käytettävissä olevien tekstitysraitojen luettelo."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Raidan nimi:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2387,23 +2387,23 @@ msgstr ""
 "\n"
 "Toistimet voivat käyttää tätä tekstitysvalintaluettelossaan."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Kieli"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Merkkikoodi"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Tiedosto:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Siirtymä (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2411,7 +2411,7 @@ msgstr ""
 "Aseta tämän tekstityksen kieli.\n"
 "Toistimet käyttävät arvoa tekstitysvalikoissaan."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2425,27 +2425,27 @@ msgstr ""
 "HandBrake kääntää koodauksen UTF-8:ksi.\n"
 "Lähteen merkistökoodaus tarvitaan käännöksen onnistumiseksi."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Valitse tuotava SRT-tiedosto."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Tuo tiedosto"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "Säädä millisekunteina siirtymää videon ja SRT-aikaleimojen välillä."
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Vain pakotetut tekstitykset"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Polta kuvaan"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2453,19 +2453,19 @@ msgstr ""
 "Polta eli hahmonna tekstitys videokuvaan.\n"
 "Tekstityksestä tulee osa videota eikä sitä voi poistaa käytöstä."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Aseta oletusraita"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lähteessä saatavilla olevien ääniraitojen luettelo"
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2475,15 +2475,15 @@ msgstr ""
 "\n"
 "Toistimet voivat käyttää tätä äänivalintaluettelossaan."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Miksaa"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Näytteenottotaajuus"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2500,49 +2500,49 @@ msgstr ""
 "DRC ”pakkaa” alueen niin, että kovaääniset jaksot heikkenevät ja hiljaiset "
 "kovenevat."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Aseta äänikoodekki, johon tämä raita koodataan."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bittinopeus"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Käytä bittinopeusvalintaa"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Laatu"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Käytä laatuvalintaa"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Aseta bittinopeus, johon tämä raita koodataan."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr "<b>Laatu:</b> Asettaa tuloksen laadun sitä tukeville tuloskoodekeille."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Aseta tulosääniraidan alamiksaus."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Aseta tulosääniraidan näytteenottotaajuus."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2551,41 +2551,41 @@ msgstr ""
 "heikennystä."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0 dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Ei käytössä"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Ohita tämä versio"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Muistuta myöhemmin"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>HandBraken uusi versio on saatavilla!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx on nyt saatavilla (sinulla on yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Julkaisutiedot</b>"
 
@@ -2729,7 +2729,7 @@ msgstr "Tunnistetut DVD-laitteet:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Tutkitaan…"
 
@@ -2742,93 +2742,122 @@ msgstr "Pysäytä haku"
 msgid "Single Title"
 msgstr "Avaa _yksittäinen nimeke"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Ääni"
 msgstr[1] "Ääni"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Tekstitykset"
 msgstr[1] "Tekstitykset"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", vain pakotettu"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", poltettu"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", oletus"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "Vieraskielisen äänen tekstitysraita"
 msgstr[1] "Vieraskielisen äänen tekstitysraita"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Kuvapistesuhde:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nimekkeitä ei löytynyt"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Uusi video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2839,134 +2868,134 @@ msgstr ""
 "\n"
 "%s %d sekunnissa…"
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sElokuvasi on mennyttä, ellet jatka koodausta."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Peru nykyinen ja lopeta"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Peru nykyinen ja aloita seuraava"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Viimeistele nykyinen ja lopeta"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Jatka koodausta"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d koodaus odottaa"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d koodausta odottaa"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "työ %d/%d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "vaihe %d / %d (tekstityshaku), "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "vaihe %d/%d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Koodataan: %s%s%.2f %% (%.2f FPS, keskim %.2f FPS, jäljellä %02d t %02d min "
 "%02d s)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Koodataan: %s%s%.2f %% (jäljellä %02d t %02d min %02d s)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Koodataan: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Etsitään alkuaikaa, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Tutkitaan nimekettä %d / %d…"
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Tutkitaan nimekettä %d / %d, esikatselu %d…"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Tauko"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Koodaus valmis!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Koodaus peruttu."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Koodaus epäonnistui."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s on nyt saatavilla (sinulla on %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Koodaus valmis"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Laske cocktailisi, HandBrake-jono on valmistunut!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Koodaus on valmistunut."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Lopetetaan HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Asetetaan tietokone valmiustilaan"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Sammutetaan tietokonetta"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/fr.po
+++ b/gtk/po/fr.po
@@ -16,7 +16,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Tof Bouf, 2022\n"
 "Language-Team: French (https://www.transifex.com/HandBrakeProject/"
@@ -111,8 +111,8 @@ msgstr "_Préréglages"
 msgid "Set De_fault"
 msgstr "Choisir \"De_fault\""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Sauvegarder"
 
@@ -120,7 +120,7 @@ msgstr "_Sauvegarder"
 msgid "Save _As"
 msgstr "Sauvegarder _sous"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Renommer"
 
@@ -170,7 +170,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Incrustés</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -192,7 +192,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Défaut</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -369,7 +369,7 @@ msgstr "0 tâche en attente"
 msgid "Start Encoding"
 msgstr "Commencer l'encodage"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Commencer"
@@ -388,7 +388,7 @@ msgstr "Pause"
 msgid "Options"
 msgstr "Options"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Quand c'est terminé: "
 
@@ -408,8 +408,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Editer"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Préréglage :"
 
@@ -417,7 +417,7 @@ msgstr "Préréglage :"
 msgid "Source:"
 msgstr "Source :"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titre :"
 
@@ -441,7 +441,7 @@ msgstr "Audio :"
 msgid "Subtitles:"
 msgstr "Sous-titres :"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Résumé"
 
@@ -537,11 +537,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Choisir la source vidéo"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Ouvrir la Source"
 
@@ -573,7 +573,7 @@ msgstr "Prévisualisation"
 msgid "Show Queue"
 msgstr "Afficher la file d'attente"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "File d'attente"
 
@@ -596,15 +596,15 @@ msgstr "<b>Source :</b>"
 msgid "None"
 msgstr "Aucun"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Vérification en cours..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titre : </b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -614,53 +614,53 @@ msgstr ""
 "Par défaut, le titre le plus long est choisi. C'est souvent le film sur un "
 "DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angle :</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Pour les DVD avec angles multiples, sélectionner les angles à encoder."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Intervalle :</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Intervalle du titre à encoder. Il peut s'agir de chapitres, de secondes ou "
 "d'images."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Définir le premier chapitre à encoder."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Définir le dernier chapitre à encoder."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Préréglage :</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Choisir le préréglage"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modifié</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Actualiser"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -668,27 +668,27 @@ msgstr ""
 "Recharger les paramètres pour la présélection.\n"
 "Les modifications seront perdues."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Sauvegarder le nouveau préréglage"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Enregistrer les réglages actuels dans un nouveau préréglage."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format :"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format de multiplexage des pistes encodées. "
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimisé pour le web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -696,11 +696,11 @@ msgstr ""
 "Optimise la disposition du fichier MP4 pour un téléchargement progressif.\n"
 "Cela permet au lecteur de débuter la lecture avant la fin du téléchargement."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Aligner les démarrages A/V"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -712,140 +712,140 @@ msgstr ""
 "audio/vidéo pour les lecteurs dysfonctionnels qui ne respectent pas les "
 "listes d’édition MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Gestion de l’iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Ajouter l'Atom pour iPod requis pour certains anciens iPods."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Durée :"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Pistes :"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtres :"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Taille :"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Rotation de la vidéo 90 degrés à la fois"
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Rognage à gauche"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Rognage du haut"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Rognage du bas"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Rognage à droite"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorphique :"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -855,11 +855,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspect des pixels :"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -875,11 +875,11 @@ msgstr ""
 "obtenir\n"
 "le ratio spécifié."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -892,11 +892,11 @@ msgstr ""
 "Les lecteurs ajusteront les dimensions pour correspondre à l'apparence "
 "spécifiée."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -906,7 +906,7 @@ msgstr ""
 "Les dimensions d'affichage seront différentes si le rapport largeur/hauteur "
 "n'est pas 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -916,84 +916,84 @@ msgstr ""
 "Les dimensions d'affichage seront différentes si le rapport largeur/hauteur "
 "n'est pas 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatique:"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensions"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Détéléciné :"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1005,7 +1005,7 @@ msgstr ""
 "Le téléciné est un processus qui ajuste la fréquence des images de vidéos en "
 "24 ips vers le NTSC en 30 ips."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1015,11 +1015,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Détection de l’entrelacement :"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1032,7 +1032,7 @@ msgstr ""
 "filtre\n"
 "identifie comme entrelacées seront désentrelacées."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1044,11 +1044,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Désentrelacer :"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1061,7 +1061,7 @@ msgstr ""
 "d’interpolation.\n"
 "Le filtre 'Yadif' est un désentrelaceur classique YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1076,11 +1076,11 @@ msgstr ""
 "d’interpolation.\n"
 "Le filtre 'Yadif' est un désentrelaceur classique YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtre anti-blocs :"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1089,12 +1089,12 @@ msgstr ""
 "Si la source présente des macroblocs visibles, ce filtre peut aider à les "
 "nettoyer."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Ajustement :"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1104,7 +1104,7 @@ msgstr ""
 "Si la source présente des macroblocs visibles, ce filtre peut aider à les "
 "nettoyer."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1115,11 +1115,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtre de réduction de bruit :"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1133,7 +1133,7 @@ msgstr ""
 "L'utilisation de ces filtres sur ce type de source permet de réduire la "
 "taille de fichier."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1148,7 +1148,7 @@ msgstr ""
 "L'utilisation de ces filtres sur ce type de source permet de réduire la "
 "taille de fichier."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1159,27 +1159,27 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtre d’accentuation :"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1187,7 +1187,7 @@ msgstr ""
 "Le filtrage d’accentuation renforce les bords et \n"
 "autres composants de haute fréquence dans la vidéo."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1196,39 +1196,39 @@ msgstr ""
 "Le filtrage d’accentuation renforce les bords et \n"
 "autres composants de haute fréquence dans la vidéo."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Niveaux de gris"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Une fois activé, filtre les composants de couleurs de la vidéo."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtres"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Encodeur vidéo :"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Encodeurs vidéo disponibles."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Fréquence d’images :"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1240,19 +1240,19 @@ msgstr ""
 "« Comme la source » est recommandé. Is votre vidéo de source a\n"
 "une fréquence variable, elle sera préservée avec « Comme la source »."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Fréquence d’images constante :"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Permet une fréquence d’image constante en sortie."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Pic de fréquence d’images (FIV)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1264,11 +1264,11 @@ msgstr ""
 "\n"
 "FIV n’est pas compatible avec certains lecteurs."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Fréquence d’image variable"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1278,7 +1278,7 @@ msgstr ""
 "\n"
 "IPSV (VFR) n'est pas compatible avec certains lecteurs."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1308,15 +1308,15 @@ msgstr ""
 "L’échelle de FFMpeg et Theora est plus linéaire.\n"
 "Ces encodeurs n’ont pas de mode sans perte."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualité constante:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Débit binaire (kbps) :"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1335,11 +1335,11 @@ msgstr ""
 "limiter le débit bonaire instantané, ajustez les réglages x264 vvv-bufsize "
 "et vbv-maxrate."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Encodage en 2 passes"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1355,18 +1355,18 @@ msgstr ""
 "statistiques seront utilisées pour les décisions d'allocation de débit "
 "binaire."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Premier passage turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Durant la 1ère passe d'un encodage en 2 passes, utiliser les réglages qui "
 "accélèrent les choses."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1387,7 +1387,7 @@ msgstr ""
 "puissiez supporter,\n"
 "car meilleur est la qualité et plus petit est le fichier final."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1403,11 +1403,11 @@ msgstr ""
 "seront\n"
 "appliquées après le préréglage mais avant les autres paramètres."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Décodage accéléré"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1417,11 +1417,11 @@ msgstr ""
 "\n"
 "À activer si votre appareil a du mal à lire le résultat (images passées)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latence nulle"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1437,11 +1437,11 @@ msgstr ""
 "Comme HandBrake n'est pas adapté à la diffusion par flux en direct,\n"
 "ce réglage a peu de valeur ici."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1451,11 +1451,11 @@ msgstr ""
 "\n"
 "Outrepasse tous les autres réglages."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Niveau:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1465,11 +1465,11 @@ msgstr ""
 "\n"
 "Outrepasse tous les autres réglages."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Plus de paramètres:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1479,45 +1479,45 @@ msgstr ""
 "\n"
 "Liste séparée par des virgules des options d'encodage."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Vidéo"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Ajouter"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Ajouter les réglages audio à la liste"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Tout ajouter"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Ajouter toutes les pistes audio à la liste"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Recharger les réglages audio depuis les valeurs par défaut"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Liste des pistes "
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Comportement des sélections :"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Choisissez quelles pistes audio du média source à utiliser"
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1528,23 +1528,23 @@ msgstr ""
 "Les pistes correspondantes seront sélectionnées en fonction du choix de "
 "Comportement de sélction."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Enlever"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Langues disponibles"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Langues sélectionnées"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Utiliser uniquement le premier encodeur pour la piste audio secondaire"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1555,26 +1555,26 @@ msgstr ""
 "Toutes les autres pistes audio secondaires seront encodées avec le premier "
 "encodeur uniquement."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Recopie auto :"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1584,11 +1584,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste MP3 lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1598,11 +1598,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste AC-3 lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1612,11 +1612,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste EAC-3 lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1626,11 +1626,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste DTS lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1640,11 +1640,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste DTS-HD lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1654,11 +1654,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste TrueHD lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1668,11 +1668,11 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste FLAC lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1682,22 +1682,22 @@ msgstr ""
 "Cela permet la sélection de la recopie de la piste AAC lorsque la recopie "
 "automatique est sélectionnée."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Solution de repli de recopie :"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1705,62 +1705,62 @@ msgstr ""
 "Définit le codec audio à utiliser pour l'encodage lorsqu’une piste "
 "compatible ne peut être trouvée pour la recopie audio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Réglage encodage audio</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Chaque piste source sélectionnée sera encodée avec les encodeurs "
 "sélectionnés."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Encodeur"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Débit binaire/Qualité"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mixage"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Fréquence d'échantillonnage"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Gain"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Sélection de piste"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Ajoute de nouveaux réglages de sous-titres à la liste"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "joute toutes les pistes de sous-titres à la liste"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Analyse bande son étrangère"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1770,15 +1770,15 @@ msgstr ""
 "rechercher d'éventuels sous-titres qui proposent un sous-titrage\n"
 "pour les segments audio en langue étrangère."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Recharger toues les sou-titre depuis les valeurs par défaut"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Choisir les pistes de sous-titres à utiliser depuis le média source"
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1798,15 +1798,15 @@ msgstr ""
 "déterminer la sélection des réglages lorsqu'il y a de l'audio en langue "
 "étrangère."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Langue préférée: Aucune"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Ajoute une passe d’analyse des pistes audio étrangères"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1823,13 +1823,13 @@ msgstr ""
 "Cette option nécessite que la langue soit choisie dans la liste des langues "
 "sélectionnées."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 "Ajoute une piste de sous-titres si la langue pour l'audio par défaut est "
 "étrangère"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1842,11 +1842,11 @@ msgstr ""
 "Cette option nécessite que la langue soit choisie dans la liste des langues "
 "sélectionnées."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Ajouter le sous-titrage intégré lorsqu'il est disponible"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1854,11 +1854,11 @@ msgstr ""
 "Les sous-titres intégrés sont des textes de sous-titrage qui peuvent être "
 "ajoutés à tout format de conteneur en tant sous-titres surimprimés"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Comportement d’incrustation* :"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1874,15 +1874,15 @@ msgstr ""
 "Une seule piste de sous-titre peut être incrustée ! Comme des conflicts "
 "pourraient survenir, la première sélectionnée gagne."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Incrusté pour lecteurs* déficients."
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Sous-titres DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1900,11 +1900,11 @@ msgstr ""
 "Une seule piste de sous-titres peut être incrustée ! Comme des conflits "
 "pourraient survenir, la première sélectionnée gagne."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Sous-titres Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1922,7 +1922,7 @@ msgstr ""
 "Une seule piste de sous-titres peut être incrustée ! Comme des conflits "
 "pourraient survenir, la première sélectionnée gagne."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1930,7 +1930,7 @@ msgstr ""
 "<small>* seul une des options d’incrustation des sous-titres ci-dessus sera "
 "utilisée, en commençant en haut.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1938,112 +1938,112 @@ msgstr ""
 "Une seule piste de sous-titre peut être incrustée ! Comme des conflicts "
 "peuvent survenir, le premier choisi gagnera."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Sous-titres"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marqueurs de chapitres"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Ajouter des marqueurs de chapitre au fichier de sortie."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Chapitres"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Chapitres"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Index"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Durée"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titre"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Chapitres"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Acteurs:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Directeur:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Date de sortie:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Commentaire:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genre:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Description:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Synopsis:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Balise"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Enregistrer sous:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nom de fichier de destination pour l'encodage."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>De:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Répertoire de destination pour votre encodage."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Répertoire de destination"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Ajouter _plusieurs"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2051,54 +2051,54 @@ msgstr "Ajouter _plusieurs"
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Tout selectionner"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marquer tous les titres pour être ajoutés à la file d’attente"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Tout effacé."
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Enlever la marque de tous les titres"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Les fichiers de destination sont OK. Aucun doublon détecté."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Préférences"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Rechercher les mises à jour automatiquement."
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Utiliser le renommage automatique (utilise le nom de la source modifié)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 "Créer le nom de fichier destination à partir du nom de fichier source ou du "
 "titre du disque."
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Modèle d'auto-nommage"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2108,26 +2108,26 @@ msgstr ""
 "Options disponibles : {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 "Utiliser une extension de fichier compatible iPod/iTunes (.m4v) pour les MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Nombre d’aperçus"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtrer les titres courts des DVD et Blu-ray (secondes)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 "Effacer les tâches terminées de la file d'attente lorsqu'un encodage se "
 "termine."
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2138,52 +2138,52 @@ msgstr ""
 "Cochez cette option pour que la file se nettoie automatiquement en "
 "supprimant les tâches terminées."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Général"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2197,65 +2197,65 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Granularité fractionnelle de Qualité constante"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Utiliser dvdnav (au lieu de libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Vérifier l’espace libre du disque de destination"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Mettre en pause l'encodage si l'espace disponible sur le disque dur est "
 "inférieur à la limite"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Limite de Mo"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Placer les historiques encodage au même endroit que le film"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Niveau de détail de l'historique d’activité"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Longévité de l'historique d’activité"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Réduire la définition des aperçus HD"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Scanner automatiquement les DVD à leur insertion"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Scanne les DVD d`´s qu'un nouveau disque est chargé"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Taille de la police de la fenêtre d'activité"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Utilise les mêmes réglages pour tous les titres dans un lot"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2269,87 +2269,87 @@ msgstr ""
 "\n"
 "Décochez-la pour pouvoir changer les réglages de chaque titre indépendamment."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Autoriser les ajustements"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Autoriser Handbrake pour les nul"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avancé"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Préréglage de la réduction de bruit :"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Pré réglage de renommage :</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nom:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Description</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Sauvegarder le nouveau préréglage"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Catégorie:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Détermine la catégorie sous laquelle ce préréglage sera affiché."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nom de catégorie:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nom de préréglage :"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Réglage par défaut"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Faire de ce préréglage le défaut lorsqu’Handbrake se lance"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensions</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Aperçu Handbrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Sélectionner les images d’aperçu."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2357,77 +2357,77 @@ msgstr ""
 "Encode et joue une courte séquence de la vidéo commençant au moment de "
 "l'aperçu actuel."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Durée:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Définit la durée de l'affichage d’aperçu en direct en secondes."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Afficher le rognage"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Afficher les zones de rognages sur l'aperçu"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Résolution de la source"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Réinitialise la fenêtre d'aperçu à la résolution de la vidéo source"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Sous-titres"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importer SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Active les réglages pour l'importation de fichiers de sous-titres SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importer SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Active les réglages pour l'importation de fichiers de sous-titres SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Liste des sous-titres incorporés"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 "Active les réglages pour l'importation de fichiers de sous-titres incorporés"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Piste source"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Liste des pistes de sous-titres disponibles pour votre source."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nom de piste:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2437,23 +2437,23 @@ msgstr ""
 "\n"
 "Les lecteurs peuvent l'utiliser dans la liste de sélection de sous-titres."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Langue"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Code caractère"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fichier:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Décallage (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2462,7 +2462,7 @@ msgstr ""
 "Cette valeur peur être utilisée par les lecteurs dans le menu des sous-"
 "titres."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2477,29 +2477,29 @@ msgstr ""
 "Nous traduisons les encodages en UTF-8.\n"
 "L’encodage caractères source est nécessaire pour effectuer cette traduction."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Sélectionner le fichier SRT à importer."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importer un fichier"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Ajuster le décalage en milliseconde entre les balises temporelles vidéo et "
 "SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Sous-titres forcés uniquement"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Incruster sur la vidéo"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2508,19 +2508,19 @@ msgstr ""
 "Le sous-titrage fera partie intégrante de la vidéo et ne pourra être "
 "désactivé."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Définir piste par défaut"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Liste des pistes audio disponibles pour votre source."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2530,15 +2530,15 @@ msgstr ""
 "\n"
 "Les lecteurs peuvent l'utilise dans la liste de sélection audio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mix"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Fréquence d’échantillonnage"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2557,31 +2557,31 @@ msgstr ""
 "plage\n"
 "en adoucissant les sons forts et en renforçant les sons faibles."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Définit le codec audio pour l'encodage de cette piste."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Débit binaire"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Active les réglages de débit binaire"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualité"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Active le réglage de qualité"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Définit le débit binaire avec lequel encoder cette piste."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2589,19 +2589,19 @@ msgstr ""
 "<b>Qualité :</b> Pour les codecs de destination qui le gèrent, ajuster la "
 "qualité de la destination."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Définit le mixage de la piste audio en sortie."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Définit la fréquence d’échantillonnage de la piste audio en sortie."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2610,42 +2610,42 @@ msgstr ""
 "audio de destination."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0 dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Arrêt"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Passer cette version"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Me le rappeler plus tard"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Une nouvelle version de HandBrake est disponible!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 "HandBrake xxx est maintenant disponible (vous disposez de la version yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Notes de version</b>"
 
@@ -2790,7 +2790,7 @@ msgstr "Lecteurs DVD détectés :"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Vérification ..."
 
@@ -2803,11 +2803,40 @@ msgstr "Arrêter la vérification"
 msgid "Single Title"
 msgstr "Ouvrir _Titre seul"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2815,7 +2844,7 @@ msgstr[0] "Audio"
 msgstr[1] "Audio"
 msgstr[2] "Audio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2823,19 +2852,19 @@ msgstr[0] "Sous-titres"
 msgstr[1] "Sous-titres"
 msgstr[2] "Sous-titres"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2843,22 +2872,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Forcés seulement"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", Incrustés"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Défaut"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2866,34 +2895,34 @@ msgstr[0] "Piste de sous-titre d'audio étranger"
 msgstr[1] "Piste de sous-titre d'audio étranger"
 msgstr[2] "Piste de sous-titre d'audio étranger"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Aspect des pixels :"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Aucun titre trouvé"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nouvelle video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2904,133 +2933,133 @@ msgstr ""
 "\n"
 "%s dans %d secondes ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sVotre video sera perdue si vous ne continuez pas l'encodage."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Annuler l'actuel et arrêter"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Annuler l'actuel, commencer le suivant"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Terminer l'actuel, commencer le suivant"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continuer l’encodage"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%dencodage en attente"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%dencodages en attente"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "tâche %d de %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "passe %d (balayage des sous-titres) de %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "passe %d de %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Encodage : %s%s%.2f %% (%.2f ips, may %.2f ips, fin est. %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Encodage : %s%s%.2f %% (fin est. %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Encodage: %s%s%.2f%%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Recherche de l'heure de début,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Vérification titre %d de %d ..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Vérification titre %d de %d aperçu %d ..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Mis en pause"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Encodage terminé!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Encodage annulé."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Encodage échoué."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Mixage : Ça pourra prendre un certain temps…"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s est désormais disponible (vous avez %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Encodage terminé"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Posez votre cocktail, votre liste de conversion HandBrake est terminé!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Votre encodage est terminé."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Quitter HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Mettre l'ordinateur en veille"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Eteindre l'ordinateur."
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -98,8 +98,8 @@ msgstr ""
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr ""
 
@@ -107,7 +107,7 @@ msgstr ""
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -154,7 +154,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -169,7 +169,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -317,7 +317,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr ""
@@ -336,7 +336,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -354,8 +354,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -363,7 +363,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -387,7 +387,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr ""
 
@@ -466,11 +466,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -502,7 +502,7 @@ msgstr ""
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr ""
 
@@ -525,242 +525,242 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -770,11 +770,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -783,11 +783,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -795,102 +795,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -898,18 +898,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -917,7 +917,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -925,11 +925,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -937,7 +937,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -946,39 +946,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -986,7 +986,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -994,78 +994,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1073,19 +1073,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1093,18 +1093,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1120,15 +1120,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1139,11 +1139,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1153,16 +1153,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1174,7 +1174,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1183,22 +1183,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1208,300 +1208,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1512,15 +1512,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1530,11 +1530,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1542,21 +1542,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1566,15 +1566,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1585,11 +1585,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1600,121 +1600,121 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1722,126 +1722,126 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1855,63 +1855,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1920,188 +1920,188 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr ""
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr ""
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2110,60 +2110,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2174,89 +2174,89 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2388,7 +2388,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2400,90 +2400,117 @@ msgstr ""
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2491,132 +2518,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/he.po
+++ b/gtk/po/he.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Omer I.S. <omeritzicschwartz@gmail.com>, 2021\n"
 "Language-Team: Hebrew (https://www.transifex.com/HandBrakeProject/"
@@ -103,8 +103,8 @@ msgstr ""
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr ""
 
@@ -112,7 +112,7 @@ msgstr ""
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -159,7 +159,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -174,7 +174,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>ברירת מחדל</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -322,7 +322,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr ""
@@ -341,7 +341,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -359,8 +359,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -368,7 +368,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -392,7 +392,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr ""
 
@@ -473,11 +473,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -509,7 +509,7 @@ msgstr ""
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr ""
 
@@ -532,242 +532,242 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -777,11 +777,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -790,11 +790,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -802,102 +802,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -905,18 +905,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -924,7 +924,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -932,11 +932,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -944,7 +944,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -953,39 +953,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -993,7 +993,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1001,78 +1001,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1080,19 +1080,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1100,18 +1100,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1127,15 +1127,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1146,11 +1146,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1160,16 +1160,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1181,7 +1181,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1190,22 +1190,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1215,300 +1215,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "פרופיל:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "הגדרות נוספות:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "הוספה"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1519,15 +1519,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1537,11 +1537,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1549,21 +1549,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1573,15 +1573,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1592,11 +1592,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1607,121 +1607,121 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1729,126 +1729,126 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1862,63 +1862,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1927,188 +1927,188 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr ""
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr ""
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2117,60 +2117,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2181,90 +2181,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2396,7 +2396,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2408,11 +2408,38 @@ msgstr ""
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
@@ -2420,7 +2447,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
@@ -2428,19 +2455,19 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2449,22 +2476,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2473,33 +2500,33 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2507,132 +2534,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/hr.po
+++ b/gtk/po/hr.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Marino Rabach, 2019\n"
 "Language-Team: Croatian (https://www.transifex.com/HandBrakeProject/"
@@ -104,8 +104,8 @@ msgstr ""
 msgid "Set De_fault"
 msgstr "Odaberi Zadano"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "Spremi"
 
@@ -113,7 +113,7 @@ msgstr "Spremi"
 msgid "Save _As"
 msgstr "Spremi kao"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "Preimenuj"
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Snimljeno</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -175,7 +175,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Zadano</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -327,7 +327,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Započni"
@@ -346,7 +346,7 @@ msgstr "Pauza"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -364,8 +364,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Uredi"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Prethodno postavljeno:"
 
@@ -373,7 +373,7 @@ msgstr "Prethodno postavljeno:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Naslov:"
 
@@ -397,7 +397,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sažetak"
 
@@ -478,11 +478,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -514,7 +514,7 @@ msgstr "Pregled"
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Red čekanja"
 
@@ -537,242 +537,242 @@ msgstr "<b>Izvor:</b>"
 msgid "None"
 msgstr "Ništa"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Pregledavanje..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Naslov:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Kut:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Raspon:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Postavka:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Izmijenjeno</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Ponovno učitaj"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web Optimizirano"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Uskladi A/V pokretanje"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Trajanje:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Zapisi:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtri:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Veličina:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -782,11 +782,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -795,11 +795,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -807,102 +807,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatski"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimenzije"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -910,18 +910,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -929,7 +929,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -937,11 +937,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deinterlace:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -949,7 +949,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -958,39 +958,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -998,7 +998,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1006,78 +1006,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Sivi tonovi"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1085,19 +1085,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1105,18 +1105,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1132,15 +1132,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1151,11 +1151,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1165,16 +1165,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1186,7 +1186,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1195,22 +1195,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Nulta latencija"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1220,300 +1220,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Razina:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Više postavki:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Dodaj sve"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Dodaj sve zvučne zapise u popis"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Popis zapisa"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Ukloni"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Auto Passthru:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Postavke zvučnog Enkodera:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Koder"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Dobitak"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Zvuk"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Dodaj sve zapise s podnaslovima u popis"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1524,15 +1524,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1542,11 +1542,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1554,21 +1554,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1578,15 +1578,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1597,11 +1597,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1612,123 +1612,123 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Podnaslovi"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Poglavlja"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Poglavlja"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Indeks"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Trajanje"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Naslov"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Poglavlja"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Režiser:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Komentar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Žanr:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Opis:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Oznake"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Spremi kao:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Za:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1736,126 +1736,126 @@ msgstr ""
 msgid "Cancel"
 msgstr "Odustani"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Odaberi sve"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Očisti sve"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Postavke"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automatska provjera ažuriranja"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Općenito"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1869,63 +1869,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Nadziraj slobodan prostor odredišnog diska"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB Limit"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1934,191 +1934,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Dopusti HandBrake za neznalice"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Napredno"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Preimenuj"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Naziv:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Opis</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Prethodno postavljeno:"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategorija:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Trajanje:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Podnaslovi"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Naziv zapisa:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Jezik"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Datoteka:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Offset (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2127,60 +2127,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Brzina uzorkovanja"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2191,49 +2191,49 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kvaliteta"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2241,40 +2241,40 @@ msgstr ""
 "<b>Dobitak zvuka:</b> Podesi pojačanje ili prigušenje izlaznog audio zapisa."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Isključeno"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Podsjeti me kasnije"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Nova verzija programa HandBrake je dostupna!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2414,7 +2414,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2427,11 +2427,40 @@ msgstr ""
 msgid "Single Title"
 msgstr "Bez naslova"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2439,7 +2468,7 @@ msgstr[0] "Zvuk"
 msgstr[1] "Zvuk"
 msgstr[2] "Zvuk"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2447,19 +2476,19 @@ msgstr[0] "Podnaslovi"
 msgstr[1] "Podnaslovi"
 msgstr[2] "Podnaslovi"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2467,22 +2496,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2490,33 +2519,33 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Novi videozapis"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2527,132 +2556,132 @@ msgstr ""
 "\n"
 "%s u %d sekundi ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sFilm će biti izgubljen ako se ne nastavi s kodiranjem."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pauzirano"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/it.po
+++ b/gtk/po/it.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Damiano Galassi <galad87@icloud.com>, 2022\n"
 "Language-Team: Italian (https://www.transifex.com/HandBrakeProject/"
@@ -108,8 +108,8 @@ msgstr "_Preimpostazioni"
 msgid "Set De_fault"
 msgstr "Imposta prede_finiti"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Salva"
 
@@ -117,7 +117,7 @@ msgstr "_Salva"
 msgid "Save _As"
 msgstr "S_alva come"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Rinomina"
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>In sovraimpressione</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Predefinito</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -367,7 +367,7 @@ msgstr "0 operazioni in attesa"
 msgid "Start Encoding"
 msgstr "Avvia codifica"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Avvia"
@@ -386,7 +386,7 @@ msgstr "Metti in pausa"
 msgid "Options"
 msgstr "Opzioni"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Al termine:"
 
@@ -406,8 +406,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Modifica"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Preimpostazione:"
 
@@ -415,7 +415,7 @@ msgstr "Preimpostazione:"
 msgid "Source:"
 msgstr "Sorgente:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titolo:"
 
@@ -439,7 +439,7 @@ msgstr "Audio:"
 msgid "Subtitles:"
 msgstr "Sottotitoli:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Riepilogo"
 
@@ -534,11 +534,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Scegli sorgente video"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Apri sorgente"
 
@@ -570,7 +570,7 @@ msgstr "Anteprima"
 msgid "Show Queue"
 msgstr "Mostra coda"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Coda"
 
@@ -593,15 +593,15 @@ msgstr "<b>Sorgente:</b>"
 msgid "None"
 msgstr "Nessuno"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Scansione..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titolo:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -611,55 +611,55 @@ msgstr ""
 "In modo predefinito viene scelto il titolo più lungo.\n"
 "Questo è spesso il titolo di un DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Angolazione:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 "Per i DVD multiangolazione, seleziona l'angolazione desiderata per la "
 "codifica."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Intervallo:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Intervallo del titolo da codificare. Possono essere capitoli, secondi o "
 "fotogrammi."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Imposta il primo capitolo da codificare."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Imposta l'ultimo capitolo da codificare."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Preimpostazione:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Scegli preimpostazione"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modificato</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Ricarica"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -667,27 +667,27 @@ msgstr ""
 "Ricarica le impostazioni per la preimpostazione attualmente selezionata.\n"
 "Le modifiche verranno scartate."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Salva nuova preimpostazione"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Salva le impostazioni attuali in una nuova preimpostazione."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formato:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formato di multiplazione delle tracce codificate."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Ottimizzato per il web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -696,11 +696,11 @@ msgstr ""
 "Ciò consente ad un lettore di avviare la riproduzione prima di scaricare "
 "l'intero file."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Allinea Inizio A/V"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -711,140 +711,140 @@ msgstr ""
 "sincronizzazione audio/video per i lettori che non rispettano gli elenchi di "
 "modifica MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Supporto iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Aggiungi l'iPod Atom necessario per alcuni vecchi iPod."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Mantieni metadati comuni"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Copia i metadati dalla sorgente alla destinazione."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Durata:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "oo:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Tracce:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtri:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Dimensione:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Dimensioni di archiviazione:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Dimensioni di visualizzazione:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Rapporto d'aspetto:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Dimensioni della sorgente</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Capovolgi:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "In orizzontale  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Capovolgi il video orizzontalmente."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Ruota:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Ruota il video in senso orario con incrementi di 90 gradi."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Ritaglia:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Come verranno applicate le impostazioni di ritaglio."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Ritaglia a sinistra"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Ritaglia in alto"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Ritaglia in basso"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Ritaglia a destra"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientamento e ritaglio</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Limite risoluzione:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Limiti della risoluzione per i formati video comuni."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Dimensione massima:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Questa è la larghezza massima a cui il video verrà memorizzato."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Questa è l'altezza massima a cui il video verrà memorizzato."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfico:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -854,11 +854,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspetto pixel:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -872,11 +872,11 @@ msgstr ""
 "rettangolari.\n"
 "I lettori ridimensioneranno l'immagine per ottenere l'aspetto specificato."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -888,11 +888,11 @@ msgstr ""
 "rettangolari.\n"
 "I lettori ridimensioneranno l'immagine per ottenere l'aspetto specificato."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Ridimensionato:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -902,7 +902,7 @@ msgstr ""
 "Le dimensioni di visualizzazione effettive saranno diverse, se il rapporto "
 "d'aspetto dei pixel non è 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -912,84 +912,84 @@ msgstr ""
 "Le dimensioni di visualizzazione effettive saranno diverse, se il rapporto "
 "d'aspetto dei pixel non è 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Dimensione ottimale"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr "Usa la risoluzione più alta consentita dalle impostazioni qui sopra."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Consenti l'upscaling"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Risoluzione e ridimensionamento</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Riempi:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Aggiungi un bordo attorno al video."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Bordo sinistro"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Bordo superiore"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Bordo inferiore"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Bordo destro"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Colore:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Colore del bordo aggiunto attorno al video."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Bordi</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Modificare le dimensioni di visualizzazione deformerà il video."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatico"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Dimensioni al termine</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensioni"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1002,7 +1002,7 @@ msgstr ""
 "Il telecinema è un processo che regola la frequenza dei fotogrammi dei film, "
 "che è di 24 fps, alla frequenza dei fotogrammi NTSC, che è di 30 fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1012,11 +1012,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Rilevamento interlacciamento:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1028,7 +1028,7 @@ msgstr ""
 "Se è abilitato un filtro di deinterlacciamento, verranno deinterlacciati\n"
 "solo i fotogrammi trovati interlacciati da questo filtro."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1041,11 +1041,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deinterlacciamento:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1057,7 +1057,7 @@ msgstr ""
 "Il filtro decomb supporta vari algoritmi di interpolazione.\n"
 "Il filtro deinterlacciamento è un classico deinterlacciatore YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1071,11 +1071,11 @@ msgstr ""
 "Il filtro decomb supporta vari algoritmi di interpolazione.\n"
 "Il filtro deinterlacciamento è un classico deinterlacciatore YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtro Deblock:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1085,12 +1085,12 @@ msgstr ""
 "Se la tua fonte mostra una 'quadrettatura', questo filtro può aiutare a "
 "ripulirlo."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Regolazione:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1101,7 +1101,7 @@ msgstr ""
 "Se la tua fonte mostra una 'quadrettatura', questo filtro può aiutare a "
 "ripulirlo."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1112,11 +1112,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtro di riduzione del rumore:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1130,7 +1130,7 @@ msgstr ""
 "L'utilizzo di questo filtro su tali sorgenti può ridurre le dimensioni dei "
 "file."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1145,7 +1145,7 @@ msgstr ""
 "L'utilizzo di questo filtro su tali sorgenti può ridurre le dimensioni dei "
 "file."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1156,27 +1156,27 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Filtro Chroma Smooth:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtro nitidezza:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1184,7 +1184,7 @@ msgstr ""
 "Il filtro nitidezza migliora i bordi ed altri\n"
 "componenti ad alta frequenza nel video."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1193,39 +1193,39 @@ msgstr ""
 "Il filtro nitidezza migliora i bordi ed altri\n"
 "componenti ad alta frequenza nel video."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Spazio dei colori:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Converti lo spazio dei colori della sorgente."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Scala di grigi"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Se abilitato, filtra i componenti a colori dal video."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtri"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codificatore video:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codificatori video disponibili."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Frequenza fotogrammi:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1238,19 +1238,19 @@ msgstr ""
 "video sorgente ha un frequenza fotogrammi variabile, l'opzione 'Uguale alla "
 "sorgente' la conserverà."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Frequenza fotogrammi costante"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Produce in output una frequenza dei fotogrammi costante."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Picco frequenza fotogrammi (variabile)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1263,11 +1263,11 @@ msgstr ""
 "\n"
 "La frequenza variabile non è compatibile con alcuni lettori."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Frequenza fotogrammi variabile"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1277,7 +1277,7 @@ msgstr ""
 "\n"
 "La frequenza variabile non è compatibile con alcuni lettori."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1307,15 +1307,15 @@ msgstr ""
 "Le scale FFMpeg e Theora sono più lineari.\n"
 "Questi codificatori non offrono una modalità senza perdite."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualità costante:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bitrate (kbps): "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1334,11 +1334,11 @@ msgstr ""
 "di limitare il bitrate istantaneo, controlla le impostazioni vbv-bufsize e "
 "vbv-maxrate di x264."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Codifica a 2 passaggi"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1354,18 +1354,18 @@ msgstr ""
 "statistiche vengono utilizzate per prendere decisioni di allocazione del "
 "bitrate."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Primo passaggio turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Durante il 1° passaggio di una codifica a 2 passaggi, usa le impostazioni "
 "che velocizzino le fasi."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1386,7 +1386,7 @@ msgstr ""
 "quanto i settaggi\n"
 "più lenti risulteranno in una migliore qualità o in file più piccoli."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1401,11 +1401,11 @@ msgstr ""
 "o impostare le caratteristiche del file di output. Le modifiche verranno\n"
 "applicate dopo la preimpostazione, ma prima di tutti gli altri parametri."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Decodifica rapida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1416,11 +1416,11 @@ msgstr ""
 "Imposta questo parametro se il dispositivo fatica a riprodurre l'output "
 "(fotogrammi persi)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latenza zero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1437,11 +1437,11 @@ msgstr ""
 "Poiché HandBrake non è adatto per trasmissioni in diretta,\n"
 "questa impostazione ha poco valore."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profilo:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1451,11 +1451,11 @@ msgstr ""
 "\n"
 "Sovrascrive tutte le altre impostazioni."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Livello:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1465,11 +1465,11 @@ msgstr ""
 "\n"
 "Sovrascrive tutte le altre impostazioni."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Altre impostazioni:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1479,45 +1479,45 @@ msgstr ""
 "\n"
 "Elenco separato da due punti delle opzioni del codificatore."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Aggiungi"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Aggiunge nuove impostazioni audio all'elenco"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Aggiungi tutto"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Aggiungi tutte le tracce audio all'elenco"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Ricarica tutte le impostazioni audio predefinite"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Elenco tracce"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Comportamento selezione:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Scegli quali tracce audio del supporto di origine sono utilizzate."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1527,38 +1527,38 @@ msgstr ""
 "Le tracce corrispondenti a queste lingue saranno selezionate usando il "
 "Comportamento selezione scelto."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Lingue disponibili"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Lingue selezionate"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Usa solo il primo codificatore per l'audio secondario"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Passthrough automatico:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1568,11 +1568,11 @@ msgstr ""
 "Ciò consente al passthrough MP2 di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1582,11 +1582,11 @@ msgstr ""
 "Ciò consente al passthrough MP3 di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1596,11 +1596,11 @@ msgstr ""
 "Ciò consente al passthrough AC-3 di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1611,11 +1611,11 @@ msgstr ""
 "Ciò consente al passthrough EAC-3 di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1625,11 +1625,11 @@ msgstr ""
 "Ciò consente al passthrough DTS di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1640,11 +1640,11 @@ msgstr ""
 "Ciò consente al passthrough DTS-HD di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1655,11 +1655,11 @@ msgstr ""
 "Ciò consente al passthrough TrueHD di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1669,11 +1669,11 @@ msgstr ""
 "Ciò consente al passthrough FLAC di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1683,11 +1683,11 @@ msgstr ""
 "Ciò consente al passthrough AAC di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1697,11 +1697,11 @@ msgstr ""
 "Ciò consente al passthrough Opus di essere selezionato quando la selezione "
 "automatica del passthrough è abilitata."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Ripiego passthrough:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1709,78 +1709,78 @@ msgstr ""
 "Imposta il codec audio da utilizzare quando non è possibile trovare una "
 "traccia appropriata per il passthrough audio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Impostazioni codificatore audio:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Ogni traccia sorgente selezionata sarà codificata con tutti i codificatori "
 "selezionati"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codificatore"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bitrate/Qualità"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mixdown"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Campionamento"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Guadagno"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Selezione tracce"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Aggiungi nuove impostazioni sottotitoli all'elenco"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Aggiungi tutte le tracce sottotitoli dall'elenco"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Scansione audio in lingua straniera"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Ricarica tutte le impostazioni sottotitoli predefinite"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 "Scegli quali tracce di sottotitoli del supporto di origine sono utilizzate."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1791,15 +1791,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Lingua preferita: Nessuna"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Aggiungi passaggio di scansione dell'audio in lingua straniera"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1809,12 +1809,12 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 "Aggiungi traccia dei sottotitoli se l'audio predefinito è in lingua straniera"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1822,11 +1822,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Aggiungi Closed Captions quando disponibili"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1834,11 +1834,11 @@ msgstr ""
 "Closed caption sono sottotitoli testuali che possono essere aggiungi a ogni "
 "contenitore come una traccia leggera"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Comportamento della sovraimpressione*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1854,15 +1854,15 @@ msgstr ""
 "Solo una traccia dei sottotitoli può essere impressa nel video! Dal momento "
 "che possono verificarsi conflitti, la prima traccia scelta vince."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Sovraimpressione per lettori scadenti*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Sottotitoli DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1873,11 +1873,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Sottotitoli Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1888,7 +1888,7 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1896,7 +1896,7 @@ msgstr ""
 "<small>* Verrà applicata solo una delle opzioni di sovraimpressione di cui "
 "sopra, partendo da quella più in alto.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1904,112 +1904,112 @@ msgstr ""
 "Solo una traccia dei sottotitoli può essere impressa nel video! Dal momento "
 "che possono verificarsi conflitti, la prima traccia scelta vince."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Sottotitoli"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcatori di capitolo"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Aggiungi marcatori di capitolo nel file di destinazione."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capitoli"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capitoli"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Indice"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Durata"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titolo"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capitoli"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Attori:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regista:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Data di uscita:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Commento:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genere:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Descrizione:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Trama:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Tag"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Salva con nome:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nome del file di destinazione per la tua codifica."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>In:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Cartella di destinazione per la codifica."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Cartella di destinazione"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Aggiunta _multipla"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2017,51 +2017,51 @@ msgstr "Aggiunta _multipla"
 msgid "Cancel"
 msgstr "Annulla"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Seleziona tutto"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marca tutti i titoli per l'aggiunta alla coda"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Cancella tutto"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Deseleziona tutti i titoli"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "File di destinazione OK. Nessun duplicato rilevato."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferenze"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Cerca aggiornamenti automaticamente"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Azione predefinita quando tutte le codifiche sono completate"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Usa nomi automatici (utilizza i nomi di origine modificati)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Modello di assegnazione automatica dei nomi"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2071,24 +2071,24 @@ msgstr ""
 "Opzioni disponibili: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Usa estensione file per iPod/iTunes (.m4v) per i file MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Numero di anteprime"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 "Rimuovi gli elementi completati dalla coda dopo la fine di una codifica"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2099,52 +2099,52 @@ msgstr ""
 "Seleziona questa opzione se vuoi che la coda si svuoti automaticamente "
 "eliminando le operazioni completate."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Generale"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr "Imposta una cartella personalizzata per i file temporanei di HandBrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2158,66 +2158,66 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Cartella temporanea"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Granularità frazionaria qualità costante"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Usa dvdnav (anziché libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Controlla lo spazio libero sul disco di destinazione"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Metti in pausa la codifica se lo spazio libero sul disco scende sotto il "
 "limite"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Limite MB"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Salva i registri delle singole codifiche nella stessa posizione del filmato"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Livello di verbosità del registro delle attività"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Longevità del registro delle attività"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Riduci la dimensione della anteprime in alta definizione"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Scansiona automaticamente il DVD quando caricato"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Scansiona il DVD ogni volta che un nuovo disco viene caricato"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Dimensione carattere della finestra delle attività"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Utilizza le stesse impostazioni per tutti i titoli in serie"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2226,162 +2226,162 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Consenti modifiche"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Consenti HandBrake per principianti"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avanzate"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Preimpostazione riduzione del rumore:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Rinomina preimpostazione</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descrizione</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Salva nuova preimpostazione"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categoria:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Imposta la categoria in cui questa preimpostazione sarà visualizzata."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nome categoria:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nome preimpostazione:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Preimpostazione predefinita"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Imposta come predefinito all'avvio di HandBrake"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensioni</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Anteprima di HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Seleziona frame di anteprima"
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Durata:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Seleziona la durata delle anteprime dirette in secondi."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Mostra ritaglio"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Mostra area ritagliata dell'anteprima"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Risoluzione sorgente"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Ripristina finestra di anteprima alla risoluzione del video sorgente"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Sottotitoli"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importa SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Abilita le impostazioni per importare i sottotitoli da un file SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importa SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Abilita le impostazioni per importare i sottotitoli da un file SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Elenco sottotitoli incorporati"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Abilita le impostazioni per selezionare i sottotitoli incorporati"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Traccia sorgente"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Elenco di tracce sottotitoli disponibili dalla sorgente."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nome traccia:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2391,23 +2391,23 @@ msgstr ""
 "\n"
 "I lettori potrebbero usarlo nella lista di selezione dei sottotitoli."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Lingua"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Codice carattere"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "File:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Scostamento (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2415,7 +2415,7 @@ msgstr ""
 "Imposta la lingua di questo sottotitolo.\n"
 "Questo valore sarà utilizzato dai lettori nel menu dei sottotitoli."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2424,27 +2424,27 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Seleziona il file SRT da importare."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importa file"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Solo sottotitoli forzati"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Imprimi nel video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2452,19 +2452,19 @@ msgstr ""
 "Effettua il rendering dei sottotitoli sul video.\n"
 "I sottotitoli diventeranno parte del video e non potranno essere disattivati."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Imposta come traccia predefinita"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Elenco delle tracce audio disponibili dalla tua sorgente."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2474,15 +2474,15 @@ msgstr ""
 "\n"
 "I lettori potrebbero usarlo nella lista di selezione audio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mixaggio"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Frequenza di campionamento"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2493,31 +2493,31 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Imposta il codec audio da utilizzare per questa traccia."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bitrate"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Abilita impostazioni bitrate"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualità"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Abilita impostazioni qualità"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Imposta il bitrate con cui codificare questa traccia."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2525,60 +2525,60 @@ msgstr ""
 "<b>Qualità:</b> Per i codec di output che lo supportano, regola la qualità "
 "dell'output."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Imposta il mixdown della traccia audio di uscita."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Imposta la frequenza di campionamento della traccia audio di output"
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Spento"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Salta questa versione"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Ricordamelo più tardi"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Una nuova versione di HandBrake è disponibile!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx è ora disponibile (la tua versione è la yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Note di rilascio</b>"
 
@@ -2721,7 +2721,7 @@ msgstr "Dispositivi DVD rilevati:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Scansione…"
 
@@ -2734,11 +2734,40 @@ msgstr "Interrompi scansione"
 msgid "Single Title"
 msgstr "Apri titolo _singolo "
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2746,7 +2775,7 @@ msgstr[0] "Audio"
 msgstr[1] "Audio"
 msgstr[2] "Audio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2754,19 +2783,19 @@ msgstr[0] "Sottotitoli"
 msgstr[1] "Sottotitoli"
 msgstr[2] "Sottotitoli"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2774,22 +2803,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Solo forzati"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", In sovraimpressione"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Predefiniti"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2797,37 +2826,37 @@ msgstr[0] "Traccia di sottotitoli per l'audio in lingua straniera"
 msgstr[1] "Traccia di sottotitoli per l'audio in lingua straniera"
 msgstr[2] "Traccia di sottotitoli per l'audio in lingua straniera"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 #, fuzzy
 msgid "storage"
 msgstr "Dimensioni di archiviazione:"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 #, fuzzy
 msgid "display"
 msgstr "Dimensioni di visualizzazione:"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Rapporto d'aspetto:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "Rapporto d'aspetto:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nessun titolo trovato"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nuovo video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2838,133 +2867,133 @@ msgstr ""
 "\n"
 "%sin%d secondi ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sSe non continui la codifica, il tuo filmato andrà perduto."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Annulla corrente e interrompi"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Annulla corrente, avvia successivo"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Termina corrente e interrompi"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continua la codifica"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d codifica in attesa"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d codifiche in attesa"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "operazione %d di %d,"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "passaggio %d (scansione sottotitoli) di %d,"
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "passaggio %d di %d,"
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Codifica: %s%s%.2f%% (%.2f fps, avg %.2f fps, ETA %02d h %02d m %02d s)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Codifica: %s%s%.2f%% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Codifica: %s%s%.2f%%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Cerca per il tempo di inizio,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Scansione titolo %d di %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Scansione titolo %d di %d anteprima %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "In pausa"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Codifica effettuata!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Codifica annullata."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Codifica non riuscita."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Multiplazione: potrebbe richiedere del tempo…"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s è ora disponibile (hai la versione %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Codifica completata"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Metti giù quel cocktail, la tua coda di HandBrake è terminata!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "La tua codifica è completa."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Chiudi Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Mettere il computer in stand-by"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Spegnere il computer"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ja.po
+++ b/gtk/po/ja.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Masato HASHIMOTO <cabezon.hashimoto@gmail.com>, 2018\n"
 "Language-Team: Japanese (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "プリセット(_P)"
 msgid "Set De_fault"
 msgstr "デフォルトに設定(_F)"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "保存(_S)"
 
@@ -114,7 +114,7 @@ msgstr "保存(_S)"
 msgid "Save _As"
 msgstr "名前をつけて保存(_A)"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "名前の変更(_R)"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>焼き込み</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -184,7 +184,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>デフォルト</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -354,7 +354,7 @@ msgstr "残りジョブ数 0"
 msgid "Start Encoding"
 msgstr "エンコードを開始します"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "開始"
@@ -373,7 +373,7 @@ msgstr "一時停止"
 msgid "Options"
 msgstr "オプション"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "完了時:"
 
@@ -393,8 +393,8 @@ msgstr ""
 msgid "Edit"
 msgstr "編集"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "プリセット:"
 
@@ -402,7 +402,7 @@ msgstr "プリセット:"
 msgid "Source:"
 msgstr "ソース:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "タイトル:"
 
@@ -426,7 +426,7 @@ msgstr "音声:"
 msgid "Subtitles:"
 msgstr "字幕:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "概要"
 
@@ -519,11 +519,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "ビデオソースを選択します"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "ソースを開く"
 
@@ -555,7 +555,7 @@ msgstr "プレビュー"
 msgid "Show Queue"
 msgstr "キューを表示します"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "キュー"
 
@@ -578,15 +578,15 @@ msgstr "<b>ソース:</b>"
 msgid "None"
 msgstr "なし"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "スキャン中..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>タイトル:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -596,54 +596,54 @@ msgstr ""
 "デフォルトではもっとも長いタイトルが選択されます。\n"
 "DVD によっては DVD のフィーチャータイトルになるときがあります。"
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>アングル:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 "マルチアングルの DVD のため、エンコードしたいアングルを選択してください。"
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>範囲:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "エンコードするタイトルの範囲を指定します。チャプター、秒、フレームで指定でき"
 "ます。"
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "エンコードする最初のチャプターを指定します。"
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "エンコードする最後のチャプターを指定します。"
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>プリセット:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "プリセットの選択"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>修正あり</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "再読み込み"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -651,27 +651,27 @@ msgstr ""
 "現在選択しているプリセットの設定を再読み込みします。\n"
 "変更は破棄されます。"
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "新規プリセットとして保存"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "現在の設定を新しいプリセットとして保存します。"
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "フォーマット:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "エンコードしたトラックを MUX するフォーマットです。"
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "ウェブ最適化"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -679,11 +679,11 @@ msgstr ""
 "MP4 ファイルのレイアウトをプログレッシブダウンロード用に最適化します。\n"
 "これによりファイル全体をダウンロードする前にプレーヤーで再生を開始できます。"
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "A/V 開始調整"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -693,140 +693,140 @@ msgstr ""
 "入やフレームドロップによって調整します。MP4 編集リストに準拠していないプレー"
 "ヤーで音声/映像の同期を改善するかもしれません。"
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G サポート"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "一部の古い iPod のための iPod Atom を追加します。"
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "時間:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "トラック:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "フィルター:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "サイズ:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "映像を時計回りに 90°ずつ回転させます。"
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "左クロップ"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "上クロップ"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "下クロップ"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "右クロップ"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "アナモフィック:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -836,11 +836,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "ピクセルアスペクト比:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -854,11 +854,11 @@ msgstr ""
 "す。\n"
 "プレーヤーは指定されたアスペクト比にするために画像をスケールします。"
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -870,11 +870,11 @@ msgstr ""
 "す。\n"
 "プレーヤーは指定されたアスペクト比にするために画像をスケールします。"
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -884,7 +884,7 @@ msgstr ""
 "ピクセルアスペクト比が 1:1 ではないとき、実際の表示サイズと異なる場合がありま"
 "す。"
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -894,84 +894,84 @@ msgstr ""
 "ピクセルアスペクト比が 1:1 ではないとき、実際の表示サイズと異なる場合がありま"
 "す。"
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "自動"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "映像サイズ"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "デテレシネ:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -984,7 +984,7 @@ msgstr ""
 "テレシネとはフィルムのフレームレート 24fps を NTSC 映像のフレームレート "
 "30fps に変換する作業です。"
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -994,11 +994,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "インターレース検出:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1010,7 +1010,7 @@ msgstr ""
 "デインターレースフィルターが有効になっていれば、このフィルターでインターレー"
 "スと検出されたフレームのみデインターレースされます。"
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1022,11 +1022,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "デインターレース:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1038,7 +1038,7 @@ msgstr ""
 "デコームフィルイターはさまざまな補完アルゴリズムをサポートしています。\n"
 "デインターレースフィルターは古典的な YADIF になります。\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1052,11 +1052,11 @@ msgstr ""
 "デコームフィルイターはさまざまな補完アルゴリズムをサポートしています。\n"
 "デインターレースフィルターは古典的な YADIF になります。\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "デブロックフィルタ:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1065,12 +1065,12 @@ msgstr ""
 "ソースに 'ブロックノイズ' が見受けられた場合、このフィルターがきれいに仕上げ"
 "てくれるかもしれません。"
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "チューン:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1080,7 +1080,7 @@ msgstr ""
 "ソースに 'ブロックノイズ' が見受けられた場合、このフィルターがきれいに仕上げ"
 "てくれるかもしれません。"
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1091,11 +1091,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "デノイズフィルター:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1107,7 +1107,7 @@ msgstr ""
 "このフィルターを使用することでそのようなソースでもファイルサイズを抑えること"
 "ができます。"
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1120,7 +1120,7 @@ msgstr ""
 "このフィルターを使用することでそのようなソースでもファイルサイズを抑えること"
 "ができます。"
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1131,27 +1131,27 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "シャープ化フィルター:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1159,7 +1159,7 @@ msgstr ""
 "シャープ化フィルターは映像内のエッジやその他高周波数のコンポーネントを向上さ"
 "せます。"
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1168,39 +1168,39 @@ msgstr ""
 "シャープ化フィルターは映像内のエッジやその他高周波数のコンポーネントを向上さ"
 "せます。"
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "グレースケール"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "このオプションを有効にすると、動画から色成分が除去されます。"
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "フィルター"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "ビデオエンコーダー:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "利用可能なビデオエンコーダーです。"
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "フレームレート:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1212,19 +1212,19 @@ msgstr ""
 "'ソースと同じ' が推奨です。ソースビデオが可変フレームレートの場合、'ソースと"
 "同じ' にしておけばそれを維持します。"
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "固定フレームレート"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "固定フレームレート出力を有効にします。"
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "ピークフレームレート (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1236,11 +1236,11 @@ msgstr ""
 "\n"
 "VFR は一部のプレーヤーと互換性がありません。"
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "可変フレームレート"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1250,7 +1250,7 @@ msgstr ""
 "\n"
 "VFR は一部のプレーヤーと互換性がありません。"
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1276,15 +1276,15 @@ msgstr ""
 "FFMpeg および Theora の場合はより直線的です。\n"
 "これらエンコーダーにロスレスモードはありません。"
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "画質指定:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "ビットレート指定 (kbps):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1301,11 +1301,11 @@ msgstr ""
 "ビットレートの最大値を制限したい場合は、x264 の vbv-bufsize および vbv-"
 "maxrate 設定を調べてください。"
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2 パスエンコーディング"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1320,16 +1320,16 @@ msgstr ""
 "映像の統計情報を採取し、2 回めのパスで統計情報を利用してビットレートの割り当"
 "てが行われます。"
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "第 1 パスをターボ"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr "2 パスエンコードの 1 回めのパスを高速化します。"
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1347,7 +1347,7 @@ msgstr ""
 "品質がより高く、小さいファイルになるよう、通常は可能な限り遅いものを選ぶこと"
 "をお勧めします。"
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1361,11 +1361,11 @@ msgstr ""
 "プリセットのあとに適用されますが、その他すべてのパラメーターより先に適用され"
 "ます。"
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "高速デコード"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1376,11 +1376,11 @@ msgstr ""
 "あなたのデバイスが再生に悪戦苦闘している場合 (フレームドロップなど) に設定し"
 "てみてください。"
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "ゼロレイテンシ"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1396,11 +1396,11 @@ msgstr ""
 "HandBrake はライブストリーム配信用途には適していないので、この設定もあまり役"
 "に立ちません。"
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "プロファイル:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1410,11 +1410,11 @@ msgstr ""
 "\n"
 "他のすべての設定を上書きします。"
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "レベル:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1424,11 +1424,11 @@ msgstr ""
 "\n"
 "他のすべての設定を上書きします。"
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "追加設定:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1438,45 +1438,45 @@ msgstr ""
 "\n"
 "エンコーダーオプションをコロンで区切って追加してください。"
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "ビデオ"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "追加"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "新しいオーディオ設定をリストに追加します"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "すべて追加"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "すべてのオーディオトラックをリストに追加します"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "すべてのオーディオ設定をデフォルトから再読み込みします"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "トラックリスト"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "選択方法:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "ソースメディアのどの音声トラックを使用するかを選択してください。"
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1485,23 +1485,23 @@ msgstr ""
 "音声に使用したい言語のリストを作成します。\n"
 "これらの言語と一致したトラックが「選択方法」で指定された方法で選ばれます。"
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "除去"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "利用可能な言語"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "選択した言語"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "二次オーディオに先頭のエンコーダーのみ使用する"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1510,26 +1510,26 @@ msgstr ""
 "先頭の音声トラックのみ全エンコーダーリストでエンコードされます。\n"
 "2つ目以降の音声出力トラックは先頭のエンコーダーのみでエンコードされます。"
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "自動パススルー:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1538,11 +1538,11 @@ msgstr ""
 "お使いの再生デバイスがMP3をサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にMP3をパススルー出来るようにします。"
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1551,11 +1551,11 @@ msgstr ""
 "お使いの再生デバイスがAC-3をサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にAC-3をパススルー出来るようにします。"
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1564,11 +1564,11 @@ msgstr ""
 "お使いの再生デバイスがEAC-3をサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にEAC-3をパススルー出来るようにします。"
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1577,11 +1577,11 @@ msgstr ""
 "お使いの再生デバイスがDTSをサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にDTSをパススルー出来るようにします。"
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1590,11 +1590,11 @@ msgstr ""
 "お使いの再生デバイスがDTS-HDをサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にDTS-HDをパススルー出来るようにします。"
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1603,11 +1603,11 @@ msgstr ""
 "お使いの再生デバイスがTrueHDをサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にTrueHDをパススルー出来るようにします。"
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1616,11 +1616,11 @@ msgstr ""
 "お使いの再生デバイスがFLACをサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にFLACをパススルー出来るようにします。"
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1629,22 +1629,22 @@ msgstr ""
 "お使いの再生デバイスがAACをサポートしている場合に有効化してください。\n"
 "これは自動パススルー選択が有効な時にAACをパススルー出来るようにします。"
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "パススルーのフォールバック:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1652,62 +1652,62 @@ msgstr ""
 "オーディオパススルーに適したトラックが見つからなかったときにエンコードする"
 "オーディオコーデックを指定します。"
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>オーディオエンコーダー設定:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "選択された各ソーストラックは選択されたすべてのエンコーダーでエンコードされま"
 "す。"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "エンコーダー"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "ビットレート/音質"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "ミックスダウン"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "サンプルレート"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "ゲイン"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "トラック選択"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "オーディオ"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "新しい字幕設定をリストに追加します"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "すべての字幕設定をリストに追加します"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "吹き替え字幕スキャン"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1716,15 +1716,15 @@ msgstr ""
 "外国語音声部分にある正しい字幕を探すよう\n"
 "追加の処理をします。"
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "すべての字幕設定をデフォルトから再読込します"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "ソースメディアのどの字幕トラックを使用するかを選択します。"
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1737,15 +1737,15 @@ msgstr ""
 "字幕に使用したい言語のリストを作成します。\n"
 "これらの言語と一致したトラックが「選択方法」で指定された方法で選ばれます。"
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "既定の言語: なし"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "吹き替え字幕スキャンパスの追加"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1760,11 +1760,11 @@ msgstr ""
 "\n"
 "このオプションは言語選択リストで言語を設定しておく必要があります。"
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "デフォルト音声が外国語のとき字幕トラックを追加する"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1775,11 +1775,11 @@ msgstr ""
 "\n"
 "このオプションは言語選択リストで言語を設定しておく必要があります。"
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "クローズドキャプションが利用できれば追加する"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1787,11 +1787,11 @@ msgstr ""
 "クローズドキャプションはあらゆるコンテナーにソフト字幕トラックとして追加でき"
 "るテキスト字幕です。"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "焼き付け方法*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1806,15 +1806,15 @@ msgstr ""
 "1つの字幕トラックのみが焼き込みできます! 競合した場合、最初に選ばれたものを使"
 "用します。"
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "不完全なプレーヤー用の焼き付け*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD 字幕"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1831,11 +1831,11 @@ msgstr ""
 "1つの字幕トラックのみが焼き込みできます! 競合した場合、最初に選ばれたものを使"
 "用します。"
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray 字幕"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1853,7 +1853,7 @@ msgstr ""
 "1つの字幕トラックのみが焼き込みできます! 競合した場合、最初に選ばれたものを使"
 "用します。"
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1861,7 +1861,7 @@ msgstr ""
 "<small>* これらのうち、先頭から見てひとつの字幕焼き付けオプションのみ適用され"
 "ます。</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1869,112 +1869,112 @@ msgstr ""
 "焼き付けることのできる字幕はひとつだけです。複数選択されていた場合は先頭に選"
 "択されたものが採用されます。"
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "チャプターマーカー"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "出力ファイルにチャプターマーカーを追加します。"
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "チャプター"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "チャプター"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "インデックス"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "時間"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "タイトル"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "チャプター"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "出演者:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "監督:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "公開日:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "コメント:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "ジャンル:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "説明:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "プロット:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "タグ"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>ファイル名:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "エンコードファイルのファイル名です。"
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>保存先:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "エンコードファイルを保存するディレクトリです。"
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "保存先ディレクトリ"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "複数追加(_M)"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1982,51 +1982,51 @@ msgstr "複数追加(_M)"
 msgid "Cancel"
 msgstr "キャンセル"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "すべて選択"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "キューに追加するために全タイトルをマークします"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "すべてクリア"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "全タイトルのマークを外します"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "保存ファイル OK。重複は検出されませんでした。"
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "設定"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "アップデートを自動的にチェックする"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "自動名前付けを使用する (修正されたソース名を使用)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "出力先ファイル名をソースのファイル名やボリュームラベルから作成する"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "自動名前付けテンプレート"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2036,25 +2036,25 @@ msgstr ""
 "利用できるオプション: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 "MP4 ファイルにおいて、iPod/iTunes フレンドリなファイル拡張子 (.m4v) を使用す"
 "る"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "プレビューの数"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "DVDやBlu-rayの短いタイトルを除外(秒)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "エンコードが完了したらキューの完了したアイテムをクリアする"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2064,52 +2064,52 @@ msgstr ""
 "完了したらキューから消したいときはこのオプションにチェックマークをつけてくだ"
 "さい。"
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "一般"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2123,63 +2123,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "固定品質の分画粒度"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "dvdnav を使用する (libdvdread を使用しない)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "出力先ストレージの空き容量を監視する"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "ストレージの空き容量がつぎの値以下であればエンコードを停止します"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB 以下"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "個別のエンコードログを動画と同じ場所に出力する"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "アクティビティログ詳細レベル"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "アクティビティログ保存期間"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "HD 画像のプレビューは縮小する"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "DVD が挿入されたら自動的にスキャンする"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "新しいディスクが挿入されるたびに DVD をスキャンします"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "アクティビティウィンドウのフォントサイズ"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "全タイトルに同じ設定を使用する"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2190,163 +2190,163 @@ msgstr ""
 "このオプションを有効にすると、キューへの追加時にすべてのタイトルに同じ設定が"
 "使用されます。"
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "詳細設定を許可"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "HandBrake For Dummies を許可"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "詳細"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "デノイズプリセット:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">プリセット名の変更</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "名前:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>説明</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "新規プリセットとして保存"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "カテゴリ:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "このプリセットのカテゴリを指定してください。"
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "カテゴリ名:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "プリセット名:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "デフォルトプリセット"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "このプリセットをデフォルトに設定します"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>解像度</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrakeプレビュー"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "プレビューフレームを選択します。"
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 "現在のプレビューポジションからの短いシーケンスをエンコードおよび再生します。"
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>時間:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "ライブプレビューする時間を秒で指定します。"
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "クロップを表示"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "プレビューのクロップした領域を表示します"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "ソースの解像度"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "プレビューウィンドウをソースビデオの解像度にリセットします"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "SRT のインポート"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "SRT 字幕ファイルをインポートする設定を有効にします"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "SSAをインポート"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "SSA字幕ファイルをインポートするための設定を有効化"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "埋め込み字幕リスト"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "埋め込み字幕を選択する設定を有効にします"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "ソーストラック"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "ソースから利用できる字幕トラックのリストです。"
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "トラック名:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2356,23 +2356,23 @@ msgstr ""
 "\n"
 "プレーヤーがこの字幕選択リストを使用することがあります。"
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "言語"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "文字コード"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "ファイル:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "オフセット (ミリ秒)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2380,7 +2380,7 @@ msgstr ""
 "この字幕の言語を設定します。\n"
 "この値がプレーヤーの字幕メニューで表示されます。"
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2394,27 +2394,27 @@ msgstr ""
 "HandBrake では文字セットを UTF-8 に変換します。\n"
 "この変換のため、ソースの文字コードが必要になります。"
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "インポートする SRT ファイルを選択します。"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "ファイルをインポート"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "動画と SRT タイムスタンプとの間のオフセットをミリ秒で指定します。"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "強制字幕のみ"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "映像に焼き込む"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2422,19 +2422,19 @@ msgstr ""
 "字幕を映像上に書き込みます。\n"
 "字幕は映像の一部となり無効にできません。"
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "デフォルトトラックの設定"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "ソースから利用できるオーディオトラックのリストです。"
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2444,15 +2444,15 @@ msgstr ""
 "\n"
 "プレーヤーはオーディオ選択リストでこの文字列を使用します。"
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mix"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "サンプルレート"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2468,50 +2468,50 @@ msgstr ""
 "ソースオーディオのダイナミックレンジが広い (とても大きい/とても小さいシーケン"
 "ス) の場合、DRC は音量を下げて/上げてレンジを '圧縮' できます。"
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "このトラックをエンコードするオーディオコーデックを指定します。"
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "ビットレート"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "ビットレート設定を有効にします"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "音質"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "音質指定を有効にします"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "このトラックをエンコードするビットレートを指定します。"
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 "<b>音質:</b> コーデックがサポートしている場合、出力の音質を調整します。"
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "出力オーディオトラックのミックスダウンを指定します。"
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "出力オーディオトラックのサンプルレートを指定します。"
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2519,41 +2519,41 @@ msgstr ""
 "<b>オーディオゲイン:</b> 出力オーディオトラックの増幅/減衰を調整します。"
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "オフ"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "このバージョンをスキップ"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "後で"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>新しいバージョンの HandBrake が利用できます!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx is now available (you have yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>リリースノート</b>"
 
@@ -2697,7 +2697,7 @@ msgstr "検出 DVD デバイス:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "スキャン中..."
 
@@ -2710,89 +2710,118 @@ msgstr "スキャン中止"
 msgid "Single Title"
 msgstr "一つのタイトルを開く(_T)"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "オーディオ"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "字幕"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", 強制のみ"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", 焼き込み"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", 既定"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "外国語音声の字幕トラック"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "ピクセルアスペクト比:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "タイトルが見つかりません"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "新規動画"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2803,134 +2832,134 @@ msgstr ""
 "\n"
 "%3$d 秒後に %2$s ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sエンコードを中止するとエンコードファイルは正しく再生できません。"
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "現在のエンコードをキャンセルして停止"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "現在のエンコードをキャンセルして次を開始"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "現在のエンコードの完了後に停止"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "エンコード続行"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "処理待ちのエンコード数 %d"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "処理待ちのエンコード数 %d"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "ジョブ %d / %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "パス %d (字幕スキャン) / %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "パス %d / %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "エンコード中: %s%s%.2f %% (%.2f fps, 平均 %.2f fps, 完了予定 %02d時間%02d"
 "分%02d秒後)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "エンコード中: %s%s%.2f %% (完了予定 %02d時間%02d分%02d秒後)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "エンコード中: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "開始時間を検索中 "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "タイトル %d / %d をスキャン中..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "タイトル %d / %d のプレビュー %d をスキャン中..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "一時停止"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "エンコード完了!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "エンコードをキャンセルしました。"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "エンコードに失敗しました。"
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "MUX中: これは多少時間がかかるかもしれません..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s が利用可能です (あなたのバージョン: %s/%d)。"
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "エンコード完了"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "カクテルを戻してください。HandBrake キューが完了しました!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "エンコードが完了しました。"
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Handbrake を終了します"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "コンピューターをスリープします"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "コンピューターをシャットダウンします"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ka.po
+++ b/gtk/po/ka.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Temuri Doghonadze <temuri.doghonadze@gmail.com>, 2022\n"
 "Language-Team: Georgian (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_პრესეტების"
 msgid "Set De_fault"
 msgstr "ნაგულისხმევად დაყე_ნება"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_შენახვა"
 
@@ -114,7 +114,7 @@ msgstr "_შენახვა"
 msgid "Save _As"
 msgstr "_შენახვა, როგორც"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_გადარქმევა"
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>ჩამწვარი</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -176,7 +176,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>ნაგულისხმები</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -330,7 +330,7 @@ msgstr "დარჩენილია 0 დავალება"
 msgid "Start Encoding"
 msgstr "კოდირების დაწყება"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "გაშვება"
@@ -349,7 +349,7 @@ msgstr "გაჩერება"
 msgid "Options"
 msgstr "პარამეტრები"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "როცა დასრულდება:"
 
@@ -367,8 +367,8 @@ msgstr ""
 msgid "Edit"
 msgstr "ჩასწორება"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "პრესეტი:"
 
@@ -376,7 +376,7 @@ msgstr "პრესეტი:"
 msgid "Source:"
 msgstr "წყარო:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "სათაური:"
 
@@ -400,7 +400,7 @@ msgstr "აუდიო:"
 msgid "Subtitles:"
 msgstr "სუბტიტრები:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "შეჯამება"
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "აირჩიეთ საწყისი ვიდეო"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "ღია კოდი"
 
@@ -515,7 +515,7 @@ msgstr "მინიატურა"
 msgid "Show Queue"
 msgstr "რიგის ჩვენება"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "რიგი"
 
@@ -538,242 +538,242 @@ msgstr "<b>წყარო:</b>"
 msgid "None"
 msgstr "არაფერი"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "ძებნა ..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>სათაური</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>კუთხე:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>დიაპაზონი:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "პირველი დასაკოდირებელი თავი."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "ბოლოს დასაკოდირებელი თავი."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>პრესეტი:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "აირჩიეთ პრესეტი"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>შეცვლილია</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "თავიდან ჩატვირთვა"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "ახალი პრესეტის შენახვა"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "მიმდინარე პარამეტრების ახალ პრესეტში შენახვა."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "ფორმატი:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "ვებისთვის ოპტიმიზირებული"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "A/V სწორების დაწყება"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G -ის მხარდაჭერა"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "ხანგრძლივობა:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "სს:წთ:წმ"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "&ტრეკები:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "ფილტრები:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "ზომა:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "საცავის ზომა:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "ჩვენების ზომა:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "თანაფარდობა:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>წყაროს ზომები</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "გადაბრუნება:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "ჰორიზონტალური ⇌"
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "ვიდეოს ჰორიზონტალურად გადაბრუნება."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "შემობრუნება:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "ამოჭრა:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "როგორ გადავატაროთ ამოჭრის პარამეტრები."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "მარცხნივ ამოჭრა"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "ზემოთ ამოჭრა"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "ქვემოთ ამოჭრა"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "მარჯვნივ ამოჭრა"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>ორიენტაცია &amp; ამოჭრა</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "გარჩევადობის ლიმიტი:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "მაქსიმალური ზომა:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "ანამორფული:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -783,11 +783,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "პიქსელის ასპექტი:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -796,11 +796,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -808,102 +808,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "გადიდებული ზომა:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "ოპტიმალური ზომა"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "გადიდების ნების დართვა"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>გაფართოება და მასშტაბირება</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "შევსება:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "ვიდეოს გარშემო საზღვრის დამატება."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "ფერი:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>საზღვრები</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "ავტომატური"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>საბოლოო ზომები</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "ზომები"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -911,18 +911,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -930,7 +930,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -938,11 +938,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -950,7 +950,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -959,39 +959,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -999,7 +999,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1007,78 +1007,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "ფერების სივრცე:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "ნაცრისფერი"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "ფილტრები"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "ვიდეო ენკოდერი:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "ხელმისაწვდომი ვიდეო ენკოდერები."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "კადრების სიჩქარე:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1086,19 +1086,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "მუდმივი კადრების სიჩქარე"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1106,18 +1106,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "ცვლადი კადრების სიჩქარე"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1133,15 +1133,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "მუდმივი ხარისხი:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "ბიტური სიჩქარე(კბწმ):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1152,11 +1152,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1166,16 +1166,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1187,7 +1187,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1196,22 +1196,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1221,300 +1221,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "პროფილი:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "დონე:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "მეტი პარამეტრი:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "ვიდეო"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "დამატება"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "ყველას დამატება"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "ტრეკების სია"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "მონიშვნის ქცევა:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "წაშლა"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "ხელმისაწვდომი ენები"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "შერჩეული ენები"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "ეკოდერი"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "ბიტური სიჩქარე/ხარისხი"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "შერევა"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "სემპლებისსიჩქარე"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "გაძლიერება"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "ტრეკის არჩევანი"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "აუდიო"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1525,15 +1525,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "სასურველი ენა: არცერთი"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1543,11 +1543,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1555,21 +1555,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1579,15 +1579,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD სუბტიტრები"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1598,11 +1598,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1613,124 +1613,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "სუბტიტრები"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "თავები"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "თავები"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "ინდექსი"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "ხანგრძლოვობა"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "სათაური"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "თავები"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "მსახიობები:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "რეჟისორი:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "რელიზის თარიღი:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "კომენტარი:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "ჟანრი:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "აღწერა:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "გრაფიკი:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "ჭდეები"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>შენახვა, როგორც:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "თქვენი კოდირების სამიზნე ფაილის სახელი."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>ვის:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "თქვენი კოდირების სამიზნე საქაღალდის საქხელი."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "სამიზნე საქაღალდე"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "_ბევრის დამატება"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1738,126 +1738,126 @@ msgstr "_ბევრის დამატება"
 msgid "Cancel"
 msgstr "გაუქმება"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "ყველას მონიშვნა"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "ყველას გასუფთავება"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "ყველა სათაურის მონიშვნის მოხსნა"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "მორგება"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "განახლების ავტომატური შემოწმება"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "შაბლონისა ავტომატური სახელი"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "მინიატურების რაოდენობა"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "ზოგადი"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1871,63 +1871,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "დროებითი საქაღალდე"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "მბ ლიმიტი"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "აქტივობის ჟურნალში ჩანაწერების დონე"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "აქტივობის ჟურნალის ხანგრძლივობა"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1936,191 +1936,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "დამატებითი"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "HandBrake -ის პრესეტები"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "სახელი:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>აღწერა</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "ახალი პრესეტის შენახვა"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "კატეგორია:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "კატეგორიის სახელი:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "პრესეტის სახელი:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "ნაგულისხმები პრესეტი"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>ზომები</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrake -ის მინიატურა"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "აირჩიეთ მინიატურის კადრები."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>ხანგრძლივობა:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "წყაროს გაფართოება"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "სუბტიტრები"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "SRT-ის შემოტანა"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "SSA-ის შემოტანა"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "ჩაშენებული სუბტიტრების სია"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "საწყისი ტრეკი"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "აუდიობილიკის სახელი:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "ენა"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "სიმბოლოს კოდი"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "ფაილი:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "წანაცვლება (მწმ)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2129,60 +2129,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "აირჩიეთ შემოსატანი SRT ფაილი."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "ფაილის შემოტანა"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "მხოლოდ იძულებითი სუბტიტრები"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "ვიდეოში ჩაშენება"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "ნაგულისხმევი ტრეკის დაყენება"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "მიქსი"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "სემპლების სიჩქარე"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2193,90 +2193,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "სიჩქარე"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "ბიტური სიჩქარის პარამეტრის ჩართვა"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "ხარისხი"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "ხარისხის პარამეტრის ჩართვა"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0დბ"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "გამორთულია"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "ამ ვერსიის გამოტოვება"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "მოგვიანებით შემახსენე"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>რელიზის შენიშნვები</b>"
 
@@ -2417,7 +2417,7 @@ msgstr "ნაპოვნი DVD მოწყობილობები:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "ძებნა ..."
 
@@ -2430,96 +2430,125 @@ msgstr "ძებნის შეჩერება"
 msgid "Single Title"
 msgstr "ერთი _სათაურის გახსნა"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "აუდიო"
 msgstr[1] "აუდიო"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "სუბტიტრები"
 msgstr[1] "სუბტიტრები"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", ნაგულისხმები"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "უცხო აუდიო სუბტიტრების ტრეკი"
 msgstr[1] "უცხო აუდიო სუბტიტრების ტრეკი"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 #, fuzzy
 msgid "storage"
 msgstr "საცავის ზომა:"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 #, fuzzy
 msgid "display"
 msgstr "ჩვენების ზომა:"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "თანაფარდობა:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "თანაფარდობა:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "სათაური ვერ ვიპოვე"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "ახალი ვიდეო"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2530,132 +2559,132 @@ msgstr ""
 "\n"
 "%s %d წამში ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "მიმდინარის გაუქმება და გაჩერება"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "მიმდინარის გაუქმება და შემდეგის გაშვება"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "მიმდინარის დასრულება და გაჩერება"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "კოდირების გაგრძელება"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "დარჩენილია %d დაკოდირება"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "დარჩენილია %d დაკოდირება"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "%d დავალება %d-დან, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "შეჩერება"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "კოდირება დასრულდა!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "კოდირება გაუქმდა."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "კოდირების შეცდომა."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "კოდირება დასრულდა"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "თქვენი კოდირება დასრულდა."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Handbrake-დან გასვლა"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "კომპიუტერის დაძინება"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "კომპიუტერის გამორთვა"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ko.po
+++ b/gtk/po/ko.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Junghee Lee <daemul72@gmail.com>, 2022\n"
 "Language-Team: Korean (https://www.transifex.com/HandBrakeProject/"
@@ -107,8 +107,8 @@ msgstr "프리셋(_P)"
 msgid "Set De_fault"
 msgstr "기본값 지정(_F)"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "저장(_S)"
 
@@ -116,7 +116,7 @@ msgstr "저장(_S)"
 msgid "Save _As"
 msgstr "다른 이름으로 저장(_A)"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "이름 바꾸기(_R)"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>진하게 인화</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>기본값</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -365,7 +365,7 @@ msgstr "0개 작업 보류 중"
 msgid "Start Encoding"
 msgstr "인코딩 시작"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "시작"
@@ -384,7 +384,7 @@ msgstr "정지"
 msgid "Options"
 msgstr "옵션"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "완료된 경우:"
 
@@ -404,8 +404,8 @@ msgstr ""
 msgid "Edit"
 msgstr "편집"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "프리셋:"
 
@@ -413,7 +413,7 @@ msgstr "프리셋:"
 msgid "Source:"
 msgstr "원본:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "제목:"
 
@@ -437,7 +437,7 @@ msgstr "오디오:"
 msgid "Subtitles:"
 msgstr "자막:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "개요"
 
@@ -530,11 +530,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "비디오 원본 선택"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "원본 열기"
 
@@ -566,7 +566,7 @@ msgstr "미리보기"
 msgid "Show Queue"
 msgstr "대기열 표시"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "대기열"
 
@@ -589,15 +589,15 @@ msgstr "<b>원본:</b>"
 msgid "None"
 msgstr "없음"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "스캔 중..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>제목:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -607,51 +607,51 @@ msgstr ""
 "기본적으로 가장 킨 제목이 선택됩니다.\n"
 "이것은 보통 DVD의 주요 제목입니다."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>구도:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "멀티 앵글 DVD의 경우, 인코딩할 앵글을 선택합니다."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>범위:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "인코딩할 제목의 범위입니다. 챕터, 초 또는 프레임일 수 있습니다."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "인코딩할 첫 챕터를 지정합니다."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "인코딩할 마지막 챕터를 지정합니다."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>프리셋:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "프리셋 선택"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>수정</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "다시 불러오기"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -659,27 +659,27 @@ msgstr ""
 "현재 선택된 프리셋으로 설정을 다시 불러옵니다.\n"
 "수정사항은 폐기됩니다."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "새 프리셋 저장"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "현재 설정을 새 프리셋에 저장합니다."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "형식:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "다중사용으로 인코딩된 트랙에 대한 형식입니다."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "웹 최적화"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -687,11 +687,11 @@ msgstr ""
 "증분 다운로드 동안 MP4 파일의 레이아웃을 최적화합니다.\n"
 "이 옵션은 재생기가 전체 파일을 다운로드하기 전에 재생을 시작할 수 있습니다."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "A/V 시작 정렬"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -702,140 +702,140 @@ msgstr ""
 "MP4 편집 목록을 준수하지 않는 손상된 플레이어의 오디오/비디오 동기화를 향상시"
 "킬 수 있습니다."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G 지원"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "일부 구형 iPod에 필요한 iPod Atom을 추가합니다."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "패스스루 공통 메타데이터"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "원본에서 출력으로 메타데이터를 복사합니다."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "재생시간:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "트랙:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "필터:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "크기:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "저장소 크기:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "디스플레이 크기:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "가로 세로 비율:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>원본 해상도</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "뒤집기:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "수평 위치  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "비디오를 수평으로 뒤집습니다."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "회전:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "비디오를 시계 방향으로 90도 회전합니다."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "자르기:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "자르기 설정을 적용하는 방법입니다."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "좌측 자르기"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "상단 자르기"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "하단 자르기"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "우측 자르기"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "해상도 제한:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "일반적인 비디오 형식에 대한 해상도 제한입니다."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "최대 크기:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "비디오가 저장되는 최대 너비입니다."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "비디오가 저장되는 최대 높이입니다."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "아나모픽:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -845,11 +845,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "가로세로 픽셀:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -862,11 +862,11 @@ msgstr ""
 "1:1 비율은 정사각 픽셀로 결정됩니다. 다른 값은 사각형 모양을 결정합니다.\n"
 "재생기는 지정된 비율에 따라서 이미지의 크기를 조절합니다."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -877,11 +877,11 @@ msgstr ""
 "1:1 비율은 정사각 픽셀로 결정됩니다. 다른 값은 사각형 모양을 결정합니다.\n"
 "재생기는 지정된 비율에 따라서 이미지의 크기를 조절합니다."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "크기 조정된 크기:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -890,7 +890,7 @@ msgstr ""
 "이 값은 비디오가 저장되는 너비입니다.\n"
 "픽셀 종횡비가 1:1이 아닌 경우 실제 표시 해상도가 달라집니다."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -899,84 +899,84 @@ msgstr ""
 "이 값은 비디오가 저장되는 높이입니다..\n"
 "픽셀 종횡비가 1:1이 아닌 경우 실제 표시 해상도가 달라집니다."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "최적의 크기"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "업스케일링 허용하기"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr "활성화하지 않으면, 크기 조정된 해상도가 원본 해상도로 제한됩니다."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>해상도 &amp; 크기 조정</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "채우기:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "비디오 주위에 테두리를 추가합니다."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "좌측 패드"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "상단 패드"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "하단 패드"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "우측 패드"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "색상:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "비디오 주위에 테두리 색이 추가되었습니다."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>테두리</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "디스플레이 크기를 변경하면 비디오가 늘어납니다."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "자동"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>최종 해상도</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "해상도"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "텔레시네 해제:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -988,7 +988,7 @@ msgstr ""
 "텔레시닝은 24fps인 필름 프레임률을 30fps인 NTSC 비디오 프레임률로 조정하는 과"
 "정입니다."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -998,11 +998,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "인터레이스 감지:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1014,7 +1014,7 @@ msgstr ""
 "인터레이스 해제 필터가 활성화된 경우, 이 필터가 인터레이스되었다 판단한 프레"
 "임만을 인터레이스 해제합니다."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1026,11 +1026,11 @@ msgstr ""
 "모드:공간 메트릭:모션 스레시:마스크 필터 모드:\n"
 "블록 스레시: 블록 폭: 블록 높이"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "인터레이스 해제:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1042,7 +1042,7 @@ msgstr ""
 "Decomb 필터는 다양한 보간법 알고리즘을 지원합니다.\n"
 "인터레이스 해제 필터는 고전적인 YADIF 인터레이스 해제도구입니다.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1056,11 +1056,11 @@ msgstr ""
 "Decomb 필터는 다양한 보간법 알고리즘을 지원합니다.\n"
 "인터레이스 해제 필터는 고전적인 YADIF 인터레이스 해제도구입니다.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "블록 제거 필터:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1068,12 +1068,12 @@ msgstr ""
 "블록 제거 필터는 일반적인 유형의 압축 아티팩트를 제거합니다.\n"
 "원본 영상에 블럭이 많다면, 이 필터가 도움이 됩니다."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "조정:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1082,7 +1082,7 @@ msgstr ""
 "블록 제거 필터는 일반적인 유형의 압축 아티팩트를 제거합니다.\n"
 "원본 영상에 블럭이 많다면, 이 필터가 도움이 됩니다."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1093,11 +1093,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "노이즈 제거 필터:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1108,7 +1108,7 @@ msgstr ""
 "필름 그레인과 다른 종류의 고주파 노이즈는 압축을 어렵게 만듭니다.\n"
 "그런 원본에 이 필터를 사용하면 파일을 더 작게 만들 수 있습니다."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1120,7 +1120,7 @@ msgstr ""
 "필름 그레인과 다른 종류의 고주파 노이즈는 압축을 어렵게 만듭니다.\n"
 "그런 원본에 이 필터를 사용하면 파일을 더 작게 만들 수 있습니다."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1131,11 +1131,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "크로마 스무스 필터:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1143,7 +1143,7 @@ msgstr ""
 "크로마 스무스 필터는 일반적인 색상 아티팩트를 제거합니다.\n"
 "낮은 해상도의 아날로그 소스 콘텐츠가 이 필터의 이점을 얻을 수 있습니다."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1152,11 +1152,11 @@ msgstr ""
 "크로마 스무스 필터는 일반적인 색상 아티팩트를 제거합니다.\n"
 "낮은 해상도의 아날로그 소스 콘텐츠가 이 필터의 이점을 얻을 수 있습니다."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "선명도 필터:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1164,7 +1164,7 @@ msgstr ""
 "선명도(Sharpen) 필터링은 비디오의 가장자리\n"
 "및 높은 빈도의 구성요소를 향상시킵니다."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1173,39 +1173,39 @@ msgstr ""
 "선명도(Sharpen) 필터링은 비디오의 가장자리\n"
 "및 높은 빈도의 구성요소를 향상시킵니다."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "색상공간:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "원본의 색상공간을 변환합니다."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "그레이스케일"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "활성화된 경우, 컬러 구성 요소를 비디오에서 필터링합니다."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "필터"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "비디오 인코더:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "사용 가능한 비디오 인코더."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "프레임레이트:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1217,19 +1217,19 @@ msgstr ""
 "'원본과 동일'이 권장됩니다. 원본 비디오가 가변\n"
 "프레임레이트라면, '원본과 동일'은 그 설정을 보존합니다."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "고정 프레임레이트"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "고정 프레임레이트 출력을 활성화합니다."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "피크 프레임레이트 (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1241,11 +1241,11 @@ msgstr ""
 "\n"
 "가변 프레임레이트는 일부 재생기와 호환되지 않을 수 있습니다."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "가변 프레임레이트"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1255,7 +1255,7 @@ msgstr ""
 "\n"
 "VFR은 일부 재생기와 호환되지 않습니다."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1282,15 +1282,15 @@ msgstr ""
 "FFMpeg과 Theora의 스케일은 좀더 선형적입니다.\n"
 "이런 인코더들은 무손실 모드를 지원하지 않습니다."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "고정 화질:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "비트레이트 (kbps): "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1306,11 +1306,11 @@ msgstr ""
 "그러나 긴 시간 동안의 평균치는 이 값에 수렴합니다. 순간 비트레이트를\n"
 "제한하려면 x264의 vbv-bufsize와 vbv-maxrate 설정을 살펴보세요."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2 패스 인코딩"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1325,17 +1325,17 @@ msgstr ""
 "통계가 수집됩니다. 그런 다음 두 번째 패스에서 이러한 통계를 사용하여 \n"
 "비트레이트 할당을 결정합니다."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "첫 번째 패스 가속"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "2패스 인코딩의 1번째 패스를 하는 동안, 속도를 높이는 설정을 사용합니다."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1354,7 +1354,7 @@ msgstr ""
 "다.\n"
 "설정을 사용하면 화질이 향상되거나 파일 크기가 작아집니다."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1368,11 +1368,11 @@ msgstr ""
 "특성을 설정할 수 있습니다.  변경사항은 프리셋 후 다른 모든 \n"
 "파라미터보다 먼저 적용됩니다."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "고속 디코딩"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1383,11 +1383,11 @@ msgstr ""
 "장치가 출력을 재생하는 데 어려움을 겪는 경우(프레임 누락), 이 옵션을 지정합니"
 "다."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "대기 시간 없음"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1403,11 +1403,11 @@ msgstr ""
 "HandBrake는 라이브 스트리밍 방송 목적으로는 적합하지 않기 때문에,\n"
 "이러한 설정은 여기서 별로 가치가 없습니다."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "프로필:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1417,11 +1417,11 @@ msgstr ""
 "\n"
 "다른 모든 설정을 덮어씁니다."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "레벨:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1431,11 +1431,11 @@ msgstr ""
 "\n"
 "다른 모든 설정을 재정의합니다."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "상세 설정:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1445,45 +1445,45 @@ msgstr ""
 "\n"
 "콜론으로 분리된 인코더 옵션 목록."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "비디오"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "추가"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "새로운 오디오 설정을 목록에 추가"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "모두 추가"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "모든 오디오 트랙을 목록에 추가"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "기본 설정에서 모든 오디오 설정 다시 불러오기"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "트랙 목록"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "선택 동작:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "사용할 원본 미디어의 오디오 트랙을 선택합니다."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1492,23 +1492,23 @@ msgstr ""
 "오디오를 선택할 언어 목록을 만듭니다.\n"
 "선택한 선택 동작을 사용하여 이러한 언어와 일치하는 트랙을 선택합니다."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "제거"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "사용 가능한 언어"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "선택된 언어"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "부 오디오에 대해서 첫 인코더만 사용"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1517,26 +1517,26 @@ msgstr ""
 "기본 오디오 트랙만 전체 인코더 목록으로 인코딩됩니다.\n"
 "다른 모든 보조 오디오 출력 트랙은 첫 번째 인코더로만 인코딩됩니다."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "자동 패스트루:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1545,11 +1545,11 @@ msgstr ""
 "재생 장치가 MP3를 지원하는 경우 이 옵션을 활성화합니다.\n"
 "이 옵션은 자동 패스트루 선택이 사용 가능할 때 MP3 경유 선택이 허용됩니다."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1559,11 +1559,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능할 때, AC-3 패스트루 선택이 허용됩니"
 "다."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1573,11 +1573,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능할 때, EAC-3 패스트루 선택이 허용됩니"
 "다."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1587,11 +1587,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능한 경우, DTS 패스트루 선택이 허용됩니"
 "다."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1601,11 +1601,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능한 경우, DTS-HD 패스트루 선택이 허용"
 "됩니다."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1615,11 +1615,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능한 경우, TrueHD 패스트루 선택이 허용"
 "됩니다."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1629,11 +1629,11 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능한 경우, FLAC 패스트루 선택이 허용됩"
 "니다."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1643,82 +1643,82 @@ msgstr ""
 "이 옵션은 자동 패스트루 선택이 사용 가능할 때, AAC 패스트루 선택이 허용됩니"
 "다."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "패스트루 대체:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 "오디오 패스트루에 적합한 트랙이 없는 경우 인코딩할 오디오 코덱을 지정합니다."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>오디오 인코딩 설정:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "선택된 각각의 원본 트랙은 선택된 모든 인코더로 인코딩됩니다"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "인코더"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "비프레이트/화질"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "믹스다운"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "샘플레이트"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "게인"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "트랙 선택"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "오디오"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "새로운 자막 설정을 목록에 추가"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "모든 자막 트랙을 목록에 추가"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "외부 오디오 스캔"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1727,15 +1727,15 @@ msgstr ""
 "외국어로 된 오디오 세그먼트에 대해 자막을 제공하는\n"
 "자막 후보를 검색하는 인코딩에 추가 패스를 추가합니다."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "기본 설정에서 모든 자막 설정 다시 불러오기"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "사용할 원본 미디어의 자막 트랙을 선택합니다."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1751,15 +1751,15 @@ msgstr ""
 "이 목록의 첫 번째 언어는 \"기본\" 언어이며, 외부 오디오가 있을 때 자막 \n"
 "선택 설정을 결정하는 데 사용됩니다."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "기본 언어: 없음"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "외부 오디오 스캔 패스 추가"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1773,11 +1773,11 @@ msgstr ""
 "\n"
 "이 옵션을 사용하려면 선택한 언어 목록에서 언어를 설정해야 합니다."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "기본 오디오가 외국어인 경우 자막 트랙 추가"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1788,11 +1788,11 @@ msgstr ""
 "\n"
 "이 옵션을 사용하려면 선택한 언어 목록에서 언어를 설정해야 합니다."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "사용 가능한 경우 자막(Closed Captions) 추가"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1800,11 +1800,11 @@ msgstr ""
 "자막(Closed Captions)은 매끄러운 자막 트랙으로 모든 컨테이너에 추가할 수 있"
 "는 텍스트 자막입니다"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "복제 시 행동*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1819,15 +1819,15 @@ msgstr ""
 "자막 트랙은 하나만 추가할 수 있습니다! 충돌이 발생할 수 있기 때문에 먼저 선택"
 "한 자막이 우선합니다."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "결함이 있는 플레이어를 위한 복제*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD 자막"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1845,11 +1845,11 @@ msgstr ""
 "자막 트랙은 하나만 추가할 수 있습니다! 충돌이 발생할 수 있기 때문에 먼저 선택"
 "한 자막이 우선합니다."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray 자막"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1867,7 +1867,7 @@ msgstr ""
 "자막 트랙은 하나만 추가할 수 있습니다! 충돌이 발생할 수 있기 때문에 먼저 선택"
 "한 자막이 우선합니다."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1875,7 +1875,7 @@ msgstr ""
 "<small>*위에서부터 시작하여 위의 자막 레코딩 옵션 중 하나만 적용됩니다.</"
 "small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1883,112 +1883,112 @@ msgstr ""
 "자막 트랙은 하나만 추가할 수 있습니다! 충돌이 발생할 수 있기 때문에 먼저 선택"
 "한 자막이 우선합니다."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "자막"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "챕터 마커"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "출력 파일에 챕터 마커를 추가합니다."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "챕터"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "챕터"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "색인"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "재생시간"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "제목"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "챕터"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "배우:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "감독:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "배포일:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "주석:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "장르:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "설명:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "줄거리:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "태그"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>다른 이름으로 저장:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "인코딩의 대상 파일 이름입니다."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>위치:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "인코딩의 대상 디렉터리입니다."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "대상 디렉터리"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "다중 추가(_M)"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1996,51 +1996,51 @@ msgstr "다중 추가(_M)"
 msgid "Cancel"
 msgstr "취소"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "전체 선택"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "모든 제목을 대기열에 추가하기로 표시"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "모두 지우기"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "모든 제목에서 마커 제거"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "대상 파일 확인. 검색된 중복 항목이 없습니다."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "환경설정"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "자동으로 업데이트 확인"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "모든 인코딩이 완료되면 기본 작업이 수행됩니다"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "자동 이름 지정 사용 (수정된 원본 이름 사용)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "원본 파일 이름 또는 볼륨 레이블에서 대상 파일 이름 만들기"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "이름 자동 템플릿"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2050,23 +2050,23 @@ msgstr ""
 "사용 가능한 옵션: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "MP4에 대해 iPod/iTunes 친화적인 확장자 (.m4v) 사용"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "미리보기 수"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "짧은 DVD 및 블루레이 제목 필터링(초)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "완료된 대기열 항목 지우기 및 인코딩 완료"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2075,52 +2075,52 @@ msgstr ""
 "기본적으로 완료된 작업은 대기열에 남아있고 완료된 것으로 표시됩니다.\n"
 "완료된 작업을 대기열에서 지우려면 이 것을 선택하세요."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "일반"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr "Handbrake 임시 파일에 대한 사용자 지정 디렉터리를 설정합니다"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2134,63 +2134,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "임시 디렉터리"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "고정 화질 부분 세분화"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "(libdvdread 대신) dvdnav 사용"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "저장 경로 사용 가능한 디스크 공간 검사"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "한도 이하로 사용가능한 디스크 공간이 없을 시, 인코딩 중지"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB 한계"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "개별 인코딩 로그를 동영상과 동일한 위치에 배치"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "작업 로그 상세 레벨"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "작업 로그 수명"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "고화질 미리 보기 비율에 따라 줄이기"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "DVD가 삽입되면 자동으로 스캔"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "새로운 디스크가 삽입되면 DVD 스캔"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "작업 창 글꼴 크기"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "묶인 모든 파일들에 대해 동일한 설정 적용"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2202,163 +2202,163 @@ msgstr ""
 "을 사용합니다.\n"
 "각 제목의 설정을 독립적으로 변경하려면 선택을 해제합니다."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "설정 변경 허용"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "초보자를 위한 HandBrake를 허용"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "고급"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "노이즈 제거 프리셋:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">프리셋 이름 변경 </span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "이름:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>설명</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "새 프리셋 저장"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "범주:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "해당 프리셋을 표시할 범주를 지정합니다."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "범주 이름:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "프리셋 이름:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "기본 프리셋"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "HandBrake 실행 시, 이를 기본 프리셋으로 지정합니다"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>해상도</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrake 미리보기"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "미리보기 프레임을 선택합니다."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 "현재 미리보기 위치에서 시작하는 짧은 비디오 시퀀스를 인코딩하고 재생합니다."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>재생시간:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "실시간 미리보기의 재생시간을 초단위로 설정."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "자르기 표시"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "미리표시에서 잘라낸 영역 표시"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "원본 해상도"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "미리보기 창을 원본 비디오 해상도로 재설정"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "자막"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "SRT 가져오기"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "SRT 자막 파일 가져오기 활성화"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "SSA 가져오기"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "SSA 자막 파일을 가져오기 위한 설정 활성화"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "내장된 자막 목록"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "내장 자막 선택 설정 활성화"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "원본 트랙"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "원본에서 사용할 수 있는 자막 트랙 목록입니다."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "트랙 이름:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2368,23 +2368,23 @@ msgstr ""
 "\n"
 "재생기들은 이것을 자막 선택 목록에서 사용할 수 있습니다."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "언어"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "문자 인코딩"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "파일:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "오프셋 (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2392,7 +2392,7 @@ msgstr ""
 "이 자막의 언어 설정.\n"
 "이 값은 자막 메뉴에서 재생기가 사용합니다."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2406,27 +2406,27 @@ msgstr ""
 "이 문자 집합을 UTF-8로 변환합니다.\n"
 "이 변환을 수행하기 위해서 원본 문자 인코딩 방식이 필요합니다."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "가져올 SRT 파일을 선택합니다."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "파일 가져오기"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "비디오와 SRT 타임스탬프 사이에 밀리초 단위로 오프셋을 조정합니다"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "강제 표시 자막만"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "비디오로 굽기"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2434,19 +2434,19 @@ msgstr ""
 "비디오에 자막을 입힙니다.\n"
 "자막은 비디오의 일부가 되고, 비활성화할 수 없습니다."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "기본 트랙 지정"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "원본에서 사용할 수 있는 오디오 트랙 목록입니다."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2456,15 +2456,15 @@ msgstr ""
 "\n"
 "재생기에서 오디오 선택 목록에 이 이름을 사용합니다."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "믹스"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "샘플레이트"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2481,90 +2481,90 @@ msgstr ""
 "다이나믹 레인지 압축은 큰 소리를 부드럽게 만들고 부드러운 소리를 크게 만들어"
 "서 레인지를 '압축'합니다."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "이 트랙을 인코딩할 오디오 코덱을 지정합니다."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "비트레이트"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "비트레이트 설정 활성화"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "화질"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "화질 설정 활성화"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "이 트랙을 인코딩할 비트레이트를 지정합니다."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr "<b>화질:</b> 출력 코덱이 지원하는 경우, 출력물의 화질을 조정."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "오디오 트랙 출력의 믹스다운을 지정합니다."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "출력 오디오 트랙의 샘플레이트를 지정합니다."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr "<b>오디오 게인:</b> 출력된 오디오 트랙의 증폭 또는 감쇄를 조정합니다."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "끄기"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "이 버전 무시"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "나중에 알려주기"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>HandBrake의 새로운 버전을 사용할 수 있습니다!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx 버전이 있습니다. (현재 버전은 yyy 입니다)"
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>배포 기록</b>"
 
@@ -2709,7 +2709,7 @@ msgstr "감지된 DVD 장치:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "스캔 중 ..."
 
@@ -2722,92 +2722,121 @@ msgstr "스캔 중지"
 msgid "Single Title"
 msgstr "단일 제목 열기(_T)"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "오디오"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "자막"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", 강제 표시만"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", 추가됨"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", 기본값"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "외부 오디오 자막 트랙"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 #, fuzzy
 msgid "storage"
 msgstr "저장소 크기:"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 #, fuzzy
 msgid "display"
 msgstr "디스플레이 크기:"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "가로 세로 비율:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "가로 세로 비율:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "제목 없음"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "새 비디오"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2818,132 +2847,132 @@ msgstr ""
 "\n"
 "%s (%d 초) ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "인코딩을 계속하지 않으면 %s동영상이 손실됩니다."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "현재 작업 취소 및 전체 중지"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "현재 작업 취소 및 다음 작업 시작"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "현재 작업 마친 후 전체 중지"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "인코딩 계속하기"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d개 인코딩 보류 중"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d개 인코딩 보류 중"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "작업 %d / %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "패스 %d / %d (자막 스캔), "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "패스 %d / %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "인코딩: %s%s%.2f %% (%.2f fps, 평균 %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "인코딩: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "인코딩: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "시작 시간 검색 중, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "제목 %d / %d 스캔 중..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "제목 %d / %d 스캔 중, 미리보기 %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "정지됨"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "인코딩 완료!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "인코딩 취소됨."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "인코딩 실패함."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "다중화: 시간이 좀 걸릴 수 있습니다..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s 버전이 사용 가능합니다. (설치 버전 %s/%d)"
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "인코딩 완료됨"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "칵테일을 내려놓으세요, HandBrake 대기열에 있는 작업이 완료됐습니다!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "인코딩이 완료됐습니다."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Handbrake 종료 중"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "컴퓨터 절전모드로 전환 중"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "컴퓨터 종료 중"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/nl.po
+++ b/gtk/po/nl.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 1.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Stephan Paternotte <stephan@paternottes.net>, 2022\n"
 "Language-Team: Dutch (https://www.transifex.com/HandBrakeProject/teams/92423/"
@@ -105,8 +105,8 @@ msgstr "_Voorinstellingen"
 msgid "Set De_fault"
 msgstr "Stel als _Standaard in"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Opslaan"
 
@@ -114,7 +114,7 @@ msgstr "_Opslaan"
 msgid "Save _As"
 msgstr "Opslaan _als"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Naam wijzigen"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>ingebrand</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Standaard</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -358,7 +358,7 @@ msgstr "0 taken in wachtrij"
 msgid "Start Encoding"
 msgstr "Codering starten"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Starten"
@@ -377,7 +377,7 @@ msgstr "Pauzeren"
 msgid "Options"
 msgstr "Opties"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Wanneer voltooid:"
 
@@ -398,8 +398,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Bewerken"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Voorinstelling:"
 
@@ -407,7 +407,7 @@ msgstr "Voorinstelling:"
 msgid "Source:"
 msgstr "Bron:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titel:"
 
@@ -431,7 +431,7 @@ msgstr "Audio:"
 msgid "Subtitles:"
 msgstr "Ondertitels:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Samenvatting"
 
@@ -527,11 +527,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Kies videobron"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Open bron"
 
@@ -563,7 +563,7 @@ msgstr "Voorvertoning"
 msgid "Show Queue"
 msgstr "Toon wachtlijst"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Wachtlijst"
 
@@ -586,15 +586,15 @@ msgstr "<b>Bron:</b>"
 msgid "None"
 msgstr "Geen"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Scannen..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titel:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -604,53 +604,53 @@ msgstr ""
 "Standaard wordt de langste titel gekozen.\n"
 "Dit is vaak de getoonde titel van een DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Kijkhoek:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Voor multi-angle DVD's, kies de gewenste kijkhoek om te encoderen."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Bereik:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Bereik van de te encoderen titel. Kunnen hoofdstukken, seconden of frames "
 "zijn."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Stel het eerste te encoderen hoofdstuk in."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Stel het laatste te encoderen hoofdstuk in."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Voorinstelling:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Kies voorinstelling"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Gewijzigd</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Herladen"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -658,27 +658,27 @@ msgstr ""
 "Herlaad de instellingen voor de huidige voorinstelling.\n"
 "Wijzigingen worden verworpen."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Nieuwe voorinstelling opslaan"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "De huidige instellingen opslaan als nieuwe voorinstelling."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formaat:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formaat waarin geëncodeerde tracks gemuxt worden."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web-geöptimaliseerd"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -687,11 +687,11 @@ msgstr ""
 "Dit laat een speler toe om het afspelen te starten voor het hele bestand is "
 "gedownload."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "A/V-start uitlijnen"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -702,140 +702,140 @@ msgstr ""
 "van audio/video verbeteren voor kapotte spelers zonder ondersteuning\n"
 "voor MP4-lijsten."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Ondersteuning voor iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Voeg iPod Atom toe, nodig voor sommige oudere iPods."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Veelgebruikte metadata doorgeven"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Kopieer metadata van de bron naar de uitvoer."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Afspeelduur:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "uu:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Sporen:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filters:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Afmetingen:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Opslagafmetingen:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Weergaveafmetingen:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Beeldverhouding:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Afmetingen van de bron</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Spiegelen:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Horizontaal  "
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Video horizontaal spiegelen."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Rotatie:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Roteer de video in stappen van 90 graden met de klok mee."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Bijsnijden:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Toepassing van instellingen voor bijsnijden."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Links bijsnijden"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Boven bijsnijden"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Onder bijsnijden"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Rechts bijsnijden"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Oriëntatie &amp; bijsnijden</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Resolutie-limiet:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Limieten voor resoluties van algemene videoformaten."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Maximum-afmetingen:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Dit is de maximale breedte waarop de video wordt opgeslagen."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Dit is de maximale hoogte waarop de video wordt opgeslagen."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorf:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -851,11 +851,11 @@ msgstr ""
 "Geen - Forceer de pixelverhouding tot 1: 1.\n"
 "Aangepast - Voer een aangepaste pixelverhouding in.</tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Pixel-aspectverhouding:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -870,11 +870,11 @@ msgstr ""
 "Spelers zullen het beeld schalen om de gespecifiëerde\n"
 "aspectverhouding te behalen."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -888,11 +888,11 @@ msgstr ""
 "Spelers zullen het beeld schalen om de gespecifiëerde\n"
 "aspectverhouding te behalen."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Verschaalde afmetingen:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -902,7 +902,7 @@ msgstr ""
 "De werkelijke weergave-afmetingen verschillen als de\n"
 "pixel-aspectverhouding niet 1:1 is."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -912,87 +912,87 @@ msgstr ""
 "De werkelijke weergave-afmetingen verschillen als de\n"
 "pixel-aspectverhouding niet 1:1 is."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Optimale afmetingen:"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 "Gebruik de hoogste resolutie die is toegestaan door bovenstaande "
 "instellingen."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Upscaling toestaan"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Indien niet ingeschakeld, zijn schaalafmetingen beperkt tot bronafmetingen."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Resolutie &amp; schaling</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Vulling:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Voeg een rand om de video."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Opvulling links"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Opvulling boven"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Opvulling onder"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Opvulling rechts"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Kleur:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Kleur van de rand om de video."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Randen</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Door de weergavegrootte te wijzigen, wordt de video uitgerekt."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatisch"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Uiteindelijke afmetingen</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Afmetingen"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1004,7 +1004,7 @@ msgstr ""
 "Telecine is het process dat framesnelheid van film van 24 fps omzet naar de "
 "NTSC video framesnelheid van 30 fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1014,11 +1014,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Interlace-detectie:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1030,7 +1030,7 @@ msgstr ""
 "Als een deinterlace-filter is ingeschakeld, zullen enkel de\n"
 "door deze filter gevonden frames deinterlaced worden."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1042,11 +1042,11 @@ msgstr ""
 "Mode:Spatiale Metriek:Spatiale Drempel:Maskerfilter Mode:\n"
 "Blokdrempel:Blokbreedte:Blokhoogte"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deinterlace:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1058,7 +1058,7 @@ msgstr ""
 "De decomb filter ondersteunt verschillende interpolatie-algoritmen.\n"
 "De deinterlace filter is een klassieke YADIF deinterlacer.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1072,11 +1072,11 @@ msgstr ""
 "De decomb filter ondersteunt verschillende interpolatie-algoritmen.\n"
 "De deinterlace filter is een klassieke YADIF deinterlacer.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Ontblokkingsfilter:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1084,12 +1084,12 @@ msgstr ""
 "De ontblokkingfilter verwijdert een veelvoorkomend artefact van compressie.\n"
 "Als de bron 'blokkig' is, kan deze filter het helpen opschonen."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Regelen:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1098,7 +1098,7 @@ msgstr ""
 "De ontblokkingfilter verwijdert een veelvoorkomend artefact van compressie.\n"
 "Als de bron 'blokkig' is, kan deze filter het helpen opschonen."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1109,11 +1109,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Ontruisfilter"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1126,7 +1126,7 @@ msgstr ""
 "Deze filter op dergelijke bronnen te gebruiken kan resulteren in kleinere "
 "bestanden."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1140,7 +1140,7 @@ msgstr ""
 "Deze filter op dergelijke bronnen te gebruiken kan resulteren in kleinere "
 "bestanden."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1151,11 +1151,11 @@ msgstr ""
 "\n"
 "SpatialeLuma:SpatialeChroma:TemporeleLuma:TemporeleChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Chroma Smooth filter:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1163,7 +1163,7 @@ msgstr ""
 "Het chroma smooth filter verwijdert veelvoorkomende kleurartefacten.\n"
 "Analoge broninhoud met een lagere resolutie kan van dit filter profiteren."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1172,11 +1172,11 @@ msgstr ""
 "Het chroma smooth filter verwijdert veelvoorkomende kleurartefacten.\n"
 "Analoge broninhoud met een lagere resolutie kan van dit filter profiteren."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Scherptefilter:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1184,7 +1184,7 @@ msgstr ""
 "De scherptefilter versterkt randen en andere\n"
 "hoogfrequente componenten in de video."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1193,39 +1193,39 @@ msgstr ""
 "De scherptefilter versterkt randen en andere\n"
 "hoogfrequente componenten in de video."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Kleurruimte:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Vertaal de kleurenruimte van de bron."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Grijswaarden"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Indien ingeschakeld, filter kleurcomponenten uit de video."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filters"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Video-encoder:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Beschikbare video-encoders"
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Framesnelheid:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1237,19 +1237,19 @@ msgstr ""
 "'Zelfde als bron' is aangeraden. Als de bronvideo een variabele\n"
 "framesnelheid heeft, zal 'Zelfde als bron' deze behouden."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Constante framesnelheid"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Stelt een constante framesnelheid in voor de uitvoer."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Piek-framesnelheid (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1261,11 +1261,11 @@ msgstr ""
 "\n"
 "VFR is niet compatibel met sommige spelers."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Variabele framesnelheid"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1275,7 +1275,7 @@ msgstr ""
 "\n"
 "VFR is niet compatibel met sommige spelers."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1303,15 +1303,15 @@ msgstr ""
 "FFMpeg en Theora hebben een meer lineaire schaal.\n"
 "Deze encoders hebben geen verliesloze modus."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Constante kwaliteit:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bitsnelheid (kbps):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1328,11 +1328,11 @@ msgstr ""
 "waarde zijn. Als de momentane bitsnelheid beperkt moet worden, moeten\n"
 "de vbv-bufsize- and vbv-maxrate-instellingen van x264 bekeken worden."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2-fasecodering"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1347,18 +1347,18 @@ msgstr ""
 "over de video verzameld. In de 2e fase worden die statistieken\n"
 "gebruikt om beslissingen over toewijzing van bitsnelheden te maken."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Turbo eerste fase"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Gebruik instellingen die het proces versnellen tijdens de 1e fase\n"
 "van de codering met 2 fasen."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1378,7 +1378,7 @@ msgstr ""
 "als draaglijk moeten ingesteld worden, aangezien tragere instellingen\n"
 "een betere kwaliteit of kleinere bestanden oplevert."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1392,11 +1392,11 @@ msgstr ""
 "of karakteristieken in de uitvoer instellen. Veranderingen worden\n"
 "toegepast na de voorinstelling maar vóór alle andere parameters."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Snel decoderen"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1407,11 +1407,11 @@ msgstr ""
 "Stel dit in als uw apparaat moeite heeft om de uitvoer af te spelen\n"
 "(verloren frames)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Geen vertraging"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1427,11 +1427,11 @@ msgstr ""
 "Aangezien HandBrake niet geschikt is voor uitzending van live-beelden,\n"
 "heeft deze instelling weinig nut."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profiel:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1441,11 +1441,11 @@ msgstr ""
 "\n"
 "Heeft voorrang op alle andere instellingen."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Niveau:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1455,11 +1455,11 @@ msgstr ""
 "\n"
 "Heeft voorrang op alle andere instellingen."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Meer instellingen:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1469,45 +1469,45 @@ msgstr ""
 "\n"
 "Lijst van encoder-opties, gescheiden door dubbel punt."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Toevoegen"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Voeg nieuwe audio-instellingen toe aan de lijst"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Allen toevoegen"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Voeg alle audio-tracks toe aan de lijst"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Stel alle audio-instellingen in op hun standaard."
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Track-lijst"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Selectiegedrag:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Kies welke audio-tracks van de bron-media gebruikt worden."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1517,23 +1517,23 @@ msgstr ""
 "Tracks die overeenkomen met deze talen worden geselecteerd door het gekozen "
 "selectiegedrag."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Verwijderen"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Beschikbare talen"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Geselecteerde talen"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Gebruik enkel de eerste encoder voor secundaire audio"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1544,15 +1544,15 @@ msgstr ""
 "Alle andere, secundaire audio-tracks voor uitvoer worden enkel met de eerste "
 "encoder geëncodeerd."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Auto Passthru:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1562,11 +1562,11 @@ msgstr ""
 "Hierdoor kan MP2-doorgave worden geselecteerd wanneer automatische doorgave-"
 "selectie is ingeschakeld."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1575,11 +1575,11 @@ msgstr ""
 "Schakel dit in als uw afspeelapparaat MP3 ondersteunt.\n"
 "Dit laat toe om MP3 passthru te selecteren als Auto Passthru is ingeschakeld."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1589,11 +1589,11 @@ msgstr ""
 "Dit laat toe om AC-3 passthru te selecteren als Auto Passthru is "
 "ingeschakeld."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1603,11 +1603,11 @@ msgstr ""
 "Dit laat toe om EAC-3 passthru te selecteren als Auto Passthru is "
 "ingeschakeld."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1616,11 +1616,11 @@ msgstr ""
 "Schakel dit in als uw afspeelapparaat DTS ondersteunt.\n"
 "Dit laat toe om DTS passthru te selecteren als Auto Passthru is ingeschakeld."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1630,11 +1630,11 @@ msgstr ""
 "Dit laat toe om DTS-HD passthru te selecteren als Auto Passthru is "
 "ingeschakeld."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1644,11 +1644,11 @@ msgstr ""
 "Dit laat toe om TrueHD passthru te selecteren als Auto Passthru is "
 "ingeschakeld."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1658,11 +1658,11 @@ msgstr ""
 "Dit laat toe om FLAC passthru te selecteren als Auto Passthru is "
 "ingeschakeld."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1671,11 +1671,11 @@ msgstr ""
 "Schakel dit in als uw afspeelapparaat AAC ondersteunt.\n"
 "Dit laat toe om AAC passthru te selecteren als Auto Passthru is ingeschakeld."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1685,11 +1685,11 @@ msgstr ""
 "Hierdoor kan Opus-doorgave worden geselecteerd wanneer automatische doorgave-"
 "selectie is ingeschakeld."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Passthru terugval-track:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1697,62 +1697,62 @@ msgstr ""
 "Stel de audio-codec om te encoderen in wanneer geen geschikte track voor "
 "audio-passthru kan gevonden worden."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Audio-encoder-instellingen:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Elke geselcteerde bron-track zal worden geëncodeerd met alle geselecteerde "
 "encoders."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Encoder"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bitsnelheid/Kwaliteit"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mixdown"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Sample-snelheid"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Versterking"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Track-selectie"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Audio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Voeg nieuwe ondertitel-instellingen toe aan de lijst"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Voeg alle ondertitel-tracks toe aan de lijst"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Vreemde taal audio-scan"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1762,15 +1762,15 @@ msgstr ""
 "zoeken naar kandidaat-ondertitels die tekst voorzien\n"
 "voor audiosegmenten in een vreemde taal."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Stel alle ondertitel-instellingen in op hun standaard."
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Kies welke ondertitel-tracks van de bronmedia gebruikt worden."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1787,15 +1787,15 @@ msgstr ""
 "De eerste taal in deze lijst is de \"voorkeur\"-taal en wordt gebruikt om\n"
 "de selectie van ondertitels te bepalen als er vreemde talen gesproken worden."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Voorkeurstaal: Geen"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Voeg fase voor vreemde talen toe"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1810,12 +1810,12 @@ msgstr ""
 "\n"
 "Voor deze optie moet er een taal in de lijst met geselcteerde talen zijn."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 "Voeg ondertitel-track toe als de standaard-audio in een vreemde taal is."
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1827,11 +1827,11 @@ msgstr ""
 "\n"
 "Deze optie vereist dat er een taal in de lijst met geselcteerde talen is"
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Voeg bijgesloten ondertitels toe indien voorhanden."
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1839,11 +1839,11 @@ msgstr ""
 "Bijgesloten ondertitels zijn ondertitels die aan elke container kunnen "
 "toegevoegd worden als een \"soft\" ondertitel-track"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Burn-In-gedrag*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1860,15 +1860,15 @@ msgstr ""
 "worden!\n"
 "Aangezien conflicten kunnen optreden, wint de eerstgekozen ondertitel."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Burn-In voor gebrekkige spelers*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD-ondertitels"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1886,11 +1886,11 @@ msgstr ""
 "Slechts één ondertitel-track kan gebruikt worden!\n"
 "Aangezien conflicten kunnen optreden, wint de eerstgekozen ondertitel."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray-ondertitels"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1908,7 +1908,7 @@ msgstr ""
 "Slechts één ondertitel-track kan gebruikt worden!\n"
 "Aangezien conflicten kunnen optreden, wint de eerstgekozen ondertitel."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1916,7 +1916,7 @@ msgstr ""
 "<small>* Slechts één van bovenstaande ondertitel-opties wordt toegepast, "
 "beginnend met de bovenste.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1924,111 +1924,111 @@ msgstr ""
 "Slechts één ondertitel-track kan ingebrand worden!\n"
 "Aangezien conflicten kunnen optreden, wint de eerstgekozen ondertitel."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Ondertitels"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Hoofdstukmarkeringen"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Voeg hoofdstukmarkeringen toe aan het uitvoerbestand."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Hoodstukken"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Hoodstukken"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Index"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Speelduur"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titel"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Hoodstukken"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Acteurs:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regisseur:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Publicatiedatum:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Commentaar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genre:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Beschrijving:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Plot:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Tags"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Opslaan als:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Doelbestandsnaam voor de encodering."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Naar:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Doelmap voor de encodering."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Doelmap"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr "Meerdere titels toevoegen"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2036,51 +2036,51 @@ msgstr "Meerdere titels toevoegen"
 msgid "Cancel"
 msgstr "Annuleer"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Alles selecteren"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Markeer alle titels om aan de wachtrij toe te voegen"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Alles opruimen"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Onmarkeer alle titels"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Doelbestanden OK. Geen duplicaten gedetecteerd."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Voorkeuren"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automatisch controleren op updates"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Standaardactie wanneer alle coderingen zijn voltooid"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Gebruik automatische naamgeving (gebruikt gewijzigde bronnaam)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "Maak doel-bestandsnaam uit bron-bestandsnaam of volume-label"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Auto-naam-sjabloon"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2090,23 +2090,23 @@ msgstr ""
 "Beschikbare opties: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Gebruik iPod/iTunes-vriendelijke (.m4v) bestandsextensie voor MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Aantal previews"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filter korte DVD- en Blu-ray-titels (seconden)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Voltooide wachtrij-items opruimen nadat een encodering is voltooid"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2117,52 +2117,52 @@ msgstr ""
 "Vink dit aan als de wachtrij zichzelf moet opschonen door voltooide taken te "
 "verwijderen."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Algemeen"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr "Stel een aangepaste map in voor tijdelijke bestanden van Handbrake"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2187,63 +2187,63 @@ msgstr ""
 "sandbox is 1/2 fysieke geheugengrootte en is mogelijk te klein voor zaken "
 "als het 2-fase stats-bestand."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Tijdelijke map"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Constante-kwaliteit fractionele granulariteit"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Gebruik dvdnav (in plaats van libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Monitor vrije ruimte van doelschijf"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Pauzeer encodering als vrije schijfruimte onder limiet valt"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB limiet"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Plaats inidividuele encode-logs in dezelfde locatie als de film"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Uitvoerigheidsniveau activiteitslog"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Levensduur activiteitslog"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "High Definition previews herschalen"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Automatisch DVD scannen bij inladen"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Scant de DVD wanneer een nieuwe schijf wordt ingeladen"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Lettergrootte activiteitsvenster"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Gebruik dezelfde instellingen voor alle titels in een groep"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2257,11 +2257,11 @@ msgstr ""
 "Vink dit uit om toe te laten om de instellingen van elke titel\n"
 "onafhankelijk te wijzigen."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr "Voorvertoning weergeven in tab Samenvatting"
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
@@ -2269,149 +2269,149 @@ msgstr ""
 "Schakel dit uit als u voorvertoning van de video op het tabblad Samenvatting "
 "wilt verbergen."
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Tweaks toelaten"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "HandBrake voor Dummies toelaten"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Geavanceerd"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr "Voorinstelling hernoemen"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Hernoem voorinstelling</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Naam:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Beschrijving</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr "Voorinstelling opslaan"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categorie:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Stel de categorie waaronder deze voorinstelling zal getoond worden in."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Categorienaam:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Naam voorinstelling:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Standaard-voorinstelling"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Maak dit de standaard-voorinstelling wanneer HandBrake opstart"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Afmetingen</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Handbrake-preview"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Selecteer previewframes"
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr "Encodeer en speel een kort stuk video vanaf de huidige preview-positie"
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr "Klik om volledig schermweergave te wisselen"
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Afspeelduur:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Stel de afspeelduur van de live preview in seconden in."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Toon knip"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Toon de geknipte oppervlakte van de preview"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Bronresolutie"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Herstel het preview-scherm naar de resolutie van de bronvideo"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr "Ondertiteling bewerken"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importeer SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Schakel instellingen in om een SRT-ondertitelbestand in te laden"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importeer SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Schakel instellingen in om een SSA-ondertitelbestand in te laden"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Lijst van ingebouwde ondertitels"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Schakel instellingen in om ingebouwde ondertitels te selecteren"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Bron-track"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lijst van beschikbare ondertiteltracks uit de bron."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Tracknaam:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2421,23 +2421,23 @@ msgstr ""
 "\n"
 "Spelers kunnen deze gebruiken in de audioselectielijst."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Taal"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Karakter-codering"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Bestand:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Verschuiving (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2445,7 +2445,7 @@ msgstr ""
 "Stel de taal van deze ondertitel in.\n"
 "Deze waarde wordt door spelers gebruikt in ondertitelmenus."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2460,29 +2460,29 @@ msgstr ""
 "De karakter-set wordt vertaald naar UTF-8.\n"
 "De karakter-set van de bron is vereist om deze vertaling te kunnen uitvoeren."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Selecteer het te importeren SRT-bestand."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importeer Bestand"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Stel de verschuiving in milliseconden tussen de video en de SRT-tijdstippen "
 "in."
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Enkel geforceerde ondertitels"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Inbranden in video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2490,19 +2490,19 @@ msgstr ""
 "Render de ondertitel over de video.\n"
 "De ondertitel wordt deel van de video en kan niet worden uitgeschakeld."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Stel standaard-track in"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr "Audiospoor bewerken"
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lijst van beschikbare audiotracks uit de bron."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2512,15 +2512,15 @@ msgstr ""
 "\n"
 "Spelers kunnen deze gebruiken in de audioselectielijst."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mix"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Sample-snelheid"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2538,31 +2538,31 @@ msgstr ""
 "laat DBC toe om het bereik te 'comprimeren' door luide geluiden stiller en "
 "stille geluiden luider te maken."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Stel de audio-codec om deze track te encoderen in."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bitsnelheid"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Bitsnelheid-instelling inschakelen"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kwaliteit"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Kwaliteit-instelling inschakelen"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Stel de bitsnelheid in om deze track mee te encoderen."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2570,19 +2570,19 @@ msgstr ""
 "<b>Kwaliteit:</b> Voor codecs die het ondersteunen, pas de kwaliteit van de "
 "uitvoer aan."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Stel de mixdown van de uitvoertrack in."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Stel de sample-snelheid van de uitvoertrack in."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2591,40 +2591,40 @@ msgstr ""
 "audiokanaal aan."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Uit"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr "HandBrake Updater"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Deze versie overslaan"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Herinner mij later"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Een nieuwere versie van HandBrake is beschikbaar!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx is nu beschikbaar (huidge versie is yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Release-opmerkingen</b>"
 
@@ -2770,7 +2770,7 @@ msgstr "Gedetecteerde DVD-apparaten:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Scannen ..."
 
@@ -2783,90 +2783,119 @@ msgstr "Stop Scan"
 msgid "Single Title"
 msgstr "Open enkele _titel"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr "FPS"
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Audiospoor"
 msgstr[1] "Audiosporen"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Ondertitelingsspoor"
 msgstr[1] "Ondertitelingssporen"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr "CFR"
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr "PFR"
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr "VFR"
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] "+ %d extra audiospoor"
 msgstr[1] "+ %d extra audiosporen"
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", enkel geforceerd"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", ingebrand"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", standaard"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "+ %d extra ondertitelingsspoor"
 msgstr[1] "+ %d extra ondertitelingssporen"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr "opslag"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr "weergave"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr "Pixelverhouding"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr "Beeldverhouding"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Geen titel gevonden"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Nieuwe video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2877,132 +2906,132 @@ msgstr ""
 "\n"
 "%s in %d seconden ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sDe film zal verloren gaan als de encodering niet wordt hervat."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Huidige annuleren en stoppen"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Huidige annuleren, start volgende"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Huidige afwerken, dan stoppen"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Hervat encodering"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d encodering in wachtrij"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d encoderingen in wachtrij"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "taak %d van %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "fase %d (ondertitel-scan) van %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "fase %d van %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Encoderen: %s%s%.2f %% (%.2f fps, gem. %.2f fps, ETA %02du%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Encoderen: %s%s%.2f %% (ETA %02du%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Encoderen: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Zoeken naar starttijd,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Titel %d van %d scannen..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Titel %d van %d scannen, preview %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Gepauzeerd"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Encoderen klaar!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Encoderen geannuleerd."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Encoderen mislukt."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Muxen: Dit kan even duren..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s is nu beschikbaar (je hebt %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Encoderen voltooid"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Zet die cocktail neer. Je HandBrake-wachtrij is klaar!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Het encoderen is voltooid."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Handbrake wordt afgesloten"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "De computer wordt in slaapstand gezet"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "De computer wordt afgesloten"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 #, fuzzy
 msgid "All Files"

--- a/gtk/po/no.po
+++ b/gtk/po/no.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Alf Andreas Stray Rambo <alf.andreas.rambo@gmail.com>, "
 "2014\n"
@@ -104,8 +104,8 @@ msgstr "_Forhåndsinnstillinger"
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Lagre"
 
@@ -113,7 +113,7 @@ msgstr "_Lagre"
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -160,7 +160,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Brennet inn</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -175,7 +175,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Standard</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -329,7 +329,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Start Omkoding"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Start"
@@ -348,7 +348,7 @@ msgstr "Pause"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -366,8 +366,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Redigere"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Forhåndsinnstilt:"
 
@@ -375,7 +375,7 @@ msgstr "Forhåndsinnstilt:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Tittel:"
 
@@ -399,7 +399,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sammendrag"
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Velg Video Kilde"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr "Forhåndsvisning"
 msgid "Show Queue"
 msgstr "Vis Køen"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Køen"
 
@@ -538,15 +538,15 @@ msgstr "<b>Kilde:</b>"
 msgid "None"
 msgstr "Ingen"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Skanning..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -556,78 +556,78 @@ msgstr ""
 "Som standard er den lengste tittelen valgt.\n"
 "Det er ofte funksjons tittelen på en DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "For flere vinklet DVD'er, velg den ønskede vinkelen til omkoding."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Utvalg av titler til omkoding. Kan være Kapitler, sekunder, eller bilder."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Sett det første kapittelet til omkoding."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Sett det siste kapittelet til omkoding."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Last inn på nytt"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Internett optimalisert"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -635,151 +635,151 @@ msgstr ""
 "Optimaliser oppsettet av MP4 filen for fremskrittsvennlig nedlasting.\n"
 "Dette gjør det mulig å starte avspilling før hele filen er lastet ned."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "IPod 4G Støtte"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Legg til iPod Atom som brukes av noen eldre versjoner av iPod."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Varighet:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Venstre Beskjæring"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Topp Beskjæring"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Bunn Beskjæring"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Høyre Beskjæring"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfisk:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -789,11 +789,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -802,11 +802,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -814,11 +814,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -828,7 +828,7 @@ msgstr ""
 "De faktiske visnings dimensjonene vil være forskjellig hvis piksel-formatet "
 "ikke er 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -838,84 +838,84 @@ msgstr ""
 "De faktiske visnings dimensjonene vil være forskjellig hvis piksel-formatet "
 "ikke er 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -923,18 +923,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -942,7 +942,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -950,11 +950,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -962,7 +962,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -971,39 +971,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1011,7 +1011,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1019,78 +1019,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Gråskala"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Video Omkoder:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Tilgjengelig video omkodere."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Bildefrekvens:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1102,19 +1102,19 @@ msgstr ""
 "'Samme som kilde' er anbefalt. Hvis kilde videoen har\n"
 "en variabel bildefrekvens, 'Samme som kilde' vil bevare det."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Konstant Bildefrekvens"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Aktiverer konstant bildefrekvens utdata."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Toppunkt Bildefrekvens (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1122,11 +1122,11 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Variabel Bildefrekvens"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1136,7 +1136,7 @@ msgstr ""
 "\n"
 "VFR er ikke kompatibel med noen avspillere."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1152,15 +1152,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Konstant Kvalitet:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bithastighet (kbps)"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1171,11 +1171,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1185,16 +1185,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1206,7 +1206,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1215,11 +1215,11 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Rask Dekoding"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1229,11 +1229,11 @@ msgstr ""
 "\n"
 "Sett denne hvis din enhet sliter med avspilling av utdataen (mistede bilder)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1243,300 +1243,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nivå:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Flere Innstillinger:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Legg til"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Legg til nye lyd innstillinger til listen"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Legg til alle"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Legg til alle lyd spor til listen"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Last inn på nytt alle lyd innstillinger fra standard"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Fjern"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Tilgjengelige Språk"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Valgt Språk"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Bruk bare første omkoder for sekundær lyd"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b> Lyd Omkoder Innstillinger:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "Hver valgt kilde spor vil bli omkodet med alle valgte omkodere"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Omkoder"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bithastighet/Kvalitet"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Samplingsfrekvens"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1547,15 +1547,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Foretrukket Språk: Ingen "
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1565,11 +1565,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1577,21 +1577,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1601,15 +1601,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1620,11 +1620,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1635,124 +1635,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Kapittel Merker"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Legg til kapittel merker til utdata filen"
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Kapitler "
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Kapitler "
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Kapitler "
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Skuespillere:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regissør:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Utgivelsedato:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Kommentar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Sjanger:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Beskrivelse:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Handling:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Merkelapp"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Destinasjons filnavn for din omkoding."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Destinasjons mappe for din omkoding."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Destinasjons mappe"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Legg til _Flere"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1760,126 +1760,126 @@ msgstr "Legg til _Flere"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Velg Alle"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Merk alle titlene for å legge dem til køen"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Fjern Alle"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Avmerk alle titlene"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Destinasjons fil OK. Ingen duplikat oppdaget."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automatisk se etter oppdateringer"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Bruk automatisk navn givning (bruker modifiserte kilde navn)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Bruk iPod/iTunes vennelig (.m4v) fil utvidelse for MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Antall av forhåndsvisninger"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1893,63 +1893,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1958,190 +1958,190 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Tillat HandBrake for Idioter"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avansert"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Forhåndsinnstilt:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Beskrivelse</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Forhåndsinnstilt:"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Kilde Spor"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Spor Navn:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Språk"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fil:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2150,60 +2150,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Brenn inn i videoen"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Sett Standard Spor"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Liste av lyd spor tilgjengelig fra din kilde"
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2214,90 +2214,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Sett en lyd kodek til å omkode dette sporet med."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Sett bithastigheten til å omkode dette sporet med."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Sett nedmiksen til utdataens lyd spor."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Sett samplingsfrekvensen til utdataens lyd spor."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Av"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Minn meg på seinere"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b> En ny versjon av HandBrake er tilgjengelig!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx er nå tilgjengelig (du har yyy)"
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2435,7 +2435,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Skanning ..."
 
@@ -2447,92 +2447,119 @@ msgstr "Stopp Skanning"
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Kilde Spor"
 msgstr[1] "Kilde Spor"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Kilde Spor"
 msgstr[1] "Kilde Spor"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Ingen Tittel Funnet"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2543,132 +2570,132 @@ msgstr ""
 "\n"
 "%s i %d sekunder ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sDin video vil bli mistet hvis du ikke fortsetter med omkodingen."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Avbryt Nåværende og Stopp"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Avbryt Nåværende, Start Neste"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Fullføre Nåværende, Så Stopp"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Fortsett Omkodingen"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "jobb %d av %d,"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Omkoder: %s%s%.2f %% (%.2f fps, snitt %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Omkoder: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Omkoder: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Søker etter start tid,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Skanning tittel %d av %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Skanning tittel %d av %d forhåndsvisning %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pauset"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Omkoding Ferdig!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Omkoding Kansellert."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Omkoding Feilet."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Multipleksing: Dette kan ta litt tid..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s er nå tilgjengelig (Du har %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Omkoding Fullført"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Sett ned den drinken, Din Handbrake kø er ferdig!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Din omkoding er fullført."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Avslutter Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Setter datamaskinen i dvale"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Slår av datamaskinen"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/pl.po
+++ b/gtk/po/pl.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Piotr Komur <pkomur@gmail.com>, 2019\n"
 "Language-Team: Polish (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_Profile"
 msgid "Set De_fault"
 msgstr "Ustaw _domyślny"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Zapisz"
 
@@ -114,7 +114,7 @@ msgstr "_Zapisz"
 msgid "Save _As"
 msgstr "Zapisz _jako"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "Zmień _nazwę"
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -176,7 +176,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -328,7 +328,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Rozpocznij konwertowanie "
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr ""
@@ -347,7 +347,7 @@ msgstr "Pauza"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -365,8 +365,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -374,7 +374,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Tytuł"
 
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Podsumowanie"
 
@@ -477,11 +477,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Wybierz źródło wideo"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Otwórz źródło"
 
@@ -513,7 +513,7 @@ msgstr "Podgląd"
 msgid "Show Queue"
 msgstr "Pokaż kolejkę"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Kolejka"
 
@@ -536,242 +536,242 @@ msgstr "<b>Źródło:</b>"
 msgid "None"
 msgstr "Brak"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Tytuł:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Kąt:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Zakres:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Profil:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Wybierz profil"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Ścieżki:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtry:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Wymiary:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Z lewej"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Od góry"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Od dołu"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Z prawej"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -781,11 +781,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -794,11 +794,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -806,102 +806,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Wymiary"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -909,18 +909,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -928,7 +928,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -936,11 +936,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -948,7 +948,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -957,39 +957,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -997,7 +997,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1005,78 +1005,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtry"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1084,19 +1084,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1104,18 +1104,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1131,15 +1131,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1150,11 +1150,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1164,16 +1164,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1185,7 +1185,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1194,22 +1194,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1219,300 +1219,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Wideo"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1523,15 +1523,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1541,11 +1541,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1553,21 +1553,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1577,15 +1577,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1596,11 +1596,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1611,124 +1611,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Napisy"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Rozdziały"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Rozdziały"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Rozdziały"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Aktorzy:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Informacje"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>W katalogu:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Dodaj _wiele"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1736,126 +1736,126 @@ msgstr "Dodaj _wiele"
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1869,63 +1869,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1934,191 +1934,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Wybierz profil"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Wybierz profil"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Napisy"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2127,60 +2127,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2191,89 +2191,89 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2406,7 +2406,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2419,11 +2419,38 @@ msgstr ""
 msgid "Single Title"
 msgstr "Otwórz pojedynczy _tytuł"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
@@ -2431,7 +2458,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2440,19 +2467,19 @@ msgstr[1] "Napisy"
 msgstr[2] "Napisy"
 msgstr[3] "Napisy"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2461,22 +2488,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2485,33 +2512,33 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2519,132 +2546,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/pt.po
+++ b/gtk/po/pt.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Rui <xymarior@yandex.com>, 2019\n"
 "Language-Team: Portuguese (https://www.transifex.com/HandBrakeProject/"
@@ -104,8 +104,8 @@ msgstr "_Predefinições"
 msgid "Set De_fault"
 msgstr "De_finir como padrão"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Gravar"
 
@@ -113,7 +113,7 @@ msgstr "_Gravar"
 msgid "Save _As"
 msgstr "Gravar _como"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Alterar nome"
 
@@ -163,7 +163,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Padrão</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -338,7 +338,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Iniciar codificação"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Iniciar"
@@ -357,7 +357,7 @@ msgstr "Pausar"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -375,8 +375,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Predefinição:"
 
@@ -384,7 +384,7 @@ msgstr "Predefinição:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -408,7 +408,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sumário"
 
@@ -491,11 +491,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Selecionar fonte de vídeo"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Abrir fonte"
 
@@ -527,7 +527,7 @@ msgstr "Pré-visualização"
 msgid "Show Queue"
 msgstr "Mostrar fila"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Fila"
 
@@ -550,66 +550,66 @@ msgstr "<b>Fonte:</b>"
 msgid "None"
 msgstr "Nenhuma"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "A analisar..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Ângulo:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Para DVD's com vários ângulos, selecione o ângulo que quer codificar."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Definir o primeiro capítulo a ser codificado."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Definir o último capítulo a ser codificado."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Predefinição:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Escolher predefinição"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Alterado</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Recarregar"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -617,177 +617,177 @@ msgstr ""
 "Recarregar as configurações para a predefinição selecionada.\n"
 "As alterações serão descartadas."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Gravar nova predefinição"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Gravar as configurações atuais numa nova predefinição."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formato:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Otimizado para Internet"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Suporte para o iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Duração:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Faixas:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtros:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -797,11 +797,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -810,11 +810,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -822,102 +822,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensões"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -925,18 +925,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -944,7 +944,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -952,11 +952,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -964,7 +964,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -973,39 +973,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1013,7 +1013,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1021,78 +1021,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codificador de vídeo:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codificadores de vídeo disponíveis."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1100,19 +1100,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1120,18 +1120,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1147,15 +1147,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualidade constante:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1166,11 +1166,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1180,16 +1180,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1201,7 +1201,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1210,22 +1210,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Descodificação rápida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1235,300 +1235,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nível:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Mais configurações:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Vídeo"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Adicionar novas configurações de áudio à lista"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Adicionar tudo"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Adicionar todas as faixas áudio à lista"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Lista de faixas"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Remover"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Idiomas disponíveis"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Idiomas selecionados"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codificador"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Ganho"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Seleção de faixas"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Áudio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1539,15 +1539,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1557,11 +1557,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1569,21 +1569,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1593,15 +1593,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1612,11 +1612,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1627,122 +1627,122 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Adicionar _vários"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1750,126 +1750,126 @@ msgstr "Adicionar _vários"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1883,63 +1883,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1948,190 +1948,190 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Gravar nova predefinição"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Gravar nova predefinição"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Linguagem"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2140,60 +2140,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2204,90 +2204,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Selecione o codec de áudio para codificar essa faixa."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Selecione o bitrate para codificar essa faixa."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2424,7 +2424,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Escaneando ..."
 
@@ -2436,11 +2436,38 @@ msgstr ""
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2448,26 +2475,26 @@ msgstr[0] "Áudio"
 msgstr[1] "Áudio"
 msgstr[2] "Áudio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2475,22 +2502,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2498,33 +2525,33 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2535,132 +2562,132 @@ msgstr ""
 "\n"
 "%s em %d segundos ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sSeu vídeo será perdido se não continuar a codificação."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Cancelar Atual e Parar"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Cancelar Atual, Começar o Próximo"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Terminar o Atual, em seguida Parar."
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continuar Codificação"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "trabalho %d de %d,"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Codificação Terminada!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Codificação Cancelada."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Falha na Codificação."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s está disponível (você tem %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Codificação Completa"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Sua codificação está completa."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Saindo Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Colocando o computador em suspensão"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Desligando o computador"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/pt_BR.po
+++ b/gtk/po/pt_BR.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Wellington Uemura <wellingtonuemura@gmail.com>, 2021\n"
 "Language-Team: Portuguese (Brazil) (https://www.transifex.com/"
@@ -107,8 +107,8 @@ msgstr "_Predefinições"
 msgid "Set De_fault"
 msgstr "De_fina como Padrão"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Salve"
 
@@ -116,7 +116,7 @@ msgstr "_Salve"
 msgid "Save _As"
 msgstr "S_alve como"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Renomeie"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Gravado em</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Padrão</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -365,7 +365,7 @@ msgstr "0 tarefas pendentes"
 msgid "Start Encoding"
 msgstr "Inicie a codificação"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Iniciar"
@@ -384,7 +384,7 @@ msgstr "Pausar"
 msgid "Options"
 msgstr "Opções"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Quando for concluído:"
 
@@ -405,8 +405,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Editar"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Predefinido:"
 
@@ -414,7 +414,7 @@ msgstr "Predefinido:"
 msgid "Source:"
 msgstr "Origem:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Títulos:"
 
@@ -438,7 +438,7 @@ msgstr "Áudio:"
 msgid "Subtitles:"
 msgstr "Legendas:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sumário"
 
@@ -534,11 +534,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Selecionar Fonte de Vídeo"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Abrir Fonte"
 
@@ -570,7 +570,7 @@ msgstr "Prévia"
 msgid "Show Queue"
 msgstr "Exibir Fila"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Fila"
 
@@ -593,15 +593,15 @@ msgstr "<b>Fonte:</b>"
 msgid "None"
 msgstr "Nenhuma"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Procurando..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Título:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -611,54 +611,54 @@ msgstr ""
 "Por padrão, o mais longo é o selecionado.\n"
 "Muitas vezes, é o título de recursos de um DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Ângulo:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 "Para DVD's com vários ângulos, selecione o desejado para ser convertido."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Intervalo:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Intervalo de título para codificação. Pode ser capítulos, segundos ou "
 "quadros."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Definir o primeiro capítulo para ser convertido."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Definir o último capítulo para ser convertido."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Predefinido:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Escolher Predefinição"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modificado</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Recarregar"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -666,27 +666,27 @@ msgstr ""
 "Recarregar as configurações para a predefinição selecionada.\n"
 "Quaisquer modificações serão descartadas."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Salvar nova Predefinição"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Salvar as configurações feitas para uma nova predefinição."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formato:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Formato a ser usado para a codificação."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Otimizado para Web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -696,11 +696,11 @@ msgstr ""
 "Isto permite que um reprodutor inicie a reprodução\n"
 "antes de terminar o download do arquivo completo."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Alinhar ao Início do A/V"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -711,140 +711,140 @@ msgstr ""
 "melhorar a sincronia de áudio/vídeo para reprodutores\n"
 "de vídeo simples com má interpretação de MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Suporte ao iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Adicionar o iPod Atom, necessário para iPods mais antigos."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Duração:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Faixas:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtros:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Tamanho:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Gira o vídeo no sentido horário em incrementos de 90 graus."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Corte à Esquerda"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Corte Acima"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Corte Abaixo"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Corte à Direita"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamórfico:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -854,11 +854,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspecto de Pixel:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -872,11 +872,11 @@ msgstr ""
 "retangulares.\n"
 "os reprodutores escolherão a imagem para realizar o aspecto especificado."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -888,11 +888,11 @@ msgstr ""
 "retangulares.\n"
 "os reprodutores escolherão a imagem para realizar o aspecto especificado."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -902,7 +902,7 @@ msgstr ""
 "As dimensões de exposição reais vão se diferenciar se a proporção de aspecto "
 "de pixel não for 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -912,84 +912,84 @@ msgstr ""
 "As dimensões de exposição reais vão se diferenciar se a proporção de aspecto "
 "de pixel não for 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automático"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Dimensões"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "De Tela de Cinema:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1001,7 +1001,7 @@ msgstr ""
 "O Telecining é um processo que ajusta os quadros do filme que são 24fps para "
 "taxas de vídeo NTSC que são 30fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1012,11 +1012,11 @@ msgstr ""
 "SobraEsquerda:SobraDireita:SobraTopo:SobraBaseQuebraDeEscrita:MétricaPlana:"
 "Paridade"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Detector de Entrelaçamento:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1028,7 +1028,7 @@ msgstr ""
 "Se um filtro de desentrelaçamento é ativado, somente os quadros entrelaçados "
 "que esse filtro encontrar serão desentrelaçados."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1042,11 +1042,11 @@ msgstr ""
 "de Máscara:\n"
 "Bloco de Descascar: Bloco Largura: Altura do Bloco"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Desentrelace:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1058,7 +1058,7 @@ msgstr ""
 "O filtro decomb suporta uma variedade algorítimos de interpolações.\n"
 "O filtro de desentrelace é o clássico filtro YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1072,11 +1072,11 @@ msgstr ""
 "O filtro decomb suporta uma variedade de algorítimos de interpolações.\n"
 "O filtro de desentrelace é o clássico YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Filtro de remoção de blocos:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1085,12 +1085,12 @@ msgstr ""
 "Se a sua fonte de exposições exibir 'bloqueio', este filtro pode ajudar a "
 "limpá-lo"
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Sintonia:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1100,7 +1100,7 @@ msgstr ""
 "Se a sua fonte de exposições exibir 'bloqueio', este filtro pode ajudar a "
 "limpá-lo"
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1111,11 +1111,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtro Redução de Ruídos:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1129,7 +1129,7 @@ msgstr ""
 "Usando este filtro em tais fontes podem resultar em tamanhos de arquivo "
 "menores."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1144,7 +1144,7 @@ msgstr ""
 "Usando este filtro em tais fontes podem resultar em tamanhos de arquivo "
 "menores."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1156,27 +1156,27 @@ msgstr ""
 "\n"
 "EspacialLuminância:EspacialCroma:TemporalLuminância:TemporalCroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Filtro de Nitidez:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1184,7 +1184,7 @@ msgstr ""
 "A filtragem de nitidez aprimora as bordas e outros\n"
 "componentes de alta frequência no vídeo."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1193,39 +1193,39 @@ msgstr ""
 "A filtragem de nitidez aprimora as bordas e outros\n"
 "componentes de alta frequência no vídeo."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Escala de Cinza"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Se ativado, filtra os componentes de cor fora do vídeo."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtros"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codificador de Vídeo:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codificadores de vídeo disponíveis."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Taxa de Quadros:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1237,19 +1237,19 @@ msgstr ""
 "'Igual à fonte' é recomendado. Se o seu vídeo de origem tiver\n"
 "uma taxa de quadros variável, 'Igual à origem' irá preservá-lo."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Taxa de Quadros Constante"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Habilita uma taxa de quadros de saída constante."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Taxa de Quadros por Pico (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1261,11 +1261,11 @@ msgstr ""
 "\n"
 "VFR não é compatível com alguns reprodutores de mídia."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Taxa de Quadros Variáveis"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1275,7 +1275,7 @@ msgstr ""
 "\n"
 "VFR não é compatível com alguns reprodutores de mídia."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1302,15 +1302,15 @@ msgstr ""
 "fonte também seja sem perdas. A escala de FFMpeg e Theora é mais linear. "
 "Esses codificadores não tem um modo sem perdas."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Qualidade Constante:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Taxa de Bits(kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1329,11 +1329,11 @@ msgstr ""
 "limitar a taxa de bits instantânea, veja as configurações vbv-bufsize e vbv-"
 "maxrate do x264."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Codificar em 2-Passos"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1350,18 +1350,18 @@ msgstr ""
 "utilizadas\n"
 "para tomar as decisões de alocação da taxa de bits."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "1º-Passo Turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Durante a 1º passo de uma codificação de 2 passagens, use esta configuração "
 "para acelerar as coisas."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1382,7 +1382,7 @@ msgstr ""
 "suportar, uma vez que, a velocidade de compressão mais lenta\n"
 "resulta em arquivos de melhor qualidade ou com um tamanho menor."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1398,11 +1398,11 @@ msgstr ""
 "pré-configuração,\n"
 "mas antes de todos os outros parâmetros."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Codificação Rápida"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1413,11 +1413,11 @@ msgstr ""
 "Defina isto se o seu dispositivo está lutando para reproduzir a saída "
 "(quadros perdidos)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latência Zero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1434,11 +1434,11 @@ msgstr ""
 "Como o HandBrake não é adequado para transmissão ao vivo, esta\n"
 "configuração é de pouco valor aqui."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Perfil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1448,11 +1448,11 @@ msgstr ""
 "\n"
 "Substitui todas as outras configurações."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nível:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1462,11 +1462,11 @@ msgstr ""
 "\n"
 "Substitui todas as outras configurações."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Mais Configurações:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1476,45 +1476,45 @@ msgstr ""
 "\n"
 "Lista separada por colo de opções de codificadores."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Vídeo"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Adicionar"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Adicionar novas configurações de áudio para a lista"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Adicionar Todas"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Adicionar Todas as Faixas de Áudio da Lista"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Recarregar todas os ajustes de áudio para padrão"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Lista de Faixas"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Selecionar Comportamento:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Escolha as faixas de áudio da fonte de mídia que serão utilizadas."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1524,23 +1524,23 @@ msgstr ""
 "Faixas correspondentes a estes idiomas serão selecionados usando o escolhido "
 "Comportamento da Seleção."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Remover"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Idiomas Disponíveis"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Idiomas Selecionados"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Use apenas o primeiro codificador de áudio secundário"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1551,26 +1551,26 @@ msgstr ""
 "Todas as outras faixas secundárias de áudio geradas, serão codificadas "
 "apenas com o primeiro codificador."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Auto Passagem Direta:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1580,11 +1580,11 @@ msgstr ""
 "Isso permite que o MP3 passe direto para ser selecionado quando a seleção de "
 "passagem direta automática for ativada."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1594,11 +1594,11 @@ msgstr ""
 "Isso permite que o AC-3 passe direto para ser selecionado quando a seleção "
 "de passagem direta automática for ativada."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1608,11 +1608,11 @@ msgstr ""
 "Isso permite que o EAC-3 passe direto para ser selecionado quando a seleção "
 "de passagem direta automática for ativada."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1622,11 +1622,11 @@ msgstr ""
 "Isso permite que o DTS passe direto para ser selecionado quando a seleção de "
 "passagem direta automática for ativada."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1636,11 +1636,11 @@ msgstr ""
 "Isso permite que o DTS-HD passe direto para ser selecionado quando a seleção "
 "de passagem direta automática for ativada."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1650,11 +1650,11 @@ msgstr ""
 "Isso permite que o TrueHD passe direto para ser selecionado quando a seleção "
 "de passagem direta automática for ativada."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1664,11 +1664,11 @@ msgstr ""
 "Isso permite que o FLAC passe direto para ser selecionado quando a seleção "
 "de passagem direta automática for ativada."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1678,22 +1678,22 @@ msgstr ""
 "Isso permite que o AAC passe direto para ser selecionado quando a seleção de "
 "passagem direta automática for ativada."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Saída de Passagem Direta:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1701,62 +1701,62 @@ msgstr ""
 "Decida se quer que o codec de áudio codifique quando uma pista conveniente "
 "não pode ser encontrada para passagem direta de áudio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b> Configurações do Codificador de Áudio:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Cada faixa da fonte selecionada será codificada com todos os "
 "codificadoresselecionados"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codificador"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Taxa de Bits/Qualidade"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mistura Baixa"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Taxa de Amostragem"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Ganho"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Selecionar Faixas"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Áudio"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Adicionar novas configurações de legenda à lista"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Adicionar todas as faixas de legendas à lista"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Examinar Áudio Estrangeiro"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1766,15 +1766,15 @@ msgstr ""
 "os candidatos para as legendas que forneçam legendas para\n"
 "os segmentos de áudio que estão numa língua estrangeira."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Recarregar todas as legendas para padrão "
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Escolhe quais faixas de legendas de origem de mídia serão utilizadas."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1792,15 +1792,15 @@ msgstr ""
 "para determinar as configurações da seleção de legendas quando há áudio "
 "externo."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Idioma Preferido: Nenhum"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Adicionar Áudio Externo verificar Passo"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1817,11 +1817,11 @@ msgstr ""
 "Esta opção requer que um idioma seja definido na lista de idiomas "
 "selecionados."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Acrescenta a faixa de legenda se o áudio padrão for estrangeiro"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1834,11 +1834,11 @@ msgstr ""
 "Esta opção requer que um idioma seja definido na lista de idiomas "
 "selecionados."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Adicionar Legendas quando disponível"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1846,11 +1846,11 @@ msgstr ""
 "As legendas fechadas são subtítulos de texto que podem ser acrescentados a "
 "qualquer container como uma pista de subtítulo suave"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Comportamento Queimar em*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1866,15 +1866,15 @@ msgstr ""
 "Apenas uma faixa de legenda pode ser queimada! Como podem ocorrer conflitos, "
 "o primeiro escolhido ganha."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Queimar em para reprodutores limitados*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Legendas do DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1892,11 +1892,11 @@ msgstr ""
 "Somente uma faixa de legenda pode ser queimada! Como podem ocorrer "
 "conflitos, o primeiro escolhido ganha."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Legendas Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1914,7 +1914,7 @@ msgstr ""
 "Somente uma faixa de legenda pode ser queimada! Como podem ocorrer "
 "conflitos, o primeiro escolhido ganha."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1922,7 +1922,7 @@ msgstr ""
 "<small>* Apenas uma das opções de legendas de gravação será aplicada, "
 "começando com a primeira.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1930,112 +1930,112 @@ msgstr ""
 "Apenas uma faixa de legendas pode ser queimada! Podem ocorrer conflitos, "
 "então o primeiro escolhido vence."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Legendas"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcadores De Capítulo"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Adiciona marcadores de capítulo para o arquivo de saída."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Indexar"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Duração"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Título"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capítulos"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Atores:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Diretor:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Data de Lançamento:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Comentário:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Gênero:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Descrição:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Sinopse:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Marcadores"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Salvar Como:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nome do arquivo de destino para a sua codificar."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Para:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Diretório de destino para o seu arquivo codificado."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Diretório de Destino"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Adic._Vários"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2043,54 +2043,54 @@ msgstr "Adic._Vários"
 msgid "Cancel"
 msgstr "Cancelar"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Selecionar Todos"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marcar todos os títulos para adicionar à fila"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Limpar Todos"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Desmarcar Todos os Títulos"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Arquivos de destino OK. Nenhum duplicado detectado."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferências"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Checar por novas versões automaticamente"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "O uso de atribuição automática de nomes (usa origem do nome modificado)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 "Crie o nome do arquivo de destino a partir do nome do arquivo de origem ou "
 "da etiqueta do volume"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Modelo de Nome Automático"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2101,23 +2101,23 @@ msgstr ""
 "{capítulos} {dia} {hora} {dia-de-criação} {horário-da-criação} {qualidade} "
 "{taxa-de-bits}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Uso amigável do iPod/iTunes (.m4v) extensão de arquivo para MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Número de visualizações"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtro de títulos em DVD e Blu-ray curtos (segundos)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Limpe os itens da fila quando ao codificação for concluída"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2127,52 +2127,52 @@ msgstr ""
 "concluídos. \n"
 "Verifique se deseja que a fila se limpe excluindo os trabalhos concluídos."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Geral"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2186,63 +2186,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Granulação fracionada de Qualidade Constante"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Usar dvdnav (ao invés de libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Monitor de destino de espaço livre no HD"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Pausa a codificação se o espaço livre em disco cair abaixo do limite"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Limite MB"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Colocar logs individuais do codificador no mesmo local do filme"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Nível de Verbosidade do Log de Atividades"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Longevidade do Log de Atividades"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Diminuir visualizações em Alta Definição"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Automaticamente procura o DVD quando carregado"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Procura o DVD sempre que um novo disco é carregado"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Tamanho da Fonte da Janela de Atividades"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Use as mesmas configurações para todos os títulos em um lote"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2257,87 +2257,87 @@ msgstr ""
 "Desmarque esta opção se quiser permitir alterações nas configurações de cada "
 "título de forma independente."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Permitir Ajustes"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Permitir HandBrake Para Leigos"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avançado"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Predefinições de Redução de Ruídos:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Renomear Predefinições</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Nome:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descrição</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Salvar nova Predefinição"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Categoria:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Defina a categoria onde esta predefinição será mostrada abaixo."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Nome da Categoria:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nome da Predefinição:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Predefinição Padrão"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Tornar esta a Predefinição padrão quando o HandBrake iniciar"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensões</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Pré visualização do HandBrake"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Seleciona os quadros de prévia."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2345,76 +2345,76 @@ msgstr ""
 "Codifica e reproduz uma pequena sequência do vídeo a partir da posição atual "
 "de visualização."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Duração:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Define a duração da visualização ao vivo em segundos."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Mostrar Corte"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Mostra a área cortada na prévia"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Resolução da Origem"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Redefine a janela de visualização para a resolução do vídeo de origem"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Legendas"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importar SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Ativar configurações para importar um arquivo de legenda SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importe o SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Ative as configurações para importar um arquivo de legenda SSA"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Lista de Legendas Incorporadas"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Ativar configurações para selecionar legendas incorporadas"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Faixa da Fonte"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Mostra as faixas de legendas disponíveis na sua fonte."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nome da Faixa:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2424,23 +2424,23 @@ msgstr ""
 "\n"
 "Alguns reprodutores podem usar isso na lista de seleção de legendas."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Idioma"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Código do Caractere"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Arquivo:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Deslocamento (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2448,7 +2448,7 @@ msgstr ""
 "Define o idioma desta legenda.\n"
 "Este valor será usado pelos reprodutores de vídeo nos menus de legendas."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2463,27 +2463,27 @@ msgstr ""
 "Nós traduzimos o conjunto de caracteres para UTF-8.\n"
 "O código de caracteres da fonte é necessário para realizar esta tradução."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Selecione o arquivo SRT para importar"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importe o arquivo"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "Ajusta o deslocamento em milissegundos entre o tempo de vídeo e SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Somente Legenda Forçada"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Queimar para o vídeo"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2491,19 +2491,19 @@ msgstr ""
 "Renderiza a legenda no vídeo.\n"
 "O subtítulo fará parte do vídeo e não poderá ser desativado."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Definir Faixa Padrão"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Mostra as faixas de áudio disponíveis na sua fonte."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2513,15 +2513,15 @@ msgstr ""
 "\n"
 "Os reprodutores de vídeo podem usar isto na lista de seleção de áudio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Misturar"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Taxa de Amostra"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2539,31 +2539,31 @@ msgstr ""
 "O DRC permite 'comprimir' o alcance fazendo sons altos mais suaves e sons "
 "suaves mais altos."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Define o codec de áudio para codificar esta faixa."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Taxa de Bits"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Habilitar ajustes de taxa de bits"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Qualidade"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Habilitar ajustes de qualidade"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Define a taxa de bits para codificar esta faixa."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2571,19 +2571,19 @@ msgstr ""
 "<b>Qualidade:</b> Para codecs de saída que suportam e ajustem a qualidade da "
 "saída."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Define a mixagem da faixa de saída de áudio."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Define a taxa de amostragem da faixa de áudio de saída."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2592,41 +2592,41 @@ msgstr ""
 "de saída."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Desativado"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Pular Esta Versão"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Lembrar Mais Tarde"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Uma nova versão do HandBrake está disponível!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx está disponível agora (você tem yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Notas da Versão</b>"
 
@@ -2771,7 +2771,7 @@ msgstr "Dispositivos de DVD detectados:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Procurando..."
 
@@ -2784,11 +2784,40 @@ msgstr "Parar Procura"
 msgid "Single Title"
 msgstr "Abrir Título_Simples"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2796,7 +2825,7 @@ msgstr[0] "Áudio"
 msgstr[1] "Áudio"
 msgstr[2] "Áudio"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2804,19 +2833,19 @@ msgstr[0] "Legendas"
 msgstr[1] "Legendas"
 msgstr[2] "Legendas"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2824,22 +2853,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Por imposição apenas"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", Queimado"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Padrão"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2847,34 +2876,34 @@ msgstr[0] "Faixa de Legendas de Áudio Estrangeira"
 msgstr[1] "Faixa de Legendas de Áudio Estrangeira"
 msgstr[2] "Faixa de Legendas de Áudio Estrangeira"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Aspecto de Pixel:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nenhum Título Encontrado"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Novo Vídeo"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2885,132 +2914,132 @@ msgstr ""
 "\n"
 "%s em %d segundos ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%s Seu filme será perdido se você parar a codificação."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Cancelar Atual e Parar"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Cancelar Atual, Começar um Novo"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Finalizar Atual, Depois Parar"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continuar Codificação"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d codificação pendente"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d codificações pendentes"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "tarefas %d de %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "passo %d (procurar legenda) de %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "passo %d de %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Codificando: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Codificando: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Codificando: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Buscando por tempo inicial,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Procurando título %d de %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Procurando título %d de %d prévia %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pausado"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Codificação Terminada!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Codificação Cancelada."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Falha ao Codificar."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Empacotando: Isso pode demorar um pouco..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s está disponível agora (você tem %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Codificação Completa"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Considere este Coquetel. Sua fila do HandBrake está pronta!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Sua codificação está pronta."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Parando o Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Colocando o computador para dormir"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Desligando o computador"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ro.po
+++ b/gtk/po/ro.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: titus <titus0818@gmail.com>, 2014\n"
 "Language-Team: Romanian (https://www.transifex.com/HandBrakeProject/"
@@ -104,8 +104,8 @@ msgstr "_Preconfigurări"
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Salvare"
 
@@ -113,7 +113,7 @@ msgstr "_Salvare"
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -163,7 +163,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Ars în</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -185,7 +185,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Implicit</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -345,7 +345,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Pornire codare"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Pornire"
@@ -364,7 +364,7 @@ msgstr "Pauză"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -382,8 +382,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Editare"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Preconfigurare:"
 
@@ -391,7 +391,7 @@ msgstr "Preconfigurare:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titlu:"
 
@@ -415,7 +415,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sumar"
 
@@ -495,11 +495,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Alegeți sursa video"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr "Previzualizare"
 msgid "Show Queue"
 msgstr "Arată coada"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Coadă"
 
@@ -554,94 +554,94 @@ msgstr "<b>Sursă:</b>"
 msgid "None"
 msgstr "Nimic"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Se scanează..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 "Pentru DVD-uri cu unghiuri multiple, selectați unghiul dorit de codificat."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Domeniu de titlu pentru codificare. Poate fi capitole, secunde, sau cadre."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Configurați primul capitol pentru codificat."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Configurați ultimul capitol pentru codificat."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Reâncarcă"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format pentru mixat pistele codificate."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimizat Web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -650,151 +650,151 @@ msgstr ""
 "Aceasta permite playerelor să inițieze redarea înaintea descărcării "
 "întregului fișier."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Suport iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Adaugă iPod Atom necesare unor iPod-uri vechi."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Durată:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Decupează stânga"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Decupează sus"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Decupează dedesubt"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Decupează dreapta"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfic:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -804,11 +804,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Aspect pixel:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -817,11 +817,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -829,11 +829,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -843,91 +843,91 @@ msgstr ""
 "Dimensiunile afișajului actual va diferi dacă proporția pixelului nu este "
 "1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automat"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -935,18 +935,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -954,7 +954,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -962,11 +962,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deântrețesere:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -974,7 +974,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -983,39 +983,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Îmbunătățire:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Filtru reducere zgomot:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1028,7 +1028,7 @@ msgstr ""
 "Utilizând acest filtru pe astfel de surse pot rezulta fișiere de dimensiuni "
 "mai mici."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1042,78 +1042,78 @@ msgstr ""
 "Utilizând acest filtru pe astfel de surse pot rezulta fișiere de dimensiuni "
 "mai mici."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Scală de gri"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Dacă este activat, se filtrează componentele de culoare din videoclip."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Codor video:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Codoare video disponibile."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Rată de cadre:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1121,19 +1121,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Rată de cadre constantă"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Activează rata de cadre constantă la ieșire."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Limitare rată de cadre (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1141,11 +1141,11 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Rată de cadre variabilă"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1155,7 +1155,7 @@ msgstr ""
 "\n"
 "VFR nu este compatibil cu unele playere."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1171,15 +1171,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Calitate constantă:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Rată de biți (kbps):"
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1190,11 +1190,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Codare 2-pași"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1204,16 +1204,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Primul pas turbo"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1225,7 +1225,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1234,11 +1234,11 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Decodare rapidă"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1249,11 +1249,11 @@ msgstr ""
 "Configurați aceasta dacă dispozitivul se chinuie să redea ieșirea (cadre "
 "aruncate)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Latență zero"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1263,11 +1263,11 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1277,11 +1277,11 @@ msgstr ""
 "\n"
 "Suprascrie toate celelalte configurări."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nivel:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1291,11 +1291,11 @@ msgstr ""
 "\n"
 "Suprascrie toate celelalte configurări."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Mai multe configurări:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1305,193 +1305,193 @@ msgstr ""
 "\n"
 "Listă separată de două puncte a opțiunilor codorului."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Adaugă"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Adaugă noi configurări audio la listă"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Adaugă tot"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Adaugă toate pistele audio la listă"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Reâncarcă toate configurările audio din implicite"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Selectare comportament:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Eliminare"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Limbi disponibile"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Limbi selectate"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Utilizează numai primul codor pentru audio secundar"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Trecere directă automat:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Trecere directă de rezervă:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1499,76 +1499,76 @@ msgstr ""
 "Configurează codorul audio pentru codificare când o pistă potrivită nu poate "
 "fi găsită pentru trecerea directă audio."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Configurări codor audio:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Fiecare pistă sursă selectată va fi codificată cu toate codoarele selectate"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Codor"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Rată de biți/Calitate"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Mixarea"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Rată eșanționare"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Câștig"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Adaugă noi configurări subtitrare la listă"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Adaugă toate pistele subtitrare la listă"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Reâncarcă toate configurările subtitrării din implicite"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1579,15 +1579,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Limbă preferată: Nici una"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1597,11 +1597,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Adaugă pistă subtitrare dacă audio implicit este străin"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1609,21 +1609,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Adaugă subtitrări în chenar când sunt disponibile"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1633,15 +1633,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1652,11 +1652,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1667,124 +1667,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Subtitrări"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Marcaje capitol"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Adaugă marcajele capitolului la fișierul de ieșire."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Capitole"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Capitole"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Index"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Durată"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titlu"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Capitole"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Actori:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Director:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Dată lansare:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Comentariu:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Gen:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Descriere:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Plot:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etichete"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Nume fișier destinație pentru rezultatul codificării."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Director destinație pentru rezultatul codificării."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Director destinație"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Adaugă _Multiple"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1792,75 +1792,75 @@ msgstr "Adaugă _Multiple"
 msgid "Cancel"
 msgstr "Anulare"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Selectează tot"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Marchează toate titlurile pentru adăugare la coadă"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Curăță tot"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Demarchează toate titlurile"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Destinația fișierelor este în regulă. Nu s-au detectat duplicate."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Preferințe"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Verifică automat pentru actualizări"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Utilizează denumirea automată (utilizează numele sursă modificat)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Model denumire-automată"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 "Utilizează extensia de fișier prietenoasă iPod/iTunes (.m4v) pentru MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Număr de previzualizări"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -1870,52 +1870,52 @@ msgstr ""
 "Bifați asta dacă doriți să se curețe coada singură prin ștergerea sarcinilor "
 "terminate."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "General"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1929,63 +1929,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Calitate constantă granularitate fracționată"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Utilizează dvdnav (în schimbul a libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Pune jurnalele de codare individuale în aceiași locație ca filmul"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Nivel detaliere jurnal activitate"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Longevitate jurnal activitate"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Reduce previzualizările de înaltă definiție"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Scanează automat DVD-urile când sunt încărcate"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Scanează DVD-ul oricând este încărcat un nou disc"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1994,87 +1994,87 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Permite îmbunătățiri"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Permite HandBrake pentru novici"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avansat"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Preconfigurare reducere zgomot:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Descriere</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Preconfigurare:"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Nume preconfigurare:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Selectați cadre de previzualizat.."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2082,99 +2082,99 @@ msgstr ""
 "Codificați și redați o scurtă secvență video pornind de la poziția de "
 "previzualizare curentă."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Durată:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Configurați durata previzualizării în direct în secunde."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Arată decuparea"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Arată zona decupată a previzualizării"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Subtitrări"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Import SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Activare configurări pentru importul unui fișier subtitrare SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Listă subtitrare inclusă"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Activare configurări pentru selectat subtitrări incluse"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Pistă sursă"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lista pistelor subtitrare disponibile din sursă."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Nume pistă:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Limbă"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Cod caracter"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fișier:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Compensare (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2182,7 +2182,7 @@ msgstr ""
 "Configurați limba acestei subtitrări.\n"
 "Această valoare va fi utilizată de playere în meniuri subtitrare."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2191,28 +2191,28 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Selectare fișier SRT de importat."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Ajustați compensarea în milisecunde între video și marcajul de timp SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Numai subtitrări forțate"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Arde în video"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2220,19 +2220,19 @@ msgstr ""
 "Randează subtitrarea peste video.\n"
 "Subtitrarea va fi parte din video și nu poate fi dezactivată."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Configurare pistă implicită"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lista pistelor audio disponibile din sursă."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2242,15 +2242,15 @@ msgstr ""
 "\n"
 "Player-ele pot utiliza aceasta în lista selecției audio."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mix"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Rată eșanționare"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2261,31 +2261,31 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Configurați codecul audio cu care veți coda această pistă."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Rată de biți"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Activează configurarea ratei de biți"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Calitate"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Activare configurarea calității"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Configurați rata de biți cu care veți coda această pistă."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2293,19 +2293,19 @@ msgstr ""
 "<b>Calitate:</b> Pentru codecurile de ieșire care suportă asta, ajustează "
 "calitatea ieșirii."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Configurați mixarea pistei de ieșire audio."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Configurare rată de eșanționare a pistei de ieșire audio."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2314,41 +2314,41 @@ msgstr ""
 "ieșire."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Închis"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Omite această versiune"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Amintește-mi mai târziu"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Este disponibilă o nouă versiune HandBrake!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx este acum disponibil (aveți yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Note de lansare</b>"
 
@@ -2486,7 +2486,7 @@ msgstr "Dispozitive DVD detectate:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Se scanează ..."
 
@@ -2499,11 +2499,38 @@ msgstr "Oprește scanarea"
 msgid "Single Title"
 msgstr "Fără titlu"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2511,7 +2538,7 @@ msgstr[0] "Pistă sursă"
 msgstr[1] "Pistă sursă"
 msgstr[2] "Pistă sursă"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2519,19 +2546,19 @@ msgstr[0] "Subtitrări"
 msgstr[1] "Subtitrări"
 msgstr[2] "Subtitrări"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2539,22 +2566,22 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2562,34 +2589,34 @@ msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Aspect pixel:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nici un titlu nu este găsit"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2600,132 +2627,132 @@ msgstr ""
 "\n"
 "%s în %d secunde ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sFilmul va fi pierdut dacă nu continuați codarea."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Anulează curent și oprește"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Anulează curent, pornește următoarea"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Termină curent, apoi oprește"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Continuă codarea"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "sarcina %d din %d,"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "trecut %d (scanare subtitrare) din %d,"
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "trecut %d din %d"
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Se codează: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Se codează: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Se codează: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Se caută timpul de pornire,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Se scanează titlul %d din %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Se scanează titlul %d din %d previzualizarea %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pauzat"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Codare terminată!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Codare anulată."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Codare eșuată."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Se multiplexează: Aceasta poate dura un timp..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s este acum disponibil (aveți %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Codare terminată"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Lăsați jos acest cocktail, coada HandBrake este gata!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Codarea dumneavoastră este terminată."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Termină Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Pune computerul în adormire"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Închide computerul"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/ru.po
+++ b/gtk/po/ru.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: VictorR2007 <victorr2007@yandex.ru>, 2019\n"
 "Language-Team: Russian (https://www.transifex.com/HandBrakeProject/"
@@ -107,8 +107,8 @@ msgstr "_Предустановки"
 msgid "Set De_fault"
 msgstr "Установить по умолчанию"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Сохранить"
 
@@ -116,7 +116,7 @@ msgstr "_Сохранить"
 msgid "Save _As"
 msgstr "_Сохранить как"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Переименовать"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Встроенные</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>По умолчанию</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -365,7 +365,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Начать кодирование"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Старт"
@@ -384,7 +384,7 @@ msgstr "Пауза"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -404,8 +404,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Изменить"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Предустановка:"
 
@@ -413,7 +413,7 @@ msgstr "Предустановка:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Название:"
 
@@ -437,7 +437,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Описание"
 
@@ -520,11 +520,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Выбрать исходное видео"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Открыть источник"
 
@@ -556,7 +556,7 @@ msgstr "Предварительный просмотр"
 msgid "Show Queue"
 msgstr "Показать очередь"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Очередь"
 
@@ -579,15 +579,15 @@ msgstr "<b>Источник:</b>"
 msgid "None"
 msgstr "Нет"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Сканирование…"
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Название:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -597,78 +597,78 @@ msgstr ""
 "По умолчанию выбрано длинное название.\n"
 "Часто  это название функций DVD."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Угол:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "Для нескольких ракурсов DVD, выберите нужный ракурс для кодирования."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Диапазон:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 "Диапазон заголовков для кодирования. Могут быть главы, секунды или кадры."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Установить первую главу для кодирования."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Установить последнюю главу для кодирования."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Предустановка:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Выберите предустановку"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Изменён</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Перезагрузить"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr "Перезагрузить настройки для текущей выбранной предустановки."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Сохранить новую предустановку"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Применить текущие настройки в новую предустановку."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Формат:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Формат мультиплексора кодирования дорожек."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Оптимизация для интернет-трансляции"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -676,11 +676,11 @@ msgstr ""
 "Оптимизирует структуру файлов mp4 для последовательной загрузки.\n"
 "Это позволяет проигрывателю начать воспроизведение до загрузки всего файла."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Запуск выравнивания А/В"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -691,140 +691,140 @@ msgstr ""
 "аудио / видео\n"
 " для проигрывателей, которые не читают списки редактирования MP4."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Поддержка iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Добавить iPod Atom, необходимый некоторым старым плеерам."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Продолжительность:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "чч:мм:сс"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Дорожки:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Фильтры:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Размер:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Повернуть видео по часовой стрелке на 90 градусов."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Обрезка слева"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Обрезка сверху"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Обрезка снизу"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Обрезка справа"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Анаморфотный:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -834,11 +834,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Пропорции в пикселах:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -853,11 +853,11 @@ msgstr ""
 "Проигрыватели будут масштабировать изображение, чтобы достичь указанного "
 "соотношения."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -870,11 +870,11 @@ msgstr ""
 "Проигрыватели будут масштабировать изображение, чтобы достичь указанного "
 "соотношения."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -884,7 +884,7 @@ msgstr ""
 "Фактические размеры дисплей будут отличаться, если соотношение сторон "
 "пиксела не равно 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -894,84 +894,84 @@ msgstr ""
 "Фактические размеры дисплей будут отличаться, если соотношение сторон "
 "пиксела не равно 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Автоматически"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Размер изображения"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Детелесин:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -984,7 +984,7 @@ msgstr ""
 "Телесин, это процесс, который регулирует частоту кадров фильма 24fps в NTSC, "
 "в видео с частотой кадров 30fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -994,11 +994,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Предустановки деинтерлейсинга:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1011,7 +1011,7 @@ msgstr ""
 "находит\n"
 " чересстрочным, будут исправлены."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1024,11 +1024,11 @@ msgstr ""
 "Отсечение: маска Режим фильтра:\n"
 "Блокировка отсечения: блокировка ширины: блокировка высоты"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Деинтерлейсинг:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1040,7 +1040,7 @@ msgstr ""
 "Фильтр устранения гребёнки поддерживает множество алгоритмов интерполяции.\n"
 "Фильтр деинтерлейса является классическим деинтерлейсером YADIF.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1054,11 +1054,11 @@ msgstr ""
 "Фильтр устранения гребёнки поддерживает множество алгоритмов интерполяции.\n"
 "Фильтр деинтерлейса является классическим деинтерлейсером YADIF.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1068,12 +1068,12 @@ msgstr ""
 "Если в источнике существует «блочность», этот фильтр может помочь в ее "
 "очистке."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Настройки:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1084,18 +1084,18 @@ msgstr ""
 "Если в источнике существует «блочность», этот фильтр может помочь в ее "
 "очистке."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Фильтр шумоподавления:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1107,7 +1107,7 @@ msgstr ""
 "Использование этого фильтра на таких источниках может привести к уменьшению "
 "размеров файлов."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1120,7 +1120,7 @@ msgstr ""
 "Использование этого фильтра на таких источниках может привести к уменьшению "
 "размеров файлов."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1131,27 +1131,27 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Фильтр резкости:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1159,7 +1159,7 @@ msgstr ""
 "Фильтрация резкости усиливает края и другиеr\n"
 "высокочастотные компоненты в видео."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1168,39 +1168,39 @@ msgstr ""
 "Фильтрация резкости усиливает края и другиеr\n"
 "высокочастотные компоненты в видео."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Чёрно-белое"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Если включено, фильтр вывода оттенков цвета в видео."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Фильтры"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Кодировщик видео:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Доступные кодировщики видео."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Частота кадров:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1212,19 +1212,19 @@ msgstr ""
 "Рекомендуется «Как в источнике». Если исходное видео имеет\n"
 "переменную частоту кадров, выбор «Как в источнике» сохранит ее."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Постоянная частота кадров"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Включает постоянную частоту кадров вывода."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Пик частоты кадров (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1236,11 +1236,11 @@ msgstr ""
 "\n"
 "VFR не совместим с некоторыми проигрывателями."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Переменная частота кадров"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1250,7 +1250,7 @@ msgstr ""
 "\n"
 "VFR не совместим с некоторыми проигрывателями."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1280,15 +1280,15 @@ msgstr ""
 "У FFMpeg и Theora шкала является более линейной.\n"
 "Эти кодировщики не имеет режима без потерь."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Постоянное качество:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Битрейт (кбит/с):   "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1307,11 +1307,11 @@ msgstr ""
 "Если нужно ограничить кратковременный битрейт, смотрите настройки x264 vbv-"
 "bufsize и vbv-maxrate."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "Кодирование в 2 прохода"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1326,18 +1326,18 @@ msgstr ""
 "статистика о видео. Тогда на втором проходе используются эти статистические\n"
 "данные в решении распределения битрейта."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Первый проход быстро"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Во время 1-го проход при 2-х проходном кодировании используйте настройки "
 "скоростного прохода."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1349,7 +1349,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1365,11 +1365,11 @@ msgstr ""
 "предустановки, но\n"
 "до всех остальных параметров."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Быстрое кодирование"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1380,11 +1380,11 @@ msgstr ""
 "Установите ее, если ваше устройство  имеет затруднение с воспроизведением на "
 "выходе (пропускает кадры)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Нулевая задержка"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1400,11 +1400,11 @@ msgstr ""
 "Поскольку HandBrake не подходит  трансляции потокового вещания,\n"
 "этот параметр не имеет здесь большого значения."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Профиль:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1414,11 +1414,11 @@ msgstr ""
 "\n"
 "Подавляет все другие настройки."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Уровень:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1428,11 +1428,11 @@ msgstr ""
 "\n"
 "Подавляет все другие настройки."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Дополнительно:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1442,45 +1442,45 @@ msgstr ""
 "\n"
 "Список вариантов опций разделять двоеточиями."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Видео"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Добавить"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Добавить новые настройки аудио в список"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Добавить все"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Добавить в список все звуковые дорожки"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Перезагрузить все настройки звука по умолчанию"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Список дорожек"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Выбор поведения:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Выберите, какие звуковые дорожки исходного носителя используются."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1490,148 +1490,148 @@ msgstr ""
 "Дорожки, соответствующие этим языкам, будут выбраны с помощью «Выбор "
 "поведения»."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Удалить"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Доступные языки"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Выбранные языки"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Использовать только первый кодировщик для вторичного аудиосигнала"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Автопроходные без перекодирования:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Резервный без перекодирования:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1639,77 +1639,77 @@ msgstr ""
 "Установить кодировщика аудио для кодирования с тем, что бы использовать "
 "когда подходящий декодер не найден."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Параметры кодирования звука:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Каждая дорожка выбранного источника будет закодирована со всеми выбранными "
 "кодировщиками."
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Кодировщик"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Битрейт/Качество"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Микширование"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Частота дискретизации"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Усиление"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Выбранная дорожка"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Аудио"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Добавить новые настройки субтитров в список"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Добавить все дорожки субтитров в список"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Сканирование иностранного языка"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Перезагрузить все настройки субтитров по умолчанию"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Выберите, какие дорожки субтитров исходного носителя используются."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1727,15 +1727,15 @@ msgstr ""
 "при определении параметров выбора субтитров, когда присутствует иностранный "
 "звук. "
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Предпочитаемый язык: нет"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Добавить сканирование иностранного языка в проход"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1745,11 +1745,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Добавить дорожку субтитров, если по умолчанию будет иностранный звук"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1757,11 +1757,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Добавлять скрытые субтитры, когда возможно"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1769,11 +1769,11 @@ msgstr ""
 "Текстовые субтитры, которые могут быть добавлены в любой контейнер, как "
 "дорожка мягких субтитров"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Поведение вшитых субтитров*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1783,15 +1783,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Вшитые субтитры для слабых проигрывателей*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Субтитры DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1802,11 +1802,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Субтитры Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1817,7 +1817,7 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1825,7 +1825,7 @@ msgstr ""
 "<small>* Будет применяться только один из указанных выше вариантов "
 "субтитров, начиная с верхнего.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1833,112 +1833,112 @@ msgstr ""
 "Может быть записана только одна дорожка субтитров! Могут возникать "
 "конфликты. Победит первый выбранный."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Субтитры"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Маркеры глав"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Добавить маркеры глав в выходной файл."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Главы"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Главы"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Индекс"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Продолжительность"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Название"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Главы"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Актеры:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Режиссёр:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Дата выпуска:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Комментарий:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Жанр:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Описание:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Сюжет:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Теги"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Сохранить как:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Название папки для перекодированных файлов."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>В:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Папка назначения для перекодированных файлов."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Каталог назначения"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Добавить _несколько"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1946,76 +1946,76 @@ msgstr "Добавить _несколько"
 msgid "Cancel"
 msgstr "Отмена"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Выбрать все"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Отметить все названия для добавления в очередь"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Очистить все"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Снять все названия"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "С файлами назначения все хорошо. Дубликаты не обнаружены."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Параметры"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Автоматически проверять наличие обновлений"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 "Использовать автоматический идентификатор (использует измененное исходное "
 "имя)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Шаблон автонаименования"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Использовать дружественное iPod/iTunes расширение файла (.m4v) для MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Количество миниатюр"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2025,52 +2025,52 @@ msgstr ""
 "завершенные.\n"
 "Отметьте это, если хотите очищать очередь до окончания выполнения задания."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Общие"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2084,65 +2084,65 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Незначительная зернистость при постоянном качестве"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Использовать dvdnav (вместо libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Мониторинг свободного места для диска назначения"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 "Пауза кодирования, если свободное место на диске опускается ниже предела"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "Ограничение Мб"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 "Помещать индивидуальные логи кодирования в то же расположение, что и фильм"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Подробный журнал уровня деятельности"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Долговечный журнала операций"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Уменьшать высокую четкость просмотра"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Автоматически сканировать DVD при загрузке"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Сканировать DVD после загрузки нового диска"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Размер шрифта окна активности"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Использовать те же настройки для всех заголовков в партии"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2156,87 +2156,87 @@ msgstr ""
 "Снимите этот флажок, если вы хотите разрешить изменение настроек каждого "
 "заголовка независимо."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Разрешить тонкие настройки"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Сделать HandBrake для чайников"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Дополнительно"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Предустановка шумоподавления:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Переименовать предустановку</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Название:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Описание</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Сохранить новую предустановку"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Категория:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Установить категорию, в которой будет отображаться эта предустановка."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Название категории:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Название предустановки:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Предустановка по умолчанию"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Сделать эту предустановку по умолчанию при запуске HandBrake"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Выбор кадра просмотра."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2244,99 +2244,99 @@ msgstr ""
 "Кодировать и воспроизводить короткие последовательности видео, начиная с "
 "текущего положения просмотра."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Продолжительность:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Установить продолжительность предварительного просмотра в секундах."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Показать границы обрезки"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Показать просмотр обрезанных областей"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Разрешение источника"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Сбросить окно предварительного просмотра до разрешения исходного видео"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Субтитры"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Импорт SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Включить настройки импорта файла субтитров SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Список встроенных субтитров"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Включить настройки выбранных встроенных субтитров"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Дорожка источника"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Список дорожек субтитров доступных в источнике."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Название дорожки:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Язык"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Кодировка"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Файл:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Смещение (мс)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2344,7 +2344,7 @@ msgstr ""
 "Установить язык этих субтитров.\n"
 "Это значение будет использоваться проигрывателями в меню субтитров."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2358,27 +2358,27 @@ msgstr ""
 "Мы переводим набор символов в UTF-8.\n"
 "Кодировка источника необходима для того, чтобы выполнить этот перевод."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Выберите файл srt для импорта."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "Установить смещение в миллисекундах между видео и  метками времени SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Только форсированные субтитры"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Записать в видео"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2386,19 +2386,19 @@ msgstr ""
 "Отображение субтитров на видео.\n"
 "Субтитры будут на части видео и не могут быть отключены."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Установить дорожку по умолчанию"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Список доступных в источнике звуковых дорожек."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2408,15 +2408,15 @@ msgstr ""
 "\n"
 "Проигрыватели могут использовать это списке выбора звука. "
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Смешивание"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Частота дискретизации"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2431,31 +2431,31 @@ msgstr ""
 "громкие и очень мягкие последовательности, DRC позволяет сжимать диапазон, "
 "делая громкие разделы мягче и мягкие разделы громче."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Установить аудио кодек для кодирования этой дорожки."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Битрейт"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Включить настройку битрейта"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Качество"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Включить настройку качества"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Установить битрейт для кодирования этой дорожки."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
@@ -2463,19 +2463,19 @@ msgstr ""
 "<b>Качество:</b> Для выходного кодека, который поддерживают это, установить "
 "качество вывода."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Установить микширование каналов выходной звуковой дорожки."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Установить частоту дискретизации дорожки вывода звука."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2484,41 +2484,41 @@ msgstr ""
 "вывода."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0дБ"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Выкл"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Пропустить эту версию"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Напомнить позже"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Доступна новая версия HandBrake!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "Доступна новая версия HandBrake xxx (у вас версия yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Заметки о релизе</b>"
 
@@ -2663,7 +2663,7 @@ msgstr "Обнаружено устройство DVD:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Сканирование…"
 
@@ -2676,11 +2676,40 @@ msgstr "Остановить сканирование"
 msgid "Single Title"
 msgstr "Открыть один _файл"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2689,7 +2718,7 @@ msgstr[1] "Аудио"
 msgstr[2] "Аудио"
 msgstr[3] "Аудио"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2698,19 +2727,19 @@ msgstr[1] "Субтитры"
 msgstr[2] "Субтитры"
 msgstr[3] "Субтитры"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2719,22 +2748,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2743,34 +2772,34 @@ msgstr[1] "Дорожка субтитров иностранного языка
 msgstr[2] "Дорожка субтитров иностранного языка"
 msgstr[3] "Дорожка субтитров иностранного языка"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Пропорции в пикселах:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Название не найдено"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Новое видео"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2781,135 +2810,135 @@ msgstr ""
 "\n"
 "%s в %d секунды ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sВаш фильм будет потерян, если вы не продолжать кодирование."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Отменить текущий и остановить"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Отменить текущий, начать следующий"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Закончить текущий, затем остановить"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Продолжить кодирование"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "задание %d из %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "проход %d (сканирование субтитров) из %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "проход %d из %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Кодирование: %s%s%.2f %% (%.2f fps, средний %.2f fps, время до окончания "
 "%02d час %02d мин %02d сек)."
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 "Кодирование: %s%s%.2f %% (время до окончания %02d час %02d мин %02d сек)."
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Кодирование: %s%s%.2f %%."
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Поиск времени начала, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Сканирование фильма %d из  %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Сканирование фильма %d из %d просмотр %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Приостановлено"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Кодирование завершено!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Кодирование отменено."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Ошибка кодирования."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Мультиплексирование: Это может занять некоторое время..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "Доступна новая версия HandBrake %s/%s (у вас версия %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Кодирование завершено"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "HandBrake завершил кодировать этот фильм!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Кодирование завершено."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Очередь"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Переход в спящий режим"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Выключение компьютера"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/si.po
+++ b/gtk/po/si.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: හෙළබස සමූහය, 2022\n"
 "Language-Team: Sinhala (https://www.transifex.com/HandBrakeProject/"
@@ -102,8 +102,8 @@ msgstr ""
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "සුරකින්න (_S)"
 
@@ -111,7 +111,7 @@ msgstr "සුරකින්න (_S)"
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -158,7 +158,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -173,7 +173,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>පෙරනිමි</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -321,7 +321,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "අරඹන්න"
@@ -340,7 +340,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -358,8 +358,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -367,7 +367,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -391,7 +391,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr ""
 
@@ -470,11 +470,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -506,7 +506,7 @@ msgstr "පෙරදසුන"
 msgid "Show Queue"
 msgstr ""
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr ""
 
@@ -529,242 +529,242 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -774,11 +774,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -787,11 +787,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -799,102 +799,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -902,18 +902,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -921,7 +921,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -929,11 +929,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -941,7 +941,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -950,39 +950,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -990,7 +990,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -998,78 +998,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1077,19 +1077,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1097,18 +1097,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1124,15 +1124,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1143,11 +1143,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1157,16 +1157,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1178,7 +1178,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1187,22 +1187,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1212,300 +1212,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1516,15 +1516,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1534,11 +1534,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1546,21 +1546,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1570,15 +1570,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1589,11 +1589,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1604,121 +1604,121 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1726,126 +1726,126 @@ msgstr ""
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1859,63 +1859,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1924,188 +1924,188 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 msgid "Rename Preset"
 msgstr ""
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 msgid "Save Preset"
 msgstr ""
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 msgid "Edit Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2114,60 +2114,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2178,89 +2178,89 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2392,7 +2392,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2404,90 +2404,117 @@ msgstr ""
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2495,132 +2522,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/sk.po
+++ b/gtk/po/sk.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Dušan Kazik <prescott66@gmail.com>, 2016\n"
 "Language-Team: Slovak (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_Predvoľby"
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Uložiť"
 
@@ -114,7 +114,7 @@ msgstr "_Uložiť"
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -161,7 +161,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -176,7 +176,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -330,7 +330,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Spustiť dekódovanie"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Spustiť"
@@ -349,7 +349,7 @@ msgstr "Pozastaviť"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -367,8 +367,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Upraviť"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Predvoľba:"
 
@@ -376,7 +376,7 @@ msgstr "Predvoľba:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titul:"
 
@@ -400,7 +400,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Súhrn"
 
@@ -479,11 +479,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -515,7 +515,7 @@ msgstr "Náhľad"
 msgid "Show Queue"
 msgstr "Zobraziť frontu"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Fronta"
 
@@ -538,242 +538,242 @@ msgstr "<b>Zdroj:</b>"
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Prehľadáva sa..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Znovu načítať"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Formát:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Optimalizácia pre web"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "Podpora pre iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Dĺžka:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Ľavé orezanie"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Vrchné orezanie"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Spodné orezanie"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Pravé orezanie"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfné:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -783,11 +783,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Pomer pixelov:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -801,11 +801,11 @@ msgstr ""
 "tvary.\n"
 "Prehrávače zmenia mierku obrazu tak, aby dosiahli určený pomer."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -813,102 +813,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Rozmery"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -916,18 +916,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -935,7 +935,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -943,11 +943,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -955,7 +955,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -964,39 +964,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1004,7 +1004,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1012,78 +1012,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Odtiene šedej"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtre"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Dekóder videa:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Dostupné dekódery videa."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Frekvencia snímok:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1091,19 +1091,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1111,18 +1111,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Premenlivá frekvencia snímok"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1138,15 +1138,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Konštantná kvalita:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bitový tok (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1157,11 +1157,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1171,16 +1171,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1192,7 +1192,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1201,22 +1201,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Rýchle dekódovanie"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Bez oneskorenia"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1226,33 +1226,33 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Úroveň:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Viac nastavení:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1262,267 +1262,267 @@ msgstr ""
 "\n"
 "Dvojbodkami oddelený zoznam volieb dekódera."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Pridať"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Pridať nové nastavenia zvuku do zoznamu"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Pridať všetko"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Pridať všetky zvukové stopy do zoznamu"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Znovu načítať všetky nastavenia zvuku z predvolených"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Správanie výberu:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Odstrániť"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Dostupné jazyky"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Vybrané jazyky"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Nastavenia dekóderu zvuku:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Dekóder"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bitová rýchlosť/Kvalita"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Vzorkovacia rýchlosť"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Zvuk"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1533,15 +1533,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Prednostný jazyk: žiadny"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1551,11 +1551,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1563,21 +1563,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1587,15 +1587,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD titulky"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1606,11 +1606,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1621,123 +1621,123 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Titulky"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Číslo"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Dĺžka"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titul"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Kapitoly"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Herci:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Režisér:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Dátum vydania:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Komentár:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Žáner:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Popis:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Značky"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1745,126 +1745,126 @@ msgstr ""
 msgid "Cancel"
 msgstr "Zrušiť"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Vybrať všetko"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Označiť všetky tituly na pridanie do fronty"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Vymazať všetko"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Odznačiť všetky tituly"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Cieľové súbory sú v poriadku. Neboli zistené žiadne duplikáty."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Nastavenia"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Automaticky kontrolovať aktualizácie"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Počet náhľadov"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Všeobecné"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1878,63 +1878,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Automaticky prehľadať DVD po načítaní"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1943,191 +1943,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Pokročilé"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Predvoľba:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Popis</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Predvoľba:"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Názov predvoľby:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Dĺžka:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Titulky"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importovať SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Zdrojová stopa"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Zoznam dostupných stôp s titulkami z vášho zdroja."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Názov stopy:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Jazyk"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Súbor:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Posun (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2136,60 +2136,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Iba nútené titulky"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Zoznam dostupných zvukových stôp z vášho zdroja."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Vzorkovacia frekvencia"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2200,90 +2200,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Nastaviť zvukový kodek, ktorým sa má dekódovať táto stopa."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bitový tok"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Povoliť nastavenie bitového toku"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kvalita"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Povoliť nastavenie kvality"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Nastaviť bitový tok, ktorým sa má dekódovať táto stopa."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Vypnuté"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Preskočiť túto verziu"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Pripomenúť neskôr"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>Je dostupná nová verzia programu HandBrake!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "Je dostupný program HandBrake xxx (vaša verzia je yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Poznámky k vydaniu</b>"
 
@@ -2422,7 +2422,7 @@ msgstr "Zistené zariadenia DVD:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Prehľadáva sa..."
 
@@ -2435,11 +2435,38 @@ msgstr "Zastaviť prehľadávanie"
 msgid "Single Title"
 msgstr "Otvoriť jeden _titul"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
@@ -2448,7 +2475,7 @@ msgstr[1] "Zvuk"
 msgstr[2] "Zvuk"
 msgstr[3] "Zvuk"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2457,19 +2484,19 @@ msgstr[1] "Titulky"
 msgstr[2] "Titulky"
 msgstr[3] "Titulky"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2478,22 +2505,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2502,34 +2529,34 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Pomer pixelov:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Nenašiel sa žiadny titul"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2540,134 +2567,134 @@ msgstr ""
 "\n"
 "%s o %d sekúnd..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sAk nebudete pokračovať v dekódovaní, váš film bude stratený."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Zrušiť aktuálne a zastaviť"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Zrušiť aktuálne a spustiť ďalšie"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Dokončiť aktuálne a zastaviť"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Pokračovať v dekódovaní"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "úloha %d z %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "prechod %d z %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "Dekóduje sa: %s%s%.2f %% (%.2f sn./s, priemer %.2f sn./s, zostáva "
 "%02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Dekóduje sa: %s%s%.2f %% (Zostáva %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Dekóduje sa: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Prehľadáva sa titul %d z %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pozastavené"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Dekódovanie dokončené!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Dekódovanie zrušené."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Dekódovanie zlyhalo."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "Je dostupný program HandBrake %s/%s (vaša verzia je %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Dekódovanie dokončené"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Vaše dekódovanie je dokončené."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Uspáva sa počítač"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Vypína sa počítač"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/sl_SI.po
+++ b/gtk/po/sl_SI.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Martin Srebotnjak <miles@filmsi.net>, 2022\n"
 "Language-Team: Slovenian (Slovenia) (https://www.transifex.com/"
@@ -107,8 +107,8 @@ msgstr "_Prednastavitve"
 msgid "Set De_fault"
 msgstr "Nastavi kot priv_zeto"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Shrani"
 
@@ -116,7 +116,7 @@ msgstr "_Shrani"
 msgid "Save _As"
 msgstr "Shrani _kot"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Preimenuj"
 
@@ -166,7 +166,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Zapečeno</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -188,7 +188,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Privzeto</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr ""
@@ -383,7 +383,7 @@ msgstr ""
 msgid "Options"
 msgstr "Možnosti"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -401,8 +401,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Uredi"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Prednastavitev:"
 
@@ -410,7 +410,7 @@ msgstr "Prednastavitev:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgstr "Zvok:"
 msgid "Subtitles:"
 msgstr "Podnapisi:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Povzetek"
 
@@ -513,11 +513,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Odpri vir"
 
@@ -549,7 +549,7 @@ msgstr "Predogled"
 msgid "Show Queue"
 msgstr "Pokaži vrsto"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Vrsta"
 
@@ -572,242 +572,242 @@ msgstr ""
 msgid "None"
 msgstr "Brez"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Prednastavitev:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Izberite prednastavitev"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Ponovno naloži"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Shrani novo prednastavitev"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Trajanje:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -817,11 +817,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -830,11 +830,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -842,102 +842,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -945,18 +945,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Zaznava prepletanja:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -964,7 +964,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -972,11 +972,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -984,7 +984,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -993,39 +993,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1033,7 +1033,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1041,78 +1041,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1120,19 +1120,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1140,18 +1140,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1167,15 +1167,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1186,11 +1186,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1200,16 +1200,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1221,7 +1221,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1230,22 +1230,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1255,300 +1255,300 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Dodaj"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Dodaj vse"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Odstrani"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Razpoložljivi jeziki"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Izbrani jeziki"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr ""
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1559,15 +1559,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1577,11 +1577,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1589,21 +1589,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1613,15 +1613,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Podnaslovi DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1632,11 +1632,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Podnaslovi Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1647,123 +1647,123 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Podnaslovi"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Poglavja"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Poglavja"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Trajanje"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Naslov"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Poglavja"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Režiser:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Komentar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Žanr:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Opis:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Shrani kot:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Ciljna mapa"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1771,126 +1771,126 @@ msgstr ""
 msgid "Cancel"
 msgstr "Prekliči"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Izberi vse"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Počisti vse"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Nastavitve"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Število predogledov"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Splošno"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1904,63 +1904,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1969,191 +1969,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Prednastavitev razpletanja:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Shrani novo prednastavitev"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Podnaslovi"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr ""
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2162,60 +2162,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2226,90 +2226,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr ""
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr ""
 
@@ -2442,7 +2442,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2454,11 +2454,38 @@ msgstr ""
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
@@ -2466,7 +2493,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2475,19 +2502,19 @@ msgstr[1] "Podnaslovi"
 msgstr[2] "Podnaslovi"
 msgstr[3] "Podnaslovi"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2496,22 +2523,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2520,33 +2547,33 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2554,132 +2581,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/sv.po
+++ b/gtk/po/sv.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Åke Engelbrektson, 2022\n"
 "Language-Team: Swedish (Sweden) (https://www.transifex.com/HandBrakeProject/"
@@ -105,8 +105,8 @@ msgstr "_Mallar"
 msgid "Set De_fault"
 msgstr "Ange som sta_ndard"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Spara"
 
@@ -114,7 +114,7 @@ msgstr "_Spara"
 msgid "Save _As"
 msgstr "Spara _som"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Byt namn"
 
@@ -164,7 +164,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Inbränd</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -186,7 +186,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Standard</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -363,7 +363,7 @@ msgstr "0 väntande jobb"
 msgid "Start Encoding"
 msgstr "Starta kodning"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Start"
@@ -382,7 +382,7 @@ msgstr "Paus"
 msgid "Options"
 msgstr "Alternativ"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "Vid slutfört:"
 
@@ -402,8 +402,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Redigera"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Mall:"
 
@@ -411,7 +411,7 @@ msgstr "Mall:"
 msgid "Source:"
 msgstr "Källa:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Titel:"
 
@@ -435,7 +435,7 @@ msgstr "Ljud:"
 msgid "Subtitles:"
 msgstr "Undertexter:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Sammanfattning"
 
@@ -529,11 +529,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Välj videokälla"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Öppna källfil"
 
@@ -565,7 +565,7 @@ msgstr "Förhandsgranska"
 msgid "Show Queue"
 msgstr "Visa kön"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Kö"
 
@@ -588,15 +588,15 @@ msgstr "<b>Källa:</b>"
 msgid "None"
 msgstr "Inget"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Söker..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Titel:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -606,51 +606,51 @@ msgstr ""
 "Som standard väljs den längsta titeln.\n"
 "Detta är ofta titeln på en DVD-skiva."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Vinkel:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "För flervinklade DVD:er, välj önskad vinkling att koda."
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Intervall:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "Intervall att koda om. Kan vara avsnitt, sekunder eller bildrutor."
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Ange första avsnittet att koda om."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Ange sista avsnittet att koda om."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Mall:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Välj mall"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Modifierad</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Läs in igen"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -658,27 +658,27 @@ msgstr ""
 "Läs in inställningarna för aktuell mall igen.\n"
 "Ändringar kommer att tas bort."
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Spara ny mall"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Spara aktuella inställningar som en ny mall."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Format:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "Format att muxa kodade spår till."
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Webboptimerat"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -686,11 +686,11 @@ msgstr ""
 "Optimera MP4-filens layout, för progressiv nedladdning.\n"
 "Detta låter en spelare starta uppspelning innan hela filen är nedladdad."
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Justera A/V Start"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -701,140 +701,140 @@ msgstr ""
 "Kan förbättra ljud-/videosynkronisering för bristfälliga spelare\n"
 "som inte hedrar MP4-redigeringslistor."
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G-stöd"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Lägg till iPod Atom, nödvändiga för vissa äldre iPod:ar."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr "Genomströmma vanlig metadata"
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr "Kopiera metadata från källa till utdata."
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Varaktighet:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Spår:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filter:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Storlek:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr "Lagringsstorlek:"
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr "Visningsstorlek:"
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr "Proportioner:"
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr "<b>Källdimensioner</b>"
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr "Vändning:"
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr "Horisontellt ⇌"
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr "Vänd videon horisontellt."
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr "Rotation:"
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "Rotera videon medurs i steg om 90 grader."
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr "Beskärning:"
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr "Hur man tillämpar beskärningsinställningar."
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Beskär vänsterkant"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Beskär överkant"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Beskär underkant"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Beskär högerkant"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr "<b>Orientering &amp; beskärning</b>"
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr "Upplösningsgräns:"
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr "Upplösningsgränser för vanliga videoformat."
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr "Maximal storlek:"
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr "Detta är den maximala bredden som videon lagras i."
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr "x"
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr "Detta är den maximala höjden som videon lagras i."
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorft:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -850,11 +850,11 @@ msgstr ""
 "    Inget     - Tvinga pixelproportionerna till 1:1.\n"
 "    Anpassat    - Ange anpassade pixelproportioner.</tt></small>"
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Pixelproportion:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -868,11 +868,11 @@ msgstr ""
 "rektangulära former.\n"
 "Mediaspelare skalar bilden för att uppnå specificerade proportioner."
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -884,11 +884,11 @@ msgstr ""
 "rektangulära former.\n"
 "Mediaspelare skalar bilden för att uppnå specificerade proportioner."
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr "Skalad storlek:"
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -898,7 +898,7 @@ msgstr ""
 "Den verkliga skärmstorleken kommer att differentieras om pixelproportionerna "
 "inte är 1:1."
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -908,86 +908,86 @@ msgstr ""
 "Den verkliga skärmstorleken kommer att differentieras om pixelproportionerna "
 "inte är 1:1."
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr "Optimal storlek"
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 "Använd den högsta upplösning som tillåts med ovanstående inställningar."
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr "Tillåt uppskalning"
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 "Om inte aktiverad, begränsas de skalade dimensionerna till källdimensionerna."
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr "<b>Upplösning &amp; skalning</b>"
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr "Fyll:"
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr "Lägg till en kant runt videon."
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr "Vänster sida"
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr "Översida"
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr "Undersida"
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr "Höger sida"
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr "Färg:"
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr "Färg på kanten runt videon."
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr "<b>Kanter</b>"
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr "Om du ändrar visningsstorleken sträcker du ut videon."
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Automatiskt"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr "<b>Slutliga dimensioner</b>"
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Storlek"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -1000,7 +1000,7 @@ msgstr ""
 "Telecining är en process som justerar filmbildfrekvens på 24fps till NTSC "
 "videobildfrekvens på 30fps."
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -1010,11 +1010,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Sammanflätningsidentifiering:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1026,7 +1026,7 @@ msgstr ""
 "Om ett avflätningsfilter aktiveras, kommer endast bildrutor\n"
 "som identifieras av detta filter att bli avflätade."
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1038,11 +1038,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Avflätning:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1054,7 +1054,7 @@ msgstr ""
 "Decomb-filtret stödjer en mängd interpoleringsalgoritmer.\n"
 "Avflätningsfiltret är en klassisk YADIF-avflätare.\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1068,11 +1068,11 @@ msgstr ""
 "Decomb-filtret stödjer en mängd interpoleringsalgoritmer.\n"
 "Avflätningsfiltret är en klassisk YADIF-avflätare.\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "Deblock-filter:"
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1081,12 +1081,12 @@ msgstr ""
 "Tillämpas på avkodad, komprimerad video för att förbättra visuell kvalitet "
 "genom att jämna ut vassa kanter."
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "Justera:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1096,7 +1096,7 @@ msgstr ""
 "Tillämpas på avkodad, komprimerad video för att förbättra visuell kvalitet "
 "genom att jämna ut vassa kanter."
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1107,11 +1107,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Brusreduceringsfilter:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1124,7 +1124,7 @@ msgstr ""
 "Användning av detta filter på sådana källor, kan resultera i mindre "
 "filstorlek."
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1138,7 +1138,7 @@ msgstr ""
 "Användning av detta filter på sådana källor, kan resultera i mindre "
 "filstorlek."
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1149,11 +1149,11 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr "Kromautjämningsfilter:"
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
@@ -1161,7 +1161,7 @@ msgstr ""
 "Kromautjämningsfiltret tar bort vanliga färgartefakter.\n"
 "Analogt källmaterial med lägre upplösning kan ha nytta av detta filter."
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 #, fuzzy
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
@@ -1170,11 +1170,11 @@ msgstr ""
 "Kromautjämningsfiltret tar bort vanliga färgartefakter.\n"
 "Analogt källmaterial med lägre upplösning kan ha nytta av detta filter."
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Skärpefilter:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1182,7 +1182,7 @@ msgstr ""
 "Skärpefiltrering förbättrar kanter och andra\n"
 "högfrekvenskomponenter i filmen."
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1191,39 +1191,39 @@ msgstr ""
 "Skärpefiltrering förbättrar kanter och andra\n"
 "högfrekvenskomponenter i filmen."
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr "Färgrymd:"
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr "Översätt färgrymden från källan."
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Gråskala"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "Om aktiverad, filtreras färgkomponenter bort från videon."
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filter"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Videokodare:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Tillgängliga videokodare."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Bildfrekvens:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1235,19 +1235,19 @@ msgstr ""
 "\"Samma som källan\" rekommenderas, om din video har\n"
 "en variabel bildfrekvens. \"Samma som källan\" bevarar den."
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Konstant bildfrekvens"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Aktiverar konstant bildfrekvens i utdata."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "Toppad bildfrekvens (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1259,11 +1259,11 @@ msgstr ""
 "\n"
 "VFR är inte kompatibel med alla mediaspelare."
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Variabel bildfrekvens"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1273,7 +1273,7 @@ msgstr ""
 "\n"
 "VFR är inte kompatibel med alla mediaspelare."
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1303,15 +1303,15 @@ msgstr ""
 "FFMpeg- och Theora-skalan är mer linjär.\n"
 "Dessa kodare har inget förlustfritt läge."
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Konstant kvalitet:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bithastighet (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1331,11 +1331,11 @@ msgstr ""
 "för\n"
 "vbv-bufsize och vbv-maxrate."
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2-passkodning"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1350,18 +1350,18 @@ msgstr ""
 "statistik om videon in. Under 2:a passet, används statistiken för att\n"
 "avgöra rätt bithastighet."
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "Turbo 1:a Pass"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 "Använd inställningar som skyndar på saker, under 1:a passet i en 2-"
 "passkodning."
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1381,7 +1381,7 @@ msgstr ""
 "eftersom\n"
 "långsammare inställningar resulterar i bättre kvalitet eller mindre filer."
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1395,11 +1395,11 @@ msgstr ""
 "utdatafilens egenskaper. Ändringar kommer att tillämpas efter\n"
 "mallen, men före alla andra parametrar."
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Snabb avkodning"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1409,11 +1409,11 @@ msgstr ""
 "\n"
 "Aktivera det här om din enhet får kämpa vid uppspelning (tappade bildrutor)."
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Nollfördröjning"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1429,11 +1429,11 @@ msgstr ""
 "Eftersom HandBrake inte är lämplig för direktsändningsändamål,\n"
 "är denna inställning av litet värde här."
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1443,11 +1443,11 @@ msgstr ""
 "\n"
 "Åsidosätter alla andra inställningar."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Nivå:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1457,11 +1457,11 @@ msgstr ""
 "\n"
 "Åsidosätter alla andra inställningar."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Fler inställningar:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1471,45 +1471,45 @@ msgstr ""
 "\n"
 "Kolonseparerad lista över kodningsalternativ."
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Lägg till"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Lägg till nya ljudinställningar i listan"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Lägg till alla"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Lägg till alla ljudspår till listan"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Läs in alla ljudinställningar från standard igen"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Spårlista"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Välj beteende:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "Välj vilket källljudspår som skall användas."
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1519,23 +1519,23 @@ msgstr ""
 "Spår som matchar dessa språk kommer att väljas med hjälp av det valda "
 "urvalsbeteendet."
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Ta bort"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Tillgängliga språk"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Välj språk"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "Använd endast första kodaren för sekundärt ljud"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1544,15 +1544,15 @@ msgstr ""
 "Endast det primära ljudspåret kommer att kodas med hela kodarlistan.\n"
 "Alla andra sekundära ljudspår kommer endast att kodas med första kodaren."
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Automatisk genomströmning:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr "MP2"
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
@@ -1562,11 +1562,11 @@ msgstr ""
 "Detta tillåter att MP2-genomströmning väljs när automatisk genomströmning är "
 "aktiverat."
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1576,11 +1576,11 @@ msgstr ""
 "Detta tillåter att MP3-genomströmning väljs när automatisk genomströmning är "
 "aktiverat."
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1590,11 +1590,11 @@ msgstr ""
 "Detta tillåter att AC-3-genomströmning väljs när automatisk genomströmning "
 "är aktiverat."
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1604,11 +1604,11 @@ msgstr ""
 "Detta tillåter att EAC-3-genomströmning väljs när automatisk genomströmning "
 "är aktiverat."
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1618,11 +1618,11 @@ msgstr ""
 "Detta tillåter att DTS-genomströmning väljs när automatisk genomströmning är "
 "aktiverat."
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1632,11 +1632,11 @@ msgstr ""
 "Detta tillåter att DTS-HD-genomströmning väljs när automatisk genomströmning "
 "är aktiverat."
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1646,11 +1646,11 @@ msgstr ""
 "Detta tillåter att ThrueHD-genomströmning väljs när automatisk "
 "genomströmning är aktiverat."
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1660,11 +1660,11 @@ msgstr ""
 "Detta tillåter att FLAC-genomströmning väljs när automatisk genomströmning "
 "är aktiverat."
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1674,11 +1674,11 @@ msgstr ""
 "Detta tillåter att AAC-genomströmning väljs när automatisk genomströmning är "
 "aktiverat."
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr "Opus"
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
@@ -1688,11 +1688,11 @@ msgstr ""
 "Detta tillåter att Opus-genomströmning väljs när automatisk genomströmning "
 "är aktiverat."
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Genomströmningsreserv:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
@@ -1700,60 +1700,60 @@ msgstr ""
 "Ange ljudkodek att koda om med, när ett passande spår för ljudgenomströmning "
 "inte kan hittas."
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Ljudkodningsinställningar:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "Varje markerat källspår kommer att kodas med alla valda kodare"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Kodare"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bithastighet/Kvalitet"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "Nermixning"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Samplingsfrekvens"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Förstärkning"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Spårval"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Ljud"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Lägg till nya undertextinställningar i listan"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "Lägg till alla undertextspår i listan"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Främmande ljudsökning"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
@@ -1763,15 +1763,15 @@ msgstr ""
 "efter undertextkandidater med undertext till segment\n"
 "av det ljud som är på främmande språk."
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Läs in alla undertextinställningar från standard igen"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "Välj vilket undertextspår som skall användas."
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1789,15 +1789,15 @@ msgstr ""
 "användas\n"
 "för att avgöra undertextvalet vid förekomst av främmande språk."
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Föredraget språk: Inget"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "Lägg till främmande ljudsökningspass"
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1814,11 +1814,11 @@ msgstr ""
 "Detta alternativ kräver att ett språk har valts från listan med "
 "\"Tillgängliga språk\"."
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "Lägg till undertextspår om standardspråket är främmande"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1831,11 +1831,11 @@ msgstr ""
 "Detta alternativ kräver att ett språk har valts från listan med "
 "\"Tillgängliga språk\"."
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "Lägg till textning när det finns tillgängligt"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
@@ -1843,11 +1843,11 @@ msgstr ""
 "Stängd textning är undertexter som kan läggas till i valfri behållare, som "
 "ett fristående undertextspår"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Inbränningsbeteende*:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1863,15 +1863,15 @@ msgstr ""
 "Endast en undertext kan brännas! Eftersom konflikter kan uppstå, vinner det "
 "först valda."
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "Inbränning för bristfälliga spelare*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD-undertexter"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1889,11 +1889,11 @@ msgstr ""
 "Endast ett undertextspår kan brännas! Eftersom konflikter kan uppstå, vinner "
 "det först valda."
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray-undertexter"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1911,7 +1911,7 @@ msgstr ""
 "Endast ett undertextspår kan brännas! Eftersom konflikter kan uppstå, vinner "
 "det först valda."
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
@@ -1919,7 +1919,7 @@ msgstr ""
 "<small>* Endast ett av ovanstående undertextalternativ kommer att tillämpas, "
 "med början överst.</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
@@ -1927,112 +1927,112 @@ msgstr ""
 "Endast ett undertextspår kan brännas in, eftersom konflikter kan uppstå! Det "
 "först valda vinner."
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Undertexter"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Avsnittsmarkörer"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Lägg till avsnittsmarkörer i utdatafilen."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Avsnitt"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Avsnitt"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "Index"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Varaktighet"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Titel"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Avsnitt"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Aktörer:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Regissör:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Publiceringsdatum:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Kommentar:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Genre:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Beskrivning:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Graf:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Taggar"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Spara som:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "Målfilsnamn för din omkodning."
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Till:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "Målmapp för din omkodning."
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Målmapp"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Lägg till _flera"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -2040,51 +2040,51 @@ msgstr "Lägg till _flera"
 msgid "Cancel"
 msgstr "Avbryt"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Markera alla"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Markera titlar för att lägga till i kön"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Rensa alla"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Avmarkera alla titlar"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "Målfilerna är OK. Inga dubbletter identifierade."
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Inställningar"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Sök automatiskt efter uppdateringar"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr "Standardåtgärd när alla kodningar är slutförda"
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Använd automatisk namngivning (använder modifierade källnamn)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "Skapa målfilsnamn från källfilsnamn eller volymetikett"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Mall för autonamn"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -2094,23 +2094,23 @@ msgstr ""
 "Tillgängliga alternativ: {source-path} {source} {title} {preset} {chapters} "
 "{date} {time} {creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "Använd iPod-/iTunes-vänligt (.m4v) filtillägg för MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Antal förhandsvisningar"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "Filtrera korta DVD- och Blu-ray-titlar (sekunder)"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "Ta bort slutförda köobjekt när en kodning har slutförts"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2120,52 +2120,52 @@ msgstr ""
 "Markera det här, om du vill att kön skall rensa sig själv och ta bort "
 "slutförda jobb."
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Allmänt"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr "Ange en anpassad katalog för Handbrakes temporära filer"
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2190,63 +2190,63 @@ msgstr ""
 "är 1/2 fysisk minnesstorlek och kan vara för liten för saker som 2-pass-"
 "statistikfilen."
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr "Temp-katalog"
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "Fraktionerad kornighet i konstant kvalitet"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Använd dvdnav (istället för libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "Övervaka måldiskens lediga utrymme"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Pausa kodningen om ledigt diskutrymme sjunker under gränsen"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB-gräns"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "Spara individuella omkodningsloggar i samma mapp som filmen"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "Utförlig aktivitetslogg"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "Varaktig aktivitetslogg"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "Skala ner HD-förhandsvisningar"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "Skanna DVD automatiskt vid inmatning"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Skannar DVD:n när en ny skiva matas in"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "Aktivitetsfönstrets teckenstorlek"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Använd samma inställningar för alla titlar i en omgång"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2259,87 +2259,87 @@ msgstr ""
 "\n"
 "Avaktivera om du vill göra oberoende inställningar för enskilda titlar."
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "Tillåt justeringar"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "Tillåt HandBrake för nybörjare"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Avancerat"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Brusreduceringsmall:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">Byt mallnamn</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Namn:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Beskrivning</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Spara ny mall"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategori:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "Ange under vilken kategori denna mall skall visas."
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Kategorinamn:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Mallnamn:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Standardmall"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "Gör det här till standardmall när HandBrake startas"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b>Dimensioner</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "Handbrake förhandsvisning"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Välj förhandsgranskningsrutor."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2347,76 +2347,76 @@ msgstr ""
 "Koda om och spela upp en kort sekvens av videon, med början från aktuell "
 "förhandsgranskningsposition."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Varaktighet:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "Ange varaktighet för förhandsgranskningen, i sekunder."
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Visa beskärning"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "Visa beskuret område"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Källupplösning"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Återställ förhandsgranskningsfönstret till källvideons upplösning"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Undertexter"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "Importera SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "Aktivera inställningar för import av SRT undertextfil"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "Importera SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "Aktivera inställningar för import av SSA undertextfil"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Inbäddad undertextlista"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Aktivera inställningar för val av inbäddade undertexter"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Källspår"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Lista över undertextspår, tillgängliga från din källa."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Spårnamn:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2426,23 +2426,23 @@ msgstr ""
 "\n"
 "Spelare kan använda detta i undertextlistan."
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Språk"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Teckenkod"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Fil:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Förskjutning (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2450,7 +2450,7 @@ msgstr ""
 "Ange språket i denna undertext.\n"
 "Detta värde används av spelare, i undertextmenyer."
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2464,28 +2464,28 @@ msgstr ""
 "Vi konverterar teckentabellen till UTF-8.\n"
 "Källans teckentabell behövs för att utföra denna konvertering."
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "Välj SRT-fil för import."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "Importera fil"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 "Justera förskjutningen i millisekunder, mellan video och SRT-tidsstämplar"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Endast obligatoriska undertexter"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Bränn in i videon"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2493,19 +2493,19 @@ msgstr ""
 "Rendera undertexten över videon.\n"
 "Undertexten blir en del av videon och kan inte avaktiveras."
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Ange standardspår"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Lista över ljudspår, tillgängliga från din källa."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2515,15 +2515,15 @@ msgstr ""
 "\n"
 "Spelare kan använda detta i ljudspårslistan."
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Mix"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Samplingsfrekvens"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2541,50 +2541,50 @@ msgstr ""
 "Låter DRC dig \"komprimera\" intervallet genom att göra höga ljud lägre och "
 "låga ljud högre."
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Ange ljudkodek att koda om detta spår med."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bithastighet"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Aktivera bithastighetsinställningar"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kvalitet"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Aktivera kvalitetsinställningar"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Ange bithastighet att koda om detta spår med."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 "<b>Kvalitet:</b> Justera utdatakvalitet, för de kodekar som stöder det."
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "Ange nermixning för utdataljudet."
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Ange samplingsfrekvens för utdataljudet."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
@@ -2593,41 +2593,41 @@ msgstr ""
 "ljudspår."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0 dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Av"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Hoppa över den här versionen"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Påminn mig senare"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>En ny version av HandBrake finns tillgänglig!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx finns nu tillgänglig (du har yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Versionsnotiser</b>"
 
@@ -2772,7 +2772,7 @@ msgstr "Identifierade DVD-enheter:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Söker..."
 
@@ -2785,96 +2785,125 @@ msgstr "Stoppa sökning"
 msgid "Single Title"
 msgstr "Öppna enskild titel"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Ljud"
 msgstr[1] "Ljud"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Undertexter"
 msgstr[1] "Undertexter"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", Endast tvingad"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", Bränd"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", Standard"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "Främmande språks undertextspår"
 msgstr[1] "Främmande språks undertextspår"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 #, fuzzy
 msgid "storage"
 msgstr "Lagringsstorlek:"
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 #, fuzzy
 msgid "display"
 msgstr "Visningsstorlek:"
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Proportioner:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 #, fuzzy
 msgid "Display Aspect Ratio"
 msgstr "Proportioner:"
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Ingen titel hittades"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Ny video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2885,132 +2914,132 @@ msgstr ""
 "\n"
 "%s på %d sekunder ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sDin film kommer att förloras om du inte fortsätter kodningen."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Avbryt pågående och stoppa"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Avbryt pågående, starta nästa"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Slutför aktuell, stoppa sedan"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Fortsätt koda"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d kodning väntar"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d kodningar väntar"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "jobb %d av %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "pass %d (undertextsökning) av %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "pass %d av %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Kodning: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Kodning: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Kodning: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Söker efter starttid, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "Genomsöker titel %d av %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "Genomsöker %d av %d förhandsgranskning %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Pausad"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Omkodning klar!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Omkodning avbruten."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Omkodning misslyckades."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "Muxning: Detta kan ta en stund..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s finns nu tillgänglig (du har %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Omkodning slutförd"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "Ställ ner drinken, din HandBrake-kö är klar!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Din omkodning är slutförd."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Avslutar HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Försätter datorn i viloläge"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Stänger av datorn"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/th.po
+++ b/gtk/po/th.po
@@ -10,7 +10,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: M. Somsak, 2014\n"
 "Language-Team: Thai (https://www.transifex.com/HandBrakeProject/teams/92423/"
@@ -103,8 +103,8 @@ msgstr "ค่า_สำเร็จรูป"
 msgid "Set De_fault"
 msgstr ""
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_บันทึก"
 
@@ -112,7 +112,7 @@ msgstr "_บันทึก"
 msgid "Save _As"
 msgstr ""
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr ""
 
@@ -162,7 +162,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>ประทับลงใน</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -183,7 +183,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>ค่าตั้งต้น</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -349,7 +349,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "เริ่มการเข้ารหัส"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "เริ่ม"
@@ -368,7 +368,7 @@ msgstr "พัก"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -388,8 +388,8 @@ msgstr ""
 msgid "Edit"
 msgstr "แก้ไข"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "ค่าสำเร็จรูป:"
 
@@ -397,7 +397,7 @@ msgstr "ค่าสำเร็จรูป:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "หัวเรื่อง:"
 
@@ -421,7 +421,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "สรุป"
 
@@ -500,11 +500,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "เลือกแหล่งวิดีโอ"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -536,7 +536,7 @@ msgstr "ตัวอย่าง"
 msgid "Show Queue"
 msgstr "แสดงคิว"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "คิว"
 
@@ -559,15 +559,15 @@ msgstr "<b>แหล่ง:</b>"
 msgid "None"
 msgstr "ไม่มี"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "กำลังอ่าน..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -577,77 +577,77 @@ msgstr ""
 "หัวเรื่องที่ยาวที่สุดจะถูกเลือกเป็นค่าตั้งต้น\n"
 "สิ่งนี้มักเป็นคุณลักษณะหัวเรื่องของ DVD"
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "สำหรับ DVD แบบหลายมุมกล้อง, เลือกมุมกล้องที่ต้องการจะเข้ารหัส"
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "ช่วงหัวเรื่องเพื่อเข้ารหัส โดยสามารถเป็นได้ทั้ง ตอน, วินาที, หรือเฟรม"
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "กำหนดตอนแรก เพื่อเข้ารหัส"
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "กำหนดตอนสุดท้าย เพื่อเข้ารหัส"
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "โหลดใหม่"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "รูปแบบ:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "รูปแบบที่จะทำการผสานแทร็คที่เข้ารหัสลงไป"
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "ให้เหมาะกับเว็บ"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -655,151 +655,151 @@ msgstr ""
 "ปรับเค้าโครงของไฟล์ MP4 ให้เหมาะสมสำหรับการดาวน์โหลดไว้ล่วงหน้า\n"
 "สิ่งนี้อนุญาตให้เครื่องเล่นสามารถเริ่มเล่นก่อนการดาวน์โหลดจะครบทั้งไฟล์"
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "รองรับ iPod 5G"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "เพิ่ม iPod Atom ที่ต้องการโดย iPods เก่าบางรุ่น"
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "ระยะเวลา:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "ขลิบซ้าย"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "ขลิบบน"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "ขลิบล่าง"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "ขลิบขวา"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "อนามอร์ฟิก:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -809,11 +809,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "สัดส่วนพิกเซล:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -826,11 +826,11 @@ msgstr ""
 "อัตราส่วน 1:1 จะกำหนดพิกเซลสี่เหลี่ยมจัตุรัส  ค่าอื่นๆจะกำหนดรูปทรงสี่เหลี่ยมผืนผ้า\n"
 "เครื่องเล่นจะสเกลภาพเพื่อที่จะให้ได้ตามสัดส่วนที่ระบุ"
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -841,11 +841,11 @@ msgstr ""
 "อัตราส่วน 1:1 จะกำหนดพิกเซลสี่เหลี่ยมจัตุรัส  ค่าอื่นๆจะกำหนดรูปทรงสี่เหลี่ยมผืนผ้า\n"
 "เครื่องเล่นจะสเกลภาพเพื่อที่จะให้ได้ตามสัดส่วนที่ระบุ"
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -854,7 +854,7 @@ msgstr ""
 "นี่คือความกว้างที่วิดีโอจะถูกจัดเก็บไว้\n"
 "มิติการแสดงผลที่แท้จริงจะแตกต่างถ้าอัตราส่วนภาพพิกเซลไม่ใช่ 1:1"
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -863,84 +863,84 @@ msgstr ""
 "นี่คือความสูงที่วิดีโอจะถูกจัดเก็บไว้\n"
 "มิติการแสดงผลที่แท้จริงจะแตกต่างถ้าอัตราส่วนภาพพิกเซลไม่ใช่ 1:1"
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "อัตโนมัติ"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Detelecine:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -951,7 +951,7 @@ msgstr ""
 "\n"
 "Telecining คือกระบวนการที่ปรับอัตราเฟรมหนัง 24fps เป็นอัตราเฟรมวิดีโอ NTSC ซึ่งเป็น 30fps"
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -961,11 +961,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -973,7 +973,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -981,11 +981,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Deinterlace:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -993,7 +993,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -1002,11 +1002,11 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1014,12 +1014,12 @@ msgstr ""
 "ตัวกรองการ Deblock จะลบชนิดธรรมดาของวัตถุการบีบอัด\n"
 "ถ้าแหล่งคุณแสดงออกว่า 'blockiness', ตัวกรองนี้จะช่วยล้างมันออกไป"
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "จูน:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1028,18 +1028,18 @@ msgstr ""
 "ตัวกรองการ Deblock จะลบชนิดธรรมดาของวัตถุการบีบอัด\n"
 "ถ้าแหล่งคุณแสดงออกว่า 'blockiness', ตัวกรองนี้จะช่วยล้างมันออกไป"
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "ตัวกรอง Denoise:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1050,7 +1050,7 @@ msgstr ""
 "Film grain และนอยส์ความถี่สูงชนิดอื่นจะยากต่อการบีบอัด\n"
 "การใช้ตัวกรองนี้กับบางแหล่งจะสามารถทำให้ขนาดไฟล์มีขนาดเล็กลงได้"
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1062,7 +1062,7 @@ msgstr ""
 "Film grain และนอยส์ความถี่สูงชนิดอื่นจะยากต่อการบีบอัด\n"
 "การใช้ตัวกรองนี้กับบางแหล่งจะสามารถทำให้ขนาดไฟล์มีขนาดเล็กลงได้"
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1073,71 +1073,71 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "สเกลสีเทา"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "ถ้าถูกใช้งาน จะกรององค์ประกอบสีออกจากวิดีโอ"
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "ตัวเข้ารหัสวิดีโอ:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "ตัวเข้ารหัสวิดีโอที่มี"
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "อัตราเฟรม:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1149,19 +1149,19 @@ msgstr ""
 "'เหมือนกับแหล่ง' จะถูกแนะนำ ถ้าวิดีโอแหล่งของคุณมีอัตราเฟรมที่แปรผัน, 'เหมือนกับแหล่ง' "
 "จะคงค่ามันเอาไว้"
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "อัตราเฟรมคงที่"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "เปิดใช้งานผลลัพท์อัตราเฟรมที่คงที่"
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "อัตราเฟรมสูงสุด (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1173,11 +1173,11 @@ msgstr ""
 "\n"
 "อัตราเฟรมแปรผันหรือ VFR จะไม่เข้ากับบางเครื่องเล่น"
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "อัตราเฟรมแปรผัน"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1187,7 +1187,7 @@ msgstr ""
 "\n"
 "อัตราเฟรมแปรผันหรือ VFR จะไม่เข้ากับบางเครื่องเล่น"
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1214,15 +1214,15 @@ msgstr ""
 "สเกลของ FFMpeg และ Theora จะเป็นเส้นตรงมากกว่า\n"
 "ตัวเข้ารหัสเหล่านี้ไม่มีโหมดไม่สูญเสีย"
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "คุณภาพคงที่:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "อัตราบิต (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1238,11 +1238,11 @@ msgstr ""
 "แต่ค่าเฉลี่ยของระยะเวลาที่ยาวนานจะเป็นค่าที่กำหนดที่นี่\n"
 "ถ้าคุณต้องการจำกัดอัตราบิตฉับพลัน ดูที่ x264's vbv-bufsize และการตั้งค่า vbv-maxrate"
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "การเข้ารหัส 2-Pass"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1257,16 +1257,16 @@ msgstr ""
 "จะถูกรวบรวม จากนั้นทำการผ่านรอบที่สอง สถิติเหล่านั้นจะถูกใช้เพื่อ\n"
 "การตัดสินจัดสรรอัตราบิต"
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "ผ่านแรกเทอร์โบ"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr "ในระหว่างเข้ารหัส 1st pass ของ 2 pass,  ใช้การตั้งค่าที่เร่งสิ่งต่างๆไปด้วยกัน"
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1278,7 +1278,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1287,11 +1287,11 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "ถอดรหัสรวดเร็ว"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1301,11 +1301,11 @@ msgstr ""
 "\n"
 "กำหนดสิ่งนี้ถ้าอุปกรณ์ดิ้นรนเพื่อเล่นไฟล์ผลลัพธ์ (เฟรมที่ตก)"
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "การแฝงเป็นศูนย์"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1315,11 +1315,11 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "โปรไฟล์:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1329,11 +1329,11 @@ msgstr ""
 "\n"
 "มีผลเหนือการตั้งค่าอื่นทั้งหมด"
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "ระดับ:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1343,11 +1343,11 @@ msgstr ""
 "\n"
 "มีผลเหนือการตั้งค่าอื่นทั้งหมด"
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "การตั้งค่าเพิ่มเติม:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1357,267 +1357,267 @@ msgstr ""
 "\n"
 "รายการที่คั่นด้วยเครื่องหมาย Colon ของตัวเลือกตัวเข้ารหัส"
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "วิดีโอ"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "เพิ่ม"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "เพิ่มการตั้งค่าเสียงใหม่สู่รายการ"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "เพิ่มทั้งหมด"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "เพิ่มแทร็คเสียงทั้งหมดสู่รายการ"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "โหลดการตั้งค่าเสียงทั้งหมดใหม่จากค่าตั้งต้น"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "พฤติกรรมการเลือก:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "เอาออก"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "ภาษาที่มี"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "ภาษาที่เลือก"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "ใช้เฉพาะตัวเข้ารหัสแรกสำหรับเสียงที่สอง"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "ส่งผ่านอัตโนมัติ:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr ""
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr ""
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr ""
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr ""
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr ""
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "การส่งผ่านยืนพื้น:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr "กำหนด codec เสียงเพื่อเข้ารหัส เมื่อไม่พบแทร็คที่เหมาะสมสำหรับการส่งผ่านเสียง"
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>การตั้งค่าตัวเข้ารหัสเสียง:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "แต่ละแทร็คแหล่งที่เลือกจะถูกเข้ารหัสด้วยตัวเข้ารหัสที่เลือกทั้งหมด"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "ตัวเข้ารหัส"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "อัตราบิต/คุณภาพ"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "ปรับลง"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "อัตราสุ่มฯ"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "ฟื้นค่า"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "เพิ่มการตั้งค่าศัพท์บรรยายใหม่สู่รายการ"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "เพิ่มแทร็คศัพท์บรรยายทั้งหมดสู่รายการ"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "โหลดการตั้งค่าศัพท์บรรยายทั้งหมดใหม่จากค่าตั้งต้น"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1628,15 +1628,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "ภาษาที่ชอบ: ไม่มี"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1646,11 +1646,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "เพิ่มแทร็คศัพท์บรรยาย ถ้าเสียงตั้งต้นเป็นเสียงต่างประเทศ"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1658,21 +1658,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "เพิ่มศัพท์บรรยายเหตุการณ์ถ้ามี"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1682,15 +1682,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1701,11 +1701,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr ""
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1716,124 +1716,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "ศัพท์บรรยาย"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "ตัวหมายตอน"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "เพิ่มตัวหมายตอนสู่ไฟล์ผลลัพธ์"
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "ตอน"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "ตอน"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "ดัชนี"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "ระยะเวลา"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "หัวเรื่อง"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "ตอน"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "นักแสดง:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "ผู้กำกับ:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "วันเผยแพร่:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "ข้อคิดเห็น:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "ประเภท:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "คำบรรยาย:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "เค้าเรื่อง:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "แท็ก"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "ชื่อไฟล์ปลายทางสำหรับการเข้ารหัสของคุณ"
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "เส้นทางปลายทางสำหรับการเข้ารหัสของคุณ"
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "เส้นทางปลายทาง"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "_เพิ่มหลายสิ่ง"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1841,74 +1841,74 @@ msgstr "_เพิ่มหลายสิ่ง"
 msgid "Cancel"
 msgstr "ยกเลิก"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "เลือกทั้งหมด"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "หมายหัวเรื่องทั้งหมดสำหรับเพิ่มสู่คิว"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "ล้างทั้งหมด"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "เลิกหมายหัวเรื่องทั้งหมด"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "ไฟล์ปลายทางโอเค ไม่พบการซ้ำซ้อน"
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "การตั้งค่า"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "ตรวจสอบการอัปเดตอัตโนมัติ"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "ใช้การตั้งชื่ออัตโนมัติ (ใช้ชื่อแหล่งที่ปรับเปลี่ยน)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "แม่แบบชื่ออัตโนมัติ"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "ใช้สกุลไฟล์ (.m4v) ซึ่งเหมาะกับ iPod/iTunes สำหรับรูปแบบ MP4"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "จำนวนตัวอย่าง"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -1917,52 +1917,52 @@ msgstr ""
 "โดยตั้งต้น, งานที่เสร็จแล้วจะยังคงอยู่ในคิว และถูกหมายเหตุว่าเสร็จสมบูรณ์\n"
 "กาเลือกสิ่งนี้ถ้าคุณต้องการให้คิวทำการลบงานที่เสร็จแล้วออกไปเลย"
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "ทั่วไป"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1976,63 +1976,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "ใช้ dvdnav (แทน libdvdread)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "วางบันทึกกิจกรรมการเข้ารหัสรายตัว ในที่ตั้งเดียวกับภาพยนตร์"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "ระดับความมากของการจดบันทึกกิจกรรม"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "ความยืนนานของการจดบัทึกกิจกรรม"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "สเกลตัวอย่างที่มีความละเอียดสูงให้ลดลง"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "อ่าน DVD อัตโนมัติเมื่อถูกโหลด"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "อ่าน DVD เมื่อใดก็ตามที่ดิสก์ใหม่ถูกโหลด"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2041,185 +2041,185 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "อนุญาตการปรับแต่ง"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "อนุญาต HandBrake For Dummies"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "ขั้นสูง"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "ค่าสำเร็จรูป Denoise:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>คำบรรยาย</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "ค่าสำเร็จรูป:"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "ชื่อค่าสำเร็จรูป:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "เลือกเฟรมดูตัวอย่าง"
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr "เข้ารหัสและเล่นช่วงสั้นๆของวิดีโอเริ่มจากตำแหน่งตัวอย่างปัจจุบัน"
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>ระยะเวลา:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "กำหนดระยะเวลาของตัวอย่างสดเป็นวินาที"
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "แสดงการขลิบ"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "แสดงพื้นที่ที่ถูกขลิบของตัวอย่าง"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "ศัพท์บรรยาย"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "นำเข้า SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "ใช้งานการตั้งค่าเพื่อนำเข้าไฟล์ศัพท์บรรยายชนิด SRT"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "รายการศัพท์บรรยายที่ถูกฝัง"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "ใช้งานการตั้งค่าเพื่อเลือกศัพท์บรรยายที่ถูกฝัง"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "แทร็คแหล่ง"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "รายการแทร็คศัพท์บรรยายที่มีจากแหล่งของคุณ"
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "ชื่อแทร็ค:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "ภาษา"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "รหัสอักขระ"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "ไฟล์:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "ค่าชดเชย (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2227,7 +2227,7 @@ msgstr ""
 "กำหนดภาษาของศัพท์บรรยายนี้\n"
 "ค่านี้จะถูกใช้โดยเครื่องเล่นในเมนูศัพท์บรรยาย"
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2241,27 +2241,27 @@ msgstr ""
 "เราแปลชุดอักขระเป็น UTF-8\n"
 "รหัสอักขระของแหล่งจึงจำเป็นเพื่อที่จะกระทำการแปลนี้"
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "เลือกไฟล์ SRT เพื่อนำเข้า"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "ปรับค่าชดเชยเป็นมิลลิวินาทีระหว่างค่าเวลาของวิดีโอและ SRT"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "เฉพาะศัพท์บรรยายที่ถูกบังคับ"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "ประทับลงในวิดีโอ"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2269,19 +2269,19 @@ msgstr ""
 "แสดงผลศัพท์บรรยายบนวิดีโอ\n"
 "ศัพท์บรรยายจะเป็นส่วนหนึ่งของวิดีโอและไม่สามารถปิดการใช้งานได้"
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "กำหนดแทร็คตั้งต้น"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "รายการแทร็คเสียงที่มีจากแหล่งของคุณ"
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2291,15 +2291,15 @@ msgstr ""
 "\n"
 "เครื่องเล่นอาจใช้สิ่งนี้ในรายการเพื่อเลือกเสียง"
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "ผสม"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "อัตราสุ่มฯ"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2314,90 +2314,90 @@ msgstr ""
 "สำหรับเสียงแหล่งที่มีช่วงจลน์กว้าง (มีการดังมากและเบามาก),\n"
 "DRC อนุญาตให้คุณ 'บีบอัด' ช่วง โดยการทำให้เสียงที่ดังเบาลง และทำให้เสียงที่เบาดังขึ้น"
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "กำหนด codec เสียงเพื่อเข้ารหัสกับแทร็คนี้"
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "อัตราบิต"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "ใช้งานการตั้งค่าอัตราบิต"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "คุณภาพ"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "ใช้งานการตั้งค่าคุณภาพ"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "กำหนดอัตราบิตเพื่อเข้ารหัสกับแทร็คนี้"
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr "<b>คุณภาพ:</b> สำหรับ codec ผลลัพธ์ที่รองรับมัน, ปรับคุณภาพของผลลัพธ์"
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "กำหนดการผสมเสียงของแทร็คเสียงผลลัพธ์"
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "กำหนดอัตราสุ่มฯของแทร็คเสียงผลลัพธ์"
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr "<b>ฟื้นค่าเสียง:</b> ปรับการขยายเสียงหรือลดเสียงของแทร็คเสียงผลลัพธ์"
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "ปิด"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "ข้ามเวอร์ชั่นนี้"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "แจ้งฉันทีหลัง"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>HandBrake มีเวอร์ชั่นใหม่แล้ว!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx มีในตอนนี้แล้ว (คุณมี yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>หมายเหตุการเผยแพร่</b>"
 
@@ -2535,7 +2535,7 @@ msgstr "อุปกรณ์ DVD ที่ตรวจพบ:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "กำลังอ่าน ..."
 
@@ -2548,89 +2548,116 @@ msgstr "หยุดอ่าน"
 msgid "Single Title"
 msgstr "ไม่มีหัวเรื่อง"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "แทร็คแหล่ง"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "ศัพท์บรรยาย"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "สัดส่วนพิกเซล:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "ไม่พบหัวเรื่อง"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2641,132 +2668,132 @@ msgstr ""
 "\n"
 "%s ใน %d วินาที ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sภาพยนตร์ของคุณจะสูญหาย ถ้าคุณไม่ทำการเข้ารหัสต่อ"
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "ยกเลิกรายการปัจจุบัน และหยุด"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "ยกเลิกรายการปัจจุบัน, เริ่มรายการถัดไป"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "เสร็จรายการปัจจุบัน, แล้วจึงหยุด"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "เข้ารหัสต่อไป"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "งาน %d จาก %d, "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "ผ่าน %d (อ่านศัพท์บรรยาย) จาก %d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "ผ่าน %d จาก %d, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "การเข้ารหัส: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "การเข้ารหัส: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "การเข้ารหัส: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "กำลังค้นหาเวลาเริ่มต้น,"
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "กำลังอ่านหัวเรื่อง %d จาก %d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "กำลังอ่านหัวเรื่อง %d จาก %d ตัวอย่าง %d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "ถูกพัก"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "เข้ารหัสเสร็จแล้ว!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "การเข้ารหัสถูกยกเลิก"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "การเข้ารหัสล้มเหลว"
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "กำลังผสาน: สิ่งนี้อาจใช้เวลาสักพัก..."
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s มีในตอนนี้แล้ว (คุณมี %s/%d)"
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "เข้ารหัสเสร็จสมบูรณ์"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "วางเครื่องดื่มนั่นลง, คิว HandBrake ของคุณเสร็จแล้ว!"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "การเข้ารหัสเสร็จสมบูรณ์"
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "กำลังออกจาก Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "กำลังทำให้คอมพิวเตอร์สลีป"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "กำลังปิดเครื่องคอมพิวเตอร์"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/tr.po
+++ b/gtk/po/tr.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Osman Öz <osmanoz50@gmail.com>, 2021\n"
 "Language-Team: Turkish (https://www.transifex.com/HandBrakeProject/"
@@ -106,8 +106,8 @@ msgstr "_Hazır Ayarlar"
 msgid "Set De_fault"
 msgstr "_Varsayılan Olarak Ayarla"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Kaydet"
 
@@ -115,7 +115,7 @@ msgstr "_Kaydet"
 msgid "Save _As"
 msgstr "_Farklı Kaydet"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Yeniden Adlandır"
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Yaz</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -180,7 +180,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>Varsayılan</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -334,7 +334,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Kodlamayı Başlat"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Başla"
@@ -353,7 +353,7 @@ msgstr "Duraklat"
 msgid "Options"
 msgstr "Seçenekler"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -371,8 +371,8 @@ msgstr ""
 msgid "Edit"
 msgstr "Düzenle"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "Ön Ayar:"
 
@@ -380,7 +380,7 @@ msgstr "Ön Ayar:"
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "Başlık:"
 
@@ -404,7 +404,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "Özet"
 
@@ -487,11 +487,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Video Kaynağı Seç"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr ""
 
@@ -523,7 +523,7 @@ msgstr "Önizleme"
 msgid "Show Queue"
 msgstr "Sırayı Göster"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "Sıra"
 
@@ -546,15 +546,15 @@ msgstr "<b>Kaynak:</b>"
 msgid "None"
 msgstr "Yok"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "Taranıyor..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>Başlık:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -564,227 +564,227 @@ msgstr ""
 "Varsayılan olarak en uzun başlık kullanılacaktır.\n"
 "Bu genellikle DVD' nin başlığıdır."
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>Açı:</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>Aralık:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "Kodlanacak ilk bölümü belirle."
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "Kodlanacak son bölümü belirle."
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>Ön Ayar:</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "Hazır Ayar Seç"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>Değiştirilmiş</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "Tekrar yükle"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "Yeni Hazır Ayarı Kaydet"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "Mevcut ayarları yeni bir Hazır Ayar'a kaydedin."
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "Biçim:"
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web'e Uygun"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "Ses/Video başlangıcı hizlama"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G Desteği"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "Bazı eski iPod'lar için gerekli olan iPod Atom'u ekleyin."
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "Süre:"
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "ss:dd:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "Parça:"
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "Filtreler:"
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "Boyut:"
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "Soldan Kırpma"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "Üstten Kırpma"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "Alttan Kırpma"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "Sağdan Kırpma"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "Anamorfik:"
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -794,11 +794,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "Piksel Çerçevesi:"
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -807,11 +807,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -819,102 +819,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Otomatik"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "Boyutlar"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "Telesine Giderme:"
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -922,18 +922,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "Geçişme Algılama:"
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -941,7 +941,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -949,11 +949,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "Geçişme Giderme:"
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -961,7 +961,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -970,39 +970,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "İnce Ayar:"
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "Gürültü Giderme Filtresi:"
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1010,7 +1010,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1018,78 +1018,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "Keskinleştirme Filtresi:"
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "Gri Tonlama"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "Filtreler"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "Video Kodlayıcısı:"
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "Kullanılabilir video kodlayıcıları."
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "Kare Hızı:"
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1097,19 +1097,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "Sabit Kare Hızı"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "Sabit kare hızı çıktısını etkinleştirir."
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "En Yüksek Kare hızı(VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1117,18 +1117,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "Değişken Kare Hızı"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1144,15 +1144,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "Sabit kalite:"
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "Bit Hızı (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1163,11 +1163,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "2 Geçişli Kodlama"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1177,16 +1177,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1198,7 +1198,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1207,22 +1207,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "Hızlı Kod Çözme"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "Sıfır Gecikme"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1232,11 +1232,11 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "Profil:"
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1246,11 +1246,11 @@ msgstr ""
 "\n"
 "Diğer tüm ayarları geçersiz kılar."
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "Seviye:"
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1260,278 +1260,278 @@ msgstr ""
 "\n"
 "Tüm diğer ayarları geçersiz kılar."
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "Daha Fazla Ayar:"
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "Video"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "Ekle"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "Listeye yeni ses ayarları ekle"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "Hepsini Ekle"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "Tüm ses parçalarını listeye ekle"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "Tüm ses ayarlarını varsayılandan geri yükle"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "Parça Listesi"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "Seçim Davranışı:"
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "Kaldır"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "Kullanılabilir Diller"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "Seçilen Diller"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "İkincil ses için sadece ilk kodlayıcıyı kullanın"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "Otomatik Doğrudan Geçirme:"
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "Doğrudan Geçirme Alternatifi:"
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Ses Kodlayıcısı Ayarları:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "Kodlayıcı"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "Bit Hızı/Kalite"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "Örnek Hızı"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "Kazanç"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "Parça Seçimi"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "Ses"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "Listeye yeni alt yazı ayarları ekle"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "Yabancı Ses Taraması"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "Tüm altyazı ayarlarını varsayılandan geri yükle"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1542,15 +1542,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "Tercih Edilen Dil: Yok"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1560,11 +1560,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1572,21 +1572,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "Yazma Davranışı *:"
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1596,15 +1596,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD Alt Yazıları"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1615,11 +1615,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Blu-ray Alt yazıları"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1630,124 +1630,124 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Alt yazı"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "Bölüm İmleçleri"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "Çıktı dosyasına bölüm imleçleri ekle."
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "Bölümler"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "Bölümler"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "Süre"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "Başlık"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "Bölümler"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "Oyuncular:"
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "Yönetmen:"
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "Yayın Tarihi:"
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "Yorum:"
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "Tür:"
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "Açıklama:"
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "Konu:"
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "Etiketler"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>Farklı Kaydet:</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>Nereye:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "Hedef Dizin"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "_Birden Çok Ekle"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1755,126 +1755,126 @@ msgstr "_Birden Çok Ekle"
 msgid "Cancel"
 msgstr "İptal"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "Hepsini Seç"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "Sıraya eklemek için tüm başlıkları işaretle"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "Hepsini Temizle"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "Tüm başlıkların işaretlerini kaldır"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "Tercihler"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "Güncellemeleri otomatik olarak kontrol et"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "Otomatik adlandırma kullan (değiştirilmiş kaynak adı kullanır)"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "Otomatik Adlandırma Şablonu"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "MP4 için iPod/iTunes'la uyumlu (.m4v) dosya uzantısını kullan"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "Önizleme sayısı"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "Genel"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1888,63 +1888,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "Dvdnav kullan (libdvdread yerine)"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "Boş disk alanı sınırın altına düşerse kodlamayı duraklat"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB Sınırı"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "HD önizlemeleri küçült"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "DVD takıldığın otomatik olarak incele"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "Yeni bir disk takıldığında DVD'yi tarar"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "Bir toplu işteki tüm başlıklar için aynı ayarları kullanın"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1953,87 +1953,87 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "_Yeni Başlayanlar için HandBrake'ye İzin Ver"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "Gelişmiş"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "Gürültü Giderme Ön Ayarı:"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\" x-large\">Hazır Ayarı Yeniden Adlandır</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "Adı:"
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>Açıklama</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Yeni Hazır Ayarı Kaydet"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "Kategori:"
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "Kategori Adı:"
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "Ön Ayar Adı:"
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "Varsayılan Hazır Ayar"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "HandBrake başladığında bu hazır ayarı kullansın"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "Önizleme karelerini seçin."
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
@@ -2041,105 +2041,105 @@ msgstr ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Süre:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "Kırpmayı Göster"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "Kaynak Çözünürlüğü"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "Önizleme penceresini kaynak videonun çözünürlüğüne sıfırla"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Alt yazı"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "SRT'yi içe aktar"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "SRT altyazı dosyalarını içe aktarma ayarlarını etkinleştir"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "Gömülü Alt Yazı Listesi"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "Gömülü alt yazıları seçmek için ayarları etkinleştir"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "Kaynak Parça"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "Kaynağınızdaki kullanılabilir alt yazıların listesi."
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "Parça Adı:"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Dil"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "Karakter Kodu"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "Dosya:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "Kaydırma (ms)"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2148,60 +2148,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "İçe aktarılacak SRT dosyasını seçin."
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "Sadece Zorlanmış Altyazılar"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "Videoya yaz"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "Varsayılan Parçayı Ayarla"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "Kaynağınızdaki kullanılabilir ses parçalarının listesi."
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "Karıştır"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "Örnek Hızı"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2212,90 +2212,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "Bu parçayı kodlamak için ses kodekini ayarlayın."
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "Bit Hızı"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "Bit hızı ayarını etkinleştir"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Kalite"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "Kalite ayarını etkinleştir"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "Bu parçayı kodlamak için bit hızı seçin."
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "Çıktılanacak ses parçasının örnek hızını ayarlayın."
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr "<b>Ses Kazancı:</b> Çıktılanacak sesi yükseltin veya alçaltın."
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "Kapalı"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "Bu versiyonu atla"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "Daha Sonra Hatırlat"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>HandBrake'in yeni bir sürümü mevcut!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx sürümü indirilebilir (yüklü sürüm yyy)."
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Sürüm Notları</b>"
 
@@ -2439,7 +2439,7 @@ msgstr "Tespit edilen DVD cihazları:"
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "Taranıyor ..."
 
@@ -2452,93 +2452,122 @@ msgstr "Taramayı Durdur"
 msgid "Single Title"
 msgstr "Tek _Başlık Aç"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "Ses"
 msgstr[1] "Ses"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "Alt yazı"
 msgstr[1] "Alt yazı"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "Piksel Çerçevesi:"
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "Başlık Bulunamadı"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "Yeni Video"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2546,132 +2575,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%sKodlamaya devam etmezseniz filminiz kaybolur."
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "Şimdikini İptal Et ve Durdur"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "Şimdikini İptal Et, Sıradakini Başlat"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "Şimdikini Bitir, Sonra Dur"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "Kodlamaya Devam Et"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "%2$d taneden %1$d tanesi, "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr "Kodlama: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02ds%02ddk%02dsn)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "Kodlama: %s%s%.2f %% (ETA %02ds%02ddk%02dsn)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "Kodlama: %s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "Başlangıç zamanı araması, "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "%2$d başlıktan %1$d tanesi incelendi ..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "%2$d başlıktan %1$d tanesi inclendi önizleme %3$d..."
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Durduruldu"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "Kodlama Başarılı!"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "Kodlama İptal edildi."
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "Kodlama Başarısız."
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s çıktı (yüklü sürüm %s/%d)."
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "Kodlama Tamam"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "Kodlamanız tamamlandı."
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "Handbrake'den Çıkılıyor"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "Bilgisayar uyku moduna alınıyor"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "Bilgisayar kapatılıyor"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/uk_UA.po
+++ b/gtk/po/uk_UA.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: Олександр (6c6c6) <6c6c6.ukr@gmail.com>, 2022\n"
 "Language-Team: Ukrainian (Ukraine) (https://www.transifex.com/"
@@ -108,8 +108,8 @@ msgstr "_Шаблони"
 msgid "Set De_fault"
 msgstr "Встановити _типовим"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "_Зберегти"
 
@@ -117,7 +117,7 @@ msgstr "_Зберегти"
 msgid "Save _As"
 msgstr "Зберегти _як"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "_Прейменувати"
 
@@ -167,7 +167,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>Пропалено в</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -189,7 +189,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>За замовчуванням</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -364,7 +364,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "Почати кодування"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "Розпочати"
@@ -383,7 +383,7 @@ msgstr "Призупинити"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -401,8 +401,8 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr ""
 
@@ -410,7 +410,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -434,7 +434,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr ""
 
@@ -517,11 +517,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "Вибрати початкове відео"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "Відкрити джерело"
 
@@ -553,7 +553,7 @@ msgstr "Попередній перегляд"
 msgid "Show Queue"
 msgstr "Показати чергу"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr ""
 
@@ -576,242 +576,242 @@ msgstr ""
 msgid "None"
 msgstr ""
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr ""
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr ""
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr ""
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr ""
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr ""
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr ""
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr ""
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr ""
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr ""
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr ""
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr ""
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr ""
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr ""
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -821,11 +821,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -834,11 +834,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ""
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -846,102 +846,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "Автоматично"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -949,18 +949,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -968,7 +968,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -976,11 +976,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -988,7 +988,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -997,39 +997,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1037,7 +1037,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -1045,78 +1045,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr ""
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr ""
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr ""
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1124,19 +1124,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1144,18 +1144,18 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1171,15 +1171,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1190,11 +1190,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1204,16 +1204,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1225,7 +1225,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1234,22 +1234,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1259,301 +1259,301 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr ""
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr ""
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr ""
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr ""
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr ""
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr ""
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr ""
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr ""
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr ""
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr ""
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>Налаштування перетворення аудіо:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 "Кожна обрана початкова доріжка буде перетворена з усіма обраними кодеками"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr ""
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr ""
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr ""
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr ""
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr ""
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr ""
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr ""
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1564,15 +1564,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr ""
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1582,11 +1582,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1594,21 +1594,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1618,15 +1618,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "Субтитри DVD"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1637,11 +1637,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "Субтитри Blu-ray"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1652,122 +1652,122 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "Субтитри"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr ""
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr ""
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr ""
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr ""
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr ""
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr ""
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "Додати _кілька"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1775,126 +1775,126 @@ msgstr "Додати _кілька"
 msgid "Cancel"
 msgstr ""
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr ""
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr ""
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr ""
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr ""
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr ""
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1908,63 +1908,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr ""
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr ""
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1973,191 +1973,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "_Прейменувати"
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr ""
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr ""
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr ""
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "Шаблони"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr ""
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr ""
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>Тривалість:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "Субтитри"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr ""
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr ""
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr ""
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr ""
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr ""
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "Мова"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr ""
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2166,60 +2166,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr ""
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr ""
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr ""
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2230,89 +2230,89 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr ""
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr ""
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "Якість"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr ""
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr ""
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr ""
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 msgid "HandBrake Updater"
 msgstr ""
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr ""
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr ""
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr ""
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr ""
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>Нотатки релізу</b>"
 
@@ -2446,7 +2446,7 @@ msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr ""
 
@@ -2459,11 +2459,38 @@ msgstr ""
 msgid "Single Title"
 msgstr "Відкрити один _файл"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+msgid "HDR"
+msgstr ""
+
+#: src/callbacks.c:2144
+msgid "SDR"
+msgstr ""
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
@@ -2471,7 +2498,7 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
@@ -2480,19 +2507,19 @@ msgstr[1] "Субтитри"
 msgstr[2] "Субтитри"
 msgstr[3] "Субтитри"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
@@ -2501,22 +2528,22 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
@@ -2525,33 +2552,33 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2559,132 +2586,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr ""
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "Призупинено"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr ""
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr ""
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr ""
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/zh_CN.po
+++ b/gtk/po/zh_CN.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: 玉堂白鹤 <yjwork@qq.com>, 2022\n"
 "Language-Team: Chinese (https://www.transifex.com/HandBrakeProject/"
@@ -106,8 +106,8 @@ msgstr "预设值(_P)"
 msgid "Set De_fault"
 msgstr "设为默认(_F)"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "保存(_S)"
 
@@ -115,7 +115,7 @@ msgstr "保存(_S)"
 msgid "Save _As"
 msgstr "另存为(_A)"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "重命名(_R)"
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr "<b>烧录</b>"
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -187,7 +187,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr "<b>默认</b>"
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -360,7 +360,7 @@ msgstr "0 个任务排队中"
 msgid "Start Encoding"
 msgstr "开始编码"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "开始"
@@ -379,7 +379,7 @@ msgstr "暂停"
 msgid "Options"
 msgstr "选项"
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr "完成时:"
 
@@ -399,8 +399,8 @@ msgstr ""
 msgid "Edit"
 msgstr "编辑"
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "预设："
 
@@ -408,7 +408,7 @@ msgstr "预设："
 msgid "Source:"
 msgstr "源文件:"
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr "标题："
 
@@ -432,7 +432,7 @@ msgstr "音频:"
 msgid "Subtitles:"
 msgstr "字幕:"
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr "摘要"
 
@@ -521,11 +521,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "选择视频源文件"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "打开源文件"
 
@@ -557,7 +557,7 @@ msgstr "预览"
 msgid "Show Queue"
 msgstr "显示队列"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "队列"
 
@@ -580,15 +580,15 @@ msgstr "<b>源文件:</b>"
 msgid "None"
 msgstr "无"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "扫描中 ..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr "<b>标题:</b>"
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
@@ -598,51 +598,51 @@ msgstr ""
 "默认使用时长最长的标题。\n"
 "这通常是 DVD 的特辑标题。"
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr "<b>角度：</b>"
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr "用于在多角度的 DVD 中，选择所希望的角度来进行编码。"
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr "<b>范围:</b>"
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr "需要编码的标题范围。可以是章节，秒或帧。"
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr "设置起始章节。"
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr "设置终止章节。"
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>预设：</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "选择预设"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr "<u><i>被修改</i></u>"
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "重新加载"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
@@ -650,27 +650,27 @@ msgstr ""
 "重新加载当前选定预设的设置。\n"
 "修改将被丢弃。"
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "保存为新预设"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr "保存当前设置为新的预设。"
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "格式："
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr "轨道混流的格式。"
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "Web 优化"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
@@ -678,11 +678,11 @@ msgstr ""
 "优化 MP4 容器布局以便渐进式下载。\n"
 "这允许用户在下载完整个文件之前就可以开始播放。"
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr "对齐音视频开头"
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
@@ -691,140 +691,140 @@ msgstr ""
 "通过插入空白帧或丢帧来对齐所有音频和视频流的初始时间戳。 \n"
 "可以改善不遵守 MP4 编辑列表的蹩脚播放器的音频/视频同步。"
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G 支持"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr "添加老旧 iPod 所需的 iPod Atom。"
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr "持续时长："
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "hh:mm:ss"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "轨道："
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "滤镜："
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr "尺寸："
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "以 90 度为增量顺时针旋转视频。"
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr "左侧裁剪"
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr "顶部裁剪"
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr "底部裁剪"
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr "右侧裁剪"
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr "变形："
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -834,11 +834,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr "像素宽高比："
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -851,11 +851,11 @@ msgstr ""
 "1:1 的像素宽高比就是正方形的像素。 其他的比例则是长方形的像素。\n"
 "播放器为显示指定宽高比将缩放画面。"
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -866,11 +866,11 @@ msgstr ""
 "1:1 的像素宽高比就是正方形的像素。 其他的比例则是矩形像素。\n"
 "播放器为显示指定宽高比将缩放图像。"
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -879,7 +879,7 @@ msgstr ""
 "这是视频存储的宽度。\n"
 "如果像素宽高比不是 1:1 的话，实际的画面显示尺寸会有所不同。"
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
@@ -888,84 +888,84 @@ msgstr ""
 "这是视频存储的高度。\n"
 "如果像素宽高比不是 1:1 的话，实际的画面显示尺寸会有所不同。"
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr "自动"
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr "尺寸"
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr "反胶卷过带滤镜："
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -976,7 +976,7 @@ msgstr ""
 "\n"
 "胶卷过带 (telecining) 用于转换 24fps 的胶卷为 30fps NTSC 视频。"
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
@@ -986,11 +986,11 @@ msgstr ""
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr "隔行扫描检测："
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -1001,7 +1001,7 @@ msgstr ""
 "\n"
 "如果启用了反交错滤镜，则只有该滤镜发现隔行扫描的帧才会进行反交错处理。"
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -1013,11 +1013,11 @@ msgstr ""
 "Mode:Spatial Metric:Motion Thresh:Spatial Thresh:Mask Filter Mode:\n"
 "Block Thresh: Block Width: Block Height"
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr "反交错："
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -1029,7 +1029,7 @@ msgstr ""
 "decomb 去梳状纹理滤镜支持各种插值算法。\n"
 "deinterlace 反交错滤镜是经典的 YADIF 去隔行过滤器。\n"
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 #, fuzzy
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
@@ -1043,11 +1043,11 @@ msgstr ""
 "decomb 去梳状纹理滤镜支持各种插值算法。\n"
 "deinterlace 反交错滤镜是经典的 YADIF 去隔行扫描器。\n"
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr "去区块滤镜："
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
@@ -1055,12 +1055,12 @@ msgstr ""
 "去区块滤镜可以去除压缩导致的区块效应。\n"
 "如果您的源文件存在区块效应，这个滤镜则可以将其清除。"
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr "调优："
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 #, fuzzy
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
@@ -1069,7 +1069,7 @@ msgstr ""
 "去区块滤镜可以去除压缩导致的区块效应。\n"
 "如果您的源文件存在区块效应，这个滤镜则可以将其清除。"
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 #, fuzzy
 msgid ""
 "Custom deblock filter string format\n"
@@ -1080,11 +1080,11 @@ msgstr ""
 "\n"
 "strength=weak|strong:thresh=0-100:blocksize=4-512"
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "降噪滤镜："
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1095,7 +1095,7 @@ msgstr ""
 "胶卷颗粒噪点及其他高频噪音通常难以压缩。\n"
 "使用该滤镜可以得到更小的输出文件。"
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1107,7 +1107,7 @@ msgstr ""
 "胶卷颗粒噪点及其他高频噪音通常难以压缩。\n"
 "使用该滤镜可以得到更小的输出文件。"
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 #, fuzzy
 msgid ""
 "Custom denoise filter string format\n"
@@ -1118,72 +1118,72 @@ msgstr ""
 "\n"
 "SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "锐化滤镜："
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr "锐化滤镜将增强视频中的边缘和其他高频成分。 "
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr "锐化滤镜将增强视频中的边缘和其他高频成分。 "
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "灰度"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "如果启用，将过滤输出文件的色彩部分。"
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "滤镜"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "视频编码器："
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "可用的视频编码器。"
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "帧率："
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1195,19 +1195,19 @@ msgstr ""
 "推荐选择“与源视频相同”。如果您的源视频使用动态帧率，\n"
 "该选项能保证其与源视频帧率一致。"
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "固定帧率"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "启用恒定帧率输出。"
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr "峰值帧率 (VFR)"
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1219,11 +1219,11 @@ msgstr ""
 "\n"
 "部分播放器可能不兼容 VFR。"
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "动态帧率"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1233,7 +1233,7 @@ msgstr ""
 "\n"
 "一些播放器与动态帧率不兼容。"
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1258,15 +1258,15 @@ msgstr ""
 "\n"
 "FFMpeg 和 Theora 的刻度是线性的，而且显然没有无损模式。"
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "恒定画质："
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "码率 (kbps):    "
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1282,11 +1282,11 @@ msgstr ""
 "如果您需要限定瞬时码率的值，您可以参考 x264 的 vbv-bufsize 和 vbv-maxrate 设"
 "置。"
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr "二次编码"
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1300,16 +1300,16 @@ msgstr ""
 "需要先勾选“码率”选项。第一次编码时，我们将采集视频统计信息。\n"
 "然后在第二次编码时，根据这些统计信息决定码率的分配。"
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr "加快首次编码"
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr "在二次编码的第一次编码中，使用加速编码的设置。"
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1327,7 +1327,7 @@ msgstr ""
 "您应该选择您所能接受的最慢的设置选项，因为较慢的设置可以\n"
 "得到更好的输出质量或者更小的输出文件。"
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1340,11 +1340,11 @@ msgstr ""
 "对于特定的源文件特性或者输出文件特性，这能提高效率。\n"
 "所修改的选项作用紧跟预设但是在其他参数之前。"
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "快速解码"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1354,11 +1354,11 @@ msgstr ""
 "\n"
 "如果您的输出在设备上播放不流畅（掉帧），请勾选此选项。"
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "零延迟"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1374,11 +1374,11 @@ msgstr ""
 "但是 HandBrake 并不适用于流媒体广播，\n"
 "所以这个设置基本没有什么意义。"
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "规格："
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
@@ -1388,11 +1388,11 @@ msgstr ""
 "\n"
 "会覆盖其他所有设置。"
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr "级别："
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
@@ -1402,11 +1402,11 @@ msgstr ""
 "\n"
 "会覆盖其他所有设置。"
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "更多设置："
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
@@ -1416,45 +1416,45 @@ msgstr ""
 "\n"
 "选项由英文冒号分隔。"
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "视频"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "添加"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "添加新的音频设置至列表"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "全部添加"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "将所有音轨到列表"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr "重新加载所有音频的默认设置"
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "轨列表"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr "选择行为："
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "选择使用源媒体的哪一个音轨。"
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1463,23 +1463,23 @@ msgstr ""
 "创建您想要选择的音频的语言列表。\n"
 "将使用所选的选择行为选择与这些语言匹配的音轨。"
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "移除"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "可用语言"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "已选择语言"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr "仅使用第一编码器，用于辅助音频"
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
@@ -1488,26 +1488,26 @@ msgstr ""
 "只有首选音轨会使用整个列表的编码器进行编码。\n"
 "其他次选音轨只会使用第一个编码器进行编码。"
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr "自动复制流："
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
@@ -1516,11 +1516,11 @@ msgstr ""
 "如果您的回放设备支持 MP3 则勾选此项。\n"
 "已勾选自动直通时则允许使用 MP3 直通。"
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
@@ -1529,11 +1529,11 @@ msgstr ""
 "如果您的回放设备支持 AC-3 则勾选此项。\n"
 "已勾选自动直通时则允许使用 AC-3 直通。"
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
@@ -1542,11 +1542,11 @@ msgstr ""
 "如果您的回放设备支持 EAC-3 则勾选此项。\n"
 "已勾选自动直通时则允许使用 EAC-3 直通。"
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
@@ -1555,11 +1555,11 @@ msgstr ""
 "如果您的回放设备支持 DTS 则勾选此项。\n"
 "已勾选自动直通时则允许使用 DTS 直通。"
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
@@ -1568,11 +1568,11 @@ msgstr ""
 "如果您的回放设备支持 DTS-HD 则勾选此项。\n"
 "已勾选自动直通时则允许使用 DTS-HD 直通。"
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
@@ -1581,11 +1581,11 @@ msgstr ""
 "如果您的回放设备支持 TrueHD 则勾选此项。\n"
 "已勾选自动直通时则允许使用 TrueHD 直通。"
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
@@ -1594,11 +1594,11 @@ msgstr ""
 "如果您的回放设备支持 FLAC 则勾选此项。\n"
 "已勾选自动直通时则允许使用 FLAC 直通。"
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
@@ -1607,96 +1607,96 @@ msgstr ""
 "如果您的回放设备支持 AAC 则勾选此项。\n"
 "已勾选自动直通时则允许使用 AAC 直通。"
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr "直通回滚："
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr "当音频直通无法找到合适的轨道时，设置用于编码的音频编解码器。"
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>音频编码设置:</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr "每一个选中的源音轨都将用所有选中编码器进行编码"
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "编码"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "比特率/质量"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr "混音"
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "采样率"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "增益"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "动态范围压缩(DRC)"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr "轨选项"
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "音频"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "新增的字幕添加到列表"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "将所有字幕轨道到列表"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr "外语音频扫描"
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr "添加一个为外语音频段搜索候选字幕的通道到编码中。"
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr "从默认设置加载所有字幕设置"
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr "选择使用源媒体的哪一个字幕轨。"
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1712,15 +1712,15 @@ msgstr ""
 "列表中的第一个语言是您的“首选”语言，并在有外语音\n"
 "轨时用于检测字幕选择设置。"
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "首选语言：无"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr "添加外语音频扫描通道 "
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1734,11 +1734,11 @@ msgstr ""
 "\n"
 "此选项需要有语言设置在已选择语言列表里。"
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr "如果默认音轨为外语则添加字幕轨"
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1749,21 +1749,21 @@ msgstr ""
 "\n"
 "此选项需要有语言设置在已选择语言列表里。"
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr "如果可用的话，添加隐藏字幕"
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr "隐藏字幕可以以软字幕轨道方式添加到任意容器"
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr "烧录偏好*："
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1777,15 +1777,15 @@ msgstr ""
 "内嵌字幕是视频的一部分，并且无法在播放时禁用。\n"
 "您只能内嵌一个字幕！由于可能的冲突，最后只会使用第一个字幕。"
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr "为老旧播放器内嵌*:"
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD 字幕"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1800,11 +1800,11 @@ msgstr ""
 "\n"
 "您只能内嵌一个字幕轨道！由于可能的冲突，最后只会使用第一个字幕。"
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "蓝光字幕"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1819,124 +1819,124 @@ msgstr ""
 "\n"
 "您只能内嵌一个字幕轨道！由于可能的冲突，最后只会使用第一个字幕。"
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr "<small>* 上述字幕内嵌选项只有一个有效，从上至下选择。</small>"
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr "您只能内嵌一个字幕轨道！由于可能的冲突，最后只会使用第一个字幕。"
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr "章节标记"
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr "添加章节标记到输出文件。"
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "章节"
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "章节"
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr "序号"
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr "持续时长"
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr "标题"
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "章节"
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "演员："
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "导演："
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "发布日期："
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr "评论："
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "种类："
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "描述："
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr "剧情："
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr "标签"
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>另存为：</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr "编码的目标文件名。"
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr "<b>位置:</b>"
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr "编码的目标文件夹。"
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr "目标文件夹"
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 #, fuzzy
 msgid "Add Multiple Titles"
 msgstr "添加多个(_M)"
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1944,51 +1944,51 @@ msgstr "添加多个(_M)"
 msgid "Cancel"
 msgstr "取消"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "全选"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr "将所有标题标记并加入队列"
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "清除所有"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr "取消标记所有标题"
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "目标文件没问题。未检测到重复文件。"
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "首选项"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "自动检查更新"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr "使用自动命名（使用修改后的源名称）"
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr "从源文件名或卷标创建目标文件名"
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "自动命名模板"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 #, fuzzy
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
@@ -1998,23 +1998,23 @@ msgstr ""
 "可用选项: {source-path} {source} {title} {preset} {chapters} {date} {time} "
 "{creation-date} {creation-time} {quality} {bitrate}"
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr "为 MP4 使用 iPod / iTunes 友好的文件扩展名（.m4v）"
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr "预览数"
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr "过滤短的 DVD 和蓝光标题（秒）"
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr "编码完成后清除已完成的队列项目"
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -2023,52 +2023,52 @@ msgstr ""
 "默认情况下，已完成编码任务仍然保留在队列中并标记为已完成。\n"
 "如果您想要编码任务完成时自动清除，则勾选此项。"
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "普通"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -2082,63 +2082,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr "恒定画质因子的调节粒度"
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr "使用 dvdnav（代替 libdvdread）"
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "监控目标磁盘可用空间"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "如果可用磁盘空间低于限制，暂停编码"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr "MB 限制"
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr "将个人编码日志放在与电影相同的位置"
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr "活动日志详细程度"
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr "活动日志保存时间"
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr "缩小高清视频的预览尺寸"
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr "DVD 装载时自动扫描"
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr "当有新碟装载时扫描 DVD"
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr "活动窗口字体大小"
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr "对批处理中的所有标题使用相同的设置"
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -2150,162 +2150,162 @@ msgstr ""
 "\n"
 "如果要允许单独更改每个标题的设置，请取消选中此项。"
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr "允许 Tweaks"
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr "为新手提供傻瓜模式"
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr "高级"
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "降噪预设："
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">重命名预设</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "命名："
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>描述</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "保存为新预设"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "类别："
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr "设置此预设将显示在下面的类别。"
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "类别名称："
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "预设名称："
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr "默认预设"
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr "设置为 HandBrake 启动时的默认预设"
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr "<b> 尺寸</b>"
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr "HandBrake 预览"
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr "选择预览画面。"
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr "从当前预览位置编码并播放一小段视频。"
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr "<b>持续时间:</b>"
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr "以秒为单位设置实时预览时间。"
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr "显示裁剪"
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr "显示预览中被裁剪部分"
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr "源分辨率"
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr "将预览窗口重置为源视频的分辨率"
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "导入 SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "勾选此项以导入 SRT 字幕文件"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr "导入 SSA"
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr "勾选此项以导入 SSA 字幕文件"
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "内嵌字幕列表"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "允许设置选择的内嵌字幕"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "源音轨"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr "您的源文件内所有可用的字幕轨列表。"
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "音轨名称："
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
@@ -2315,23 +2315,23 @@ msgstr ""
 "\n"
 "播放器可以在字幕轨选择列表中使用。"
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "语言"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr "字符编码"
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "文件:"
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr "延迟(毫秒）"
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
@@ -2339,7 +2339,7 @@ msgstr ""
 "设置该字幕的语言。\n"
 "这个值用于播放器中的字幕菜单。"
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2353,27 +2353,27 @@ msgstr ""
 "我们一般将其转换为 UTF-8。\n"
 "因此，我们需要源文件的字符编码。"
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "选择要导入的 SRT 文件。"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr "导入文件"
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr "调整视频与 SRT 文件的时间偏移量，单位为毫秒"
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr "仅强制字幕"
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr "烧录进视频"
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
@@ -2381,19 +2381,19 @@ msgstr ""
 "在视频中显示该字幕。\n"
 "字幕将作为视频的一部分，并且不能被禁用。"
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "设置默认轨"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr "您的源文件内可用的音频轨列表。"
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
@@ -2403,15 +2403,15 @@ msgstr ""
 "\n"
 "播放器可以在音轨选择列表中使用。"
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr "混合"
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "采样率"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2426,90 +2426,90 @@ msgstr ""
 "对于源音轨有较大音量范围的（非常响亮和非常柔和的序列），动态范围压缩 (DRC) 允"
 "许您压缩其范围使得大音量降低而小音量有所增加。"
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr "设置该轨道的音频编码。"
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "码率"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "启用码率设置"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "质量"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "启用质量设置"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr "设置该轨道的码率。"
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr "<b>音质：</b> 调整输出的音频质量，需要编码器支持。"
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr "00.0"
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr "设置输出音轨的混音。"
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "设置输出音轨的采样率。"
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr "<b>音频增益：</b> 调整输出音量大小。"
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "关闭"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "跳过此版本"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "稍后提醒我"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>有新版本的 HandBrake 可用!</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx 现在可用 (您拥有 yyy)。"
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>发行说明</b>"
 
@@ -2653,7 +2653,7 @@ msgstr "侦测到 DVD 设备："
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "扫描中 ..."
 
@@ -2666,89 +2666,118 @@ msgstr "停止扫描"
 msgid "Single Title"
 msgstr "打开单个标题"
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "动态范围压缩(DRC)"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "动态范围压缩(DRC)"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "音频"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "字幕"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ", 仅强制"
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ", 已烧录"
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ", 默认"
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, fuzzy, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] "外语音频字幕轨道"
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 #, fuzzy
 msgid "Pixel Aspect Ratio"
 msgstr "像素宽高比："
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr "找不到标题"
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "新视频"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2759,133 +2788,133 @@ msgstr ""
 "\n"
 "%s在%d秒 ..."
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr "%s如果您不继续编码，您的电影将会丢失。"
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "取消当前任务并停止"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "取消当前任务，开始下一个"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "完成当前任务，然后停止"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "继续编码"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr "%d个编码进程排队中"
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr "%d个编码进程排队中"
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "正在进行第%d个任务 ，共%d个任务， "
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr "正在处理%d(扫描字幕中)of%d, "
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr "正在处理%dof%d "
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 "正在编码：%s%s%.2f %% (%.2f fps，平均 %.2f fps，还需%02d小时%02d分%02d秒)"
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr "正在编码：%s%s%.2f %% (还需 %02d小时%02d分%02d秒)"
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr "正在编码：%s%s%.2f %%"
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr "搜索开始时间， "
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr "正在扫描标题%d，共%d..."
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr "正在扫描标题%dof%d，预览%d……"
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr "暂停"
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "编码完成！"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "编码取消。"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "编码失败。"
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr "合成中：这可能需要一段时间…"
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s 现在可用 (您拥有 %s/%d)。"
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "编码完成"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr "放下鸡尾酒，您的 HandBrake 队列已经完成！"
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "您的编码已完成。"
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "退出 Handbrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr "计算机转入休眠"
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "关闭此计算机"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/po/zh_TW.po
+++ b/gtk/po/zh_TW.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ghb 0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/HandBrake/Handbrake/issues\n"
-"POT-Creation-Date: 2023-02-18 23:39+0000\n"
+"POT-Creation-Date: 2023-03-02 18:42+0000\n"
 "PO-Revision-Date: 2018-10-10 18:14+0000\n"
 "Last-Translator: toto6038 <toto6038@gmail.com>, 2022\n"
 "Language-Team: Chinese (Taiwan) (https://www.transifex.com/HandBrakeProject/"
@@ -106,8 +106,8 @@ msgstr "預設檔 (_P)"
 msgid "Set De_fault"
 msgstr "設成預設 (_F)"
 
-#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8754
-#: src/ghb3.ui:9320 src/ghb3.ui:9730
+#: src/menu.ui:116 src/ghb3.ui:172 src/ghb3.ui:414 src/ghb3.ui:8755
+#: src/ghb3.ui:9321 src/ghb3.ui:9731
 msgid "_Save"
 msgstr "儲存 (_S)"
 
@@ -115,7 +115,7 @@ msgstr "儲存 (_S)"
 msgid "Save _As"
 msgstr "另存為 (_A)"
 
-#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8597
+#: src/menu.ui:124 src/ghb3.ui:180 src/ghb3.ui:432 src/ghb3.ui:8598
 msgid "_Rename"
 msgstr "重新命名 (_R)"
 
@@ -165,7 +165,7 @@ msgstr ""
 msgid "<b>Burned In</b>"
 msgstr ""
 
-#: src/ghb3.ui:110 src/ghb3.ui:9685
+#: src/ghb3.ui:110 src/ghb3.ui:9686
 msgid ""
 "Set the default output subtitle track.\n"
 "\n"
@@ -180,7 +180,7 @@ msgstr ""
 msgid "<b>Default</b>"
 msgstr ""
 
-#: src/ghb3.ui:123 src/ghb3.ui:9647
+#: src/ghb3.ui:123 src/ghb3.ui:9648
 msgid ""
 "Use only subtitles that have been flagged\n"
 "as forced in the source subtitle track\n"
@@ -333,7 +333,7 @@ msgstr ""
 msgid "Start Encoding"
 msgstr "開始編碼"
 
-#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6986 src/queuehandler.c:2025
+#: src/ghb3.ui:700 src/ghb3.ui:2321 src/ghb3.ui:6987 src/queuehandler.c:2025
 #: src/queuehandler.c:2038
 msgid "Start"
 msgstr "開始"
@@ -352,7 +352,7 @@ msgstr "暫停"
 msgid "Options"
 msgstr ""
 
-#: src/ghb3.ui:844 src/ghb3.ui:7503
+#: src/ghb3.ui:844 src/ghb3.ui:7504
 msgid "When Done:"
 msgstr ""
 
@@ -370,8 +370,8 @@ msgstr ""
 msgid "Edit"
 msgstr "編輯 "
 
-#: src/ghb3.ui:1035 src/ghb3.ui:4486 src/ghb3.ui:4646 src/ghb3.ui:4828
-#: src/ghb3.ui:5308
+#: src/ghb3.ui:1035 src/ghb3.ui:4487 src/ghb3.ui:4647 src/ghb3.ui:4829
+#: src/ghb3.ui:5309
 msgid "Preset:"
 msgstr "預設檔："
 
@@ -379,7 +379,7 @@ msgstr "預設檔："
 msgid "Source:"
 msgstr ""
 
-#: src/ghb3.ui:1112 src/ghb3.ui:7066
+#: src/ghb3.ui:1112 src/ghb3.ui:7067
 msgid "Title:"
 msgstr ""
 
@@ -403,7 +403,7 @@ msgstr ""
 msgid "Subtitles:"
 msgstr ""
 
-#: src/ghb3.ui:1340 src/ghb3.ui:3187
+#: src/ghb3.ui:1340 src/ghb3.ui:3188
 msgid "Summary"
 msgstr ""
 
@@ -484,11 +484,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:2279 src/callbacks.c:4301
+#: src/ghb3.ui:2279 src/callbacks.c:4351
 msgid "Choose Video Source"
 msgstr "選擇影片來源"
 
-#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4300
+#: src/ghb3.ui:2281 src/callbacks.c:1720 src/callbacks.c:4350
 msgid "Open Source"
 msgstr "打開來源"
 
@@ -520,7 +520,7 @@ msgstr "預覽"
 msgid "Show Queue"
 msgstr "顯示佇列"
 
-#: src/ghb3.ui:2393 src/callbacks.c:4731
+#: src/ghb3.ui:2393 src/callbacks.c:4781
 msgid "Queue"
 msgstr "佇列"
 
@@ -543,242 +543,242 @@ msgstr "<b>來源：</b>"
 msgid "None"
 msgstr "無"
 
-#: src/ghb3.ui:2509 src/callbacks.c:4273
+#: src/ghb3.ui:2510 src/callbacks.c:4323
 msgid "Scanning..."
 msgstr "掃描中..."
 
-#: src/ghb3.ui:2543
+#: src/ghb3.ui:2544
 msgid "<b>Title:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2571
+#: src/ghb3.ui:2572
 msgid ""
 "Set the title to encode.\n"
 "By default the longest title is chosen.\n"
 "This is often the feature title of a DVD."
 msgstr ""
 
-#: src/ghb3.ui:2598
+#: src/ghb3.ui:2599
 msgid "<b>Angle:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2610
+#: src/ghb3.ui:2611
 msgid "For multi-angle DVD's, select the desired angle to encode."
 msgstr ""
 
-#: src/ghb3.ui:2626
+#: src/ghb3.ui:2627
 msgid "<b>Range:</b>"
 msgstr ""
 
-#: src/ghb3.ui:2637
+#: src/ghb3.ui:2638
 msgid "Range of title to encode. Can be chapters, seconds, or frames."
 msgstr ""
 
-#: src/ghb3.ui:2650
+#: src/ghb3.ui:2651
 msgid "Set the first chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2666
+#: src/ghb3.ui:2667
 msgid "-"
 msgstr "-"
 
-#: src/ghb3.ui:2678
+#: src/ghb3.ui:2679
 msgid "Set the last chapter to encode."
 msgstr ""
 
-#: src/ghb3.ui:2704
+#: src/ghb3.ui:2705
 msgid "<b>Preset:</b>"
 msgstr "<b>預設檔：</b>"
 
-#: src/ghb3.ui:2740
+#: src/ghb3.ui:2741
 msgid "Choose Preset"
 msgstr "選擇預設檔"
 
-#: src/ghb3.ui:2771
+#: src/ghb3.ui:2772
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ghb3.ui:2780 src/ghb3.ui:5650 src/ghb3.ui:6434
+#: src/ghb3.ui:2781 src/ghb3.ui:5651 src/ghb3.ui:6435
 msgid "Reload"
 msgstr "重新載入"
 
-#: src/ghb3.ui:2783
+#: src/ghb3.ui:2784
 msgid ""
 "Reload the settings for the currently selected preset.\n"
 "Modifications will be discarded."
 msgstr ""
 
-#: src/ghb3.ui:2795
+#: src/ghb3.ui:2796
 msgid "Save New Preset"
 msgstr "儲存新的預設檔"
 
-#: src/ghb3.ui:2798
+#: src/ghb3.ui:2799
 msgid "Save the current settings to a new Preset."
 msgstr ""
 
-#: src/ghb3.ui:2878
+#: src/ghb3.ui:2879
 msgid "Format:"
 msgstr "格式："
 
-#: src/ghb3.ui:2896
+#: src/ghb3.ui:2897
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ghb3.ui:2908 src/queuehandler.c:286
+#: src/ghb3.ui:2909 src/queuehandler.c:286
 msgid "Web Optimized"
 msgstr "針對網頁最佳化"
 
-#: src/ghb3.ui:2913
+#: src/ghb3.ui:2914
 msgid ""
 "Optimize the layout of the MP4 file for progressive download.\n"
 "This allows a player to initiate playback before downloading the entire file."
 msgstr ""
 
-#: src/ghb3.ui:2929
+#: src/ghb3.ui:2930
 msgid "Align A/V Start"
 msgstr ""
 
-#: src/ghb3.ui:2934
+#: src/ghb3.ui:2935
 msgid ""
 "Aligns the initial timestamps of all audio and video streams by\n"
 "inserting blank frames or dropping frames. May improve audio/video\n"
 "sync for broken players that do not honor MP4 edit lists."
 msgstr ""
 
-#: src/ghb3.ui:2951
+#: src/ghb3.ui:2952
 msgid "iPod 5G Support"
 msgstr "iPod 5G 支援"
 
-#: src/ghb3.ui:2956
+#: src/ghb3.ui:2957
 msgid "Add iPod Atom needed by some older iPods."
 msgstr ""
 
-#: src/ghb3.ui:2971
+#: src/ghb3.ui:2972
 msgid "Passthru Common Metadata"
 msgstr ""
 
-#: src/ghb3.ui:2976
+#: src/ghb3.ui:2977
 msgid "Copy metadata from source to output."
 msgstr ""
 
-#: src/ghb3.ui:2998
+#: src/ghb3.ui:2999
 msgid "Duration:"
 msgstr ""
 
-#: src/ghb3.ui:3016
+#: src/ghb3.ui:3017
 msgid "hh:mm:ss"
 msgstr "HH:MM:SS"
 
-#: src/ghb3.ui:3031
+#: src/ghb3.ui:3032
 msgid "Tracks:"
 msgstr "軌道："
 
-#: src/ghb3.ui:3071
+#: src/ghb3.ui:3072
 msgid "Filters:"
 msgstr "濾鏡："
 
-#: src/ghb3.ui:3111
+#: src/ghb3.ui:3112
 msgid "Size:"
 msgstr ""
 
-#: src/ghb3.ui:3136 src/ghb3.ui:3235 src/ghb3.ui:3273 src/ghb3.ui:3311
-#: src/ghb3.ui:4147 src/ghb3.ui:4285
+#: src/ghb3.ui:3137 src/ghb3.ui:3236 src/ghb3.ui:3274 src/ghb3.ui:3312
+#: src/ghb3.ui:4148 src/ghb3.ui:4286
 msgid "--"
 msgstr "--"
 
-#: src/ghb3.ui:3223 src/ghb3.ui:4135
+#: src/ghb3.ui:3224 src/ghb3.ui:4136
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ghb3.ui:3261 src/ghb3.ui:4179
+#: src/ghb3.ui:3262 src/ghb3.ui:4180
 msgid "Display Size:"
 msgstr ""
 
-#: src/ghb3.ui:3299 src/ghb3.ui:4273
+#: src/ghb3.ui:3300 src/ghb3.ui:4274
 msgid "Aspect Ratio:"
 msgstr ""
 
-#: src/ghb3.ui:3336
+#: src/ghb3.ui:3337
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:3383
+#: src/ghb3.ui:3384
 msgid "Flipping:"
 msgstr ""
 
-#: src/ghb3.ui:3394
+#: src/ghb3.ui:3395
 msgid "Horizontal ⇌"
 msgstr ""
 
-#: src/ghb3.ui:3399
+#: src/ghb3.ui:3400
 msgid "Flip video horizontally."
 msgstr ""
 
-#: src/ghb3.ui:3416
+#: src/ghb3.ui:3417
 msgid "Rotation:"
 msgstr ""
 
-#: src/ghb3.ui:3432
+#: src/ghb3.ui:3433
 msgid "Rotate the video clockwise in 90 degree increments."
 msgstr "將影片旋轉順時鐘 90 度"
 
-#: src/ghb3.ui:3447
+#: src/ghb3.ui:3448
 msgid "Cropping:"
 msgstr ""
 
-#: src/ghb3.ui:3463
+#: src/ghb3.ui:3464
 msgid "How to apply crop settings."
 msgstr ""
 
-#: src/ghb3.ui:3479
+#: src/ghb3.ui:3480
 msgid "Left Crop"
 msgstr ""
 
-#: src/ghb3.ui:3496
+#: src/ghb3.ui:3497
 msgid "Top Crop"
 msgstr ""
 
-#: src/ghb3.ui:3513
+#: src/ghb3.ui:3514
 msgid "Bottom Crop"
 msgstr ""
 
-#: src/ghb3.ui:3530
+#: src/ghb3.ui:3531
 msgid "Right Crop"
 msgstr ""
 
-#: src/ghb3.ui:3566
+#: src/ghb3.ui:3567
 msgid "<b>Orientation &amp; Cropping</b>"
 msgstr ""
 
-#: src/ghb3.ui:3605
+#: src/ghb3.ui:3606
 msgid "Resolution Limit:"
 msgstr ""
 
-#: src/ghb3.ui:3620
+#: src/ghb3.ui:3621
 msgid "Resolution limits for common video formats."
 msgstr ""
 
-#: src/ghb3.ui:3636
+#: src/ghb3.ui:3637
 msgid "Maximum Size:"
 msgstr ""
 
-#: src/ghb3.ui:3651
+#: src/ghb3.ui:3652
 msgid "This is the maximum width that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3668 src/ghb3.ui:3837 src/ghb3.ui:4211
+#: src/ghb3.ui:3669 src/ghb3.ui:3838 src/ghb3.ui:4212
 msgid "x"
 msgstr ""
 
-#: src/ghb3.ui:3683
+#: src/ghb3.ui:3684
 msgid "This is the maximum height that the video will be stored at."
 msgstr ""
 
-#: src/ghb3.ui:3699
+#: src/ghb3.ui:3700
 msgid "Anamorphic:"
 msgstr ""
 
-#: src/ghb3.ui:3714
+#: src/ghb3.ui:3715
 msgid ""
 "<b>Anamorphic Modes:</b><small><tt>\n"
 "    Automatic - Use a pixel aspect ratio that maximizes\n"
@@ -788,11 +788,11 @@ msgid ""
 "    Custom    - Enter a custom pixel aspect ratio.</tt></small>"
 msgstr ""
 
-#: src/ghb3.ui:3735
+#: src/ghb3.ui:3736
 msgid "Pixel Aspect:"
 msgstr ""
 
-#: src/ghb3.ui:3750
+#: src/ghb3.ui:3751
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "\n"
@@ -801,11 +801,11 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3770
+#: src/ghb3.ui:3771
 msgid ":"
 msgstr ":"
 
-#: src/ghb3.ui:3785
+#: src/ghb3.ui:3786
 msgid ""
 "Pixel aspect defines the shape of the pixels.\n"
 "A 1:1 ratio defines a square pixel.  Other values define rectangular "
@@ -813,102 +813,102 @@ msgid ""
 "Players will scale the image in order to achieve the specified aspect."
 msgstr ""
 
-#: src/ghb3.ui:3804
+#: src/ghb3.ui:3805
 msgid "Scaled Size:"
 msgstr ""
 
-#: src/ghb3.ui:3819
+#: src/ghb3.ui:3820
 msgid ""
 "This is the width that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3852
+#: src/ghb3.ui:3853
 msgid ""
 "This is the height that the video will be stored at.\n"
 "The actual display dimensions will differ if the pixel aspect ratio is not "
 "1:1."
 msgstr ""
 
-#: src/ghb3.ui:3866
+#: src/ghb3.ui:3867
 msgid "Optimal Size"
 msgstr ""
 
-#: src/ghb3.ui:3871
+#: src/ghb3.ui:3872
 msgid "Use highest resolution permitted by above settings."
 msgstr ""
 
-#: src/ghb3.ui:3886
+#: src/ghb3.ui:3887
 msgid "Allow Upscaling"
 msgstr ""
 
-#: src/ghb3.ui:3891
+#: src/ghb3.ui:3892
 msgid "If not enabled, scaled dimensions will be limited to source dimensions."
 msgstr ""
 
-#: src/ghb3.ui:3916
+#: src/ghb3.ui:3917
 msgid "<b>Resolution &amp; Scaling</b>"
 msgstr ""
 
-#: src/ghb3.ui:3956
+#: src/ghb3.ui:3957
 msgid "Fill:"
 msgstr ""
 
-#: src/ghb3.ui:3973
+#: src/ghb3.ui:3974
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ghb3.ui:3990
+#: src/ghb3.ui:3991
 msgid "Left Pad"
 msgstr ""
 
-#: src/ghb3.ui:4007
+#: src/ghb3.ui:4008
 msgid "Top Pad"
 msgstr ""
 
-#: src/ghb3.ui:4024
+#: src/ghb3.ui:4025
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ghb3.ui:4041
+#: src/ghb3.ui:4042
 msgid "Right Pad"
 msgstr ""
 
-#: src/ghb3.ui:4057
+#: src/ghb3.ui:4058
 msgid "Color:"
 msgstr ""
 
-#: src/ghb3.ui:4074
+#: src/ghb3.ui:4075
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ghb3.ui:4096
+#: src/ghb3.ui:4097
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ghb3.ui:4194 src/ghb3.ui:4226 src/ghb3.ui:4244
+#: src/ghb3.ui:4195 src/ghb3.ui:4227 src/ghb3.ui:4245
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ghb3.ui:4239 src/hb-backend.c:123 src/hb-backend.c:239
+#: src/ghb3.ui:4240 src/hb-backend.c:123 src/hb-backend.c:239
 #: src/hb-backend.c:311
 msgid "Automatic"
 msgstr ""
 
-#: src/ghb3.ui:4310
+#: src/ghb3.ui:4311
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:4323
+#: src/ghb3.ui:4324
 msgid "Dimensions"
 msgstr ""
 
-#: src/ghb3.ui:4341
+#: src/ghb3.ui:4342
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ghb3.ui:4357
+#: src/ghb3.ui:4358
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -916,18 +916,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ghb3.ui:4372 src/ghb3.ui:4918
+#: src/ghb3.ui:4373 src/ghb3.ui:4919
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ghb3.ui:4391
+#: src/ghb3.ui:4392
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ghb3.ui:4407
+#: src/ghb3.ui:4408
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -935,7 +935,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ghb3.ui:4423
+#: src/ghb3.ui:4424
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -943,11 +943,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ghb3.ui:4443
+#: src/ghb3.ui:4444
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ghb3.ui:4459
+#: src/ghb3.ui:4460
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -955,7 +955,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ghb3.ui:4496
+#: src/ghb3.ui:4497
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -964,39 +964,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ghb3.ui:4526
+#: src/ghb3.ui:4527
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4542
+#: src/ghb3.ui:4543
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4566 src/ghb3.ui:4669 src/ghb3.ui:4749 src/ghb3.ui:4850
-#: src/ghb3.ui:5348
+#: src/ghb3.ui:4567 src/ghb3.ui:4670 src/ghb3.ui:4750 src/ghb3.ui:4851
+#: src/ghb3.ui:5349
 msgid "Tune:"
 msgstr ""
 
-#: src/ghb3.ui:4576
+#: src/ghb3.ui:4577
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ghb3.ui:4584 src/ghb3.ui:4767
+#: src/ghb3.ui:4585 src/ghb3.ui:4768
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ghb3.ui:4605
+#: src/ghb3.ui:4606
 msgid "Denoise Filter:"
 msgstr "降噪濾鏡："
 
-#: src/ghb3.ui:4621
+#: src/ghb3.ui:4622
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -1007,7 +1007,7 @@ msgstr ""
 "膠片顆粒或其他高頻噪訊是極難壓縮的。\n"
 "針對此類來源使用此濾鏡以產生較小的檔案。"
 
-#: src/ghb3.ui:4656 src/ghb3.ui:4679
+#: src/ghb3.ui:4657 src/ghb3.ui:4680
 #, fuzzy
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
@@ -1019,34 +1019,34 @@ msgstr ""
 "膠片顆粒或其他高頻噪訊是極難壓縮的。\n"
 "針對此類來源使用此濾鏡以產生較小的檔案。"
 
-#: src/ghb3.ui:4688 src/ghb3.ui:4868
+#: src/ghb3.ui:4689 src/ghb3.ui:4869
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ghb3.ui:4709
+#: src/ghb3.ui:4710
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ghb3.ui:4725
+#: src/ghb3.ui:4726
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4759
+#: src/ghb3.ui:4760
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ghb3.ui:4788
+#: src/ghb3.ui:4789
 msgid "Sharpen Filter:"
 msgstr "銳利化濾鏡："
 
-#: src/ghb3.ui:4804
+#: src/ghb3.ui:4805
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
@@ -1054,7 +1054,7 @@ msgstr ""
 "銳利化濾鏡可在影片強化邊緣及其他\n"
 "高頻細節。"
 
-#: src/ghb3.ui:4838 src/ghb3.ui:4860
+#: src/ghb3.ui:4839 src/ghb3.ui:4861
 #, fuzzy
 msgid ""
 "Sharpen filtering enhances edges and other\n"
@@ -1063,39 +1063,39 @@ msgstr ""
 "銳利化濾鏡可在影片強化邊緣及其他\n"
 "高頻細節。"
 
-#: src/ghb3.ui:4889
+#: src/ghb3.ui:4890
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ghb3.ui:4905
+#: src/ghb3.ui:4906
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ghb3.ui:4934 src/hb-backend.c:4896
+#: src/ghb3.ui:4935 src/hb-backend.c:4896
 msgid "Grayscale"
 msgstr "灰階"
 
-#: src/ghb3.ui:4939
+#: src/ghb3.ui:4940
 msgid "If enabled, filter colour components out of video."
 msgstr "若被啟用，影片中的彩色部分將被剔除。"
 
-#: src/ghb3.ui:4956
+#: src/ghb3.ui:4957
 msgid "Filters"
 msgstr "濾鏡"
 
-#: src/ghb3.ui:4987
+#: src/ghb3.ui:4988
 msgid "Video Encoder:"
 msgstr "影片編碼器："
 
-#: src/ghb3.ui:5001
+#: src/ghb3.ui:5002
 msgid "Available video encoders."
 msgstr "可用的影片編碼器。"
 
-#: src/ghb3.ui:5017
+#: src/ghb3.ui:5018
 msgid "Framerate:"
 msgstr "影格率："
 
-#: src/ghb3.ui:5032
+#: src/ghb3.ui:5033
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1107,19 +1107,19 @@ msgstr ""
 "推薦「和來源相同」。若您的來源影片具有可變動的影格率，「和來源相同」將保留"
 "它。"
 
-#: src/ghb3.ui:5047
+#: src/ghb3.ui:5048
 msgid "Constant Framerate"
 msgstr "固定影格率"
 
-#: src/ghb3.ui:5052
+#: src/ghb3.ui:5053
 msgid "Enables constant framerate output."
 msgstr "啟用固定影格率輸出。"
 
-#: src/ghb3.ui:5066
+#: src/ghb3.ui:5067
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ghb3.ui:5071
+#: src/ghb3.ui:5072
 msgid ""
 "Enables variable framerate output with a peak\n"
 "rate determined by the framerate setting.\n"
@@ -1127,11 +1127,11 @@ msgid ""
 "VFR is not compatible with some players."
 msgstr ""
 
-#: src/ghb3.ui:5089
+#: src/ghb3.ui:5090
 msgid "Variable Framerate"
 msgstr "可變動的影格率"
 
-#: src/ghb3.ui:5094
+#: src/ghb3.ui:5095
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
@@ -1141,7 +1141,7 @@ msgstr ""
 "\n"
 "VFR 與有些播放器不相容。"
 
-#: src/ghb3.ui:5130 src/ghb3.ui:5162
+#: src/ghb3.ui:5131 src/ghb3.ui:5163
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1157,15 +1157,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ghb3.ui:5157
+#: src/ghb3.ui:5158
 msgid "Constant Quality:"
 msgstr "固定品質："
 
-#: src/ghb3.ui:5188
+#: src/ghb3.ui:5189
 msgid "Bitrate (kbps):    "
 msgstr "位元速率 (kbps)："
 
-#: src/ghb3.ui:5193 src/ghb3.ui:5215
+#: src/ghb3.ui:5194 src/ghb3.ui:5216
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1181,11 +1181,11 @@ msgstr ""
 "但長時間的平均位元速率數值可在此設定。若您需要\n"
 "限制瞬時的位元速率，請使用 x264 的 vbv-bufsize 及 vbv-maxrate 設定。"
 
-#: src/ghb3.ui:5232
+#: src/ghb3.ui:5233
 msgid "2-Pass Encoding"
 msgstr ""
 
-#: src/ghb3.ui:5237
+#: src/ghb3.ui:5238
 msgid ""
 "Perform 2 Pass Encoding.\n"
 "\n"
@@ -1195,16 +1195,16 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ghb3.ui:5255
+#: src/ghb3.ui:5256
 msgid "Turbo First Pass"
 msgstr ""
 
-#: src/ghb3.ui:5260
+#: src/ghb3.ui:5261
 msgid ""
 "During the 1st pass of a 2 pass encode, use settings that speed things along."
 msgstr ""
 
-#: src/ghb3.ui:5322
+#: src/ghb3.ui:5323
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1216,7 +1216,7 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ghb3.ui:5365
+#: src/ghb3.ui:5366
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1225,11 +1225,11 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ghb3.ui:5381
+#: src/ghb3.ui:5382
 msgid "Fast Decode"
 msgstr "快速解碼"
 
-#: src/ghb3.ui:5386
+#: src/ghb3.ui:5387
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
@@ -1239,11 +1239,11 @@ msgstr ""
 "\n"
 "若您的裝置在播放輸出檔時有困難（如：丟失影格）請選此。"
 
-#: src/ghb3.ui:5404
+#: src/ghb3.ui:5405
 msgid "Zero Latency"
 msgstr "零延遲"
 
-#: src/ghb3.ui:5408
+#: src/ghb3.ui:5409
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1259,300 +1259,300 @@ msgstr ""
 "由於 HandBrake 並不適合串流直播用途，\n"
 "此設定作用不大。"
 
-#: src/ghb3.ui:5432
+#: src/ghb3.ui:5433
 msgid "Profile:"
 msgstr "設定檔："
 
-#: src/ghb3.ui:5449
+#: src/ghb3.ui:5450
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5467
+#: src/ghb3.ui:5468
 msgid "Level:"
 msgstr ""
 
-#: src/ghb3.ui:5484
+#: src/ghb3.ui:5485
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ghb3.ui:5509
+#: src/ghb3.ui:5510
 msgid "More Settings:"
 msgstr "更多設定："
 
-#: src/ghb3.ui:5527
+#: src/ghb3.ui:5528
 msgid ""
 "Additional encoder settings.\n"
 "\n"
 "Colon separated list of encoder options."
 msgstr ""
 
-#: src/ghb3.ui:5561 src/callbacks.c:5706
+#: src/ghb3.ui:5562 src/callbacks.c:5756
 msgid "Video"
 msgstr "影片"
 
 #. Add Button
-#: src/ghb3.ui:5625 src/ghb3.ui:5818 src/ghb3.ui:6395 src/ghb3.ui:6615
-#: src/ghb3.ui:7560 src/audiohandler.c:1758
+#: src/ghb3.ui:5626 src/ghb3.ui:5819 src/ghb3.ui:6396 src/ghb3.ui:6616
+#: src/ghb3.ui:7561 src/audiohandler.c:1758
 msgid "Add"
 msgstr "新增"
 
-#: src/ghb3.ui:5627
+#: src/ghb3.ui:5628
 msgid "Add new audio settings to the list"
 msgstr "增加新音訊設定至清單"
 
-#: src/ghb3.ui:5637 src/ghb3.ui:6407
+#: src/ghb3.ui:5638 src/ghb3.ui:6408
 msgid "Add All"
 msgstr "新增全部"
 
-#: src/ghb3.ui:5639
+#: src/ghb3.ui:5640
 msgid "Add all audio tracks to the list"
 msgstr "新增所有音軌至清單"
 
-#: src/ghb3.ui:5652
+#: src/ghb3.ui:5653
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:5696 src/ghb3.ui:6480
+#: src/ghb3.ui:5697 src/ghb3.ui:6481
 msgid "Track List"
 msgstr "軌道清單"
 
-#: src/ghb3.ui:5727 src/ghb3.ui:6515
+#: src/ghb3.ui:5728 src/ghb3.ui:6516
 msgid "Selection Behavior:"
 msgstr ""
 
-#: src/ghb3.ui:5742
+#: src/ghb3.ui:5743
 msgid "Choose which audio tracks of the source media are used."
 msgstr "選擇要使用的來源媒體音軌。"
 
-#: src/ghb3.ui:5803
+#: src/ghb3.ui:5804
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ghb3.ui:5834 src/ghb3.ui:6631
+#: src/ghb3.ui:5835 src/ghb3.ui:6632
 msgid "Remove"
 msgstr "移除"
 
-#: src/ghb3.ui:5852 src/ghb3.ui:6649
+#: src/ghb3.ui:5853 src/ghb3.ui:6650
 msgid "Available Languages"
 msgstr "可用的語言"
 
-#: src/ghb3.ui:5865 src/ghb3.ui:6662
+#: src/ghb3.ui:5866 src/ghb3.ui:6663
 msgid "Selected Languages"
 msgstr "已選的語言"
 
-#: src/ghb3.ui:5881
+#: src/ghb3.ui:5882
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ghb3.ui:5886
+#: src/ghb3.ui:5887
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ghb3.ui:5922
+#: src/ghb3.ui:5923
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ghb3.ui:5933
+#: src/ghb3.ui:5934
 msgid "MP2"
 msgstr ""
 
-#: src/ghb3.ui:5938
+#: src/ghb3.ui:5939
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5954
+#: src/ghb3.ui:5955
 msgid "MP3"
 msgstr "MP3"
 
-#: src/ghb3.ui:5959
+#: src/ghb3.ui:5960
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5975
+#: src/ghb3.ui:5976
 msgid "AC-3"
 msgstr "AC-3"
 
-#: src/ghb3.ui:5980
+#: src/ghb3.ui:5981
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:5996
+#: src/ghb3.ui:5997
 msgid "EAC-3"
 msgstr "EAC-3"
 
-#: src/ghb3.ui:6001
+#: src/ghb3.ui:6002
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6017
+#: src/ghb3.ui:6018
 msgid "DTS"
 msgstr "DTS"
 
-#: src/ghb3.ui:6022
+#: src/ghb3.ui:6023
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6038
+#: src/ghb3.ui:6039
 msgid "DTS-HD"
 msgstr "DTS-HD"
 
-#: src/ghb3.ui:6043
+#: src/ghb3.ui:6044
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6059
+#: src/ghb3.ui:6060
 msgid "TrueHD"
 msgstr "TrueHD"
 
-#: src/ghb3.ui:6064
+#: src/ghb3.ui:6065
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6080
+#: src/ghb3.ui:6081
 msgid "FLAC"
 msgstr "FLAC"
 
-#: src/ghb3.ui:6085
+#: src/ghb3.ui:6086
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6101
+#: src/ghb3.ui:6102
 msgid "AAC"
 msgstr "AAC"
 
-#: src/ghb3.ui:6106
+#: src/ghb3.ui:6107
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6122
+#: src/ghb3.ui:6123
 msgid "Opus"
 msgstr ""
 
-#: src/ghb3.ui:6127
+#: src/ghb3.ui:6128
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ghb3.ui:6160
+#: src/ghb3.ui:6161
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ghb3.ui:6172
+#: src/ghb3.ui:6173
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ghb3.ui:6201
+#: src/ghb3.ui:6202
 msgid "<b>Audio Encoder Settings:</b>"
 msgstr "<b>音訊編碼器設定：</b>"
 
-#: src/ghb3.ui:6202
+#: src/ghb3.ui:6203
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ghb3.ui:6227 src/ghb3.ui:9847
+#: src/ghb3.ui:6228 src/ghb3.ui:9848
 msgid "Encoder"
 msgstr "編碼器"
 
-#: src/ghb3.ui:6238 src/ghb3.ui:9860
+#: src/ghb3.ui:6239 src/ghb3.ui:9861
 msgid "Bitrate/Quality"
 msgstr "位元速率/品質"
 
-#: src/ghb3.ui:6249
+#: src/ghb3.ui:6250
 msgid "Mixdown"
 msgstr ""
 
-#: src/ghb3.ui:6260
+#: src/ghb3.ui:6261
 msgid "Samplerate"
 msgstr "取樣率"
 
-#: src/ghb3.ui:6271 src/ghb3.ui:9904 src/queuehandler.c:610
+#: src/ghb3.ui:6272 src/ghb3.ui:9905 src/queuehandler.c:610
 msgid "Gain"
 msgstr "增益"
 
-#: src/ghb3.ui:6282 src/ghb3.ui:9923
+#: src/ghb3.ui:6283 src/ghb3.ui:9924
 msgid "DRC"
 msgstr "DRC"
 
-#: src/ghb3.ui:6319 src/ghb3.ui:6875
+#: src/ghb3.ui:6320 src/ghb3.ui:6876
 msgid "Track Selection"
 msgstr ""
 
-#: src/ghb3.ui:6331
+#: src/ghb3.ui:6332
 msgid "Audio"
 msgstr "音訊"
 
-#: src/ghb3.ui:6397
+#: src/ghb3.ui:6398
 msgid "Add new subtitle settings to the list"
 msgstr "新增字幕設定至清單"
 
-#: src/ghb3.ui:6409
+#: src/ghb3.ui:6410
 msgid "Add all subtitle tracks to the list"
 msgstr "新增所有字幕軌至清單"
 
-#: src/ghb3.ui:6419 src/callbacks.c:2306 src/queuehandler.c:647
+#: src/ghb3.ui:6420 src/callbacks.c:2356 src/queuehandler.c:647
 #: src/queuehandler.c:1083 src/subtitlehandler.c:414 src/subtitlehandler.c:1245
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/ghb3.ui:6421
+#: src/ghb3.ui:6422
 msgid ""
 "Add an extra pass to the encode which searches\n"
 "for subtitle candidates that provide subtitles for\n"
 "segments of the audio that are in a foreign language."
 msgstr ""
 
-#: src/ghb3.ui:6436
+#: src/ghb3.ui:6437
 msgid "Reload all subtitle settings from defaults"
 msgstr ""
 
-#: src/ghb3.ui:6530
+#: src/ghb3.ui:6531
 msgid "Choose which subtitle tracks of the source media are used."
 msgstr ""
 
-#: src/ghb3.ui:6595
+#: src/ghb3.ui:6596
 msgid ""
 "Create a list of languages you would like to select subtitles for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
@@ -1563,15 +1563,15 @@ msgid ""
 "for determining subtitle selection settings when there is foreign audio."
 msgstr ""
 
-#: src/ghb3.ui:6676
+#: src/ghb3.ui:6677
 msgid "Preferred Language: None"
 msgstr "偏好的語言：無"
 
-#: src/ghb3.ui:6703
+#: src/ghb3.ui:6704
 msgid "Add Foreign Audio Scan Pass"
 msgstr ""
 
-#: src/ghb3.ui:6708
+#: src/ghb3.ui:6709
 msgid ""
 "Add \"Foreign Audio Scan\" when the default audio track is your preferred "
 "language.\n"
@@ -1581,11 +1581,11 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6723
+#: src/ghb3.ui:6724
 msgid "Add subtitle track if default audio is foreign"
 msgstr ""
 
-#: src/ghb3.ui:6728
+#: src/ghb3.ui:6729
 msgid ""
 "When the default audio track is not your preferred language, add a subtitle "
 "track.\n"
@@ -1593,21 +1593,21 @@ msgid ""
 "This option requires a language to be set in the Selected Languages list."
 msgstr ""
 
-#: src/ghb3.ui:6742
+#: src/ghb3.ui:6743
 msgid "Add Closed Captions when available"
 msgstr ""
 
-#: src/ghb3.ui:6747
+#: src/ghb3.ui:6748
 msgid ""
 "Closed captions are text subtitles that can be added to any container as a "
 "soft subtitle track"
 msgstr ""
 
-#: src/ghb3.ui:6768
+#: src/ghb3.ui:6769
 msgid "Burn-In Behavior*:"
 msgstr ""
 
-#: src/ghb3.ui:6780
+#: src/ghb3.ui:6781
 msgid ""
 "Set the behavior of subtitle \"Burn-In\".\n"
 "\n"
@@ -1617,15 +1617,15 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6807
+#: src/ghb3.ui:6808
 msgid "Burn-In for deficient players*:"
 msgstr ""
 
-#: src/ghb3.ui:6816
+#: src/ghb3.ui:6817
 msgid "DVD Subtitles"
 msgstr "DVD 字幕"
 
-#: src/ghb3.ui:6821
+#: src/ghb3.ui:6822
 msgid ""
 "Burn the first selected DVD subtitle track. All other DVD subtitle tracks "
 "will be discarded.\n"
@@ -1636,11 +1636,11 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6835
+#: src/ghb3.ui:6836
 msgid "Blu-ray Subtitles"
 msgstr "藍光字幕"
 
-#: src/ghb3.ui:6840
+#: src/ghb3.ui:6841
 msgid ""
 "Burn the first selected Blu-ray subtitle track. All other Blu-ray subtitle "
 "tracks will be discarded.\n"
@@ -1651,123 +1651,123 @@ msgid ""
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6862
+#: src/ghb3.ui:6863
 msgid ""
 "<small>* Only one of the above subtitle burn options will be applied, "
 "starting with the top.</small>"
 msgstr ""
 
-#: src/ghb3.ui:6863
+#: src/ghb3.ui:6864
 msgid ""
 "Only one subtitle track can be burned! Since conflicts can occur, the first "
 "chosen wins."
 msgstr ""
 
-#: src/ghb3.ui:6887
+#: src/ghb3.ui:6888
 msgid "Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:6905 src/callbacks.c:2363 src/queuehandler.c:276
+#: src/ghb3.ui:6906 src/callbacks.c:2413 src/queuehandler.c:276
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ghb3.ui:6910
+#: src/ghb3.ui:6911
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ghb3.ui:6921
+#: src/ghb3.ui:6922
 #, fuzzy
 msgid "Import Chapters"
 msgstr "章節："
 
-#: src/ghb3.ui:6925
+#: src/ghb3.ui:6926
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6936
+#: src/ghb3.ui:6937
 #, fuzzy
 msgid "Export Chapters"
 msgstr "章節："
 
-#: src/ghb3.ui:6940
+#: src/ghb3.ui:6941
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ghb3.ui:6974
+#: src/ghb3.ui:6975
 msgid "Index"
 msgstr ""
 
-#: src/ghb3.ui:6998
+#: src/ghb3.ui:6999
 msgid "Duration"
 msgstr ""
 
-#: src/ghb3.ui:7009
+#: src/ghb3.ui:7010
 msgid "Title"
 msgstr ""
 
-#: src/ghb3.ui:7046
+#: src/ghb3.ui:7047
 msgid "Chapters"
 msgstr "章節："
 
-#: src/ghb3.ui:7101
+#: src/ghb3.ui:7102
 msgid "Actors:"
 msgstr "演員："
 
-#: src/ghb3.ui:7136
+#: src/ghb3.ui:7137
 msgid "Director:"
 msgstr "導演："
 
-#: src/ghb3.ui:7171
+#: src/ghb3.ui:7172
 msgid "Release Date:"
 msgstr "釋出日期："
 
-#: src/ghb3.ui:7206
+#: src/ghb3.ui:7207
 msgid "Comment:"
 msgstr ""
 
-#: src/ghb3.ui:7241
+#: src/ghb3.ui:7242
 msgid "Genre:"
 msgstr "類型："
 
-#: src/ghb3.ui:7276
+#: src/ghb3.ui:7277
 msgid "Description:"
 msgstr "敘述："
 
-#: src/ghb3.ui:7311
+#: src/ghb3.ui:7312
 msgid "Plot:"
 msgstr ""
 
-#: src/ghb3.ui:7349
+#: src/ghb3.ui:7350
 msgid "Tags"
 msgstr ""
 
-#: src/ghb3.ui:7379
+#: src/ghb3.ui:7380
 msgid "<b>Save As:</b>"
 msgstr "<b>另存為：</b>"
 
-#: src/ghb3.ui:7393
+#: src/ghb3.ui:7394
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7413
+#: src/ghb3.ui:7414
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ghb3.ui:7426
+#: src/ghb3.ui:7427
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ghb3.ui:7429
+#: src/ghb3.ui:7430
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ghb3.ui:7544
+#: src/ghb3.ui:7545
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ghb3.ui:7552 src/ghb3.ui:8589 src/ghb3.ui:8746 src/ghb3.ui:9312
-#: src/ghb3.ui:9722 src/callbacks.c:5560 src/callbacks.c:5568
-#: src/callbacks.c:5577 src/hb-backend.c:4300 src/hb-backend.c:4333
+#: src/ghb3.ui:7553 src/ghb3.ui:8590 src/ghb3.ui:8747 src/ghb3.ui:9313
+#: src/ghb3.ui:9723 src/callbacks.c:5610 src/callbacks.c:5618
+#: src/callbacks.c:5627 src/hb-backend.c:4300 src/hb-backend.c:4333
 #: src/hb-backend.c:4372 src/hb-backend.c:4403 src/hb-backend.c:4431
 #: src/hb-backend.c:4477 src/hb-backend.c:4534 src/hb-backend.c:4554
 #: src/hb-backend.c:4574 src/hb-backend.c:4635 src/hb-backend.c:4690
@@ -1775,74 +1775,74 @@ msgstr ""
 msgid "Cancel"
 msgstr "取消"
 
-#: src/ghb3.ui:7593
+#: src/ghb3.ui:7594
 msgid "Select All"
 msgstr "選擇全部"
 
-#: src/ghb3.ui:7597
+#: src/ghb3.ui:7598
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ghb3.ui:7610
+#: src/ghb3.ui:7611
 msgid "Clear All"
 msgstr "清除全部"
 
-#: src/ghb3.ui:7614
+#: src/ghb3.ui:7615
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ghb3.ui:7675
+#: src/ghb3.ui:7676
 msgid "Destination files OK.  No duplicates detected."
 msgstr "目的地檔案正常。未偵測到重複檔案。"
 
-#: src/ghb3.ui:7697 src/ghb3.ui:7709
+#: src/ghb3.ui:7698 src/ghb3.ui:7710
 msgid "Preferences"
 msgstr "偏好設定。"
 
-#: src/ghb3.ui:7800
+#: src/ghb3.ui:7801
 msgid "Automatically check for updates"
 msgstr "自動檢查更新"
 
-#: src/ghb3.ui:7837
+#: src/ghb3.ui:7838
 msgid "Default action when all encodes are complete"
 msgstr ""
 
-#: src/ghb3.ui:7859
+#: src/ghb3.ui:7860
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ghb3.ui:7860
+#: src/ghb3.ui:7861
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ghb3.ui:7884
+#: src/ghb3.ui:7885
 msgid "Auto-Name Template"
 msgstr "自動命名樣板"
 
-#: src/ghb3.ui:7895
+#: src/ghb3.ui:7896
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ghb3.ui:7915
+#: src/ghb3.ui:7916
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ghb3.ui:7958
+#: src/ghb3.ui:7959
 msgid "Number of previews"
 msgstr ""
 
-#: src/ghb3.ui:7996
+#: src/ghb3.ui:7997
 msgid "Filter short DVD and Blu-ray titles (seconds)"
 msgstr ""
 
-#: src/ghb3.ui:8010
+#: src/ghb3.ui:8011
 msgid "Clear completed queue items after an encode completes"
 msgstr ""
 
-#: src/ghb3.ui:8014
+#: src/ghb3.ui:8015
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "Check this if you want the queue to clean itself up by deleting completed "
@@ -1851,52 +1851,52 @@ msgstr ""
 "已完成的工作預設將留在佇列中，並被標示已完成。\n"
 "若您希望佇列自動清除已完成的工作，請勾選。"
 
-#: src/ghb3.ui:8027
+#: src/ghb3.ui:8028
 msgid "Power Saving"
 msgstr ""
 
-#: src/ghb3.ui:8045
+#: src/ghb3.ui:8046
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ghb3.ui:8051
+#: src/ghb3.ui:8052
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ghb3.ui:8062
+#: src/ghb3.ui:8063
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ghb3.ui:8068
+#: src/ghb3.ui:8069
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ghb3.ui:8079
+#: src/ghb3.ui:8080
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ghb3.ui:8085
+#: src/ghb3.ui:8086
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ghb3.ui:8096
+#: src/ghb3.ui:8097
 msgid "General"
 msgstr "一般"
 
-#: src/ghb3.ui:8121
+#: src/ghb3.ui:8122
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ghb3.ui:8125 src/ghb3.ui:8145
+#: src/ghb3.ui:8126 src/ghb3.ui:8146
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1910,63 +1910,63 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ghb3.ui:8155
+#: src/ghb3.ui:8156
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ghb3.ui:8195
+#: src/ghb3.ui:8196
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ghb3.ui:8212
+#: src/ghb3.ui:8213
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ghb3.ui:8235
+#: src/ghb3.ui:8236
 msgid "Monitor destination disk free space"
 msgstr "監測目的地磁碟剩餘空間"
 
-#: src/ghb3.ui:8239 src/ghb3.ui:8261
+#: src/ghb3.ui:8240 src/ghb3.ui:8262
 msgid "Pause encoding if free disk space drops below limit"
 msgstr "在剩餘磁碟空間低於限制時暫停編碼"
 
-#: src/ghb3.ui:8276
+#: src/ghb3.ui:8277
 msgid "MB Limit"
 msgstr ""
 
-#: src/ghb3.ui:8304
+#: src/ghb3.ui:8305
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ghb3.ui:8340
+#: src/ghb3.ui:8341
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ghb3.ui:8375
+#: src/ghb3.ui:8376
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ghb3.ui:8396
+#: src/ghb3.ui:8397
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ghb3.ui:8413
+#: src/ghb3.ui:8414
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ghb3.ui:8417
+#: src/ghb3.ui:8418
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ghb3.ui:8455
+#: src/ghb3.ui:8456
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ghb3.ui:8472
+#: src/ghb3.ui:8473
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ghb3.ui:8476
+#: src/ghb3.ui:8477
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1975,191 +1975,191 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ghb3.ui:8493
+#: src/ghb3.ui:8494
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ghb3.ui:8499
+#: src/ghb3.ui:8500
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ghb3.ui:8522
+#: src/ghb3.ui:8523
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ghb3.ui:8538
+#: src/ghb3.ui:8539
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ghb3.ui:8560
+#: src/ghb3.ui:8561
 msgid "Advanced"
 msgstr ""
 
-#: src/ghb3.ui:8577
+#: src/ghb3.ui:8578
 #, fuzzy
 msgid "Rename Preset"
 msgstr "降噪預設檔："
 
-#: src/ghb3.ui:8639
+#: src/ghb3.ui:8640
 msgid "<span size=\"x-large\">Rename Preset</span>"
 msgstr "<span size=\"x-large\">重新命名預設檔</span>"
 
-#: src/ghb3.ui:8659
+#: src/ghb3.ui:8660
 msgid "Name:"
 msgstr "名稱："
 
-#: src/ghb3.ui:8716 src/ghb3.ui:8989
+#: src/ghb3.ui:8717 src/ghb3.ui:8990
 msgid "<b>Description</b>"
 msgstr "<b>敘述</b>"
 
-#: src/ghb3.ui:8734
+#: src/ghb3.ui:8735
 #, fuzzy
 msgid "Save Preset"
 msgstr "儲存新的預設檔"
 
-#: src/ghb3.ui:8802
+#: src/ghb3.ui:8803
 msgid "Category:"
 msgstr "類別："
 
-#: src/ghb3.ui:8817
+#: src/ghb3.ui:8818
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ghb3.ui:8833
+#: src/ghb3.ui:8834
 msgid "Category Name:"
 msgstr "類別名稱："
 
-#: src/ghb3.ui:8866
+#: src/ghb3.ui:8867
 msgid "Preset Name:"
 msgstr "預設檔名稱："
 
-#: src/ghb3.ui:8900
+#: src/ghb3.ui:8901
 msgid "Default Preset"
 msgstr ""
 
-#: src/ghb3.ui:8905
+#: src/ghb3.ui:8906
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ghb3.ui:8931
+#: src/ghb3.ui:8932
 msgid "<b>Dimensions</b>"
 msgstr ""
 
-#: src/ghb3.ui:9012
+#: src/ghb3.ui:9013
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ghb3.ui:9093
+#: src/ghb3.ui:9094
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ghb3.ui:9115
+#: src/ghb3.ui:9116
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ghb3.ui:9171
+#: src/ghb3.ui:9172
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ghb3.ui:9207
+#: src/ghb3.ui:9208
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ghb3.ui:9219
+#: src/ghb3.ui:9220
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ghb3.ui:9235
+#: src/ghb3.ui:9236
 msgid "Show Crop"
 msgstr ""
 
-#: src/ghb3.ui:9239
+#: src/ghb3.ui:9240
 msgid "Show Cropped area of the preview"
 msgstr ""
 
-#: src/ghb3.ui:9250
+#: src/ghb3.ui:9251
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ghb3.ui:9254
+#: src/ghb3.ui:9255
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
-#: src/ghb3.ui:9299 src/subtitlehandler.c:1743
+#: src/ghb3.ui:9300 src/subtitlehandler.c:1743
 #, fuzzy
 msgid "Edit Subtitles"
 msgstr "字幕"
 
-#: src/ghb3.ui:9354
+#: src/ghb3.ui:9355
 msgid "Import SRT"
 msgstr "匯入 SRT"
 
-#: src/ghb3.ui:9359
+#: src/ghb3.ui:9360
 msgid "Enable settings to import an SRT subtitle file"
 msgstr "啟用此設定以匯入 SRT 字幕檔"
 
-#: src/ghb3.ui:9370
+#: src/ghb3.ui:9371
 msgid "Import SSA"
 msgstr ""
 
-#: src/ghb3.ui:9375
+#: src/ghb3.ui:9376
 msgid "Enable settings to import an SSA subtitle file"
 msgstr ""
 
-#: src/ghb3.ui:9387
+#: src/ghb3.ui:9388
 msgid "Embedded Subtitle List"
 msgstr "內嵌式字幕清單"
 
-#: src/ghb3.ui:9392
+#: src/ghb3.ui:9393
 msgid "Enable settings to select embedded subtitles"
 msgstr "啟用此設定以選擇內嵌式字幕"
 
-#: src/ghb3.ui:9419 src/ghb3.ui:9767
+#: src/ghb3.ui:9420 src/ghb3.ui:9768
 msgid "Source Track"
 msgstr "來源軌道"
 
-#: src/ghb3.ui:9434
+#: src/ghb3.ui:9435
 msgid "List of subtitle tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9448 src/ghb3.ui:9797
+#: src/ghb3.ui:9449 src/ghb3.ui:9798
 msgid "Track Name:"
 msgstr "軌道名稱"
 
-#: src/ghb3.ui:9464
+#: src/ghb3.ui:9465
 msgid ""
 "Set the subtitle track name.\n"
 "\n"
 "Players may use this in the subtitle selection list."
 msgstr ""
 
-#: src/ghb3.ui:9497
+#: src/ghb3.ui:9498
 msgid "Language"
 msgstr "語言"
 
-#: src/ghb3.ui:9511
+#: src/ghb3.ui:9512
 msgid "Character Code"
 msgstr ""
 
-#: src/ghb3.ui:9525
+#: src/ghb3.ui:9526
 msgid "File:"
 msgstr "檔案："
 
-#: src/ghb3.ui:9540
+#: src/ghb3.ui:9541
 msgid "Offset (ms)"
 msgstr ""
 
-#: src/ghb3.ui:9555
+#: src/ghb3.ui:9556
 msgid ""
 "Set the language of this subtitle.\n"
 "This value will be used by players in subtitle menus."
 msgstr ""
 
-#: src/ghb3.ui:9573
+#: src/ghb3.ui:9574
 msgid ""
 "Set the character code used by the SRT file you are importing.\n"
 "\n"
@@ -2168,60 +2168,60 @@ msgid ""
 "The source's character code is needed in order to perform this translation."
 msgstr ""
 
-#: src/ghb3.ui:9597
+#: src/ghb3.ui:9598
 msgid "Select the SRT file to import."
 msgstr "選擇要匯入的 SRT 檔案。"
 
-#: src/ghb3.ui:9600
+#: src/ghb3.ui:9601
 msgid "Import File"
 msgstr ""
 
-#: src/ghb3.ui:9618
+#: src/ghb3.ui:9619
 msgid "Adjust the offset in milliseconds between video and SRT timestamps"
 msgstr ""
 
-#: src/ghb3.ui:9642 src/subtitlehandler.c:119
+#: src/ghb3.ui:9643 src/subtitlehandler.c:119
 msgid "Forced Subtitles Only"
 msgstr ""
 
-#: src/ghb3.ui:9663
+#: src/ghb3.ui:9664
 msgid "Burn into video"
 msgstr ""
 
-#: src/ghb3.ui:9668
+#: src/ghb3.ui:9669
 msgid ""
 "Render the subtitle over the video.\n"
 "The subtitle will be part of the video and can not be disabled."
 msgstr ""
 
-#: src/ghb3.ui:9680
+#: src/ghb3.ui:9681
 msgid "Set Default Track"
 msgstr "設定預設軌道"
 
-#: src/ghb3.ui:9709 src/audiohandler.c:1473
+#: src/ghb3.ui:9710 src/audiohandler.c:1473
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/ghb3.ui:9783
+#: src/ghb3.ui:9784
 msgid "List of audio tracks available from your source."
 msgstr ""
 
-#: src/ghb3.ui:9813
+#: src/ghb3.ui:9814
 msgid ""
 "Set the audio track name.\n"
 "\n"
 "Players may use this in the audio selection list."
 msgstr ""
 
-#: src/ghb3.ui:9876
+#: src/ghb3.ui:9877
 msgid "Mix"
 msgstr ""
 
-#: src/ghb3.ui:9889
+#: src/ghb3.ui:9890
 msgid "Sample Rate"
 msgstr "取樣率"
 
-#: src/ghb3.ui:9919 src/ghb3.ui:10158 src/audiohandler.c:1931
+#: src/ghb3.ui:9920 src/ghb3.ui:10159 src/audiohandler.c:1931
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2232,90 +2232,90 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/ghb3.ui:9940 src/audiohandler.c:1782
+#: src/ghb3.ui:9941 src/audiohandler.c:1782
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:9962 src/audiohandler.c:1796
+#: src/ghb3.ui:9963 src/audiohandler.c:1796
 msgid "Bitrate"
 msgstr "位元速率"
 
-#: src/ghb3.ui:9967
+#: src/ghb3.ui:9968
 msgid "Enable bitrate setting"
 msgstr "啟用位元速率設定"
 
-#: src/ghb3.ui:9977 src/audiohandler.c:1801
+#: src/ghb3.ui:9978 src/audiohandler.c:1801
 msgid "Quality"
 msgstr "品質"
 
-#: src/ghb3.ui:9982
+#: src/ghb3.ui:9983
 msgid "Enable quality setting"
 msgstr "啟用品質設定"
 
-#: src/ghb3.ui:10003 src/audiohandler.c:1815
+#: src/ghb3.ui:10004 src/audiohandler.c:1815
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/ghb3.ui:10023
+#: src/ghb3.ui:10024
 msgid ""
 "<b>Quality:</b> For output codec's that support it, adjust the quality of "
 "the output."
 msgstr ""
 
-#: src/ghb3.ui:10045
+#: src/ghb3.ui:10046
 msgid "00.0"
 msgstr ""
 
-#: src/ghb3.ui:10072 src/audiohandler.c:1867
+#: src/ghb3.ui:10073 src/audiohandler.c:1867
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/ghb3.ui:10088 src/audiohandler.c:1880
+#: src/ghb3.ui:10089 src/audiohandler.c:1880
 msgid "Set the sample rate of the output audio track."
 msgstr "設定輸出檔案的音軌取樣率。"
 
-#: src/ghb3.ui:10111 src/audiohandler.c:1901
+#: src/ghb3.ui:10112 src/audiohandler.c:1901
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/ghb3.ui:10129 src/audiohandler.c:1911
+#: src/ghb3.ui:10130 src/audiohandler.c:1911
 msgid "0dB"
 msgstr "0dB"
 
 #. Audio DRC Label
-#: src/ghb3.ui:10176 src/audiohandler.c:427 src/audiohandler.c:765
-#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5333
+#: src/ghb3.ui:10177 src/audiohandler.c:427 src/audiohandler.c:765
+#: src/audiohandler.c:1168 src/audiohandler.c:1945 src/callbacks.c:5383
 #: src/hb-backend.c:200 src/hb-backend.c:213 src/hb-backend.c:225
 #: src/hb-backend.c:250 src/hb-backend.c:321 src/hb-backend.c:333
 #: src/hb-backend.c:345 src/hb-backend.c:406
 msgid "Off"
 msgstr "關閉"
 
-#: src/ghb3.ui:10201
+#: src/ghb3.ui:10202
 #, fuzzy
 msgid "HandBrake Updater"
 msgstr "HandBrake"
 
-#: src/ghb3.ui:10213
+#: src/ghb3.ui:10214
 msgid "Skip This Version"
 msgstr "略過此版本"
 
-#: src/ghb3.ui:10221
+#: src/ghb3.ui:10222
 msgid "Remind Me Later"
 msgstr "稍後提醒我"
 
-#: src/ghb3.ui:10290
+#: src/ghb3.ui:10291
 msgid "<b>A new version of HandBrake is available!</b>"
 msgstr "<b>新版的 HandBrake 已可使用！</b>"
 
-#: src/ghb3.ui:10306
+#: src/ghb3.ui:10307
 msgid "HandBrake xxx is now available (you have yyy)."
 msgstr "HandBrake xxx 目前已可使用 (您有 yyy)。"
 
-#: src/ghb3.ui:10334
+#: src/ghb3.ui:10335
 msgid "<b>Release Notes</b>"
 msgstr "<b>發行公告</b>"
 
@@ -2455,7 +2455,7 @@ msgstr "偵測到的 DVD 裝置："
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1526 src/callbacks.c:4355
+#: src/callbacks.c:1526 src/callbacks.c:4405
 msgid "Scanning ..."
 msgstr "掃描中..."
 
@@ -2467,88 +2467,117 @@ msgstr "停止掃描"
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2124 src/callbacks.c:2221
+#: src/callbacks.c:2127 src/callbacks.c:2271
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2125
+#: src/callbacks.c:2131
+#, c-format
+msgid "Dolby Vision %d.%d"
+msgstr ""
+
+#: src/callbacks.c:2135 src/callbacks.c:2138
+msgid "HDR10+"
+msgstr ""
+
+#: src/callbacks.c:2140
+msgid "HDR10"
+msgstr ""
+
+#: src/callbacks.c:2142
+#, fuzzy
+msgid "HDR"
+msgstr "DRC"
+
+#: src/callbacks.c:2144
+#, fuzzy
+msgid "SDR"
+msgstr "DRC"
+
+#. TRANSLATORS: This is the bit depth of the video
+#: src/callbacks.c:2152
+#, c-format
+msgid "%d-bit"
+msgstr ""
+
+#: src/callbacks.c:2174
 #, fuzzy
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] "音訊"
 
-#: src/callbacks.c:2126
+#: src/callbacks.c:2177
 #, fuzzy
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] "字幕"
 
-#: src/callbacks.c:2225
+#: src/callbacks.c:2275
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2229
+#: src/callbacks.c:2279
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2233
+#: src/callbacks.c:2283
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2275
+#: src/callbacks.c:2325
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2309 src/callbacks.c:2341 src/queuehandler.c:650
+#: src/callbacks.c:2359 src/callbacks.c:2391 src/queuehandler.c:650
 #: src/queuehandler.c:687
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2313 src/callbacks.c:2345 src/queuehandler.c:654
+#: src/callbacks.c:2363 src/callbacks.c:2395 src/queuehandler.c:654
 #: src/queuehandler.c:691
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2317 src/callbacks.c:2349 src/queuehandler.c:658
+#: src/callbacks.c:2367 src/callbacks.c:2399 src/queuehandler.c:658
 #: src/queuehandler.c:695
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2355
+#: src/callbacks.c:2405
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 
-#: src/callbacks.c:2510
+#: src/callbacks.c:2560
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2511
+#: src/callbacks.c:2561
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2512
+#: src/callbacks.c:2562
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2513
+#: src/callbacks.c:2563
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2650 src/hb-backend.c:2263 src/hb-backend.c:2383
+#: src/callbacks.c:2700 src/hb-backend.c:2263 src/hb-backend.c:2383
 #: src/hb-backend.c:2395
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2651
+#: src/callbacks.c:2701
 msgid "New Video"
 msgstr "新影片"
 
-#: src/callbacks.c:3660 src/callbacks.c:3673 src/callbacks.c:3695
-#: src/callbacks.c:3733
+#: src/callbacks.c:3710 src/callbacks.c:3723 src/callbacks.c:3745
+#: src/callbacks.c:3783
 #, c-format
 msgid ""
 "%s\n"
@@ -2556,132 +2585,132 @@ msgid ""
 "%s in %d seconds ..."
 msgstr ""
 
-#: src/callbacks.c:3830 src/callbacks.c:3881
+#: src/callbacks.c:3880 src/callbacks.c:3931
 #, c-format
 msgid "%sYour movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:3833 src/callbacks.c:3884 src/queuehandler.c:1824
+#: src/callbacks.c:3883 src/callbacks.c:3934 src/queuehandler.c:1824
 msgid "Cancel Current and Stop"
 msgstr "取消目前的，並停止"
 
-#: src/callbacks.c:3834
+#: src/callbacks.c:3884
 msgid "Cancel Current, Start Next"
 msgstr "取消目前的，並開始下一個"
 
-#: src/callbacks.c:3835
+#: src/callbacks.c:3885
 msgid "Finish Current, then Stop"
 msgstr "完成目前的，並停止"
 
-#: src/callbacks.c:3836 src/callbacks.c:3885
+#: src/callbacks.c:3886 src/callbacks.c:3935
 msgid "Continue Encoding"
 msgstr "繼續編碼"
 
-#: src/callbacks.c:4068
+#: src/callbacks.c:4118
 #, c-format
 msgid "%d encode pending"
 msgstr ""
 
-#: src/callbacks.c:4072
+#: src/callbacks.c:4122
 #, c-format
 msgid "%d encodes pending"
 msgstr ""
 
-#: src/callbacks.c:4129 src/callbacks.c:4197
+#: src/callbacks.c:4179 src/callbacks.c:4247
 #, c-format
 msgid "job %d of %d, "
 msgstr "工作 %d/%d，"
 
-#: src/callbacks.c:4139
+#: src/callbacks.c:4189
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4144
+#: src/callbacks.c:4194
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4157
+#: src/callbacks.c:4207
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4167 src/callbacks.c:4207
+#: src/callbacks.c:4217 src/callbacks.c:4257
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4177 src/callbacks.c:4216
+#: src/callbacks.c:4227 src/callbacks.c:4266
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4203
+#: src/callbacks.c:4253
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4278
+#: src/callbacks.c:4328
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4282
+#: src/callbacks.c:4332
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4366
+#: src/callbacks.c:4416
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4397
+#: src/callbacks.c:4447
 msgid "Encode Done!"
 msgstr "編碼完成！"
 
-#: src/callbacks.c:4401
+#: src/callbacks.c:4451
 msgid "Encode Canceled."
 msgstr "已取消編碼。"
 
-#: src/callbacks.c:4406
+#: src/callbacks.c:4456
 msgid "Encode Failed."
 msgstr "編碼失敗。"
 
-#: src/callbacks.c:4448
+#: src/callbacks.c:4498
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5366
+#: src/callbacks.c:5416
 #, c-format
 msgid "HandBrake %s/%s is now available (you have %s/%d)."
 msgstr "HandBrake %s/%s 已經可供使用（您有 %s/%d）。"
 
-#: src/callbacks.c:5545
+#: src/callbacks.c:5595
 msgid "Encode Complete"
 msgstr "編碼完畢"
 
-#: src/callbacks.c:5547
+#: src/callbacks.c:5597
 msgid "Put down that cocktail, Your HandBrake queue is done!"
 msgstr ""
 
-#: src/callbacks.c:5558 src/callbacks.c:5566 src/callbacks.c:5575
+#: src/callbacks.c:5608 src/callbacks.c:5616 src/callbacks.c:5625
 msgid "Your encode is complete."
 msgstr "您的編碼工作已經完成。"
 
-#: src/callbacks.c:5559
+#: src/callbacks.c:5609
 msgid "Quitting Handbrake"
 msgstr "退出 HandBrake"
 
-#: src/callbacks.c:5567
+#: src/callbacks.c:5617
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5576
+#: src/callbacks.c:5626
 msgid "Shutting down the computer"
 msgstr "關機"
 
 #. Add filters
-#: src/callbacks.c:5705 src/chapters.c:603 src/chapters.c:633
+#: src/callbacks.c:5755 src/chapters.c:603 src/chapters.c:633
 #: src/presets.c:2044 src/queuehandler.c:1694
 msgid "All Files"
 msgstr ""

--- a/gtk/src/ghb3.ui
+++ b/gtk/src/ghb3.ui
@@ -2474,6 +2474,7 @@ libx264 authors:
                         <property name="can-focus">False</property>
                         <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
                         <property name="halign">start</property>
+                        <property name="ellipsize">end</property>
                         <property name="label" translatable="yes"></property>
                       </object>
                       <packing>

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1020,8 +1020,8 @@ ghb_vquality_default(signal_user_data_t *ud)
     case HB_VCODEC_FFMPEG_MPEG2:
     case HB_VCODEC_FFMPEG_MPEG4:
         return 3;
-    case HB_VCODEC_FFMPEG_SVT_AV1_8BIT:
-    case HB_VCODEC_FFMPEG_SVT_AV1_10BIT:
+    case HB_VCODEC_SVT_AV1_8BIT:
+    case HB_VCODEC_SVT_AV1_10BIT:
         return 30;
     default:
     {
@@ -4461,7 +4461,7 @@ ghb_validate_video(GhbValue *settings, GtkWindow *parent)
         v_unsup = TRUE;
     }
     else if ((mux->format & HB_MUX_MASK_WEBM) &&
-             (vcodec != HB_VCODEC_FFMPEG_VP8 && vcodec != HB_VCODEC_FFMPEG_VP9 && vcodec != HB_VCODEC_FFMPEG_VP9_10BIT && vcodec != HB_VCODEC_FFMPEG_SVT_AV1 && vcodec != HB_VCODEC_FFMPEG_SVT_AV1_10BIT))
+             (vcodec != HB_VCODEC_FFMPEG_VP8 && vcodec != HB_VCODEC_FFMPEG_VP9 && vcodec != HB_VCODEC_FFMPEG_VP9_10BIT && vcodec != HB_VCODEC_SVT_AV1 && vcodec != HB_VCODEC_SVT_AV1_10BIT))
     {
         // webm only supports vp8, vp9 and av1.
         message = g_strdup_printf(


### PR DESCRIPTION
Displays the bit depth, HDR status and chroma information of a source in the summary label in the GTK UI. Thanks to @galad87 for the original implementation. Also fixes compilation by using the updated definition names for svt_av1.

Closes #3385.