### PR TITLE
contrib: update libass to version 0.17.1.

### DIFF
--- a/contrib/libass/A00-fribidi-include.patch
+++ b/contrib/libass/A00-fribidi-include.patch
@@ -1,5 +1,18 @@
+diff --git a/libass/ass_render.h b/libass/ass_render.h
+index 581c131..79dacd1 100644
+--- a/libass/ass_render.h
++++ b/libass/ass_render.h
+@@ -22,7 +22,7 @@
+ 
+ #include <inttypes.h>
+ #include <stdbool.h>
+-#include <fribidi.h>
++#include <fribidi/fribidi.h>
+ #include <ft2build.h>
+ #include FT_FREETYPE_H
+ #include FT_GLYPH_H
 diff --git a/libass/ass_shaper.h b/libass/ass_shaper.h
-index 2c4166d..3cb12b0 100644
+index 819a3fd..ad73516 100644
 --- a/libass/ass_shaper.h
 +++ b/libass/ass_shaper.h
 @@ -21,7 +21,7 @@
@@ -10,4 +23,4 @@ index 2c4166d..3cb12b0 100644
 +#include <fribidi/fribidi.h>
  #include <stdbool.h>
  #include "ass_render.h"
- 
+ #include "ass_cache.h"

--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -7,9 +7,9 @@ endif
 $(eval $(call import.MODULE.defs,LIBASS,libass,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBASS))
 
-LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libass-0.16.0.tar.gz
-LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.16.0/libass-0.16.0.tar.gz
-LIBASS.FETCH.sha256  = fea8019b1887cab9ab00c1e58614b4ec2b1cee339b3f7e446f5fab01b032d430
+LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libass-0.17.1.tar.gz
+LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.17.1/libass-0.17.1.tar.gz
+LIBASS.FETCH.sha256  = d653be97198a0543c69111122173c41a99e0b91426f9e17f06a858982c2fb03d
 
 # Tell configure where to find our versions of these libs
 ifneq (1,$(FEATURE.flatpak))
@@ -37,3 +37,5 @@ ifneq ($(HOST.system),linux)
         FRIBIDI_LIBS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/))lib -lfribidi" \
         FRIBIDI_CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/))include"
 endif
+
+LIBASS.CONFIGURE.extra += --disable-libunibreak


### PR DESCRIPTION
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux