### PR TITLE
QSV Cleanups

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4220,7 +4220,6 @@ static void job_setup(hb_job_t * job, hb_title_t * title)
     {
         job->qsv.ctx = hb_qsv_context_init();
     }
-    job->qsv.enc_info.is_init_done = 0;
     job->qsv.decode                = !!(title->video_decode_support &
                                         HB_DECODE_SUPPORT_QSV);
 #endif

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -814,16 +814,6 @@ struct hb_job_s
 #if HB_PROJECT_FEATURE_QSV
         hb_qsv_context *ctx;
 #endif
-        // shared encoding parameters
-        // initialized by the QSV encoder, then used upstream (e.g. by filters)
-        // to configure their output so that it matches what the encoder expects
-        struct
-        {
-            int pic_struct;
-            int align_width;
-            int align_height;
-            int is_init_done;
-        } enc_info;
     } qsv;
 
     int hw_decode;

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -18,7 +18,6 @@ int            hb_qsv_available();
 
 // Public API
 int  hb_qsv_impl_set_preferred(const char *name);
-void hb_qsv_force_workarounds(); // for developers only
 
 #ifdef __LIBHB__
 // Private API
@@ -95,7 +94,6 @@ typedef struct hb_qsv_info_s
 int            hb_qsv_create_mfx_session(mfxIMPL implementation, int adapter_index, mfxVersion *pver, mfxSession *psession);
 hb_display_t * hb_qsv_display_init(const uint32_t dri_render_node);
 int            hb_qsv_video_encoder_is_enabled(int adapter_index, int encoder);
-int            hb_qsv_audio_encoder_is_enabled(int encoder);
 int            hb_qsv_info_init();
 void           hb_qsv_info_close();
 void           hb_qsv_info_print();
@@ -111,12 +109,6 @@ int            hb_qsv_implementation_is_hardware(mfxIMPL implementation);
 /* Intel Quick Sync Video DECODE utilities */
 const char* hb_qsv_decode_get_codec_name(enum AVCodecID codec_id);
 int hb_qsv_decode_is_enabled(hb_job_t *job);
-
-/*
- * mfxCoreInterface::CopyFrame had a bug preventing us from using it, but
- * it was fixed in newer drivers - we can use this to determine usability
- */
-int hb_qsv_copyframe_is_slow(int encoder);
 
 /* Media SDK parameters handling */
 enum
@@ -272,7 +264,6 @@ int hb_qsv_replace_surface_mid(HBQSVFramesContext* hb_qsv_frames_ctx, const QSVM
 int hb_qsv_release_surface_from_pool_by_surface_pointer(HBQSVFramesContext* hb_enc_qsv_frames_ctx, const mfxFrameSurface1 *surface);
 int hb_qsv_get_buffer(AVCodecContext *s, AVFrame *frame, int flags);
 enum AVPixelFormat hb_qsv_get_format(AVCodecContext *s, const enum AVPixelFormat *pix_fmts);
-int hb_qsv_preset_is_zero_copy_enabled(const hb_dict_t *job_dict);
 void hb_qsv_uninit_dec(AVCodecContext *s);
 void hb_qsv_uninit_enc(hb_job_t *job);
 int hb_qsv_setup_job(hb_job_t *job);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2220,6 +2220,12 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
         return 0;
     }
 
+    // there isn't any rotate hw filter yet, fallback to sw filters
+    if (job->title->rotation)
+    {
+        return 0;
+    }
+
     qsv_full_path_is_enabled = (hb_qsv_decode_is_enabled(job) &&
         info && hb_qsv_implementation_is_hardware(info->implementation) &&
         job->qsv.ctx && !job->qsv.ctx->num_sw_filters);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -788,15 +788,6 @@ int hb_qsv_video_encoder_is_enabled(int adapter_index, int encoder)
     }
 }
 
-int hb_qsv_audio_encoder_is_enabled(int encoder)
-{
-    switch (encoder)
-    {
-        default:
-            return 0;
-    }
-}
-
 static void init_video_param(mfxVideoParam *videoParam)
 {
     if (videoParam == NULL)
@@ -2234,23 +2225,6 @@ int hb_qsv_full_path_is_enabled(hb_job_t *job)
         job->qsv.ctx && !job->qsv.ctx->num_sw_filters);
 #endif
     return qsv_full_path_is_enabled;
-}
-
-int hb_qsv_copyframe_is_slow(int encoder)
-{
-    hb_qsv_info_t *info = hb_qsv_encoder_info_get(hb_qsv_get_adapter_index(), encoder);
-    if (info != NULL && hb_qsv_implementation_is_hardware(info->implementation))
-    {
-        hb_qsv_adapter_details_t* details = hb_qsv_get_adapters_details_by_index(hb_qsv_get_adapter_index());
-        if (details)
-        {
-            // we should really check the driver version, but since it's not
-            // available, checking the API version is the best we can do :-(
-            return !HB_CHECK_MFX_VERSION(details->qsv_hardware_version, 1, 7);
-        }
-        return 0;
-    }
-    return 0;
 }
 
 int hb_qsv_codingoption_xlat(int val)
@@ -3713,20 +3687,6 @@ const char* hb_qsv_impl_get_via_name(int impl)
     else if ((impl & 0xF00) == MFX_IMPL_VIA_ANY)
         return "via ANY";
     else return NULL;
-}
-
-void hb_qsv_force_workarounds()
-{
-#define FORCE_WORKAROUNDS ~(HB_QSV_CAP_OPTION2_BREFTYPE)
-    hb_qsv_adapter_details_t* details = hb_qsv_get_adapters_details_by_index(hb_qsv_get_adapter_index());
-    if (details)
-    {
-        details->qsv_software_info_avc.capabilities  &= FORCE_WORKAROUNDS;
-        details->qsv_hardware_info_avc.capabilities  &= FORCE_WORKAROUNDS;
-        details->qsv_software_info_hevc.capabilities &= FORCE_WORKAROUNDS;
-        details->qsv_hardware_info_hevc.capabilities &= FORCE_WORKAROUNDS;
-    }
-#undef FORCE_WORKAROUNDS
 }
 
 int hb_qsv_get_platform(int adapter_index)

--- a/test/test.c
+++ b/test/test.c
@@ -2180,7 +2180,6 @@ static int ParseOptions( int argc, char ** argv )
     #define ENCODER_LEVEL_LIST   291
     #define NORMALIZE_MIX        293
     #define AUDIO_DITHER         294
-    #define QSV_BASELINE         295
     #define QSV_ASYNC_DEPTH      296
     #define QSV_ADAPTER          297
     #define QSV_IMPLEMENTATION   298
@@ -2229,7 +2228,6 @@ static int ParseOptions( int argc, char ** argv )
             { "no-dvdnav",   no_argument,       NULL,    DVDNAV },
 
 #if HB_PROJECT_FEATURE_QSV
-            { "qsv-baseline",         no_argument,       NULL,        QSV_BASELINE,       },
             { "qsv-async-depth",      required_argument, NULL,        QSV_ASYNC_DEPTH,    },
             { "qsv-adapter",          required_argument, NULL,        QSV_ADAPTER         },
             { "qsv-implementation",   required_argument, NULL,        QSV_IMPLEMENTATION, },
@@ -3169,9 +3167,6 @@ static int ParseOptions( int argc, char ** argv )
                 } 
                 break;
 #if HB_PROJECT_FEATURE_QSV
-            case QSV_BASELINE:
-                hb_qsv_force_workarounds();
-                break;
             case QSV_ASYNC_DEPTH:
                 qsv_async_depth = atoi(optarg);
                 break;


### PR DESCRIPTION
Removed some unused code and fixed the case in which the source is autorotated in decavcodec.c by disabling the full gpu path.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux