### PR TITLE
various small QSV changes

### DIFF
--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1161,7 +1161,7 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
     hb_work_private_t *pv = calloc(1, sizeof(hb_work_private_t));
     w->private_data       = pv;
 
-    pv->is_sys_mem         = hb_qsv_full_path_is_enabled(job) ? 0 : 1; // TODO: re-implement QSV VPP filtering support
+    pv->is_sys_mem         = hb_qsv_full_path_is_enabled(job) ? 0 : 1;
     pv->job                = job;
     pv->qsv_info           = hb_qsv_encoder_info_get(hb_qsv_get_adapter_index(), job->vcodec);
     pv->delayed_processing = hb_list_init();

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1661,18 +1661,6 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
 
     /* MFXVideoENCODE_Init with desired encoding parameters */
     sts = MFXVideoENCODE_Init(session, pv->param.videoParam);
-// workaround for the early 15.33.x driver, should be removed later
-#define HB_DRIVER_FIX_33
-#ifdef  HB_DRIVER_FIX_33
-    int la_workaround = 0;
-    if (sts < MFX_ERR_NONE &&
-        pv->param.videoParam->mfx.RateControlMethod == MFX_RATECONTROL_LA)
-    {
-        pv->param.videoParam->mfx.RateControlMethod = MFX_RATECONTROL_CBR;
-        sts = MFXVideoENCODE_Init(session, pv->param.videoParam);
-        la_workaround = 1;
-    }
-#endif
     if (sts < MFX_ERR_NONE) // ignore warnings
     {
         hb_error("encqsvInit: MFXVideoENCODE_Init failed (%d)", sts);
@@ -1766,16 +1754,6 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
 
     /* We don't need this encode session once we have the header */
     MFXVideoENCODE_Close(session);
-
-#ifdef HB_DRIVER_FIX_33
-    if (la_workaround)
-    {
-        videoParam.mfx.RateControlMethod =
-        pv->param.videoParam->mfx.RateControlMethod = MFX_RATECONTROL_LA;
-        option2->LookAheadDepth = pv->param.codingOption2.LookAheadDepth;
-        hb_log("encqsvInit: using LookAhead workaround (\"early 33 fix\")");
-    }
-#endif
 
     // when using system memory, we re-use this same session
     if (pv->is_sys_mem)

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1275,9 +1275,6 @@ int encqsvInit(hb_work_object_t *w, hb_job_t *job)
 #if defined(_WIN32) || defined(__MINGW32__)
     if (pv->is_sys_mem && hb_qsv_implementation_is_hardware(pv->qsv_info->implementation))
     {
-        // select the right hardware implementation based on dx index
-        if (!job->qsv.ctx->qsv_device)
-            hb_qsv_param_parse_dx_index(pv->job, hb_qsv_get_adapter_index());
         mfxIMPL hw_preference = MFX_IMPL_VIA_D3D11;
         pv->qsv_info->implementation = hb_qsv_dx_index_to_impl(job->qsv.ctx->dx_index) | hw_preference;
     }

--- a/libhb/handbrake/decomb.h
+++ b/libhb/handbrake/decomb.h
@@ -20,6 +20,5 @@
 #define MODE_YADIF_ENABLE       1
 #define MODE_YADIF_SPATIAL      2
 #define MODE_XXDIF_BOB          4
-#define MODE_DEINTERLACE_QSV    8
 
 #endif // HANDBRAKE_DECOMB_H

--- a/libhb/handbrake/param.h
+++ b/libhb/handbrake/param.h
@@ -20,8 +20,6 @@ struct hb_filter_param_s
     const char *settings;
 };
 
-void hb_param_configure_qsv(void);
-
 hb_dict_t * hb_generate_filter_settings(int filter_id, const char *preset,
                                         const char *tune, const char *custom);
 char * hb_generate_filter_settings_json(int filter_id, const char *preset,

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -335,9 +335,8 @@ typedef struct hb_qsv_context {
     int la_is_enabled;
     int qsv_hw_filters_are_enabled;
     int full_path_is_enabled;
-    char *vpp_scale_mode;
-    char *vpp_interpolation_method;
-    char *qsv_device;
+    const char *vpp_scale_mode;
+    const char *vpp_interpolation_method;
     int dx_index;
     AVBufferRef *hb_hw_device_ctx;
     AVBufferRef *hb_ffmpeg_qsv_hw_frames_ctx;

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -500,7 +500,6 @@ int hb_qsv_get_free_surface(hb_qsv_space *, hb_qsv_context *, mfxFrameInfo *,
                      hb_qsv_split);
 int hb_qsv_get_free_encode_task(hb_qsv_list *);
 
-int av_is_qsv_available(mfxIMPL, mfxVersion *);
 int hb_qsv_wait_on_sync(hb_qsv_context *, hb_qsv_stage *);
 
 void hb_qsv_add_context_usage(hb_qsv_context *, int);

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -2198,10 +2198,6 @@ int hb_global_init()
         return -1;
     }
 
-#if HB_PROJECT_FEATURE_QSV
-    hb_param_configure_qsv();
-#endif
-
     /* libavcodec */
     hb_avcodec_init();
 
@@ -2235,6 +2231,7 @@ int hb_global_init()
 #if HB_PROJECT_FEATURE_QSV
     if (!disable_hardware)
     {
+        hb_qsv_available();
         hb_register(&hb_encqsv);
     }
 #endif

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -13,9 +13,6 @@
 #include "handbrake/param.h"
 #include "handbrake/common.h"
 #include "handbrake/colormap.h"
-#if HB_PROJECT_FEATURE_QSV
-#include "handbrake/qsv_common.h"
-#endif
 #include <regex.h>
 
 static hb_filter_param_t nlmeans_presets[] =
@@ -217,13 +214,11 @@ static hb_filter_param_t yadif_presets[] =
     { 3, "Default",            "default",      "mode=3"         },
     { 2, "Skip Spatial Check", "skip-spatial", "mode=1"         },
     { 5, "Bob",                "bob",          "mode=7"         },
-#if HB_PROJECT_FEATURE_QSV
-    { 6, "QSV",                "qsv",          "mode=11"        },
-#endif
     { 0,  NULL,                NULL,           NULL             },
     { 2, "Fast",               "fast",         "mode=1"         },
     { 3, "Slow",               "slow",         "mode=1"         },
     { 4, "Slower",             "slower",       "mode=3"         },
+    { 6, "QSV",                "qsv",          "mode=11"        },
     { 7, "QSV",                "qsv",          "mode=3"         }
 };
 
@@ -289,16 +284,6 @@ static filter_param_map_t param_map[] =
 
     { HB_FILTER_INVALID,     NULL,                NULL,     0, 0, },
 };
-
-void hb_param_configure_qsv(void)
-{
-#if HB_PROJECT_FEATURE_QSV
-    if (!hb_qsv_available())
-    {
-        memset(&yadif_presets[4], 0, sizeof(hb_filter_param_t));
-    }
-#endif
-}
 
 /* NL-means presets and tunes
  *

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -218,8 +218,6 @@ static hb_filter_param_t yadif_presets[] =
     { 2, "Fast",               "fast",         "mode=1"         },
     { 3, "Slow",               "slow",         "mode=1"         },
     { 4, "Slower",             "slower",       "mode=3"         },
-    { 6, "QSV",                "qsv",          "mode=11"        },
-    { 7, "QSV",                "qsv",          "mode=3"         }
 };
 
 static hb_filter_param_t bwdif_presets[] =

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -998,6 +998,12 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
     /* Reset capabilities before querying */
     info->capabilities = 0;
 
+    /* Disable lowpower if the encoder is software */
+    if (hb_qsv_implementation_is_hardware(info->implementation) == 0)
+    {
+         lowpower = 0;
+    }
+
     /*
      * First of all, check availability of an encoder for
      * this combination of a codec ID and implementation.
@@ -1011,10 +1017,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
             mfxStatus mfxRes;
             init_video_param(&inputParam);
             inputParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                inputParam.mfx.LowPower = lowpower;
-            }
+            inputParam.mfx.LowPower = lowpower;
             memset(&videoParam, 0, sizeof(mfxVideoParam));
             videoParam.mfx.CodecId = inputParam.mfx.CodecId;
 
@@ -1107,10 +1110,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&inputParam);
             inputParam.mfx.CodecId           = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                inputParam.mfx.LowPower      = lowpower;
-            }
+            inputParam.mfx.LowPower          = lowpower;
             inputParam.mfx.RateControlMethod = MFX_RATECONTROL_LA;
             inputParam.mfx.TargetKbps        = 5000;
 
@@ -1125,10 +1125,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 // also check for LA + interlaced support
                 init_video_param(&inputParam);
                 inputParam.mfx.CodecId             = info->codec_id;
-                if (hb_qsv_implementation_is_hardware(info->implementation))
-                {
-                    inputParam.mfx.LowPower        = lowpower;
-                }
+                inputParam.mfx.LowPower            = lowpower;
                 inputParam.mfx.RateControlMethod   = MFX_RATECONTROL_LA;
                 inputParam.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_FIELD_TFF;
                 inputParam.mfx.TargetKbps          = 5000;
@@ -1148,10 +1145,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&inputParam);
             inputParam.mfx.CodecId           = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                inputParam.mfx.LowPower      = lowpower;
-            }
+            inputParam.mfx.LowPower          = lowpower;
             inputParam.mfx.RateControlMethod = MFX_RATECONTROL_ICQ;
             inputParam.mfx.ICQQuality        = 20;
 
@@ -1172,10 +1166,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_video_signal_info(&extVideoSignalInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extVideoSignalInfo;
@@ -1207,10 +1198,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_coding_option(&extCodingOption);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extCodingOption;
@@ -1246,10 +1234,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_coding_option2(&extCodingOption2);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extCodingOption2;
@@ -1363,10 +1348,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_chroma_loc_info(&extChromaLocInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extChromaLocInfo;
@@ -1391,10 +1373,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_mastering_display_colour_volume(&extMasteringDisplayColourVolume);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extMasteringDisplayColourVolume;
@@ -1409,10 +1388,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
 
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            if (hb_qsv_implementation_is_hardware(info->implementation))
-            {
-                videoParam.mfx.LowPower = lowpower;
-            }
+            videoParam.mfx.LowPower = lowpower;
             init_ext_content_light_level_info(&extContentLightLevelInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extContentLightLevelInfo;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2183,7 +2183,7 @@ static int hb_qsv_parse_options(hb_job_t *job)
 int hb_qsv_setup_job(hb_job_t *job)
 {
     // parse the json parameter
-    if (job->qsv.ctx && job->qsv.ctx->dx_index >= 0)
+    if (job->qsv.ctx && job->qsv.ctx->dx_index >= -1)
     {
         hb_qsv_param_parse_dx_index(job, job->qsv.ctx->dx_index);
     }
@@ -3748,8 +3748,7 @@ int hb_qsv_get_platform(int adapter_index)
     {
         const hb_qsv_adapter_details_t *details = hb_list_item(g_qsv_adapters_details_list, i);
         // find DirectX adapter with given index in list of QSV adapters
-        // if -1 use first adapter with highest priority
-        if (details && ((details->index == adapter_index) || (adapter_index == -1)))
+        if (details && (details->index == adapter_index))
         {
             return qsv_map_mfx_platform_codename(details->platform.CodeName);
         }
@@ -3763,8 +3762,7 @@ int hb_qsv_param_parse_dx_index(hb_job_t *job, const int dx_index)
     {
         const hb_qsv_adapter_details_t *details = hb_list_item(g_qsv_adapters_details_list, i);
         // find DirectX adapter with given index in list of QSV adapters
-        // if -1 use first adapter with highest priority
-        if (details && ((details->index == dx_index) || (dx_index == -1)))
+        if (details && (details->index == dx_index))
         {
             job->qsv.ctx->dx_index = details->index;
             hb_log("qsv: %s qsv adapter with index %u has been selected", hb_qsv_get_adapter_type(details), details->index);
@@ -3772,7 +3770,6 @@ int hb_qsv_param_parse_dx_index(hb_job_t *job, const int dx_index)
             return 0;
         }
     }
-    hb_error("qsv: hb_qsv_param_parse_dx_index incorrect qsv device index %d", dx_index);
     job->qsv.ctx->dx_index = hb_qsv_get_adapter_index();
     return -1;
 }

--- a/libhb/qsv_libav.c
+++ b/libhb/qsv_libav.c
@@ -581,18 +581,6 @@ int hb_qsv_list_unlock(hb_qsv_list *l){
     return ret;
 }
 
-int av_is_qsv_available(mfxIMPL impl, mfxVersion * ver)
-{
-    mfxStatus sts = MFX_ERR_NONE;
-    mfxSession mfx_session;
-
-    memset(&mfx_session, 0, sizeof(mfxSession));
-    sts = MFXInit(impl, ver, &mfx_session);
-    if (sts >= 0)
-        MFXClose(mfx_session);
-    return sts;
-}
-
 int hb_qsv_wait_on_sync(hb_qsv_context *qsv, hb_qsv_stage *stage)
 {
     int iter = 0;


### PR DESCRIPTION
Remove a 10 years old workaround, maybe it's not needed anymore? An old QSV deinterlace settings that's not available anymore, and simplify device index selection.
The device index was called again and again from a lot of place, however I only have a single device so I can't test if my changes work or not.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
