### PR TITLE
contrib: update SVT-AV1 to version 1.6.0.

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -3,9 +3,9 @@ __deps__ :=
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v1.5.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.5.0/SVT-AV1-v1.5.0.tar.gz
-SVT-AV1.FETCH.sha256  = 64e27b024eb43e4ba4e7b85584e0497df534043b2ce494659532c585819d0333
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v1.6.0.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.6.0/SVT-AV1-v1.6.0.tar.gz
+SVT-AV1.FETCH.sha256  = 3bc207247568ac713245063555082bfc905edc31df3bf6355e3b194cb73ad817
 
 SVT-AV1.build_dir             = build
 SVT-AV1.CONFIGURE.exe         = cmake


### PR DESCRIPTION
> Encoder
> - Improve the tradeoffs for the random access mode across presets M1-M13:
>  - Speeding up the higher quality presets by 30-40%
>  - Improving the BD-rate by 1-2% for the faster presets
> - Improve the tradeoffs for the low delay mode for both scrren content and non-screen content encoding modes
> - Add a toggle to remove the legacy one-frame buffer at the input of the pipeline alowing the low delay mode to operate at sub-frame processing latencies
> - Add a new API allowing the user to specify quantization offsets for a region of interest per frame
> 
> Build, cleanup and bug fixes
> - Various cleanups and functional bug fixes
> - Fix the startup minigop size BD-rate loss
> - Add ability to run the ci-testing offline


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
