### PR TITLE
Build system changes for BSD

### DIFF
--- a/configure
+++ b/configure
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 inpath()
 {
@@ -13,19 +12,13 @@ inpath()
     return 1
 }
 
-pp=""
-for p in python3 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python2 python2.7 python
+for p in python3 python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python
 do
     if ( inpath $p ); then
-        pp="$p"
-        break
+        exec $p `dirname $0`/make/configure.py "$@"
+        exit 0
     fi
 done
-if [ "$pp" != "" ]; then
-    exec $pp `dirname $0`/make/configure.py "$@"
-    exit 0
-else
-    echo "ERROR: no suitable version of python found."
-fi
 
+echo "ERROR: no suitable version of python found."
 exit 1

--- a/configure
+++ b/configure
@@ -13,23 +13,19 @@ inpath()
     return 1
 }
 
-if ( inpath bash ); then
-    pp=""
-    for p in python3 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python2 python2.7 python
-    do
-        if ( inpath $p ); then
-            pp="$p"
-            break
-        fi
-    done
-    if [ "$pp" != "" ]; then
-        exec $pp `dirname $0`/make/configure.py "$@"
-        exit 0
-    else
-        echo "ERROR: no suitable version of python found."
+pp=""
+for p in python3 python3.8 python3.7 python3.6 python3.5 python3.4 python3.3 python3.2 python3.1 python2 python2.7 python
+do
+    if ( inpath $p ); then
+        pp="$p"
+        break
     fi
+done
+if [ "$pp" != "" ]; then
+    exec $pp `dirname $0`/make/configure.py "$@"
+    exit 0
 else
-    echo "ERROR: bash shell not found."
+    echo "ERROR: no suitable version of python found."
 fi
 
 exit 1

--- a/contrib/x264/A00-version-string.patch
+++ b/contrib/x264/A00-version-string.patch
@@ -22,7 +22,7 @@ index d685efbd..7f270c4b 100644
 +#ifdef  X264_POINTVER
 +#undef  X264_POINTVER
 +#endif
-+#define X264_BUILD    164
++#define X264_BUILD 164
 +#define X264_VERSION " r3100 ed0f7a6"
 +#define X264_POINTVER "0.164.3100 ed0f7a6"
  

--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -179,7 +179,7 @@ widget.deps: makedeps.py
 	$(HB_PYTHON) $(srcdir)/makedeps.py
 
 fr.handbrake.ghb.metainfo.xml: fr.handbrake.ghb.metainfo.xml.in
-	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@
+	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@ || cp $< $@
 
 fr.handbrake.ghb.metainfo.xml.in: fr.handbrake.ghb.metainfo.xml.in.in
 	sed -e 's^RELEASE_TAG^<release version="$(HB.version)" date="$(word 1,$(HB.repo.date))" />^' $< > $@

--- a/gtk/src/Makefile.am
+++ b/gtk/src/Makefile.am
@@ -178,6 +178,7 @@ widget_reverse.deps: makedeps.py
 widget.deps: makedeps.py
 	$(HB_PYTHON) $(srcdir)/makedeps.py
 
+## copy file if msgfmt fails as workaround for outdated version on NetBSD
 fr.handbrake.ghb.metainfo.xml: fr.handbrake.ghb.metainfo.xml.in
 	$(AM_V_GEN) $(MSGFMT) --xml --template $< -d $(top_srcdir)/po -o $@ || cp $< $@
 

--- a/gtk/src/audiohandler.h
+++ b/gtk/src/audiohandler.h
@@ -44,4 +44,8 @@ void ghb_audio_title_change(signal_user_data_t *ud, gboolean title_valid);
 void ghb_clear_audio_selection(GtkBuilder *builder);
 gboolean ghb_audio_quality_enabled(const GhbValue *asettings);
 
+void audio_list_selection_changed_cb(GtkTreeSelection *ts, signal_user_data_t *ud);
+void audio_edit_clicked_cb(GtkWidget *widget, gchar *path, signal_user_data_t *ud);
+void audio_remove_clicked_cb(GtkWidget *widget, gchar *path, signal_user_data_t *ud);
+
 #endif // _AUDIOHANDLER_H_

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -2147,8 +2147,21 @@ srt_codeset_opts_set(signal_user_data_t *ud, const gchar *name,
                            -1);
     }
 }
-
-extern G_MODULE_EXPORT void combo_search_key_press_cb(void);
+#if GTK_CHECK_VERSION(4, 4, 0)
+extern G_MODULE_EXPORT gboolean
+combo_search_key_press_cb(
+    GtkEventControllerKey * keycon,
+    guint                   keyval,
+    guint                   keycode,
+    GdkModifierType         state,
+    signal_user_data_t    * ud);
+#else
+extern G_MODULE_EXPORT gboolean
+combo_search_key_press_cb(
+    GtkWidget *widget,
+    GdkEvent *event,
+    signal_user_data_t *ud);
+#endif
 
 static void
 language_opts_set(signal_user_data_t *ud, const gchar *name,
@@ -2186,7 +2199,7 @@ language_opts_set(signal_user_data_t *ud, const gchar *name,
 #if !GTK_CHECK_VERSION(4, 4, 0)
     // This is handled by GtkEventControllerKey in gtk4
     // Initialized in ghb_combo_init()
-    g_signal_connect(combo, "key-press-event", combo_search_key_press_cb, ud);
+    g_signal_connect(combo, "key-press-event", G_CALLBACK(combo_search_key_press_cb), ud);
 #endif
 }
 

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -199,10 +199,6 @@ change_font(GtkWidget *widget, gpointer data)
     //gtk_container_foreach((GtkContainer*)window, change_font, "sans 20");
 #endif
 
-extern G_MODULE_EXPORT void audio_list_selection_changed_cb(void);
-extern G_MODULE_EXPORT void audio_edit_clicked_cb(void);
-extern G_MODULE_EXPORT void audio_remove_clicked_cb(void);
-
 // Create and bind the tree model to the tree view for the audio track list
 // Also, connect up the signal that lets us know the selection has changed
 static void
@@ -257,16 +253,12 @@ bind_audio_tree_model(signal_user_data_t *ud)
     //gtk_tree_view_column_set_min_width(column, 24);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
-    g_signal_connect(selection, "changed", audio_list_selection_changed_cb, ud);
-    g_signal_connect(edit_cell, "clicked", audio_edit_clicked_cb, ud);
-    g_signal_connect(delete_cell, "clicked", audio_remove_clicked_cb, ud);
+    g_signal_connect(selection, "changed", G_CALLBACK(audio_list_selection_changed_cb), ud);
+    g_signal_connect(edit_cell, "clicked", G_CALLBACK(audio_edit_clicked_cb), ud);
+    g_signal_connect(delete_cell, "clicked", G_CALLBACK(audio_remove_clicked_cb), ud);
 
     g_debug("Done");
 }
-
-extern G_MODULE_EXPORT void subtitle_list_selection_changed_cb(void);
-extern G_MODULE_EXPORT void subtitle_edit_clicked_cb(void);
-extern G_MODULE_EXPORT void subtitle_remove_clicked_cb(void);
 
 // Create and bind the tree model to the tree view for the subtitle track list
 // Also, connect up the signal that lets us know the selection has changed
@@ -320,16 +312,10 @@ bind_subtitle_tree_model(signal_user_data_t *ud)
                                     _(" "), delete_cell, "icon-name", 4, NULL);
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
 
-    g_signal_connect(selection, "changed", subtitle_list_selection_changed_cb, ud);
-    g_signal_connect(edit_cell, "clicked", subtitle_edit_clicked_cb, ud);
-    g_signal_connect(delete_cell, "clicked", subtitle_remove_clicked_cb, ud);
+    g_signal_connect(selection, "changed", G_CALLBACK(subtitle_list_selection_changed_cb), ud);
+    g_signal_connect(edit_cell, "clicked", G_CALLBACK(subtitle_edit_clicked_cb), ud);
+    g_signal_connect(delete_cell, "clicked", G_CALLBACK(subtitle_remove_clicked_cb), ud);
 }
-
-extern G_MODULE_EXPORT void presets_list_selection_changed_cb(void);
-extern G_MODULE_EXPORT void presets_drag_data_received_cb(void);
-extern G_MODULE_EXPORT void presets_drag_motion_cb(void);
-extern G_MODULE_EXPORT void preset_edited_cb(void);
-extern void presets_row_expanded_cb(void);
 
 #if GTK_CHECK_VERSION(4, 4, 0)
 static const char * presets_drag_entries[] = {
@@ -363,7 +349,7 @@ bind_presets_tree_model(signal_user_data_t *ud)
     column = gtk_tree_view_column_new_with_attributes(_("Preset Name"), cell,
         "text", 0, "weight", 1, "style", 2, "editable", 4, NULL);
 
-    g_signal_connect(cell, "edited", preset_edited_cb, ud);
+    g_signal_connect(cell, "edited", G_CALLBACK(preset_edited_cb), ud);
 
     gtk_tree_view_append_column(treeview, GTK_TREE_VIEW_COLUMN(column));
     gtk_tree_view_column_set_expand(column, TRUE);
@@ -386,11 +372,11 @@ bind_presets_tree_model(signal_user_data_t *ud)
                                            GDK_ACTION_MOVE);
 #endif
 
-    g_signal_connect(treeview, "drag_data_received", presets_drag_data_received_cb, ud);
-    g_signal_connect(treeview, "drag_motion", presets_drag_motion_cb, ud);
-    g_signal_connect(treeview, "row_expanded", presets_row_expanded_cb, ud);
-    g_signal_connect(treeview, "row_collapsed", presets_row_expanded_cb, ud);
-    g_signal_connect(selection, "changed", presets_list_selection_changed_cb, ud);
+    g_signal_connect(treeview, "drag_data_received", G_CALLBACK(presets_drag_data_received_cb), ud);
+    g_signal_connect(treeview, "drag_motion", G_CALLBACK(presets_drag_motion_cb), ud);
+    g_signal_connect(treeview, "row_expanded", G_CALLBACK(presets_row_expanded_cb), ud);
+    g_signal_connect(treeview, "row_collapsed", G_CALLBACK(presets_row_expanded_cb), ud);
+    g_signal_connect(selection, "changed", G_CALLBACK(presets_list_selection_changed_cb), ud);
     g_debug("Done");
 }
 

--- a/gtk/src/makedeps.py
+++ b/gtk/src/makedeps.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import collections
 import sys
 import json

--- a/gtk/src/power-manager.c
+++ b/gtk/src/power-manager.c
@@ -240,15 +240,16 @@ upower_proxy_new_cb (GObject *source, GAsyncResult *result,
     {
         g_signal_connect(proxy, "g-properties-changed",
                          G_CALLBACK(upower_status_cb), ud);
+        g_dbus_proxy_call(proxy, "EnumerateDevices", NULL,
+                          G_DBUS_CALL_FLAGS_NONE, 10000, NULL,
+                          (GAsyncReadyCallback) upower_devices_cb, ud);
+        upower_proxy = proxy;
     }
     else
     {
         g_debug("Could not create DBus proxy: %s", error->message);
         g_error_free(error);
     }
-    g_dbus_proxy_call(proxy, "EnumerateDevices", NULL, G_DBUS_CALL_FLAGS_NONE,
-                      10000, NULL, (GAsyncReadyCallback) upower_devices_cb, ud);
-    upower_proxy = proxy;
 }
 
 static void

--- a/gtk/src/presets.h
+++ b/gtk/src/presets.h
@@ -60,4 +60,47 @@ GhbValue* ghb_settings_to_preset(GhbValue *settings);
 void ghb_preset_menu_button_refresh(signal_user_data_t *ud,
                                     const char *name, int type);
 
+void presets_list_selection_changed_cb(
+    GtkTreeSelection *selection, signal_user_data_t *ud);
+#if GTK_CHECK_VERSION(4, 4, 0)
+void presets_drag_data_received_cb(
+    GtkTreeView        *tv,
+    GdkDrop            *dc,
+    GtkSelectionData   *selection_data,
+    signal_user_data_t *ud);
+gboolean presets_drag_motion_cb(
+    GtkTreeView        *tv,
+    GdkDrop            *ctx,
+    gint                x,
+    gint                y,
+    signal_user_data_t *ud);
+#else
+void presets_drag_data_received_cb(
+    GtkTreeView        *tv,
+    GdkDragContext     *dc,
+    gint                x,
+    gint                y,
+    GtkSelectionData   *selection_data,
+    guint               info,
+    guint               t,
+    signal_user_data_t *ud);
+gboolean presets_drag_motion_cb(
+    GtkTreeView        *tv,
+    GdkDragContext     *ctx,
+    gint                x,
+    gint                y,
+    guint               time,
+    signal_user_data_t *ud);
+#endif
+void preset_edited_cb(
+    GtkCellRendererText *cell,
+    gchar               *treepath_s,
+    gchar               *text,
+    signal_user_data_t  *ud);
+void presets_row_expanded_cb(
+    GtkTreeView        *treeview,
+    GtkTreeIter        *iter,
+    GtkTreePath        *treepath,
+    signal_user_data_t *ud);
+
 #endif // _GHB_PRESETS_H_

--- a/gtk/src/subtitlehandler.h
+++ b/gtk/src/subtitlehandler.h
@@ -40,4 +40,10 @@ GhbValue *ghb_get_subtitle_settings(GhbValue *settings);
 char * ghb_subtitle_short_description(const GhbValue *subsource,
                                       const GhbValue *subsettings);
 
+
+void subtitle_list_selection_changed_cb(GtkTreeSelection *ts, signal_user_data_t *ud);
+void subtitle_edit_clicked_cb(GtkWidget *widget, gchar *path, signal_user_data_t *ud);
+void subtitle_remove_clicked_cb(GtkWidget *widget, gchar *path, signal_user_data_t *ud);
+
+
 #endif // _SUBTITLEHANDLER_H_

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -1921,7 +1921,7 @@ static void compute_init_delay(hb_work_private_t *pv, mfxBitstream *bs)
         if (pv->bfrm_delay < 1 || pv->bfrm_delay > BFRM_DELAY_MAX)
         {
             hb_log("compute_init_delay: "
-                   "invalid delay %d (PTS: %"PRIu64", DTS: %"PRId64")",
+                   "invalid delay %d (PTS: %llu, DTS: %lld)",
                    pv->bfrm_delay, bs->TimeStamp, bs->DecodeTimeStamp);
 
             /* we have B-frames, the frame delay should be at least 1 */

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -21,8 +21,7 @@
 #endif
 
 #ifndef SYS_DARWIN
-#if defined( SYS_FREEBSD ) || defined ( __FreeBSD__ ) || defined(SYS_NETBSD) || \
-    defined( SYS_OPENBSD ) || defined ( __OpenBSD__ )
+#if defined( SYS_FREEBSD ) || defined( SYS_NETBSD ) || defined( SYS_OPENBSD )
 #include <stdlib.h>
 #else
 #include <malloc.h>

--- a/libhb/handbrake/compat.h
+++ b/libhb/handbrake/compat.h
@@ -15,12 +15,10 @@
  * Some MinGW-w64 distributions #define strtok_r in pthread.h,
  * however their so-called "implementation" isn't thread-safe.
  */
-#ifdef USE_PTHREAD
 #include <pthread.h>
 #ifdef strtok_r
 #undef strtok_r
 #endif // strtok_r
-#endif // USE_PTHREAD
 
 char *strtok_r(char *s, const char *delim, char **save_ptr);
 #endif // HB_NEED_STRTOK_R

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -152,10 +152,7 @@ void hb_get_user_config_filename( char name[1024], char *fmt, ... );
  ***********************************************************************/
 typedef struct hb_thread_s hb_thread_t;
 
-#if defined( SYS_BEOS )
-#  define HB_LOW_PRIORITY    5
-#  define HB_NORMAL_PRIORITY 10
-#elif defined( SYS_DARWIN )
+#if defined( SYS_DARWIN )
 #  define HB_LOW_PRIORITY    31
 #  define HB_NORMAL_PRIORITY 31
 #elif defined( SYS_CYGWIN )

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -45,7 +45,7 @@ LIBHB.out += $(LIBHB.a)
 
 ###############################################################################
 
-LIBHB.GCC.D += __LIBHB__ USE_PTHREAD
+LIBHB.GCC.D += __LIBHB__
 LIBHB.GCC.I += $(LIBHB.build/) $(CONTRIB.build/)include
 
 ifeq (1,$(FEATURE.qsv))

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -6,6 +6,9 @@ __deps__ := A52DEC BZIP2 LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS LIBDCA \
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
     __deps__ += FONTCONFIG
 endif
+ifeq (netbsd,$(HOST.system))
+    __deps__ += LIBJPEGTURBO
+endif
 
 $(eval $(call import.MODULE.defs,LIBHB,libhb,$(__deps__)))
 $(eval $(call import.GCC,LIBHB))

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -839,8 +839,7 @@ static void attribute_align_thread hb_thread_func( void * _t )
     hb_thread_t * t = (hb_thread_t *) _t;
 
 #if (defined( SYS_DARWIN ) && !defined(__aarch64__)) || defined( SYS_FREEBSD ) || \
-    defined ( __FreeBSD__ ) || defined(SYS_NETBSD) || defined( SYS_OPENBSD ) || \
-    defined ( __OpenBSD__ )
+    defined( SYS_NETBSD ) || defined( SYS_OPENBSD )
     /* Set the thread priority
        Do not change priority on Darwin arm systems */
     struct sched_param param;
@@ -951,8 +950,8 @@ hb_lock_t * hb_lock_init()
 
     pthread_mutexattr_init(&mta);
 
-#if defined( SYS_CYGWIN ) || defined( SYS_FREEBSD ) || defined ( __FreeBSD__ ) || \
-    defined(SYS_NETBSD) || defined( SYS_OPENBSD ) || defined ( __OpenBSD__ )
+#if defined( SYS_CYGWIN ) || defined( SYS_FREEBSD ) || defined( SYS_NETBSD ) || \
+    defined( SYS_OPENBSD )
     pthread_mutexattr_settype(&mta, PTHREAD_MUTEX_NORMAL);
 #endif
 

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -21,10 +21,6 @@
 #include <pthread.h>
 #endif
 
-#ifdef SYS_BEOS
-#include <kernel/OS.h>
-#endif
-
 #if defined(SYS_DARWIN) || defined(SYS_FREEBSD) || defined(SYS_NETBSD) || defined(SYS_OPENBSD)
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -182,13 +178,10 @@ void hb_snooze( int delay )
     {
         return;
     }
-#if defined( SYS_BEOS )
-    snooze( 1000 * delay );
-#elif defined( SYS_DARWIN ) || defined( SYS_LINUX ) || defined( SYS_FREEBSD) || \
-      defined(SYS_NETBSD) || defined(SYS_OPENBSD) || defined( SYS_SunOS )
-    usleep( 1000 * delay );
-#elif defined( SYS_CYGWIN ) || defined( SYS_MINGW )
+#if defined( SYS_CYGWIN ) || defined( SYS_MINGW )
     Sleep( delay );
+#else
+    usleep( 1000 * delay );
 #endif
 }
 
@@ -438,11 +431,6 @@ static int init_cpu_count()
     sched_getaffinity( 0, sizeof(p_aff), &p_aff );
     for( cpu_count = 0, bit = 0; bit < sizeof(p_aff); bit++ )
          cpu_count += (((uint8_t *)&p_aff)[bit / 8] >> (bit % 8)) & 1;
-
-#elif defined(SYS_BEOS)
-    system_info info;
-    get_system_info( &info );
-    cpu_count = info.cpu_count;
 
 #elif defined(SYS_DARWIN) || defined(SYS_FREEBSD) || defined(SYS_NETBSD) || defined(SYS_OPENBSD)
     size_t length = sizeof( cpu_count );
@@ -815,9 +803,7 @@ struct hb_thread_s
     hb_lock_t     * lock;
     int             exited;
 
-#if defined( SYS_BEOS )
-    thread_id       thread;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_t       thread;
 //#elif defined( SYS_CYGWIN )
 //    HANDLE          thread;
@@ -878,10 +864,6 @@ static void attribute_align_thread hb_thread_func( void * _t )
     pthread_setname_np( t->name );
 #endif
 
-#if defined( SYS_BEOS )
-    signal( SIGINT, SIG_IGN );
-#endif
-
     /* Start the actual routine */
     t->function( t->arg );
 
@@ -913,12 +895,7 @@ hb_thread_t * hb_thread_init( const char * name, void (* function)(void *),
     t->lock     = hb_lock_init();
 
     /* Create and start the thread */
-#if defined( SYS_BEOS )
-    t->thread = spawn_thread( (thread_func) hb_thread_func,
-                              name, priority, t );
-    resume_thread( t->thread );
-
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_create( &t->thread, NULL,
                     (void * (*)( void * )) hb_thread_func, t );
 
@@ -945,11 +922,7 @@ void hb_thread_close( hb_thread_t ** _t )
     hb_thread_t * t = *_t;
 
     /* Join the thread */
-#if defined( SYS_BEOS )
-    long exit_value;
-    wait_for_thread( t->thread, &exit_value );
-
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_join( t->thread, NULL );
 
 //#elif defined( SYS_CYGWIN )
@@ -985,9 +958,7 @@ int hb_thread_has_exited( hb_thread_t * t )
  ***********************************************************************/
 struct hb_lock_s
 {
-#if defined( SYS_BEOS )
-    sem_id          sem;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_mutex_t mutex;
 //#elif defined( SYS_CYGWIN )
 //    HANDLE          mutex;
@@ -1006,9 +977,7 @@ hb_lock_t * hb_lock_init()
 {
     hb_lock_t * l = calloc( sizeof( hb_lock_t ), 1 );
 
-#if defined( SYS_BEOS )
-    l->sem = create_sem( 1, "sem" );
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_mutexattr_t mta;
 
     pthread_mutexattr_init(&mta);
@@ -1034,9 +1003,7 @@ void hb_lock_close( hb_lock_t ** _l )
     {
         return;
     }
-#if defined( SYS_BEOS )
-    delete_sem( l->sem );
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_mutex_destroy( &l->mutex );
 //#elif defined( SYS_CYGWIN )
 //    CloseHandle( l->mutex );
@@ -1048,9 +1015,7 @@ void hb_lock_close( hb_lock_t ** _l )
 
 void hb_lock( hb_lock_t * l )
 {
-#if defined( SYS_BEOS )
-    acquire_sem( l->sem );
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_mutex_lock( &l->mutex );
 //#elif defined( SYS_CYGWIN )
 //    WaitForSingleObject( l->mutex, INFINITE );
@@ -1059,9 +1024,7 @@ void hb_lock( hb_lock_t * l )
 
 void hb_unlock( hb_lock_t * l )
 {
-#if defined( SYS_BEOS )
-    release_sem( l->sem );
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_mutex_unlock( &l->mutex );
 //#elif defined( SYS_CYGWIN )
 //    ReleaseMutex( l->mutex );
@@ -1073,9 +1036,7 @@ void hb_unlock( hb_lock_t * l )
  ***********************************************************************/
 struct hb_cond_s
 {
-#if defined( SYS_BEOS )
-    int                 thread;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_cond_t      cond;
 //#elif defined( SYS_CYGWIN )
 //    HANDLE              event;
@@ -1098,9 +1059,7 @@ hb_cond_t * hb_cond_init()
     if( c == NULL )
         return NULL;
 
-#if defined( SYS_BEOS )
-    c->thread = -1;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_cond_init( &c->cond, NULL );
 //#elif defined( SYS_CYGWIN )
 //    c->event = CreateEvent( NULL, FALSE, FALSE, NULL );
@@ -1117,8 +1076,7 @@ void hb_cond_close( hb_cond_t ** _c )
     {
         return;
     }
-#if defined( SYS_BEOS )
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_cond_destroy( &c->cond );
 //#elif defined( SYS_CYGWIN )
 //    CloseHandle( c->event );
@@ -1130,13 +1088,7 @@ void hb_cond_close( hb_cond_t ** _c )
 
 void hb_cond_wait( hb_cond_t * c, hb_lock_t * lock )
 {
-#if defined( SYS_BEOS )
-    c->thread = find_thread( NULL );
-    release_sem( lock->sem );
-    suspend_thread( c->thread );
-    acquire_sem( lock->sem );
-    c->thread = -1;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_cond_wait( &c->cond, &lock->mutex );
 //#elif defined( SYS_CYGWIN )
 //    SignalObjectAndWait( lock->mutex, c->event, INFINITE, FALSE );
@@ -1160,13 +1112,7 @@ void hb_yield(void)
 
 void hb_cond_timedwait( hb_cond_t * c, hb_lock_t * lock, int msec )
 {
-#if defined( SYS_BEOS )
-    c->thread = find_thread( NULL );
-    release_sem( lock->sem );
-    suspend_thread( c->thread );
-    acquire_sem( lock->sem );
-    c->thread = -1;
-#elif USE_PTHREAD
+#if USE_PTHREAD
     struct timespec ts;
     hb_clock_gettime(&ts);
     ts.tv_nsec += (msec % 1000) * 1000000;
@@ -1178,22 +1124,7 @@ void hb_cond_timedwait( hb_cond_t * c, hb_lock_t * lock, int msec )
 
 void hb_cond_signal( hb_cond_t * c )
 {
-#if defined( SYS_BEOS )
-    while( c->thread != -1 )
-    {
-        thread_info info;
-        get_thread_info( c->thread, &info );
-        if( info.state == B_THREAD_SUSPENDED )
-        {
-            resume_thread( c->thread );
-            break;
-        }
-        /* Looks like we have been called between hb_cond_wait's
-           release_sem() and suspend_thread() lines. Wait until the
-           thread is actually suspended before we resume it */
-        snooze( 5000 );
-    }
-#elif USE_PTHREAD
+#if USE_PTHREAD
     pthread_cond_signal( &c->cond );
 //#elif defined( SYS_CYGWIN )
 //    PulseEvent( c->event );

--- a/make/configure.py
+++ b/make/configure.py
@@ -699,10 +699,10 @@ class ArchAction( Action ):
             pass
         elif host_tuple.match( '*-*-freebsd*' ):
             self.mode['i386']   = 'i386-portsbuild-freebsd%s' % (host_tuple.release)
-            self.mode['amd64'] = 'amd64-portsbuild-freebsd%s' % (host_tuple.release)
+            self.mode['amd64']  = 'amd64-portsbuild-freebsd%s' % (host_tuple.release)
         elif host_tuple.match( '*-*-openbsd*' ):
             self.mode['i386']   = 'i386-unknown-openbsd%s' % (host_tuple.release)
-            self.mode['amd64'] = 'amd64-unknown-openbsd%s' % (host_tuple.release)
+            self.mode['amd64']  = 'amd64-unknown-openbsd%s' % (host_tuple.release)
         else:
             self.msg_pass = 'WARNING'
 
@@ -1364,7 +1364,7 @@ def createCLI( cross = None ):
     ## add build options
     grp = cli.add_argument_group( 'Build Options' )
     grp.add_argument( '--snapshot', default=False, action='store_true', help='Force a snapshot build' )
-    h = IfHost( 'Build extra contribs for flatpak packaging', '*-*-linux*', '*-*-freebsd*', '*-*-openbsd*', none=argparse.SUPPRESS ).value
+    h = IfHost( 'Build extra contribs for flatpak packaging', '*-*-linux*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--flatpak', default=False, action='store_true', help=h )
     cli.add_argument_group( grp )
 
@@ -1409,7 +1409,7 @@ def createCLI( cross = None ):
     h = IfHost( 'enable assembly code in non-contrib modules', 'NOMATCH*-*-darwin*', 'NOMATCH*-*-linux*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--enable-asm', default=False, action='store_true', help=h )
 
-    h = IfHost( 'disable GTK GUI', '*-*-linux*', '*-*-freebsd*', '*-*-netbsd*', '*-*-openbsd*', none=argparse.SUPPRESS ).value
+    h = IfHost( 'disable GTK GUI', '*-*-linux*', '*-*-*bsd*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--disable-gtk', default=False, action='store_true', help=h )
 
     grp.add_argument( '--disable-gtk-update-checks', default=False, action='store_true', help=argparse.SUPPRESS )
@@ -1417,10 +1417,10 @@ def createCLI( cross = None ):
     h = 'enable GTK GUI for Windows' if (cross is not None and 'mingw' in cross) else argparse.SUPPRESS
     grp.add_argument( '--enable-gtk-mingw', default=False, action='store_true', help=h )
 
-    h = IfHost( 'Build GUI with GTK4', '*-*-linux*', '*-*-freebsd*', '*-*-openbsd*', none=argparse.SUPPRESS ).value
+    h = IfHost( 'Build GUI with GTK4', '*-*-linux*', '*-*-*bsd*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--enable-gtk4', default=False, action='store_true', help=h )
 
-    h = IfHost( 'disable GStreamer (live preview)', '*-*-linux*', '*-*-freebsd*', '*-*-netbsd*', '*-*-openbsd*', none=argparse.SUPPRESS ).value
+    h = IfHost( 'disable GStreamer (live preview)', '*-*-linux*', '*-*-*bsd*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--disable-gst', default=False, action='store_true', help=h )
 
     h = IfHost( 'x265 video encoder', '*-*-*', none=argparse.SUPPRESS ).value
@@ -1655,7 +1655,7 @@ try:
                       'cc',
                       os.environ.get('CC', None),
                       'gcc',
-                      IfBuild( 'clang', '*-*-freebsd*' ),
+                      IfBuild( 'clang', '*-*-*bsd*' ),
                       IfBuild( 'gcc-4', '*-*-cygwin*' )]
         gcc        = ToolProbe(*filter(None, gcc_tools))
         if build_tuple.match( '*-*-darwin*' ):

--- a/make/configure.py
+++ b/make/configure.py
@@ -1745,7 +1745,7 @@ try:
     ## prepare list of targets and NAME=VALUE args to pass to make
     targets = []
     exports = []
-    rx_exports = re.compile( '([^=]+)=(.*)' )
+    rx_exports = re.compile( '([^=-]+)=(.*)' )
     for arg in args:
         m = rx_exports.match( arg )
         if m:
@@ -2225,6 +2225,15 @@ int main()
     stdout.write( 'Enable VCE:         %s' % options.enable_vce )
     stdout.write( ' (%s)\n' % note_unsupported ) if not (host_tuple.system == 'linux' or host_tuple.match( 'x86_64-w64-mingw32*' )) else stdout.write( '\n' )
     stdout.write( 'Enable libdovi:     %s\n' % options.enable_libdovi )
+
+    if len(targets) > 0:
+        print( print_blue('Note:'), 'passthrough arguments:', *targets)
+
+    if len(exports) > 0:
+        print( print_blue('Note:'), 'exported variables:', end = ' ')
+        for export in exports:
+            print('%s=%s'% (export[0], export[1]), end = ' ')
+        print()
 
     if options.launch:
         stdout.write( '%s\n' % ('-' * 79) )

--- a/make/configure.py
+++ b/make/configure.py
@@ -1401,8 +1401,8 @@ def createCLI( cross = None ):
     h = IfHost( 'enable assembly code in non-contrib modules', 'NOMATCH*-*-darwin*', 'NOMATCH*-*-linux*', none=argparse.SUPPRESS ).value
     grp.add_argument( '--enable-asm', default=False, action='store_true', help=h )
 
-    # GTK GUI is disabled by default on macOS and Windows, enabled otherwise
-    require_gtk = not (host_tuple.match('*-*-mingw*', '*-*-cygwin*', '*-*-darwin*'))
+    # GTK GUI is enabled by default on Linux and BSD
+    require_gtk = (host_tuple.match('*-*-linux*', '*-*-*bsd*'))
     h = 'enable GTK GUI' if not require_gtk else argparse.SUPPRESS
     grp.add_argument( '--enable-gtk', dest="enable_gtk", default=require_gtk, action='store_true', help=h)
     h = 'disable GTK GUI' if require_gtk else argparse.SUPPRESS
@@ -2211,7 +2211,7 @@ int main()
     stdout.write( 'Harden:             %s\n' % options.enable_harden )
     stdout.write( 'Sandbox:            %s' % options.enable_sandbox )
     stdout.write( ' (%s)\n' % note_unsupported ) if not host_tuple.system == 'darwin' else stdout.write( '\n' )
-    stdout.write( 'Enable GTK GUI:     %s\n' % options.enable_gtk ) if options.enable_gtk or not host_tuple.match('*-*-mingw*', '*-*-cygwin*', '*-*-darwin*') else stdout.write('')
+    stdout.write( 'Enable GTK GUI:     %s\n' % options.enable_gtk ) if options.enable_gtk or host_tuple.match('*-*-linux*', '*-*-*bsd*') else stdout.write('')
     stdout.write( 'Enable FDK-AAC:     %s\n' % options.enable_fdk_aac )
     stdout.write( 'Enable FFmpeg AAC:  %s' % options.enable_ffmpeg_aac )
     stdout.write( '  (%s)\n' % note_required ) if host_tuple.system != 'darwin' else stdout.write( '\n' )

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -102,6 +102,7 @@ ifneq (,$(filter $(HOST.system),solaris))
 endif
 
 ifneq (,$(filter $(HOST.system),netbsd))
+    # needed to avoid conflict with jpeg-9e
     MODULES += contrib/libjpeg-turbo
 endif
 
@@ -122,33 +123,7 @@ ifeq (1-mingw,$(FEATURE.gtk.mingw)-$(HOST.system))
     MODULES += gtk
 endif
 
-ifeq (1-linux,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+linux
-    MODULES += gtk
-endif
-
-ifeq (1-freebsd,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+freebsd
-    MODULES += gtk
-endif
-
-ifeq (1-kfreebsd,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+kfreebsd
-    MODULES += gtk
-endif
-
-ifeq (1-gnu,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+gnu
-    MODULES += gtk
-endif
-
-ifeq (1-netbsd,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+netbsd
-    MODULES += gtk
-endif
-
-ifeq (1-openbsd,$(FEATURE.gtk)-$(HOST.system))
-    ## build gtk when gtk+openbsd
+ifeq (1-,$(FEATURE.gtk)-$(filter $(HOST.system),darwin cygwin mingw))
     MODULES += gtk
 endif
 

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -101,6 +101,9 @@ ifneq (,$(filter $(HOST.system),solaris))
     MODULES += contrib/libiconv
 endif
 
+ifneq (,$(filter $(HOST.system),netbsd))
+    MODULES += contrib/libjpeg-turbo
+endif
 
 ## these must come after contrib since some contrib modules are optional
 MODULES += libhb
@@ -139,12 +142,12 @@ ifeq (1-gnu,$(FEATURE.gtk)-$(HOST.system))
     MODULES += gtk
 endif
 
-ifeq (1-netbsd,$(FEATURE.gtk)-$(BUILD.system))
+ifeq (1-netbsd,$(FEATURE.gtk)-$(HOST.system))
     ## build gtk when gtk+netbsd
     MODULES += gtk
 endif
 
-ifeq (1-openbsd,$(FEATURE.gtk)-$(BUILD.system))
+ifeq (1-openbsd,$(FEATURE.gtk)-$(HOST.system))
     ## build gtk when gtk+openbsd
     MODULES += gtk
 endif

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -119,11 +119,7 @@ else
     MODULES += test
 endif
 
-ifeq (1-mingw,$(FEATURE.gtk.mingw)-$(HOST.system))
-    MODULES += gtk
-endif
-
-ifeq (1-,$(FEATURE.gtk)-$(filter $(HOST.system),darwin cygwin mingw))
+ifeq (1,$(FEATURE.gtk))
     MODULES += gtk
 endif
 

--- a/make/python_launcher
+++ b/make/python_launcher
@@ -1,5 +1,4 @@
 #!/bin/sh
-#
 
 inpath()
 {
@@ -13,7 +12,7 @@ inpath()
     return 1
 }
 
-for p in python3 python2 python python3.7 python3.6 python2.7
+for p in python3 python3.11 python3.10 python3.9 python3.8 python3.7 python3.6 python
 do
     if ( inpath $p ); then
         exec $p "$@"

--- a/scripts/build-presets.sh
+++ b/scripts/build-presets.sh
@@ -1,7 +1,7 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # usage: build-presets
 
-SELF="${BASH_SOURCE[0]}"
+SELF="$0"
 SELF_DIR=$(cd $(dirname "${SELF}") && pwd -P)
 SELF_DIR="${SELF_DIR:-$(pwd)}"
 LIBHB_DIR="${SELF_DIR}/../libhb"
@@ -14,7 +14,7 @@ fi
 
 JSON_TEMP=$(mktemp preset_builtin.json.XXX)
 C_TEMP=$(mktemp preset_builtin.h.XXX)
-if [[ "${JSON_TEMP:-}" == "" ]] || [[ "${C_TEMP:-}" == "" ]]; then
+if [ "${JSON_TEMP:-}" = "" ] || [ "${C_TEMP:-}" = "" ]; then
     echo "unable to create temporary files" >2
     exit 1
 fi

--- a/scripts/create_flatpak_manifest.py
+++ b/scripts/create_flatpak_manifest.py
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import types
 import os
 import sys
@@ -8,11 +7,7 @@ import json
 import getopt
 import posixpath
 from collections import OrderedDict
-try:
-    from urllib.parse import urlsplit, unquote
-except ImportError:  # Python 2
-    from urlparse import urlsplit
-    from urllib import unquote
+from urllib.parse import urlsplit, unquote
 
 
 def url2filename(url):

--- a/scripts/create_resources.py
+++ b/scripts/create_resources.py
@@ -1,7 +1,6 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 
-from __future__ import print_function
 import types
 import os
 import sys

--- a/scripts/localization/translate_linux.sh
+++ b/scripts/localization/translate_linux.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Usage: Set environment variables, then run ./translate_linux.sh
 # Using your own HandBrake Fork, example:
 #     export HB_GIT_REPO=https://github.com/<your-username>/HandBrake.git

--- a/scripts/localization/translate_win.sh
+++ b/scripts/localization/translate_win.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Usage: Set environment variables, then run ./translate_windows.sh
 # Using your own HandBrake Fork, example:
 #     export HB_GIT_REPO=https://github.com/<your-username>/HandBrake.git

--- a/scripts/quotestring.py
+++ b/scripts/quotestring.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import re
 import argparse

--- a/scripts/repo-info.sh
+++ b/scripts/repo-info.sh
@@ -1,18 +1,16 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Retrieves git repository info for directory ${1} using command ${2}
 
-function repo_info()
+repo_info()
 {
-    local repo_dir git_exe commit upstream err
-
     # Process args
     repo_dir='.'
-    if [[ ${1} ]]; then
+    if [ -n "${1}" ]; then
         repo_dir=${1}
     fi
-    git_exe='git'
-    if [[ ${2} ]]; then
+    git_exe="git"
+    if [ -n "${2}" ]; then
         git_exe=${2}
     fi
 
@@ -23,19 +21,19 @@ function repo_info()
     fi
 
     # Check whether we have git
-    if ! hash ${git_exe} 2>/dev/null; then
+    if [ -z "$(command -v ${git_exe})" ]; then
         echo "Command '${git_exe}' not found." 1>&2
         return 1
     fi
 
     # Check if there is a valid git repo here
-    HASH=$(${git_exe} rev-parse HEAD)
-    SHORTHASH=$(${git_exe} rev-parse --short HEAD)
+    HASH=$(${git_exe} rev-parse HEAD 2> /dev/null)
+    SHORTHASH=$(${git_exe} rev-parse --short HEAD 2> /dev/null)
     err=$?
-    if [[ ${err} -ne 0 ]]; then
+    if [ $err -ne 0 ]; then
         echo "Not a valid repository." 1>&2
         return ${err}
-    elif [[ -z ${HASH} ]]; then
+    elif [ -z "${HASH}" ]; then
         echo "Not a valid repository." 1>&2
         return 1
     fi
@@ -45,8 +43,8 @@ function repo_info()
 
     # check if an annotated tag is reachable from HEAD
     TAG=$(${git_exe} describe --tags --abbrev=0 --exact-match --match \[0-9\]\*.\[0-9\]\*.\[0-9\]\* HEAD 2> /dev/null)
-    if [[ ${TAG} ]]; then
-        # if TAG is a release tag and HASH == TAG_HASH, this is release code
+    if [ -n "${TAG}" ]; then
+    # if TAG is a release tag and HASH == TAG_HASH, this is release code
         TAG_HASH=$(${git_exe} rev-list ${TAG} --max-count=1)
         REV=$(${git_exe} rev-list $(${git_exe} merge-base ${TAG} HEAD).. --count)
     else
@@ -56,7 +54,7 @@ function repo_info()
     BRANCH=$(${git_exe} symbolic-ref -q --short HEAD)
     REMOTE="${URL}"
     upstream=$(${git_exe} config branch.${BRANCH}.remote)
-    if [[ ${upstream} ]]; then
+    if [ -n "${upstream}" ]; then
         REMOTE="${upstream}"
     fi
     DATE=$(${git_exe} log -1 --format="format:%ci")
@@ -66,9 +64,9 @@ function repo_info()
     echo "URL=${URL}"
     echo "HASH=${HASH}"
     echo "SHORTHASH=${SHORTHASH}"
-    if [[ ${TAG} ]]; then echo "TAG=${TAG}"; fi
-    if [[ ${TAG_HASH} ]]; then echo "TAG_HASH=${TAG_HASH}"; fi
-    if [[ ${REV} ]]; then echo "REV=${REV}"; fi
+    if [ -n "${TAG}" ]; then echo "TAG=${TAG}"; fi
+    if [ -n "${TAG_HASH}" ]; then echo "TAG_HASH=${TAG_HASH}"; fi
+    if [ -n "${REV}" ]; then echo "REV=${REV}"; fi
     echo "BRANCH=${BRANCH}"
     echo "REMOTE=${REMOTE}"
     echo "DATE=${DATE}"

--- a/scripts/tag-release.sh
+++ b/scripts/tag-release.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 #
 # Usage: tag-release.sh <release-ver> [<ref>]
 #
@@ -22,17 +22,14 @@
 #   git push origin refs/tags/X.Y.Z
 #
 
-SELF="${BASH_SOURCE[0]}"
-SELF_NAME=$(basename "${SELF}")
-
 GIT_EXE='git'
 
-function validate_repo()
+validate_repo()
 {
     local HASH err AHEAD BEHIND proceed
 
     # Check whether we have git
-    if ! hash ${GIT_EXE} 2>/dev/null; then
+    if [ -z "$(command -v ${GIT_EXE})" ]; then
         echo "Command '${GIT_EXE}' not found." 1>&2
         return 1
     fi
@@ -40,15 +37,15 @@ function validate_repo()
     # Check if there is a valid git repo here
     HASH=$(${GIT_EXE} rev-parse HEAD)
     err=$?
-    if [[ ${err} -ne 0 ]]; then
+    if [ ${err} -ne 0 ]; then
         echo "Not a valid repository." 1>&2
         return ${err}
-    elif [[ -z ${HASH} ]]; then
+    elif [ -z "${HASH}" ]; then
         echo "Not a valid repository." 1>&2
         return 1
     fi
 
-    if [[ -n "$(${GIT_EXE} status --porcelain)" ]]; then
+    if [ -n "$(${GIT_EXE} status --porcelain)" ]; then
         echo "There are uncommitted changes.  Aborting." 1>&2
         return 1
     fi
@@ -56,47 +53,47 @@ function validate_repo()
     echo "Fetching repo data..."
     ${GIT_EXE} fetch
     err=$?
-    if [[ ${err} -ne 0 ]]; then
+    if [ ${err} -ne 0 ]; then
         echo "Failed to fetch repo data." 1>&2
         return ${err}
     fi
     AHEAD=$(${GIT_EXE} rev-list @{u}..HEAD --count)
     BEHIND=$(${GIT_EXE} rev-list HEAD..@{u} --count)
-    if [[ ${AHEAD} -ne 0 ]]; then
+    if [ ${AHEAD} -ne 0 ]; then
         echo "There are unpushed changes. Continue anyway? (y/N)"
         read proceed
-        if [[ ( "x${proceed}" != "xy" ) && ( "x${proceed}" != "xY" ) ]] ; then
+        if [ "x${proceed}" != "xy" ] && [ "x${proceed}" != "xY" ] ; then
             echo "Aborting..."
             return 1
         fi
     fi
-    if [[ ${BEHIND} -ne 0 ]]; then
+    if [ ${BEHIND} -ne 0 ]; then
         echo "There are unmerged upstream changes. Continue anyway? (y/N)"
         read proceed
-        if [[ ( "x${proceed}" != "xy" ) && ( "x${proceed}" != "xY" ) ]] ; then
+        if [ "x${proceed}" != "xy" ] && [ "x${proceed}" != "xY" ] ; then
             echo "Aborting..."
             return 1
         fi
     fi
 }
 
-function tag_release()
+tag_release()
 {
     local TAG REF COMMIT BRANCH proceed new_branch ERR HASH
 
     TAG=${1}
     REF=${2}
 
-    if [ "x${TAG}" == "x" ]; then
+    if [ "x${TAG}" = "x" ]; then
         echo "Missing release tag (e.g. 1.0.0)"
-        echo "Usage: ${SELF_NAME} tag [commit]"
+        echo "Usage: tag-release.sh tag [commit]"
         return 1
     fi
 
     # bugfix branch name
     BRANCH=${TAG%.[0-9]*}.x
 
-    if [ "x${REF}" == "x" ]; then
+    if [ "x${REF}" = "x" ]; then
         echo "Creating release tag ${TAG} and branch ${BRANCH} from HEAD, proceed? (y/N)"
         # retrieve full hash of HEAD
         COMMIT=$(${GIT_EXE} rev-list HEAD --max-count=1)
@@ -106,7 +103,7 @@ function tag_release()
         COMMIT=$(${GIT_EXE} rev-list ${REF} --max-count=1)
     fi
     read proceed
-    if [[ ( "x${proceed}" != "xy" ) && ( "x${proceed}" != "xY" ) ]] ; then
+    if [ "x${proceed}" != "xy" ] && [ "x${proceed}" != "xY" ] ; then
         echo "Aborting..."
         return 0
     fi
@@ -183,7 +180,7 @@ function tag_release()
     echo "    git push -u origin ${BRANCH}"
     echo "    git push origin refs/tags/${TAG}"
     read proceed
-    if [[ ( "x${proceed}" == "xy" ) || ( "x${proceed}" == "xY" ) ]] ; then
+    if [ "x${proceed}" = "xy" ] || [ "x${proceed}" = "xY" ] ; then
         if [ $new_branch .eq 1 ]; then
             ${GIT_EXE} push -u origin "${BRANCH}"
             ERR=$?
@@ -204,7 +201,7 @@ function tag_release()
 
 }
 
-function main()
+main()
 {
     if validate_repo; then
         tag_release "$@"


### PR DESCRIPTION
These changes are mostly to fix building on the different BSD variants, plus some changes to the build scripts to remove the bash requirement. As BSD and macOS don't have bash installed by default, it means one less program to install. I also added some colors to the configure script, which aren't strictly necessary but make the output a little easier to read. This change can be removed if you'd prefer to keep it as it is.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
- [x] FreeBSD
- [x] NetBSD
- [x] OpenBSD
