### PR TITLE
libhb: preserve Ambient Viewing Environment metadata as defined by H.…

### DIFF
--- a/contrib/ffmpeg/A18-ambient-viewing-fix.patch
+++ b/contrib/ffmpeg/A18-ambient-viewing-fix.patch
@@ -1,0 +1,20 @@
+diff --git a/libavcodec/h2645_sei.c b/libavcodec/h2645_sei.c
+index 6e4a9a1..5d108d7 100644
+--- a/libavcodec/h2645_sei.c
++++ b/libavcodec/h2645_sei.c
+@@ -650,6 +650,8 @@ int ff_h2645_sei_to_frame(AVFrame *frame, H2645SEI *sei,
+         dst_env->ambient_illuminance = av_make_q(env->ambient_illuminance, 10000);
+         dst_env->ambient_light_x     = av_make_q(env->ambient_light_x,     50000);
+         dst_env->ambient_light_y     = av_make_q(env->ambient_light_y,     50000);
++
++        env->present = 0;
+     }
+ 
+     return 0;
+@@ -665,6 +667,4 @@ void ff_h2645_sei_reset(H2645SEI *s)
+     av_freep(&s->unregistered.buf_ref);
+     av_buffer_unref(&s->dynamic_hdr_plus.info);
+     av_buffer_unref(&s->dynamic_hdr_vivid.info);
+-
+-    s->ambient_viewing_environment.present = 0;
+ }

--- a/contrib/x265/A05-ambient-viewing-enviroment-sei.patch
+++ b/contrib/x265/A05-ambient-viewing-enviroment-sei.patch
@@ -1,0 +1,115 @@
+diff --git a/source/common/param.cpp b/source/common/param.cpp
+index 8c32fafa2..0b56235c9 100755
+--- a/source/common/param.cpp
++++ b/source/common/param.cpp
+@@ -378,6 +378,7 @@ void x265_param_default(x265_param* param)
+     param->preferredTransferCharacteristics = -1;
+     param->pictureStructure = -1;
+     param->bEmitCLL = 1;
++    param->bEmitAmbientViewingEnvironment = 0;
+ 
+     param->bEnableFrameDuplication = 0;
+     param->dupThreshold = 70;
+@@ -1880,6 +1881,7 @@ int x265_check_params(x265_param* param)
+                      || param->bEmitIDRRecoverySEI
+                    || !!param->interlaceMode
+                      || param->preferredTransferCharacteristics > 1
++                     || param->bEmitAmbientViewingEnvironment
+                      || param->toneMapFile
+                      || param->naluFile);
+ 
+@@ -2766,6 +2768,10 @@ void x265_copy_params(x265_param* dst, x265_param* src)
+     dst->bEmitCLL = src->bEmitCLL;
+     dst->maxCLL = src->maxCLL;
+     dst->maxFALL = src->maxFALL;
++    dst->ambientIlluminance = src->ambientIlluminance;
++    dst->ambientLightX = src->ambientLightX;
++    dst->ambientLightY = src->ambientLightY;
++    dst->bEmitAmbientViewingEnvironment = src->bEmitAmbientViewingEnvironment;
+     dst->log2MaxPocLsb = src->log2MaxPocLsb;
+     dst->bEmitVUIHRDInfo = src->bEmitVUIHRDInfo;
+     dst->bEmitVUITimingInfo = src->bEmitVUITimingInfo;
+diff --git a/source/encoder/encoder.cpp b/source/encoder/encoder.cpp
+index 5950f87e9..545283474 100644
+--- a/source/encoder/encoder.cpp
++++ b/source/encoder/encoder.cpp
+@@ -3276,6 +3276,15 @@ void Encoder::getStreamHeaders(NALList& list, Entropy& sbacCoder, Bitstream& bs)
+         }
+     }
+ 
++    if (m_param->bEmitAmbientViewingEnvironment)
++    {
++        SEIAmbientViewingEnvironment ambientsei;
++        ambientsei.ambientIlluminance = m_param->ambientIlluminance;
++        ambientsei.ambientLightX = m_param->ambientLightX;
++        ambientsei.ambientLightY = m_param->ambientLightY;
++        ambientsei.writeSEImessages(bs, m_sps, NAL_UNIT_PREFIX_SEI, list, m_param->bSingleSeiNal);
++    }
++
+     if (m_param->bEmitInfoSEI)
+     {
+         char *opts = x265_param2string(m_param, m_sps.conformanceWindow.rightOffset, m_sps.conformanceWindow.bottomOffset);
+diff --git a/source/encoder/sei.h b/source/encoder/sei.h
+index 03e210639..712e4efb4 100644
+--- a/source/encoder/sei.h
++++ b/source/encoder/sei.h
+@@ -242,6 +242,25 @@ public:
+     }
+ };
+ 
++class SEIAmbientViewingEnvironment : public SEI
++{
++public:
++    SEIAmbientViewingEnvironment()
++    {
++        m_payloadType = AMBIENT_VIEWING_ENVIRONMENT;
++        m_payloadSize = 8;
++    }
++    uint32_t ambientIlluminance;
++    uint16_t ambientLightX;
++    uint16_t ambientLightY;
++    void writeSEI(const SPS&)
++    {
++        WRITE_CODE(ambientIlluminance, 32, "ambient_illuminance");
++        WRITE_CODE(ambientLightX,      16, "ambient_light_x");
++        WRITE_CODE(ambientLightY,      16, "ambient_light_y");
++    }
++};
++
+ class SEIDecodedPictureHash : public SEI
+ {
+ public:
+diff --git a/source/x265.h b/source/x265.h
+index 9f3abd9d9..b6a4d3fe1 100644
+--- a/source/x265.h
++++ b/source/x265.h
+@@ -371,6 +371,7 @@ typedef enum
+     MASTERING_DISPLAY_INFO               = 137,
+     CONTENT_LIGHT_LEVEL_INFO             = 144,
+     ALTERNATIVE_TRANSFER_CHARACTERISTICS = 147,
++    AMBIENT_VIEWING_ENVIRONMENT          = 148,
+ } SEIPayloadType;
+ 
+ typedef struct x265_sei_payload
+@@ -1903,6 +1904,11 @@ typedef struct x265_param
+      * value to that value. */
+     uint16_t maxLuma;
+ 
++    /* ISO/IEC 23008-2:2017, D.2.39 ambient viewing environment SEI message */
++    uint32_t ambientIlluminance;
++    uint16_t ambientLightX;
++    uint16_t ambientLightY;
++
+     /* Maximum of the picture order count */
+     int log2MaxPocLsb;
+ 
+@@ -2114,6 +2120,9 @@ typedef struct x265_param
+     /*Emit content light level info SEI*/
+     int         bEmitCLL;
+ 
++    /* Emit ambient viewing environment SEI */
++    int         bEmitAmbientViewingEnvironment;
++
+     /*
+     * Signals picture structure SEI timing message for every frame
+     * picture structure 7 is signalled for frame doubling

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4174,6 +4174,7 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
 
     job->mastering      = title->mastering;
     job->coll           = title->coll;
+    job->ambient        = title->ambient;
     job->dovi           = title->dovi;
     job->passthru_dynamic_hdr_metadata |= title->dovi.dv_profile ? DOVI : NONE;
     job->passthru_dynamic_hdr_metadata |= title->hdr_10_plus ? HDR_10_PLUS : NONE;

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1147,6 +1147,14 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
         {
             pv->title->hdr_10_plus = 1;
         }
+
+        // Check for Ambient Viewing Environment metadata
+        sd = av_frame_get_side_data(pv->frame, AV_FRAME_DATA_AMBIENT_VIEWING_ENVIRONMENT);
+        if (sd != NULL && sd->size > 0)
+        {
+            AVAmbientViewingEnvironment *ambient = (AVAmbientViewingEnvironment *)sd->data;
+            pv->title->ambient = hb_ambient_ff_to_hb(*ambient);
+        }
     }
 
     return out;

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -306,6 +306,14 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
         }
     }
 
+    if (job->ambient.ambient_illuminance.num && job->ambient.ambient_illuminance.den)
+    {
+        param->ambientIlluminance = rescale(job->ambient.ambient_illuminance, 10000);
+        param->ambientLightX = rescale(job->ambient.ambient_light_x, 50000);
+        param->ambientLightY = rescale(job->ambient.ambient_light_y, 50000);
+        param->bEmitAmbientViewingEnvironment = 1;
+    }
+
     if (job->chroma_location != AVCHROMA_LOC_UNSPECIFIED)
     {
         char chromaLocation[256];

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -349,6 +349,13 @@ struct hb_content_light_metadata_s
     unsigned max_fall;
 };
 
+struct hb_ambient_viewing_environment_metadata_s
+{
+    hb_rational_t ambient_illuminance;
+    hb_rational_t ambient_light_x;
+    hb_rational_t ambient_light_y;
+};
+
 struct hb_dovi_conf_s
 {
     unsigned dv_version_major;
@@ -719,6 +726,7 @@ struct hb_job_s
 
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t coll;
+    hb_ambient_viewing_environment_metadata_t ambient;
     hb_dovi_conf_t dovi;
 
     enum {NONE = 0x0, ALL = 0x3, DOVI = 0x1, HDR_10_PLUS = 0x2} passthru_dynamic_hdr_metadata;
@@ -1189,6 +1197,7 @@ struct hb_title_s
 
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t     coll;
+    hb_ambient_viewing_environment_metadata_t ambient;
     hb_dovi_conf_t  dovi;
     int             hdr_10_plus;
 

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -20,6 +20,7 @@
 #include "libavutil/downmix_info.h"
 #include "libavutil/display.h"
 #include "libavutil/mastering_display_metadata.h"
+#include "libavutil/ambient_viewing_environment.h"
 #include "libavutil/dovi_meta.h"
 #include "libswscale/swscale.h"
 #include "libswresample/swresample.h"
@@ -46,6 +47,9 @@ int hb_colr_mat_ff_to_hb(int colr_mat);
 
 hb_mastering_display_metadata_t hb_mastering_ff_to_hb(AVMasteringDisplayMetadata mastering);
 AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t mastering);
+
+hb_ambient_viewing_environment_metadata_t hb_ambient_ff_to_hb(AVAmbientViewingEnvironment ambient);
+AVAmbientViewingEnvironment hb_ambient_hb_to_ff(hb_ambient_viewing_environment_metadata_t ambient);
 
 AVDOVIDecoderConfigurationRecord hb_dovi_hb_to_ff(hb_dovi_conf_t dovi);
 hb_dovi_conf_t hb_dovi_ff_to_hb(AVDOVIDecoderConfigurationRecord dovi);

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -46,6 +46,7 @@ typedef struct hb_fifo_s hb_fifo_t;
 typedef struct hb_lock_s hb_lock_t;
 typedef struct hb_mastering_display_metadata_s hb_mastering_display_metadata_t;
 typedef struct hb_content_light_metadata_s hb_content_light_metadata_t;
+typedef struct hb_ambient_viewing_environment_metadata_s hb_ambient_viewing_environment_metadata_t;
 typedef struct hb_dovi_conf_s hb_dovi_conf_t;
 
 #endif // HANDBRAKE_TYPES_H

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -543,6 +543,28 @@ AVMasteringDisplayMetadata hb_mastering_hb_to_ff(hb_mastering_display_metadata_t
     return ff_mastering;
 }
 
+hb_ambient_viewing_environment_metadata_t hb_ambient_ff_to_hb(AVAmbientViewingEnvironment ambient)
+{
+    hb_ambient_viewing_environment_metadata_t hb_ambient;
+
+    hb_ambient.ambient_illuminance = hb_rational_ff_to_hb(ambient.ambient_illuminance);
+    hb_ambient.ambient_light_x = hb_rational_ff_to_hb(ambient.ambient_light_x);
+    hb_ambient.ambient_light_y = hb_rational_ff_to_hb(ambient.ambient_light_y);
+
+    return hb_ambient;
+}
+
+AVAmbientViewingEnvironment hb_ambient_hb_to_ff(hb_ambient_viewing_environment_metadata_t ambient)
+{
+    AVAmbientViewingEnvironment ff_ambient;
+
+    ff_ambient.ambient_illuminance = hb_rational_hb_to_ff(ambient.ambient_illuminance);
+    ff_ambient.ambient_light_x = hb_rational_hb_to_ff(ambient.ambient_light_x);
+    ff_ambient.ambient_light_y = hb_rational_hb_to_ff(ambient.ambient_light_y);
+
+    return ff_ambient;
+}
+
 AVDOVIDecoderConfigurationRecord hb_dovi_hb_to_ff(hb_dovi_conf_t dovi)
 {
     AVDOVIDecoderConfigurationRecord ff_dovi;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1329,6 +1329,14 @@ skip_preview:
                    title->coll.max_fall);
         }
 
+        if (title->ambient.ambient_illuminance.num)
+        {
+            hb_log("scan: ambient viewing environment: ambient_illuminance=%f, ambient_light_x=%f, ambient_light_x=%f",
+                   hb_q2d(title->ambient.ambient_illuminance),
+                   hb_q2d(title->ambient.ambient_light_x),
+                   hb_q2d(title->ambient.ambient_light_y));
+        }
+
         if (title->dovi.dv_profile > 0)
         {
             hb_log("scan: dolby vision configuration record: version: %d.%d, profile: %d, level: %d, rpu flag: %d, el flag: %d, bl flag: %d, compatibility id: %d",


### PR DESCRIPTION
…274 when possible. Currently used in movies recorded on iPhone.

Recompressed iPhone recording now display properly in QuickTime Player at last.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux