### PR TITLE
Add support for excluded File extensions

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3541,7 +3541,7 @@ void ghb_backend_scan_stop (void)
 void
 ghb_backend_scan(const gchar *path, gint titleindex, gint preview_count, uint64_t min_duration)
 {
-    hb_scan( h_scan, path, titleindex, preview_count, 1, min_duration );
+    hb_scan( h_scan, path, titleindex, preview_count, 1, min_duration, 0, 0, NULL );
     hb_status.scan.state |= GHB_STATE_SCANNING;
     // initialize count and cur to something that won't cause FPE
     // when computing progress
@@ -3556,7 +3556,7 @@ void
 ghb_backend_queue_scan(const gchar *path, gint titlenum)
 {
     ghb_log_func();
-    hb_scan( h_queue, path, titlenum, -1, 0, 0 );
+    hb_scan( h_queue, path, titlenum, -1, 0, 0, 0, 0, NULL );
     hb_status.queue.state |= GHB_STATE_SCANNING;
 }
 

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -22,12 +22,18 @@ static int compare_str(const void *a, const void *b)
     return strncmp(*(const char**)a, *(const char**)b, PATH_MAX);
 }
 
+static int endsWith (char* base, char* str) {
+    int blen = strlen(base);
+    int slen = strlen(str);
+    return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
+}
+
 /***********************************************************************
  * hb_batch_init
  ***********************************************************************
  *
  **********************************************************************/
-hb_batch_t * hb_batch_init( hb_handle_t *h, char * path )
+hb_batch_t * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_extensions )
 {
     hb_batch_t    * d;
     hb_stat_t       sb;
@@ -60,13 +66,41 @@ hb_batch_t * hb_batch_init( hb_handle_t *h, char * path )
     }
 
     files = malloc(count * sizeof(char*));
-
+    
+    // Excluded Extensions
+    int extension_count = hb_list_count(exclude_extensions);
+    hb_log("Excluding %i file extension(s) from scan. ", extension_count);
+    
+    for(int i = 0; i < extension_count; i++ )
+    {
+        char * file_extension = hb_list_item( exclude_extensions, i );
+        hb_log(" - Excluding Extension: %s", file_extension);
+    }
+    
     // Find all regular files
     ii = 0;
     hb_rewinddir(dir);
     while ( (entry = hb_readdir( dir ) ) )
     {
         filename = hb_strdup_printf( "%s" DIR_SEP_STR "%s", path, entry->d_name );
+        
+        int excluded = 0;
+        for(int i = 0; i < extension_count; i++ )
+        {
+            char * file_extension = hb_list_item( exclude_extensions, i );
+            if (endsWith(filename, file_extension))
+            {
+                hb_deep_log(2, " -- Excluding File: %s", filename);
+                excluded = 1;
+            }
+        }
+        
+        if (excluded)
+        {
+            free( filename );
+            continue;
+        }
+                
         if ( hb_stat( filename, &sb ) )
         {
             free( filename );

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -22,7 +22,7 @@ static int compare_str(const void *a, const void *b)
     return strncmp(*(const char**)a, *(const char**)b, PATH_MAX);
 }
 
-static int endsWith (char* base, char* str) {
+static int ends_with (char* base, char* str) {
     int blen = strlen(base);
     int slen = strlen(str);
     return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
@@ -71,7 +71,7 @@ hb_batch_t * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_ext
     int extension_count = hb_list_count(exclude_extensions);
     hb_log("Excluding %i file extension(s) from scan. ", extension_count);
     
-    for(int i = 0; i < extension_count; i++ )
+    for (int i = 0; i < extension_count; i++ )
     {
         char * file_extension = hb_list_item( exclude_extensions, i );
         hb_log(" - Excluding Extension: %s", file_extension);
@@ -85,10 +85,10 @@ hb_batch_t * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_ext
         filename = hb_strdup_printf( "%s" DIR_SEP_STR "%s", path, entry->d_name );
         
         int excluded = 0;
-        for(int i = 0; i < extension_count; i++ )
+        for (int i = 0; i < extension_count; i++ )
         {
             char * file_extension = hb_list_item( exclude_extensions, i );
-            if (endsWith(filename, file_extension))
+            if (ends_with(filename, file_extension))
             {
                 hb_deep_log(2, " -- Excluding File: %s", filename);
                 excluded = 1;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3841,6 +3841,30 @@ void hb_list_close( hb_list_t ** _l )
     *_l = NULL;
 }
 
+/**********************************************************************
+ * hb_string_list_copy
+ **********************************************************************
+ * Make a copy of a string list.
+ *********************************************************************/
+hb_list_t *hb_string_list_copy(const hb_list_t *src)
+{
+    hb_list_t *list = hb_list_init();
+    char *string = NULL;
+
+    if (src)
+    {
+        for (int i = 0; i < hb_list_count(src); i++)
+        {
+            if ((string = hb_list_item(src, i)))
+            {
+                hb_list_add(list, strdup(string));
+            }
+        }
+    }
+    return list;
+}
+
+
 int global_verbosity_level; //Necessary for hb_deep_log
 /**********************************************************************
  * hb_valog

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -138,6 +138,8 @@ void        hb_list_rem( hb_list_t *, void * );
 void      * hb_list_item( const hb_list_t *, int );
 void        hb_list_close( hb_list_t ** );
 
+hb_list_t * hb_string_list_copy(const hb_list_t *src);
+
 void hb_reduce( int *x, int *y, int num, int den );
 void hb_limit_rational( int *x, int *y, int64_t num, int64_t den, int limit );
 void hb_reduce64( int64_t *x, int64_t *y, int64_t num, int64_t den );

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -53,6 +53,11 @@ void          hb_scan2( hb_handle_t *, const char * path,
                        int title_index, int preview_count,
                        int store_previews, uint64_t min_duration,
                        int crop_auto_switch_threshold, int crop_median_threshold );
+                       
+void          hb_scan3( hb_handle_t *, const char * path,
+                       int title_index, int preview_count,
+                       int store_previews, uint64_t min_duration,
+                       int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions);
 
 void          hb_scan_stop( hb_handle_t * );
 void          hb_force_rescan( hb_handle_t * );

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -48,14 +48,6 @@ void          hb_dvd_set_dvdnav( int enable );
    a VOB file. If title_index is 0, scan all titles. */
 void          hb_scan( hb_handle_t *, const char * path,
                        int title_index, int preview_count,
-                       int store_previews, uint64_t min_duration );
-void          hb_scan2( hb_handle_t *, const char * path,
-                       int title_index, int preview_count,
-                       int store_previews, uint64_t min_duration,
-                       int crop_auto_switch_threshold, int crop_median_threshold );
-                       
-void          hb_scan3( hb_handle_t *, const char * path,
-                       int title_index, int preview_count,
                        int store_previews, uint64_t min_duration,
                        int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions);
 

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -285,7 +285,7 @@ hb_thread_t * hb_scan_init( hb_handle_t *, volatile int * die,
                             const char * path, int title_index,
                             hb_title_set_t * title_set, int preview_count,
                             int store_previews, uint64_t min_duration,
-                            int crop_auto_switch_threshold, int crop_median_threshold );
+                            int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions );
 hb_thread_t * hb_work_init( hb_list_t * jobs,
                             volatile int * die, hb_error_code * error, hb_job_t ** job );
 void ReadLoop( void * _w );
@@ -326,7 +326,7 @@ extern const hb_muxer_t hb_demux[];
  **********************************************************************/
 typedef struct hb_batch_s hb_batch_t;
 
-hb_batch_t  * hb_batch_init( hb_handle_t *h, char * path );
+hb_batch_t  * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_extensions );
 void          hb_batch_close( hb_batch_t ** _d );
 int           hb_batch_title_count( hb_batch_t * d );
 hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t );

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -359,19 +359,6 @@ void hb_remove_previews( hb_handle_t * h )
     closedir( dir );
 }
 
-// We can remove this after we update all the UI's
-void hb_scan( hb_handle_t * h, const char * path, int title_index,
-              int preview_count, int store_previews, uint64_t min_duration )
-{
-    hb_scan3(h, path, title_index, preview_count, store_previews, min_duration, 0, 0, NULL);
-}
-
-void hb_scan2( hb_handle_t * h, const char * path, int title_index,
-              int preview_count, int store_previews, uint64_t min_duration,
-              int crop_threshold_frames, int crop_threshold_pixels)
-{
-    hb_scan3(h, path, title_index, preview_count, store_previews, min_duration, 0, 0, NULL);
-}
 
 /**
  * Initializes a scan of the by calling hb_scan_init
@@ -385,7 +372,7 @@ void hb_scan2( hb_handle_t * h, const char * path, int title_index,
  * @param crop_threshold_pixels The variance in pixels detected that are allowed for.
  * @param exclude_extensions A list of extensions to exclude for this scan.
  */
-void hb_scan3( hb_handle_t * h, const char * path, int title_index,
+void hb_scan( hb_handle_t * h, const char * path, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
               int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
 {

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -363,7 +363,14 @@ void hb_remove_previews( hb_handle_t * h )
 void hb_scan( hb_handle_t * h, const char * path, int title_index,
               int preview_count, int store_previews, uint64_t min_duration )
 {
-    hb_scan2(h, path, title_index, preview_count, store_previews, min_duration, 0, 0);
+    hb_scan3(h, path, title_index, preview_count, store_previews, min_duration, 0, 0, NULL);
+}
+
+void hb_scan2( hb_handle_t * h, const char * path, int title_index,
+              int preview_count, int store_previews, uint64_t min_duration,
+              int crop_threshold_frames, int crop_threshold_pixels)
+{
+    hb_scan3(h, path, title_index, preview_count, store_previews, min_duration, 0, 0, NULL);
 }
 
 /**
@@ -376,10 +383,11 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
  * @param min_duration Ignore titles below a given threshold
  * @param crop_threshold_frames The number of frames to trigger smart crop
  * @param crop_threshold_pixels The variance in pixels detected that are allowed for.
+ * @param exclude_extensions A list of extensions to exclude for this scan.
  */
-void hb_scan2( hb_handle_t * h, const char * path, int title_index,
+void hb_scan3( hb_handle_t * h, const char * path, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
-              int crop_threshold_frames, int crop_threshold_pixels)
+              int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
 {
     hb_title_t * title;
 
@@ -452,7 +460,7 @@ void hb_scan2( hb_handle_t * h, const char * path, int title_index,
     h->scan_thread = hb_scan_init( h, &h->scan_die, path, title_index,
                                    &h->title_set, preview_count,
                                    store_previews, min_duration,
-                                   crop_threshold_frames, crop_threshold_pixels);
+                                   crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
 }
 
 void hb_force_rescan( hb_handle_t * h )

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1029,8 +1029,8 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
     }
 
     // If the job wants to use Hardware decode, it must also be
-    // enabled during scan.  So enable it here.
-    hb_scan(h, path, title_index, -1, 0, 0);
+    // enabled during scan.  So enable it here.                      
+    hb_scan(h, path, title_index, -1, 0, 0, 0, 0, NULL);
 
     // Wait for scan to complete
     hb_state_t state;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -31,6 +31,9 @@ typedef struct
     
     int            crop_threshold_frames;
     int            crop_threshold_pixels;
+    
+    hb_list_t    * exclude_extensions;
+    
 } hb_scan_t;
 
 #define PREVIEW_READ_THRESH (200)
@@ -202,7 +205,7 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
                             const char * path, int title_index,
                             hb_title_set_t * title_set, int preview_count,
                             int store_previews, uint64_t min_duration,
-                            int crop_threshold_frames, int crop_threshold_pixels)
+                            int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
 {
     hb_scan_t * data = calloc( sizeof( hb_scan_t ), 1 );
 
@@ -218,6 +221,7 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     
     data->crop_threshold_frames = crop_threshold_frames;
     data->crop_threshold_pixels = crop_threshold_pixels;
+    data->exclude_extensions = exclude_extensions;
     
     // Initialize scan state
     hb_state_t state;
@@ -297,7 +301,7 @@ static void ScanFunc( void * _data )
                                            data->title_set->list_title );
         }
     }
-    else if ( ( data->batch = hb_batch_init( data->h, data->path ) ) )
+    else if ( ( data->batch = hb_batch_init( data->h, data->path, data->exclude_extensions ) ) )
     {
         if( data->title_index )
         {

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -221,7 +221,7 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     
     data->crop_threshold_frames = crop_threshold_frames;
     data->crop_threshold_pixels = crop_threshold_pixels;
-    data->exclude_extensions = exclude_extensions;
+    data->exclude_extensions    = hb_string_list_copy(exclude_extensions);
     
     // Initialize scan state
     hb_state_t state;
@@ -472,6 +472,15 @@ finish:
         hb_batch_close( &data->batch );
     }
     free( data->path );
+    
+    // clean up excluded extensions list
+    char *extension;
+    while ((extension = hb_list_item(data->exclude_extensions, 0)))
+    {
+        hb_list_rem(data->exclude_extensions, extension);
+        free(extension);
+    }
+
     free( data );
     _data = NULL;
     hb_buffer_pool_free();

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -291,10 +291,10 @@ HB_OBJC_DIRECT_MEMBERS
 
     [self preventAutoSleep];
 
-    hb_scan2(_hb_handle, url.fileSystemRepresentation,
+    hb_scan(_hb_handle, url.fileSystemRepresentation,
               (int)index, (int)previewsNum,
               keepPreviews, min_title_duration_ticks,
-              0, 0);
+              0, 0, NULL);
 
     // Start the timer to handle libhb state changes
     [self startUpdateTimerWithInterval:0.2];

--- a/test/test.c
+++ b/test/test.c
@@ -594,8 +594,8 @@ int main( int argc, char ** argv )
 
         hb_system_sleep_prevent(h);
 
-        hb_scan2(h, input, titleindex, preview_count, store_previews,
-                min_title_duration * 90000LL, crop_threshold_frames, crop_threshold_pixels);
+        hb_scan(h, input, titleindex, preview_count, store_previews,
+                min_title_duration * 90000LL, crop_threshold_frames, crop_threshold_pixels, NULL);
 
         EventLoop(h, preset_dict);
         hb_value_free(&preset_dict);

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -154,7 +154,7 @@ namespace HandBrake.Interop.Interop
 
             // Start the Scan
             IntPtr pathPtr = InteropUtilities.ToUtf8PtrFromString(path);
-            HBFunctions.hb_scan3(this.Handle, pathPtr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr);
+            HBFunctions.hb_scan(this.Handle, pathPtr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr);
             Marshal.FreeHGlobal(pathPtr);
 
             this.scanPollTimer = new Timer();

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -49,10 +49,7 @@ namespace HandBrake.Interop.Interop.HbLib
         public static extern void hb_dvd_set_dvdnav(int enable);
 
         [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration);
-
-        [DllImport("hb", EntryPoint = "hb_scan3", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan3(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
+        public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
 
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_stop(IntPtr hbHandle);

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -51,6 +51,9 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration);
 
+        [DllImport("hb", EntryPoint = "hb_scan3", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void hb_scan3(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
+
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_stop(IntPtr hbHandle);
 

--- a/win/CS/HandBrake.Interop/Interop/Interfaces/IHandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/IHandBrakeInstance.cs
@@ -10,6 +10,7 @@
 namespace HandBrake.Interop.Interop.Interfaces
 {
     using System;
+    using System.Collections.Generic;
 
     using HandBrake.Interop.Interop.Interfaces.EventArgs;
     using HandBrake.Interop.Interop.Interfaces.Model.Preview;
@@ -93,7 +94,12 @@ namespace HandBrake.Interop.Interop.Interfaces
         /// <param name="titleIndex">
         /// The title Index.
         /// </param>
-        void StartScan(string path, int previewCount, TimeSpan minDuration, int titleIndex);
+        /// <param name="excludedExtensions">
+        /// A list of file extensions to exclude.
+        /// These should be the extension name only. No .
+        /// Case Insensitive.
+        /// </param>
+        void StartScan(string path, int previewCount, TimeSpan minDuration, int titleIndex, List<string> excludedExtensions);
 
         /// <summary>
         /// Stop any running scans

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -3091,6 +3091,15 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Add Extension.
+        /// </summary>
+        public static string Options_AddExt {
+            get {
+                return ResourceManager.GetString("Options_AddExt", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Advanced.
         /// </summary>
         public static string Options_Advanced {
@@ -3276,6 +3285,33 @@ namespace HandBrakeWPF.Properties {
         public static string Options_Encoding {
             get {
                 return ResourceManager.GetString("Options_Encoding", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Exclude File Extensions.
+        /// </summary>
+        public static string Options_ExcludeExtensions {
+            get {
+                return ResourceManager.GetString("Options_ExcludeExtensions", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The following file extensions will be ignored when scanning a folder. The list is case insensitive. &quot;.&quot; is not required..
+        /// </summary>
+        public static string Options_ExcludeExtensionsInfo {
+            get {
+                return ResourceManager.GetString("Options_ExcludeExtensionsInfo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This file extension already exists in the list..
+        /// </summary>
+        public static string Options_ExtensionExists {
+            get {
+                return ResourceManager.GetString("Options_ExtensionExists", resourceCulture);
             }
         }
         

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2780,4 +2780,16 @@ To allow multiple simultaneous encodes, turn on "Process Isolation" in Tools Men
   <data name="QueueViewModel_StopButContinueJob" xml:space="preserve">
     <value>There are currently jobs running. Would you like to complete the current jobs before stopping the queue?</value>
   </data>
+  <data name="Options_AddExt" xml:space="preserve">
+    <value>Add Extension</value>
+  </data>
+  <data name="Options_ExcludeExtensions" xml:space="preserve">
+    <value>Exclude File Extensions</value>
+  </data>
+  <data name="Options_ExcludeExtensionsInfo" xml:space="preserve">
+    <value>The following file extensions will be ignored when scanning a folder. The list is case insensitive. "." is not required.</value>
+  </data>
+  <data name="Options_ExtensionExists" xml:space="preserve">
+    <value>This file extension already exists in the list.</value>
+  </data>
 </root>

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -226,8 +226,10 @@ namespace HandBrakeWPF.Services.Scan
 
                 HandBrakeUtils.SetDvdNav(!this.userSettingService.GetUserSetting<bool>(UserSettingConstants.DisableLibDvdNav));
 
+                List<string> excludedExtensions = this.userSettingService.GetUserSetting<List<string>>(UserSettingConstants.ExcludedExtensions);
+
                 this.ServiceLogMessage("Starting Scan ...");
-                this.instance.StartScan(sourcePath.ToString(), previewCount, minDuration, title != 0 ? title : 0);
+                this.instance.StartScan(sourcePath.ToString(), previewCount, minDuration, title != 0 ? title : 0, excludedExtensions);
 
                 this.ScanStarted?.Invoke(this, System.EventArgs.Empty);
             }

--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -356,7 +356,7 @@ namespace HandBrakeWPF.Services
             defaults.Add(UserSettingConstants.IsUpdateAvailableBuild, 0);
             defaults.Add(UserSettingConstants.ExtendedQueueDisplay, true);
             defaults.Add(UserSettingConstants.HardwareDetectTimeoutSeconds, 12);
-            defaults.Add(UserSettingConstants.ExcludedExtensions, new List<string> { "png", "jpg" });
+            defaults.Add(UserSettingConstants.ExcludedExtensions, new List<string> { "png", "jpg", "srt", "ass", "ssa", "txt" });
 
 
             return defaults;

--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -356,8 +356,9 @@ namespace HandBrakeWPF.Services
             defaults.Add(UserSettingConstants.IsUpdateAvailableBuild, 0);
             defaults.Add(UserSettingConstants.ExtendedQueueDisplay, true);
             defaults.Add(UserSettingConstants.HardwareDetectTimeoutSeconds, 12);
+            defaults.Add(UserSettingConstants.ExcludedExtensions, new List<string> { "png", "jpg" });
 
-            
+
             return defaults;
         }
 

--- a/win/CS/HandBrakeWPF/UserSettingConstants.cs
+++ b/win/CS/HandBrakeWPF/UserSettingConstants.cs
@@ -93,5 +93,6 @@ namespace HandBrakeWPF
         public const string ExtendedQueueDisplay = "ExtendedQueueDisplay";
         public const string HardwareDetectTimeoutSeconds = "HardwareDetectTimeoutSeconds";
         public const string ShowPresetDesc = "ShowPresetDescription";
+        public const string ExcludedExtensions = "ExcludedFileExtensions";
     }
 }

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -10,16 +10,20 @@
 namespace HandBrakeWPF.ViewModels
 {
     using System;
+    using System.Collections.Generic;
     using System.ComponentModel;
     using System.Diagnostics;
     using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Windows;
+    using System.Windows.Documents;
     using System.Windows.Media;
 
     using HandBrake.App.Core.Utilities;
     using HandBrake.Interop.Interop;
+
+    using HandBrakeWPF.Commands;
     using HandBrakeWPF.Helpers;
     using HandBrakeWPF.Model;
     using HandBrakeWPF.Model.Options;
@@ -114,14 +118,15 @@ namespace HandBrakeWPF.ViewModels
         private bool enableQuickSyncHyperEncode;
         private bool enableNvDecSupport;
         private bool useIsoDateFormat;
+        private BindingList<string> excludedFileExtensions;
 
         public OptionsViewModel(
             IUserSettingService userSettingService,
-            IUpdateService updateService, 
-            IAboutViewModel aboutViewModel, 
-            IErrorService errorService, 
-            IPresetService presetService, 
-            INotificationService notificationService, 
+            IUpdateService updateService,
+            IAboutViewModel aboutViewModel,
+            IErrorService errorService,
+            IPresetService presetService,
+            INotificationService notificationService,
             ILog logService)
         {
             this.Title = "Options";
@@ -136,6 +141,7 @@ namespace HandBrakeWPF.ViewModels
 
             this.SelectedTab = OptionsTab.General;
             this.UpdateMessage = Resources.OptionsViewModel_CheckForUpdatesMsg;
+            this.RemoveExtensionCommand = new SimpleRelayCommand<string>(this.RemoveExcludedExtension);
         }
 
         public OptionsTab SelectedTab
@@ -880,7 +886,22 @@ namespace HandBrakeWPF.ViewModels
             }
         }
 
-        /* Video */ 
+        public BindingList<string> ExcludedFileExtensions
+        {
+            get => this.excludedFileExtensions;
+            set
+            {
+                if (Equals(value, this.excludedFileExtensions)) return;
+                this.excludedFileExtensions = value;
+                this.OnPropertyChanged();
+            }
+        }
+
+        public List<string> SelectedExtensions { get; set; }
+
+        public string NewExtension { get; set; }
+
+        /* Video */
         public bool EnableQuickSyncEncoding
         {
             get => this.enableQuickSyncEncoding && this.IsQuickSyncAvailable;
@@ -1267,6 +1288,38 @@ namespace HandBrakeWPF.ViewModels
             this.AutonameFormat = "{source}-{title}";
         }
 
+        public void AddExcludedExtension()
+        {
+            if (!string.IsNullOrEmpty(NewExtension))
+            {
+                NewExtension = NewExtension.Replace(".", string.Empty);
+
+                if (this.ExcludedFileExtensions.Contains(NewExtension, StringComparer.OrdinalIgnoreCase))
+                {
+                    this.errorService.ShowMessageBox(Resources.Options_ExtensionExists, Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
+                    return;
+                }
+
+                this.ExcludedFileExtensions.Add(this.NewExtension);
+                this.NewExtension = null;
+                this.NotifyOfPropertyChange(() => this.NewExtension);
+            }
+        }
+
+    
+        public SimpleRelayCommand<string> RemoveExtensionCommand { get; set; }
+
+        public void RemoveExcludedExtension(string extension)
+        {
+            if (!string.IsNullOrEmpty(extension))
+            {
+                if (this.ExcludedFileExtensions.Contains(extension, StringComparer.OrdinalIgnoreCase))
+                {
+                    this.ExcludedFileExtensions.Remove(extension);
+                }
+            }
+        }
+
         #endregion
 
         public override void OnLoad()
@@ -1452,6 +1505,8 @@ namespace HandBrakeWPF.ViewModels
             this.PauseOnLowBattery = userSettingService.GetUserSetting<bool>(UserSettingConstants.PauseEncodingOnLowBattery);
             this.LowBatteryLevel = userSettingService.GetUserSetting<int>(UserSettingConstants.LowBatteryLevel);
 
+            this.ExcludedFileExtensions = new BindingList<string>(userSettingService.GetUserSetting<List<string>>(UserSettingConstants.ExcludedExtensions));
+
             // #############################
             // Safe Mode
             // #############################
@@ -1586,6 +1641,7 @@ namespace HandBrakeWPF.ViewModels
             this.userSettingService.SetUserSetting(UserSettingConstants.ClearCompletedFromQueue, this.ClearQueueOnEncodeCompleted);
             this.userSettingService.SetUserSetting(UserSettingConstants.PreviewScanCount, this.SelectedPreviewCount);
             this.userSettingService.SetUserSetting(UserSettingConstants.X264Step, double.Parse(this.SelectedGranularity, CultureInfo.InvariantCulture));
+            this.userSettingService.SetUserSetting(UserSettingConstants.ExcludedExtensions, new List<string>(this.ExcludedFileExtensions));
 
             int value;
             if (int.TryParse(this.MinLength.ToString(CultureInfo.InvariantCulture), out value))
@@ -1598,12 +1654,10 @@ namespace HandBrakeWPF.ViewModels
             this.userSettingService.SetUserSetting(UserSettingConstants.PauseEncodingOnLowBattery, this.PauseOnLowBattery);
             this.userSettingService.SetUserSetting(UserSettingConstants.LowBatteryLevel, this.LowBatteryLevel);
 
-            /* Experimental */
             this.userSettingService.SetUserSetting(UserSettingConstants.ProcessIsolationEnabled, this.RemoteServiceEnabled);
             this.userSettingService.SetUserSetting(UserSettingConstants.ProcessIsolationPort, this.RemoteServicePort);
             this.userSettingService.SetUserSetting(UserSettingConstants.SimultaneousEncodes, this.SimultaneousEncodes);
         }
-
 
         public void LaunchHelp()
         {

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -897,9 +897,9 @@ namespace HandBrakeWPF.ViewModels
             }
         }
 
-        public List<string> SelectedExtensions { get; set; }
-
         public string NewExtension { get; set; }
+
+        public SimpleRelayCommand<string> RemoveExtensionCommand { get; set; }
 
         /* Video */
         public bool EnableQuickSyncEncoding
@@ -1078,7 +1078,6 @@ namespace HandBrakeWPF.ViewModels
                 this.NotifyOfPropertyChange(() => this.DownloadProgressPercentage);
             }
         }
-
 
         public bool RemoteServiceEnabled
         {
@@ -1305,9 +1304,6 @@ namespace HandBrakeWPF.ViewModels
                 this.NotifyOfPropertyChange(() => this.NewExtension);
             }
         }
-
-    
-        public SimpleRelayCommand<string> RemoveExtensionCommand { get; set; }
 
         public void RemoveExcludedExtension(string extension)
         {

--- a/win/CS/HandBrakeWPF/Views/Options/OptionsAdvanced.xaml
+++ b/win/CS/HandBrakeWPF/Views/Options/OptionsAdvanced.xaml
@@ -6,6 +6,7 @@
              xmlns:converters="clr-namespace:HandBrakeWPF.Converters"
              xmlns:Properties="clr-namespace:HandBrakeWPF.Properties"
              xmlns:options="clr-namespace:HandBrakeWPF.Converters.Options"
+             xmlns:b="http://schemas.microsoft.com/xaml/behaviors"
              mc:Ignorable="d" 
              d:DesignHeight="450" d:DesignWidth="800">
 
@@ -68,6 +69,54 @@
                     <TextBlock Text="{x:Static Properties:Resources.Options_PriorityLevel}" Width="250" VerticalAlignment="Center" />
                     <ComboBox Name="processPriorityLevel" ItemsSource="{Binding PriorityLevelOptions, Converter={StaticResource ProcessPriorityConverter}}" SelectedItem="{Binding SelectedPriority, Converter={StaticResource ProcessPriorityConverter}}" Width="120" />
                 </StackPanel>
+            </StackPanel>
+        </StackPanel>
+
+        <StackPanel Orientation="Vertical" Margin="0,10,0,10">
+
+            <TextBlock Text="{x:Static Properties:Resources.Options_ExcludeExtensions}" Style="{StaticResource subHeader}" Margin="0,0,0,10"/>
+            <TextBlock Text="{x:Static Properties:Resources.Options_ExcludeExtensionsInfo}" Margin="0,0,0,10" Style="{StaticResource subText}" />
+
+            <StackPanel Orientation="Vertical" Margin="20,0,0,0">
+                <ListBox ItemsSource="{Binding ExcludedFileExtensions}" Width="150" HorizontalAlignment="Left" Height="100" >
+
+                    <ListBox.ItemContainerStyle>
+                        <Style TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource {x:Type ListBoxItem}}">
+                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                            <Setter Property="Margin" Value="0,0,0,1" />
+                        </Style>
+                    </ListBox.ItemContainerStyle>
+
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:Name="ExtensionTemplate">
+                            <Grid>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+
+                                <TextBlock Text="{Binding}" />
+
+
+                                <Image Width="16" Height="16"  Source="../Images/close64.png" Grid.Column="1">
+                                    <b:Interaction.Triggers>
+                                        <b:EventTrigger EventName="MouseDown">
+                                            <b:InvokeCommandAction Command="{Binding DataContext.RemoveExtensionCommand, RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type ListBox}}}" CommandParameter="{Binding}" />
+                                        </b:EventTrigger>
+                                    </b:Interaction.Triggers>
+                                </Image>
+                            </Grid>
+
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+
+                <StackPanel Orientation="Horizontal" Margin="0,5,0,0">
+                    <TextBox Text="{Binding NewExtension}" Width="150" />
+                    <Button Content="{x:Static Properties:Resources.Options_AddExt}" Command="{Binding RelayCommand}" CommandParameter="AddExcludedExtension" Margin="10,0,0,0" />
+                </StackPanel>
+
+
             </StackPanel>
         </StackPanel>
 


### PR DESCRIPTION
**Description of Change:**

- Add support for excluding file extensions for batch scan.
- By Default:  png, jpg, txt, srt, ssa, ass are excluded. Users can change this if they choose.
- Add a new preference to the Windows UI to allow controlling this option.
- Consolidated hb_scan and hb_scan2

#2541

**Tested on:**

- [x] Windows 10+  (via MinGW)


**Screenshots (If relevant):**
![image](https://github.com/HandBrake/HandBrake/assets/628593/0999fcb3-da4a-4681-91d8-c28b5ac5961f)
![image](https://github.com/HandBrake/HandBrake/assets/628593/6ba85d54-8ecd-4a68-9286-aac21c80bc86)


**Log file output (If relevant):**
![image](https://github.com/HandBrake/HandBrake/assets/628593/16141d2a-c31b-4fb4-87a2-51447c8c2e4b)
