### PR TITLE
nvenc: Improve hardware detection for NVENC so unsupported encoders a…

### DIFF
--- a/libhb/handbrake/nvenc_common.h
+++ b/libhb/handbrake/nvenc_common.h
@@ -18,6 +18,7 @@ int            hb_nvenc_av1_available();
 int            hb_check_nvenc_available();
 int            hb_check_nvdec_available();
 
+int            hb_nvenc_get_max_instances();
 
 char*          hb_map_nvenc_preset_name (const char * preset);
 
@@ -33,5 +34,7 @@ const char*    hb_nvdec_get_codec_name(enum AVCodecID codec_id);
 int            hb_nvdec_is_enabled(hb_job_t *job);
 
 int            hb_nvdec_are_filters_supported(hb_list_t *filters);
+
+
 
 #endif // HANDBRAKE_NVENC_COMMON_H

--- a/libhb/handbrake/nvenc_common.h
+++ b/libhb/handbrake/nvenc_common.h
@@ -18,8 +18,6 @@ int            hb_nvenc_av1_available();
 int            hb_check_nvenc_available();
 int            hb_check_nvdec_available();
 
-int            hb_nvenc_get_max_instances();
-
 char*          hb_map_nvenc_preset_name (const char * preset);
 
 int            hb_nvdec_available(int codec_id);
@@ -34,7 +32,5 @@ const char*    hb_nvdec_get_codec_name(enum AVCodecID codec_id);
 int            hb_nvdec_is_enabled(hb_job_t *job);
 
 int            hb_nvdec_are_filters_supported(hb_list_t *filters);
-
-
 
 #endif // HANDBRAKE_NVENC_COMMON_H

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -60,7 +60,7 @@ int hb_nvenc_get_cuda_version() {
                 apiErr = cu->cuDeviceComputeCapability(&major, &minor, dev);
                
                 if (apiErr == CUDA_SUCCESS) {
-                    cuda_version = major * 100 + minor;
+                    cuda_version = major * 1000 + minor;
                     hb_log("CUDA Version: %i.%i", major, minor);
                     
                     free(cu);
@@ -143,7 +143,7 @@ int hb_nvenc_h265_available()
         return is_nvenc_hevc_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 600) {
+    if (hb_nvenc_get_cuda_version() >= 6000) {
         is_nvenc_hevc_available = 1;
     }else {
         is_nvenc_hevc_available = 0;
@@ -164,7 +164,7 @@ int hb_nvenc_av1_available()
         return is_nvenc_av1_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 809) {
+    if (hb_nvenc_get_cuda_version() >= 8009) {
         is_nvenc_av1_available = 1;
     } else {
         is_nvenc_av1_available = 0;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -35,9 +35,9 @@ double hb_nvenc_get_cuda_version() {
     int major, minor, devices;
       
     apiErr = cuda_load_functions(&cu, NULL);
-    if (apiErr == NV_ENC_SUCCESS) {
+    if (apiErr == CUDA_SUCCESS) {
         apiErr = cu->cuInit(0);
-        if (apiErr == NV_ENC_SUCCESS) {
+        if (apiErr == CUDA_SUCCESS) {
             
             cu->cuDeviceGetCount(&devices);
             if (!devices) {
@@ -58,7 +58,7 @@ double hb_nvenc_get_cuda_version() {
 
             apiErr = cu->cuDeviceComputeCapability(&major, &minor, dev);
            
-            if (apiErr == NV_ENC_SUCCESS) {
+            if (apiErr == CUDA_SUCCESS) {
                 cuda_version = (double)major + ((double)minor / 10.0);
                 hb_log("CUDA Version: %.1f", cuda_version);
                 

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -22,7 +22,7 @@ static int is_nvenc_hevc_available = -1;
 
 static double cuda_version = -1;
 
-double hb_nvenc_get_cuda_version() {
+int hb_nvenc_get_cuda_version() {
    
    if (cuda_version != -1) {
        return cuda_version;
@@ -60,12 +60,8 @@ double hb_nvenc_get_cuda_version() {
                 apiErr = cu->cuDeviceComputeCapability(&major, &minor, dev);
                
                 if (apiErr == CUDA_SUCCESS) {
-                    char str[6];
-                    char *ptr;
-                     
-                    sprintf(str, "%d.%d", major, minor);
-                    cuda_version = strtod(str, &ptr);
-                    hb_log("CUDA Version: %.1f", cuda_version);
+                    cuda_version = major * 100 + minor;
+                    hb_log("CUDA Version: %i.%i", major, minor);
                     
                     free(cu);
                     free(dev);
@@ -147,7 +143,7 @@ int hb_nvenc_h265_available()
         return is_nvenc_hevc_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 6.0) {
+    if (hb_nvenc_get_cuda_version() >= 600) {
         is_nvenc_hevc_available = 1;
     }else {
         is_nvenc_hevc_available = 0;
@@ -168,7 +164,7 @@ int hb_nvenc_av1_available()
         return is_nvenc_av1_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 8.9) {
+    if (hb_nvenc_get_cuda_version() >= 809) {
         is_nvenc_av1_available = 1;
     } else {
         is_nvenc_av1_available = 0;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -36,9 +36,11 @@ int hb_nvenc_get_cuda_version() {
         int major, minor, devices;
           
         apiErr = cuda_load_functions(&cu, NULL);
-        if (apiErr == CUDA_SUCCESS) {
+        if (apiErr == CUDA_SUCCESS) 
+        {
             apiErr = cu->cuInit(0);
-            if (apiErr == CUDA_SUCCESS) {
+            if (apiErr == CUDA_SUCCESS) 
+            {
                 
                 cu->cuDeviceGetCount(&devices);
                 if (!devices) {
@@ -48,7 +50,8 @@ int hb_nvenc_get_cuda_version() {
                 }
                     
                 // For now, lets just work off the primary device we find.
-                for (int i = 0; i < devices; ++i) {
+                for (int i = 0; i < devices; ++i) 
+                {
                     int result = cu->cuDeviceGet(&dev, i);
                     if (result == CUDA_SUCCESS)
                     {
@@ -59,7 +62,8 @@ int hb_nvenc_get_cuda_version() {
 
                 apiErr = cu->cuDeviceComputeCapability(&major, &minor, dev);
                
-                if (apiErr == CUDA_SUCCESS) {
+                if (apiErr == CUDA_SUCCESS) 
+                {
                     cuda_version = major * 1000 + minor;
                     hb_log("CUDA Version: %i.%i", major, minor);
                     
@@ -96,23 +100,30 @@ int hb_check_nvenc_available()
         NvencFunctions *nvenc_dl = NULL;
 
         int loadErr = nvenc_load_functions(&nvenc_dl, context);
-        if (loadErr < 0) {
+        if (loadErr < 0) 
+        {
             is_nvenc_available = 0;
             return 0;
         }
 
         NVENCSTATUS apiErr = nvenc_dl->NvEncodeAPIGetMaxSupportedVersion(&nvenc_ver);
-        if (apiErr != NV_ENC_SUCCESS) {
+        if (apiErr != NV_ENC_SUCCESS) 
+        {
             is_nvenc_available = 0;
             hb_log("nvenc: not available");
             return 0;
-        } else {
+        }
+        else 
+        {
             hb_log("nvenc: version %d.%d is available", nvenc_ver >> 4, nvenc_ver & 0xf);
             is_nvenc_available = 1;
             
-            if (hb_check_nvdec_available()){
+            if (hb_check_nvdec_available())
+            {
                 hb_log("nvdec: is available");
-            } else {
+            } 
+            else 
+            {
                 hb_log("nvdec: is not compiled into this build");
             }
             return 1;
@@ -138,14 +149,18 @@ int hb_nvenc_h265_available()
         return is_nvenc_hevc_available;
     }
     
-    if (!hb_check_nvenc_available()){
+    if (!hb_check_nvenc_available())
+    {
         is_nvenc_hevc_available = 0;
         return is_nvenc_hevc_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 6000) {
+    if (hb_nvenc_get_cuda_version() >= 6000) 
+    {
         is_nvenc_hevc_available = 1;
-    }else {
+    } 
+    else 
+    {
         is_nvenc_hevc_available = 0;
     }
         
@@ -164,9 +179,12 @@ int hb_nvenc_av1_available()
         return is_nvenc_av1_available;
     }
     
-    if (hb_nvenc_get_cuda_version() >= 8009) {
+    if (hb_nvenc_get_cuda_version() >= 8009) 
+    {
         is_nvenc_av1_available = 1;
-    } else {
+    } 
+    else 
+    {
         is_nvenc_av1_available = 0;
     }
         

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -60,7 +60,11 @@ double hb_nvenc_get_cuda_version() {
                 apiErr = cu->cuDeviceComputeCapability(&major, &minor, dev);
                
                 if (apiErr == CUDA_SUCCESS) {
-                    cuda_version = (double)major + ((double)minor / 10.0);
+                    char str[6];
+                    char *ptr;
+                     
+                    sprintf(str, "%d.%d", major, minor);
+                    cuda_version = strtod(str, &ptr);
                     hb_log("CUDA Version: %.1f", cuda_version);
                     
                     free(cu);


### PR DESCRIPTION
…re not shown. Fixes #1666

**Description of Change:**

Use the CUDA version to detect the capabilities of the card. This allows us to hide HEVC and AV1 NVEnc encoders on cards that are not supported.

#1666

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

