### PR TITLE
Drop old intltool references

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,7 +29,7 @@ jobs:
         sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libturbojpeg0-dev libssl-dev
         sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build patch tar yasm zlib1g-dev appstream
         sudo pip3 install meson
-        sudo apt-get install gstreamer1.0-libav intltool libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgtk-3-dev libnotify-dev
+        sudo apt-get install gstreamer1.0-libav libappindicator-dev libdbus-glib-1-dev libglib2.0-dev libgtk-3-dev libnotify-dev
         sudo apt-get install libva-dev libdrm-dev llvm clang
 
     - name: Setup Toolchain

--- a/.github/workflows/windows-arm.yml
+++ b/.github/workflows/windows-arm.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Environment Setup
       run: |
         sudo apt-get purge cmake -y
-        sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake
+        sudo apt-get install automake autoconf build-essential libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake
         sudo pip3 install meson
 
     - name: Setup Toolchain

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Environment
       run: |
         sudo apt-get purge cmake -y
-        sudo apt-get install automake autoconf build-essential intltool libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake libssl-dev
+        sudo apt-get install automake autoconf build-essential libtool libtool-bin make nasm patch tar yasm zlib1g-dev ninja-build gzip pax cmake libssl-dev
         sudo pip3 install meson
         rustup target add x86_64-pc-windows-gnu
 

--- a/gtk/ghb.spec
+++ b/gtk/ghb.spec
@@ -12,7 +12,7 @@ Prefix:		%{_prefix}
 BuildRoot:	%(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 BuildRequires: glib2-devel, gtk3-devel, webkitgtk3-devel
 BuildRequires: gstreamer1-devel, gstreamer1-plugins-base-devel
-BuildRequires: bzip2-devel, intltool, libnotify-devel, libtool
+BuildRequires: bzip2-devel, libnotify-devel, libtool
 Requires:	gtk3, coreutils
 
 %define debug_package %{nil}

--- a/pkg/linux/debian/control
+++ b/pkg/linux/debian/control
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>=0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>=0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.artful
+++ b/pkg/linux/debian/control.artful
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.bionic
+++ b/pkg/linux/debian/control.bionic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.cosmic
+++ b/pkg/linux/debian/control.cosmic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.disco
+++ b/pkg/linux/debian/control.disco
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.eoan
+++ b/pkg/linux/debian/control.eoan
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.focal
+++ b/pkg/linux/debian/control.focal
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
+Build-Depends: meson, ninja-build, debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, nasm (>= 2.13), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev, libvpx-dev, libva-dev, libdrm-dev, libnuma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.karmic
+++ b/pkg/linux/debian/control.karmic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 0.7.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.lucid
+++ b/pkg/linux/debian/control.lucid
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0)
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.maverick
+++ b/pkg/linux/debian/control.maverick
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkit-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.natty
+++ b/pkg/linux/debian/control.natty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.oneiric
+++ b/pkg/linux/debian/control.oneiric
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libwebkitgtk-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, subversion, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.precise
+++ b/pkg/linux/debian/control.precise
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer0.10-dev, libgstreamer-plugins-base0.10-dev, wget, python (>= 2.6), libappindicator-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.quantal
+++ b/pkg/linux/debian/control.quantal
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.raring
+++ b/pkg/linux/debian/control.raring
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.saucy
+++ b/pkg/linux/debian/control.saucy
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.1.0), libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.trusty
+++ b/pkg/linux/debian/control.trusty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.utopic
+++ b/pkg/linux/debian/control.utopic
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, wget, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.vivid
+++ b/pkg/linux/debian/control.vivid
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.wily
+++ b/pkg/linux/debian/control.wily
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.xenial
+++ b/pkg/linux/debian/control.xenial
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev, libspeex-dev, liblzma-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.yakkety
+++ b/pkg/linux/debian/control.yakkety
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 

--- a/pkg/linux/debian/control.zesty
+++ b/pkg/linux/debian/control.zesty
@@ -2,7 +2,7 @@ Source: handbrake
 Section: graphics
 Priority: optional
 Maintainer: John Stebbins <jstebbins.hb@gmail.com>
-Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, intltool, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
+Build-Depends: debhelper (>= 6), autotools-dev, libtool, libtool-bin, autoconf, yasm (>= 1.2.0), cmake, libbz2-dev, zlib1g-dev, libgtk-3-dev, libwebkitgtk-3.0-dev, libnotify-dev, libgstreamer1.0-dev, libgstreamer-plugins-base1.0-dev, python (>= 2.6), libappindicator3-dev, libfribidi-dev (>= 0.19.0), libxml2-dev, libogg-dev, libtheora-dev, libvorbis-dev, libopus-dev, libsamplerate0-dev, libfreetype6-dev, libfontconfig1-dev, libass-dev, libmp3lame-dev, libx264-dev, libjansson-dev
 Standards-Version: 3.8.4
 Homepage: http://www.handbrake.fr/
 


### PR DESCRIPTION
**Description of Change:**

Drop old references to intltool which isn't used anymore in the codebase/build system.

**Tested on:**

- [X] Ubuntu Linux