### PR TITLE
contrib: update libopus to version 1.4.

### DIFF
--- a/contrib/libopus/module.defs
+++ b/contrib/libopus/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBOPUS,libopus))
 $(eval $(call import.CONTRIB.defs,LIBOPUS))
 
-LIBOPUS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/opus-1.3.1.tar.gz
-LIBOPUS.FETCH.url    += https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz
-LIBOPUS.FETCH.sha256  = 65b58e1e25b2a114157014736a3d9dfeaad8d41be1c8179866f144a2fb44ff9d
+LIBOPUS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/opus-1.4.tar.gz
+LIBOPUS.FETCH.url    += https://github.com/xiph/opus/releases/download/v1.4/opus-1.4.tar.gz
+LIBOPUS.FETCH.sha256  = c9b32b4253be5ae63d1ff16eea06b94b5f0f2951b7a02aceef58e3a3ce49c51f
 
 LIBOPUS.CONFIGURE.shared = --enable-shared=no
 LIBOPUS.CONFIGURE.extra = --disable-doc --disable-extra-programs


### PR DESCRIPTION
Opus 1.4 brings the following improvements and fixes:

Improved tuning of the Opus in-band FEC (LBRR). See the
https://gitlab.xiph.org/xiph/opus/-/issues/2360 for details
Added a OPUS_SET_INBAND_FEC(2) option that turns on FEC, but does not
force SILK mode (FEC will be disabled in CELT mode)
Improved tuning and various fixes to DTX
Added Meson support, improved CMake support

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux