### PR TITLE
Assorted QSV cleanups

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -201,7 +201,8 @@ static int log_encoder_params(const hb_work_private_t *pv, const mfxVideoParam *
         else if (option->Header.BufferId != MFX_EXTBUFF_VIDEO_SIGNAL_INFO &&
                  option->Header.BufferId != MFX_EXTBUFF_CHROMA_LOC_INFO &&
                  option->Header.BufferId != MFX_EXTBUFF_MASTERING_DISPLAY_COLOUR_VOLUME &&
-                 option->Header.BufferId != MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO)
+                 option->Header.BufferId != MFX_EXTBUFF_CONTENT_LIGHT_LEVEL_INFO &&
+                 option->Header.BufferId != MFX_EXTBUFF_AV1_BITSTREAM_PARAM)
         {
             hb_log("Unknown Header.BufferId=%d", option->Header.BufferId);
         }

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1484,12 +1484,12 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     {
         pv->param.rc.lookahead = pv->param.rc.lookahead && (pv->param.rc.icq || job->vquality <= HB_INVALID_VIDEO_QUALITY);
     }
-#if HB_PROJECT_FEATURE_QSV
+
     if (pv->job->qsv.ctx != NULL)
     {
         job->qsv.ctx->la_is_enabled = pv->param.rc.lookahead ? 1 : 0;
     }
-#endif
+
     // libmfx BRC parameters are 16 bits thus maybe overflow, then BRCParamMultiplier is needed
     // Comparison vbitrate in Kbps (kilobit) with vbv_max_bitrate, vbv_buffer_size, vbv_buffer_init in KB (kilobyte)
     brc_param_multiplier = (FFMAX(FFMAX3(job->vbitrate, pv->param.rc.vbv_max_bitrate, pv->param.rc.vbv_buffer_size),
@@ -2402,7 +2402,6 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
     }
     else
     {
-#if HB_PROJECT_FEATURE_QSV
         QSVMid *mid = NULL;
         if (in->qsv_details.frame && in->qsv_details.frame->data[3])
         {
@@ -2416,7 +2415,7 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
             hb_error("encqsv: in->qsv_details no surface available");
             goto fail;
         }
-#endif
+
         // At this point, enc_qsv takes ownership of the QSV resources
         // in the 'in' buffer.
         in->qsv_details.qsv_atom = NULL;
@@ -2517,12 +2516,12 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         hb_error("encqsvWork: qsv_enc_work failed %d", err);
         goto fail;
     }
-#if HB_PROJECT_FEATURE_QSV
+
     if (in->qsv_details.frame)
     {
         in->qsv_details.frame->data[3] = 0;
     }
-#endif
+
     *buf_out = hb_buffer_list_clear(&pv->encoded_frames);
     return HB_WORK_OK;
 

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -105,6 +105,7 @@ hb_display_t * hb_qsv_display_init(const uint32_t dri_render_node);
 int            hb_qsv_video_encoder_is_enabled(int adapter_index, int encoder);
 int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();
+void           hb_qsv_info_close();
 void           hb_qsv_info_print();
 hb_list_t*     hb_qsv_adapters_list();
 int            hb_qsv_hyper_encode_available(int adapter_index);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -518,15 +518,6 @@ void hb_qsv_info_close()
         hb_list_close(&g_qsv_adapters_list);
         g_qsv_adapters_list = NULL;
     }
-#if defined(_WIN32) || defined(__MINGW32__)
-    if (g_qsv_adapters_info.Adapters)
-    {
-        av_free(g_qsv_adapters_info.Adapters);
-    }
-    g_qsv_adapters_info.Adapters = NULL;
-    g_qsv_adapters_info.NumAlloc = 0;
-    g_qsv_adapters_info.NumActual = 0;
-#endif
 }
 
 static int hb_qsv_make_adapters_list(hb_list_t **qsv_adapters_list, hb_list_t **qsv_adapters_details_list)


### PR DESCRIPTION
Remove a bunch of dead code, and fix a warning log when encoding in AV1.
hb_qsv_info_close() is untested and unused.

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux