### PR TITLE
libhb: do not disable the vfr filter when mode is 0

### DIFF
--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -289,8 +289,23 @@ int hb_nvdec_are_filters_supported(hb_list_t *filters)
     for (int i = 0; i < hb_list_count(filters); i++)
     {
         hb_filter_object_t *filter = hb_list_item(filters, i);
-        hb_deep_log( 2, "nvdec: %s isn't yet supported for CUDA video frames", filter->name);
-        ret = 0;
+
+        switch (filter->id)
+        {
+            case HB_FILTER_VFR:
+            {
+                // Mode 0 doesn't require access to the frame data
+                int mode = hb_dict_get_int(filter->settings, "mode");
+                if (mode == 0)
+                {
+                    break;
+                }
+            }
+            default:
+                hb_deep_log( 2, "nvdec: %s isn't yet supported for CUDA video frames", filter->name);
+                ret = 0;
+                break;
+        }
     }
 
     return ret;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4982,6 +4982,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
     {
         int i = 0;
         int num_sw_filters = 0;
+        int num_hw_filters = 0;
         if (job->list_filter != NULL && hb_list_count(job->list_filter) > 0)
         {
             for (i = 0; i < hb_list_count(job->list_filter); i++)
@@ -4992,6 +4993,7 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
                 {
                     // cropping and scaling always done via VPP filter
                     case HB_FILTER_CROP_SCALE:
+                        num_hw_filters++;
                         break;
                     case HB_FILTER_VFR:
                     {
@@ -5003,13 +5005,14 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
                         }
                     }
                     default:
+                        // count only filters with access to frame data
                         num_sw_filters++;
                         break;
                 }
             }
         }
         job->qsv.ctx->num_sw_filters = num_sw_filters;
-        job->qsv.ctx->qsv_hw_filters_are_enabled = ((hb_list_count(job->list_filter) == 1) && hb_qsv_full_path_is_enabled(job)) ? 1 : 0;
+        job->qsv.ctx->qsv_hw_filters_are_enabled = ((num_hw_filters > 0) && hb_qsv_full_path_is_enabled(job)) ? 1 : 0;
         if (job->qsv.ctx->qsv_hw_filters_are_enabled)
         {
             job->qsv.ctx->hb_vpp_qsv_frames_ctx = av_mallocz(sizeof(HBQSVFramesContext));

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4993,13 +4993,15 @@ int hb_qsv_sanitize_filter_list(hb_job_t *job)
                     // cropping and scaling always done via VPP filter
                     case HB_FILTER_CROP_SCALE:
                         break;
-
-                    case HB_FILTER_YADIF:
-                    case HB_FILTER_ROTATE:
-                    case HB_FILTER_RENDER_SUB:
-                    case HB_FILTER_AVFILTER:
-                        num_sw_filters++;
-                        break;
+                    case HB_FILTER_VFR:
+                    {
+                        // Mode 0 doesn't require access to the frame data
+                        int mode = hb_dict_get_int(filter->settings, "mode");
+                        if (mode == 0)
+                        {
+                            break;
+                        }
+                    }
                     default:
                         num_sw_filters++;
                         break;

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -538,6 +538,11 @@ static void hb_vfr_close( hb_filter_object_t * filter )
         hb_log("vfr: %d frames output, %d dropped and %d duped for CFR/PFR",
                pv->count_frames, pv->drops, pv->dups );
     }
+    else
+    {
+        hb_log("vfr: %d frames output, %d dropped",
+               pv->count_frames, pv->drops);
+    }
 
     if( pv->job )
     {

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1387,27 +1387,7 @@ static void sanitize_filter_list(hb_job_t *job, hb_geometry_t src_geo)
         }
     }
 
-    int is_detel = 0;
-    hb_filter_object_t * filter = hb_filter_find(list, HB_FILTER_DETELECINE);
-    if (filter != NULL)
-    {
-        is_detel = 1;
-    }
-
-    filter = hb_filter_find(list, HB_FILTER_VFR);
-    if (filter != NULL)
-    {
-        int mode = hb_dict_get_int(filter->settings, "mode");
-        // "Same as source" FPS and no HB_FILTER_DETELECINE
-        if ( (mode == 0) && (is_detel == 0) )
-        {
-            hb_list_rem(list, filter);
-            hb_filter_close(&filter);
-            hb_log("Skipping vfr filter");
-        }
-    }
-
-    filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
+    hb_filter_object_t *filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
     if (filter != NULL)
     {
         hb_dict_t* settings = filter->settings;


### PR DESCRIPTION
Mode 0 is still useful to handle video tracks with very short frames that can't be represented with the 90000 timescale. Fix #5075 and #5010.
This was disabled in #2353, but from what I can see in mode 0 it doesn't need to access the frame data, so it should be safe to keep it on even for hw frames.

Ping @galinart 

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux