### PR TITLE
Scan improvements

### DIFF
--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -81,8 +81,8 @@ hb_batch_t * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_ext
         int excluded = 0;
         for (int i = 0; i < extension_count; i++ )
         {
-            char * file_extension = hb_list_item( exclude_extensions, i );
-            if (ends_with(filename, file_extension))
+            const char *file_extension = hb_list_item(exclude_extensions, i);
+            if (hb_str_ends_with(filename, file_extension))
             {
                 hb_deep_log(2, " -- Excluding File: %s", filename);
                 excluded = 1;
@@ -91,19 +91,19 @@ hb_batch_t * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_ext
         
         if (excluded)
         {
-            free( filename );
+            free(filename);
             continue;
         }
                 
-        if ( hb_stat( filename, &sb ) )
+        if (hb_stat(filename, &sb))
         {
-            free( filename );
+            free(filename);
             continue;
         }
 
-        if ( !S_ISREG( sb.st_mode ) )
+        if (!S_ISREG(sb.st_mode))
         {
-            free( filename );
+            free(filename);
             continue;
         }
 
@@ -161,7 +161,7 @@ hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t )
     filename = hb_list_item( d->list_file, t - 1 );
     if ( filename == NULL )
         return NULL;
-        
+
     hb_log( "batch: scanning %s", filename );
     title = hb_title_init( filename, t );
     stream = hb_stream_open(d->h, filename, title, 1);
@@ -177,65 +177,62 @@ hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t )
     return title;
 }
 
-hb_title_t * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t )
+hb_title_t * hb_batch_title_scan_single(hb_handle_t *h, char *filename, int title_index)
 {
-    hb_title_t   * title;
-    hb_stream_t  * stream;
-  
-    
-    if ( t < 0 ) 
+    hb_title_t   *title;
+    hb_stream_t  *stream;
+
+    if (title_index < 0)
     {
         return NULL;
     }
-    
+
     if (!hb_is_valid_batch_path(filename))
     {
         return NULL;
     }
 
-    hb_log( "batch: scanning %s", filename );
-    title = hb_title_init( filename, t );
+    hb_log("batch: scanning %s", filename);
+    title = hb_title_init(filename, title_index);
     
-    if ( title == NULL )
+    if (title == NULL)
     {
         return NULL;
     }
 
     stream = hb_stream_open(h, filename, title, 1);
-    
-    if ( stream == NULL )
+
+    if (stream == NULL)
     {
-        hb_title_close( &title );
+        hb_title_close(&title);
         return NULL;
     }
-        
-    title = hb_stream_title_scan( stream, title );
-    hb_stream_close( &stream );
+
+    title = hb_stream_title_scan(stream, title);
+    hb_stream_close(&stream);
 
     return title;
 }
 
-int hb_is_valid_batch_path(char * filename)
+int hb_is_valid_batch_path(const char *filename)
 {
-    hb_stat_t      sb;
-      
-    if ( hb_stat( filename, &sb ) )
+    hb_stat_t sb;
+
+    if (hb_stat(filename, &sb))
     {
-       free( filename );
-       return NULL;
+        return 0;
     }
-    
-    if ( S_ISDIR( sb.st_mode ) ) 
+
+    if (S_ISDIR(sb.st_mode))
     {
-        return NULL;
+        return 0;
     }
-        
-    if ( !S_ISREG( sb.st_mode ) )
+
+    if (!S_ISREG(sb.st_mode))
     {
-        free( filename );
-        return NULL;
+        return 0;
     }
-    
+
     return 1;
 }
 

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -177,6 +177,30 @@ hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t )
     return title;
 }
 
+hb_title_t * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t )
+{
+    hb_title_t   * title;
+    hb_stream_t  * stream;
+    
+    if ( t < 0 )
+        return NULL;
+
+    hb_log( "batch: scanning %s", filename );
+    title = hb_title_init( filename, t );
+    
+    stream = hb_stream_open(h, filename, title, 1);
+    if ( stream == NULL )
+    {
+        hb_title_close( &title );
+        return NULL;
+    }
+    
+    title = hb_stream_title_scan( stream, title );
+    hb_stream_close( &stream );
+
+    return title;
+}
+
 /***********************************************************************
  * hb_batch_close
  ***********************************************************************

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -22,12 +22,6 @@ static int compare_str(const void *a, const void *b)
     return strncmp(*(const char**)a, *(const char**)b, PATH_MAX);
 }
 
-static int ends_with (char* base, char* str) {
-    int blen = strlen(base);
-    int slen = strlen(str);
-    return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
-}
-
 /***********************************************************************
  * hb_batch_init
  ***********************************************************************

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -181,27 +181,15 @@ hb_title_t * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t
 {
     hb_title_t   * title;
     hb_stream_t  * stream;
-    hb_stat_t      sb;
+  
     
     if ( t < 0 ) 
     {
         return NULL;
     }
     
-    if ( hb_stat( filename, &sb ) )
+    if (!hb_is_valid_batch_path(filename))
     {
-       free( filename );
-       return NULL;
-    }
-    
-    if ( S_ISDIR( sb.st_mode ) ) 
-    {
-        return NULL;
-    }
-        
-    if ( !S_ISREG( sb.st_mode ) )
-    {
-        free( filename );
         return NULL;
     }
 
@@ -225,6 +213,30 @@ hb_title_t * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t
     hb_stream_close( &stream );
 
     return title;
+}
+
+int hb_is_valid_batch_path(char * filename)
+{
+    hb_stat_t      sb;
+      
+    if ( hb_stat( filename, &sb ) )
+    {
+       free( filename );
+       return NULL;
+    }
+    
+    if ( S_ISDIR( sb.st_mode ) ) 
+    {
+        return NULL;
+    }
+        
+    if ( !S_ISREG( sb.st_mode ) )
+    {
+        free( filename );
+        return NULL;
+    }
+    
+    return 1;
 }
 
 /***********************************************************************

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -161,7 +161,7 @@ hb_title_t * hb_batch_title_scan( hb_batch_t * d, int t )
     filename = hb_list_item( d->list_file, t - 1 );
     if ( filename == NULL )
         return NULL;
-
+        
     hb_log( "batch: scanning %s", filename );
     title = hb_title_init( filename, t );
     stream = hb_stream_open(d->h, filename, title, 1);
@@ -181,20 +181,46 @@ hb_title_t * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t
 {
     hb_title_t   * title;
     hb_stream_t  * stream;
+    hb_stat_t      sb;
     
-    if ( t < 0 )
+    if ( t < 0 ) 
+    {
         return NULL;
+    }
+    
+    if ( hb_stat( filename, &sb ) )
+    {
+       free( filename );
+       return NULL;
+    }
+    
+    if ( S_ISDIR( sb.st_mode ) ) 
+    {
+        return NULL;
+    }
+        
+    if ( !S_ISREG( sb.st_mode ) )
+    {
+        free( filename );
+        return NULL;
+    }
 
     hb_log( "batch: scanning %s", filename );
     title = hb_title_init( filename, t );
     
+    if ( title == NULL )
+    {
+        return NULL;
+    }
+
     stream = hb_stream_open(h, filename, title, 1);
+    
     if ( stream == NULL )
     {
         hb_title_close( &title );
         return NULL;
     }
-    
+        
     title = hb_stream_title_scan( stream, title );
     hb_stream_close( &stream );
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -520,6 +520,14 @@ static int hb_container_is_enabled(int format)
     }
 }
 
+int ends_with (char* base, char* str) 
+{
+    int blen = strlen(base);
+    int slen = strlen(str);
+    return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
+}
+
+
 void hb_common_global_init(int disable_hardware)
 {
     static int common_init_done = 0;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -520,13 +520,12 @@ static int hb_container_is_enabled(int format)
     }
 }
 
-int ends_with (char* base, char* str) 
+int hb_str_ends_with(const char *base, const char *str)
 {
     int blen = strlen(base);
     int slen = strlen(str);
     return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
 }
-
 
 void hb_common_global_init(int disable_hardware)
 {

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -370,7 +370,7 @@ struct hb_dovi_conf_s
     unsigned dv_bl_signal_compatibility_id;
 };
 
-int ends_with (char* base, char* str);
+int hb_str_ends_with(const char *base, const char *str);
 
 /*******************************************************************************
  * Lists of rates, mixdowns, encoders etc.

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -370,6 +370,8 @@ struct hb_dovi_conf_s
     unsigned dv_bl_signal_compatibility_id;
 };
 
+int ends_with (char* base, char* str);
+
 /*******************************************************************************
  * Lists of rates, mixdowns, encoders etc.
  *******************************************************************************

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -50,6 +50,10 @@ void          hb_scan( hb_handle_t *, const char * path,
                        int title_index, int preview_count,
                        int store_previews, uint64_t min_duration,
                        int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions);
+                       
+void          hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
+                      int preview_count, int store_previews, uint64_t min_duration,
+                      int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions);
 
 void          hb_scan_stop( hb_handle_t * );
 void          hb_force_rescan( hb_handle_t * );

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -282,7 +282,7 @@ static inline int hb_image_height(int pix_fmt, int height, int plane)
  * Threads: scan.c, work.c, reader.c, muxcommon.c
  **********************************************************************/
 hb_thread_t * hb_scan_init( hb_handle_t *, volatile int * die,
-                            const char * path, int title_index,
+                            hb_list_t * paths, int title_index,
                             hb_title_set_t * title_set, int preview_count,
                             int store_previews, uint64_t min_duration,
                             int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions );

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -331,6 +331,7 @@ void          hb_batch_close( hb_batch_t ** _d );
 int           hb_batch_title_count( hb_batch_t * d );
 hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t );
 hb_title_t  * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t );
+int           hb_is_valid_batch_path(char * filename);
 
 /***********************************************************************
  * dvd.c

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -331,7 +331,7 @@ void          hb_batch_close( hb_batch_t ** _d );
 int           hb_batch_title_count( hb_batch_t * d );
 hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t );
 hb_title_t  * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t );
-int           hb_is_valid_batch_path(char * filename);
+int           hb_is_valid_batch_path( const char * filename );
 
 /***********************************************************************
  * dvd.c

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -330,6 +330,7 @@ hb_batch_t  * hb_batch_init( hb_handle_t *h, char * path, hb_list_t * exclude_ex
 void          hb_batch_close( hb_batch_t ** _d );
 int           hb_batch_title_count( hb_batch_t * d );
 hb_title_t  * hb_batch_title_scan( hb_batch_t * d, int t );
+hb_title_t  * hb_batch_title_scan_single( hb_handle_t * h, char * filename, int t );
 
 /***********************************************************************
  * dvd.c

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -363,10 +363,13 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
               int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
 {
-    // TODO Compatibility later for the other UI's.  Remove when they are updated.
-    hb_list_t * file_paths = hb_list_init();
-    hb_list_add(file_paths, (char*) path);
+    // TODO: Compatibility later for the other UI's.  Remove when they are updated.
+    hb_list_t *file_paths = hb_list_init();
+    hb_list_add(file_paths, (char *)path);
+
     hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
+
+    hb_list_close(&file_paths);
 }
 
 /**
@@ -387,10 +390,11 @@ void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
 {
     hb_title_t * title;
 
-    char * single_path = NULL;
+    char *single_path = NULL;
     int path_count = hb_list_count(paths);
 
-    if (path_count == 1) {
+    if (path_count == 1)
+    {
         single_path = hb_list_item(paths, 0);
     }
     
@@ -459,8 +463,9 @@ void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
     }
 #endif
 
-    char * path_info = single_path;
-    if ( path_count > 1) {
+    char *path_info = single_path;
+    if (path_count > 1)
+    {
         path_info = "(multiple)";
     }
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -365,7 +365,7 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
 {
     // TODO Compatibility later for the other UI's.  Remove when they are updated.
     hb_list_t * file_paths = hb_list_init();
-    hb_list_add(file_paths, path);
+    hb_list_add(file_paths, (char*) path);
     hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
 }
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -359,6 +359,15 @@ void hb_remove_previews( hb_handle_t * h )
     closedir( dir );
 }
 
+void hb_scan( hb_handle_t * h, const char * path, int title_index,
+              int preview_count, int store_previews, uint64_t min_duration,
+              int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
+{
+    // TODO Compatibility later for the other UI's.  Remove when they are updated.
+    hb_list_t * file_paths = hb_list_init();
+    hb_list_add(file_paths, path);
+    hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
+}
 
 /**
  * Initializes a scan of the by calling hb_scan_init
@@ -372,16 +381,23 @@ void hb_remove_previews( hb_handle_t * h )
  * @param crop_threshold_pixels The variance in pixels detected that are allowed for.
  * @param exclude_extensions A list of extensions to exclude for this scan.
  */
-void hb_scan( hb_handle_t * h, const char * path, int title_index,
+void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
               int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
 {
     hb_title_t * title;
 
-    // Check if scanning is necessary.
-    if (h->title_set.path != NULL && !strcmp(h->title_set.path, path))
+    char * single_path = NULL;
+    int path_count = hb_list_count(paths);
+
+    if (path_count == 1) {
+        single_path = hb_list_item(paths, 0);
+    }
+    
+    // Check if scanning is necessary. Only works on Single Path.
+    if (single_path != NULL && h->title_set.path != NULL && !strcmp(h->title_set.path, single_path))
     {
-        // Current title_set path matches requested path.
+        // Current title_set path matches requested single_path.
         // Check if the requested title has already been scanned.
         int ii;
         for (ii = 0; ii < hb_list_count(h->title_set.list_title); ii++)
@@ -443,8 +459,13 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
     }
 #endif
 
-    hb_log( "hb_scan: path=%s, title_index=%d", path, title_index );
-    h->scan_thread = hb_scan_init( h, &h->scan_die, path, title_index,
+    char * path_info = single_path;
+    if ( path_count > 1) {
+        path_info = "(multiple)";
+    }
+
+    hb_log( "hb_scan: path=%s, title_index=%d", path_info, title_index );
+    h->scan_thread = hb_scan_init( h, &h->scan_die, paths, title_index,
                                    &h->title_set, preview_count,
                                    store_previews, min_duration,
                                    crop_threshold_frames, crop_threshold_pixels, exclude_extensions);

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -366,7 +366,7 @@ static void ScanFunc( void * _data )
     else if (hb_list_count(data->paths) > 1) // We have many file paths to process.
     {
         hb_log ("Multi File Scan");
-        // TODO -> do we want to support excluded extensions here?
+
         // If dragging a batch of files, maybe not, but if the UI's implement a recursive folder maybe?
         for( i = 0; i < hb_list_count( data->paths ); i++ )
         {
@@ -378,12 +378,11 @@ static void ScanFunc( void * _data )
             {
                 hb_list_add( data->title_set->list_title, title );
             }
-            else
-            {
-                hb_title_close( &title );
-                hb_log( "scan: unrecognized file type" );
-                goto finish;
-            }
+        }
+        
+        if ( hb_list_count(data->title_set->list_title) == 0)
+        {
+            goto finish;
         }
     }
     else // Single File.

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -201,6 +201,36 @@ static int get_color_range(int color_range)
     }
 }
 
+static int is_known_filetype (char * filename) 
+{
+    if (ends_with(filename, "mp4"))
+    {
+        return 1;
+    }
+    
+    if (ends_with(filename, "mkv"))
+    {
+        return 1;
+    }
+    
+    if (ends_with(filename, "avi"))
+    {
+        return 1;
+    }
+    
+    if (ends_with(filename, "webm"))
+    {
+        return 1;
+    }
+    
+    if (ends_with(filename, "wmv"))
+    {
+        return 1;
+    }
+    
+    return 0;
+}
+
 hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
                             const char * path, int title_index,
                             hb_title_set_t * title_set, int preview_count,
@@ -251,7 +281,7 @@ static void ScanFunc( void * _data )
     data->stream = NULL;
 
     /* Try to open the path as a DVD. If it fails, try as a file */
-    if( ( data->bd = hb_bd_init( data->h, data->path ) ) )
+    if( !is_known_filetype(data->path) && ( data->bd = hb_bd_init( data->h, data->path ) ) )
     {
         hb_log( "scan: BD has %d title(s)",
                 hb_bd_title_count( data->bd ) );
@@ -276,7 +306,7 @@ static void ScanFunc( void * _data )
                                           data->title_set->list_title );
         }
     }
-    else if( ( data->dvd = hb_dvd_init( data->h, data->path ) ) )
+    else if( !is_known_filetype(data->path) && ( data->dvd = hb_dvd_init( data->h, data->path ) ) )
     {
         hb_log( "scan: DVD has %d title(s)",
                 hb_dvd_title_count( data->dvd ) );

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -379,11 +379,6 @@ static void ScanFunc( void * _data )
                 hb_list_add( data->title_set->list_title, title );
             }
         }
-        
-        if ( hb_list_count(data->title_set->list_title) == 0)
-        {
-            goto finish;
-        }
     }
     else // Single File.
     {
@@ -501,9 +496,13 @@ static void ScanFunc( void * _data )
         title->flags |= HBTF_SCAN_COMPLETE;
     }
     
-    if (single_path != NULL && hb_list_count(data->title_set->list_title) > 0)
+    if (hb_list_count(data->title_set->list_title) > 0)
     {
-        data->title_set->path = strdup(single_path);
+        if ( single_path != NULL ) {
+            data->title_set->path = strdup(single_path);
+        } else {
+            data->title_set->path = NULL; // we have many paths.
+        }
     }
     else
     {

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -201,34 +201,20 @@ static int get_color_range(int color_range)
     }
 }
 
+static const char * const known_file_types[] =
+{
+    "mp4", "m4v", "mov", "flv", "mkv", "avi", "webm", "wmv",  NULL
+};
+
 static int is_known_filetype(const char *filename)
 {
-    if (hb_str_ends_with(filename, "mp4") || hb_str_ends_with(filename, "m4v") ||
-        hb_str_ends_with(filename, "mov") || hb_str_ends_with(filename, "flv"))
+    for (int i = 0; known_file_types[i] != NULL; i++)
     {
-        return 1;
+        if (hb_str_ends_with(filename, known_file_types[i]))
+        {
+            return 1;
+        }
     }
-
-    if (hb_str_ends_with(filename, "mkv"))
-    {
-        return 1;
-    }
-
-    if (hb_str_ends_with(filename, "avi"))
-    {
-        return 1;
-    }
-
-    if (hb_str_ends_with(filename, "webm"))
-    {
-        return 1;
-    }
-
-    if (hb_str_ends_with(filename, "wmv"))
-    {
-        return 1;
-    }
-
     return 0;
 }
 

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -814,7 +814,12 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
     {
         stream = hb_stream_open(data->h, title->path, title, 0);
     }
-
+    else 
+    {
+        // We have a batch of files.
+        stream = hb_stream_open(data->h, title->path, title, 0);
+    }
+    
     if (title->video_codec == WORK_NONE)
     {
         hb_error("No video decoder set!");

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -203,7 +203,7 @@ static int get_color_range(int color_range)
 
 static int is_known_filetype (char * filename) 
 {
-    if (ends_with(filename, "mp4"))
+    if (ends_with(filename, "mp4") || ends_with(filename, "m4v") || ends_with(filename, "mov") || ends_with(filename, "flv"))
     {
         return 1;
     }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -365,18 +365,19 @@ static void ScanFunc( void * _data )
     }
     else if (hb_list_count(data->paths) > 1) // We have many file paths to process.
     {
-        hb_log ("Multi File Scan");
-
         // If dragging a batch of files, maybe not, but if the UI's implement a recursive folder maybe?
         for( i = 0; i < hb_list_count( data->paths ); i++ )
         {
             single_path = hb_list_item( data->paths, i);
            
-            UpdateState1(data, i + 1);
-            title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
-            if ( title != NULL )
-            {
-                hb_list_add( data->title_set->list_title, title );
+            if (hb_is_valid_batch_path(single_path))
+            {           
+                UpdateState1(data, i + 1);
+                title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
+                if ( title != NULL )
+                {
+                    hb_list_add( data->title_set->list_title, title );
+                }
             }
         }
     }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -265,7 +265,7 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     p.progress = 0.0;
 #undef p
     hb_set_state(handle, &state);
-
+    
     return hb_thread_init( "scan", ScanFunc, data, HB_NORMAL_PRIORITY );
 }
 
@@ -279,12 +279,12 @@ static void ScanFunc( void * _data )
     data->bd = NULL;
     data->dvd = NULL;
     data->stream = NULL;
-    
+        
     char * single_path = NULL;
     if (hb_list_count(data->paths) == 1) {
         single_path = hb_list_item(data->paths, 0);
     }
-    
+        
     /* Try to open the path as a DVD. If it fails, try as a file */
     if( single_path != NULL && !is_known_filetype(single_path) && ( data->bd = hb_bd_init( data->h, single_path ) ) )
     {
@@ -365,6 +365,7 @@ static void ScanFunc( void * _data )
     }
     else if (hb_list_count(data->paths) > 1) // We have many file paths to process.
     {
+           hb_log (" Multi File Scan");
         // TODO -> do we want to support excluded extensions here?
         // If dragging a batch of files, maybe not, but if the UI's implement a recursive folder maybe?
         for( i = 0; i < hb_list_count( data->paths ); i++ )
@@ -547,7 +548,7 @@ finish:
         hb_list_rem(data->paths, output_filepath);
         free(output_filepath);
     }
-    hb_list_close( data->paths );
+    hb_list_close( &data->paths );
     
     // clean up excluded extensions list
     char *extension;
@@ -821,7 +822,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
     }
     else if (data->stream)
     {
-        stream = hb_stream_open(data->h, data->paths, title, 0);
+        stream = hb_stream_open(data->h, title->path, title, 0);
     }
 
     if (title->video_codec == WORK_NONE)

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -372,9 +372,10 @@ static void ScanFunc( void * _data )
         {
             single_path = hb_list_item(data->paths, i);
 
+            UpdateState1(data, i + 1);
+
             if (hb_is_valid_batch_path(single_path))
             {
-                UpdateState1(data, i + 1);
                 title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
                 if (title != NULL)
                 {
@@ -1854,6 +1855,8 @@ static int  AllAudioOK( hb_title_t * title )
 static void UpdateState1(hb_scan_t *scan, int title)
 {
     hb_state_t state;
+    
+    int is_multi_file = hb_list_count(scan->paths) > 0;
 
     hb_get_state2(scan->h, &state);
 #define p state.param.scanning
@@ -1863,7 +1866,8 @@ static void UpdateState1(hb_scan_t *scan, int title)
     p.title_count = scan->dvd ? hb_dvd_title_count( scan->dvd ) :
                     scan->bd ? hb_bd_title_count( scan->bd ) :
                     scan->batch ? hb_batch_title_count( scan->batch ) :
-                               hb_list_count(scan->title_set->list_title);
+                    is_multi_file ? hb_list_count(scan->paths) :
+                    hb_list_count(scan->title_set->list_title);
     p.preview_cur = 0;
     p.preview_count = 1;
     p.progress = 0.5 * ((float)p.title_cur + ((float)p.preview_cur / p.preview_count)) / p.title_count;

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -201,33 +201,34 @@ static int get_color_range(int color_range)
     }
 }
 
-static int is_known_filetype (char * filename) 
+static int is_known_filetype(const char *filename)
 {
-    if (ends_with(filename, "mp4") || ends_with(filename, "m4v") || ends_with(filename, "mov") || ends_with(filename, "flv"))
+    if (hb_str_ends_with(filename, "mp4") || hb_str_ends_with(filename, "m4v") ||
+        hb_str_ends_with(filename, "mov") || hb_str_ends_with(filename, "flv"))
     {
         return 1;
     }
-    
-    if (ends_with(filename, "mkv"))
+
+    if (hb_str_ends_with(filename, "mkv"))
     {
         return 1;
     }
-    
-    if (ends_with(filename, "avi"))
+
+    if (hb_str_ends_with(filename, "avi"))
     {
         return 1;
     }
-    
-    if (ends_with(filename, "webm"))
+
+    if (hb_str_ends_with(filename, "webm"))
     {
         return 1;
     }
-    
-    if (ends_with(filename, "wmv"))
+
+    if (hb_str_ends_with(filename, "wmv"))
     {
         return 1;
     }
-    
+
     return 0;
 }
 
@@ -265,7 +266,7 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     p.progress = 0.0;
 #undef p
     hb_set_state(handle, &state);
-    
+
     return hb_thread_init( "scan", ScanFunc, data, HB_NORMAL_PRIORITY );
 }
 
@@ -280,8 +281,9 @@ static void ScanFunc( void * _data )
     data->dvd = NULL;
     data->stream = NULL;
         
-    char * single_path = NULL;
-    if (hb_list_count(data->paths) == 1) {
+    char *single_path = NULL;
+    if (hb_list_count(data->paths) == 1)
+    {
         single_path = hb_list_item(data->paths, 0);
     }
         
@@ -366,17 +368,17 @@ static void ScanFunc( void * _data )
     else if (hb_list_count(data->paths) > 1) // We have many file paths to process.
     {
         // If dragging a batch of files, maybe not, but if the UI's implement a recursive folder maybe?
-        for( i = 0; i < hb_list_count( data->paths ); i++ )
+        for (i = 0; i < hb_list_count( data->paths ); i++)
         {
-            single_path = hb_list_item( data->paths, i);
-           
+            single_path = hb_list_item(data->paths, i);
+
             if (hb_is_valid_batch_path(single_path))
             {           
                 UpdateState1(data, i + 1);
                 title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
-                if ( title != NULL )
+                if (title != NULL)
                 {
-                    hb_list_add( data->title_set->list_title, title );
+                    hb_list_add(data->title_set->list_title, title);
                 }
             }
         }
@@ -496,12 +498,14 @@ static void ScanFunc( void * _data )
         title      = hb_list_item( data->title_set->list_title, i );
         title->flags |= HBTF_SCAN_COMPLETE;
     }
-    
+
     if (hb_list_count(data->title_set->list_title) > 0)
     {
-        if ( single_path != NULL ) {
+        if (single_path != NULL)
+        {
             data->title_set->path = strdup(single_path);
-        } else {
+        } else
+        {
             data->title_set->path = NULL; // we have many paths.
         }
     }
@@ -529,7 +533,7 @@ finish:
     {
         hb_batch_close( &data->batch );
     }
-    
+
     // Clear down any file paths.
     char *output_filepath;
     while ((output_filepath = hb_list_item(data->paths, 0)))
@@ -538,7 +542,7 @@ finish:
         free(output_filepath);
     }
     hb_list_close( &data->paths );
-    
+
     // clean up excluded extensions list
     char *extension;
     while ((extension = hb_list_item(data->exclude_extensions, 0)))
@@ -809,16 +813,12 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
     {
         stream = hb_stream_open(data->h, title->path, title, 0);
     }
-    else if (data->stream)
-    {
-        stream = hb_stream_open(data->h, title->path, title, 0);
-    }
     else 
     {
         // We have a batch of files.
         stream = hb_stream_open(data->h, title->path, title, 0);
     }
-    
+
     if (title->video_codec == WORK_NONE)
     {
         hb_error("No video decoder set!");

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -365,28 +365,18 @@ static void ScanFunc( void * _data )
     }
     else if (hb_list_count(data->paths) > 1) // We have many file paths to process.
     {
-           hb_log (" Multi File Scan");
+        hb_log ("Multi File Scan");
         // TODO -> do we want to support excluded extensions here?
         // If dragging a batch of files, maybe not, but if the UI's implement a recursive folder maybe?
         for( i = 0; i < hb_list_count( data->paths ); i++ )
         {
             single_path = hb_list_item( data->paths, i);
-            
-            
-            if (data->title_index == 0)
+           
+            UpdateState1(data, i + 1);
+            title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
+            if ( title != NULL )
             {
-                data->title_index = 1;
-            }
-            
-            hb_title_t * title = hb_title_init( single_path, data->title_index );
-            data->stream = hb_stream_open(data->h, single_path, title, 1);
-            if (data->stream != NULL)
-            {
-                title = hb_stream_title_scan( data->stream, title );
-                if ( title )
-                {
-                    hb_list_add( data->title_set->list_title, title );
-                }
+                hb_list_add( data->title_set->list_title, title );
             }
             else
             {

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -373,7 +373,7 @@ static void ScanFunc( void * _data )
             single_path = hb_list_item(data->paths, i);
 
             if (hb_is_valid_batch_path(single_path))
-            {           
+            {
                 UpdateState1(data, i + 1);
                 title = hb_batch_title_scan_single(data->h, single_path, (int)i + 1);
                 if (title != NULL)
@@ -541,7 +541,7 @@ finish:
         hb_list_rem(data->paths, output_filepath);
         free(output_filepath);
     }
-    hb_list_close( &data->paths );
+    hb_list_close(&data->paths);
 
     // clean up excluded extensions list
     char *extension;
@@ -550,6 +550,7 @@ finish:
         hb_list_rem(data->exclude_extensions, extension);
         free(extension);
     }
+    hb_list_close(&data->exclude_extensions);
 
     free( data );
     _data = NULL;

--- a/macosx/HBAppDelegate.m
+++ b/macosx/HBAppDelegate.m
@@ -185,7 +185,7 @@
 
 - (void)application:(NSApplication *)sender openURLs:(nonnull NSArray<NSURL *> *)urls
 {
-    [self.mainController openURL:urls.firstObject];
+    [self.mainController openURLs:urls];
 }
 
 - (BOOL)validateMenuItem:(NSMenuItem *)menuItem

--- a/macosx/HBController.h
+++ b/macosx/HBController.h
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)launchAction;
 
-- (void)openURL:(NSURL *)fileURL;
+- (void)openURLs:(NSArray<NSURL *> *)fileURLs;
 - (void)openJob:(HBJob *)job completionHandler:(void (^)(BOOL result))handler;
 
 - (IBAction)browseSources:(id)sender;

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -46,7 +46,7 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 @property (nonatomic, readonly, strong) HBCore *core;
 @property (nonatomic, readonly, strong) HBAppDelegate *delegate;
 
-@property (nonatomic, strong) HBSecurityAccessToken *fileToken;
+@property (nonatomic, strong) NSArray<HBSecurityAccessToken *> *fileTokens;
 @property (nonatomic, strong) NSURL *destinationFolderURL;
 @property (nonatomic, strong) HBSecurityAccessToken *destinationFolderToken;
 
@@ -320,12 +320,10 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 - (BOOL)performDragOperation:(id <NSDraggingInfo>)sender
 {
     NSArray<NSURL *> *fileURLs = [self fileURLsFromPasteboard:[sender draggingPasteboard]];
-
     if (fileURLs.count)
     {
-        [self openURL:fileURLs.firstObject];
+        [self openURLs:fileURLs];
     }
-
     [self.window.contentView setShowFocusRing:NO];
     return YES;
 }
@@ -677,7 +675,7 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 /**
  * Here we actually tell hb_scan to perform the source scan, using the path to source and title number
  */
-- (void)scanURL:(NSURL *)fileURL titleIndex:(NSUInteger)index completionHandler:(void(^)(NSArray<HBTitle *> *titles))completionHandler
+- (void)scanURLs:(NSArray<NSURL *> *)fileURLs titleIndex:(NSUInteger)index completionHandler:(void(^)(NSArray<HBTitle *> *titles))completionHandler
 {
     // Save the current settings
     [self updateCurrentPreset];
@@ -690,12 +688,16 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     // Clear the undo manager, we can't undo this action
     [self.window.undoManager removeAllActions];
 
-    NSURL *mediaURL = [HBUtilities mediaURLFromURL:fileURL];
+    NSArray<NSURL *> *mediaURLs = fileURLs;
 
-    NSError *outError = NULL;
+    if (fileURLs.count == 1)
+    {
+        mediaURLs = @[[HBUtilities mediaURLFromURL:fileURLs.firstObject]];
+    }
 
     // Check if we can scan the source and if there is any warning.
-    BOOL canScan = [self.core canScan:mediaURL error:&outError];
+    NSError *outError = NULL;
+    BOOL canScan = [self.core canScan:mediaURLs error:&outError];
 
     // Notify the user that we don't support removal of copy protection.
     if (canScan && outError.code == 101 && !self.suppressCopyProtectionWarning)
@@ -719,10 +721,10 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
         NSUInteger hb_num_previews = [NSUserDefaults.standardUserDefaults integerForKey:HBPreviewsNumber];
         NSUInteger min_title_duration_seconds = [NSUserDefaults.standardUserDefaults integerForKey:HBMinTitleScanSeconds];
 
-        [self.core scanURL:mediaURL
-                titleIndex:index
-                  previews:hb_num_previews minDuration:min_title_duration_seconds keepPreviews:YES
-           progressHandler:^(HBState state, HBProgress progress, NSString *info)
+        [self.core scanURLs:mediaURLs
+                 titleIndex:index
+                   previews:hb_num_previews minDuration:min_title_duration_seconds keepPreviews:YES
+            progressHandler:^(HBState state, HBProgress progress, NSString *info)
          {
              self.sourceLabel.stringValue = info;
              self.scanIndicator.hidden = NO;
@@ -742,8 +744,8 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
                  {
                      [self.titlePopUp addItemWithTitle:title.description];
                  }
-                 self.window.representedURL = mediaURL;
-                 self.window.title = mediaURL.lastPathComponent;
+                 self.window.representedURL = mediaURLs.firstObject;
+                 self.window.title = mediaURLs.firstObject.lastPathComponent;
              }
              else
              {
@@ -752,20 +754,20 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
              }
 
              // Set the last searched source directory in the prefs here
-             if ([NSWorkspace.sharedWorkspace isFilePackageAtPath:mediaURL.URLByDeletingLastPathComponent.path])
+             if ([NSWorkspace.sharedWorkspace isFilePackageAtPath:mediaURLs.firstObject.URLByDeletingLastPathComponent.path])
              {
-                 [NSUserDefaults.standardUserDefaults setURL:mediaURL.URLByDeletingLastPathComponent.URLByDeletingLastPathComponent forKey:HBLastSourceDirectoryURL];
+                 [NSUserDefaults.standardUserDefaults setURL:mediaURLs.firstObject.URLByDeletingLastPathComponent.URLByDeletingLastPathComponent forKey:HBLastSourceDirectoryURL];
              }
              else
              {
-                 [NSUserDefaults.standardUserDefaults setURL:mediaURL.URLByDeletingLastPathComponent forKey:HBLastSourceDirectoryURL];
+                 [NSUserDefaults.standardUserDefaults setURL:mediaURLs.firstObject.URLByDeletingLastPathComponent forKey:HBLastSourceDirectoryURL];
              }
 
              completionHandler(self.core.titles);
 
-             // Clear the undo manager, the completion handle
+             // Clear the undo manager, the completion handler
              // set the job in the main window
-             // and don't want to make it undoable
+             // and we don't want to make it undoable
              [self.window.undoManager removeAllActions];
              [self.window.toolbar validateVisibleItems];
              [self _touchBar_validateUserInterfaceItems];
@@ -808,17 +810,26 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     }
 }
 
-- (void)openURL:(NSURL *)fileURL titleIndex:(NSUInteger)index
+- (void)openURLs:(NSArray<NSURL *> *)fileURLs titleIndex:(NSUInteger)index
 {
     [self showWindow:self];
 
-    self.fileToken = [HBSecurityAccessToken tokenWithAlreadyAccessedObject:fileURL];
+    NSMutableArray<HBSecurityAccessToken *> *tokens = [[NSMutableArray alloc] init];
+    for (NSURL *fileURL in fileURLs)
+    {
+        [tokens addObject:[HBSecurityAccessToken tokenWithAlreadyAccessedObject:fileURL]];
+    }
 
-    [self scanURL:fileURL titleIndex:index completionHandler:^(NSArray<HBTitle *> *titles)
+    self.fileTokens = tokens;
+
+    [self scanURLs:fileURLs titleIndex:index completionHandler:^(NSArray<HBTitle *> *titles)
     {
         if (titles.count)
         {
-            [NSDocumentController.sharedDocumentController noteNewRecentDocumentURL:fileURL];
+            for (NSURL *fileURL in fileURLs)
+            {
+                [NSDocumentController.sharedDocumentController noteNewRecentDocumentURL:fileURL];
+            }
 
             HBTitle *featuredTitle = titles.firstObject;
             for (HBTitle *title in titles)
@@ -852,7 +863,15 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 {
     if (self.core.state != HBStateScanning)
     {
-        [self openURL:fileURL titleIndex:0];
+        [self openURLs:@[fileURL] titleIndex:0];
+    }
+}
+
+- (void)openURLs:(NSArray<NSURL *> *)fileURL
+{
+    if (self.core.state != HBStateScanning)
+    {
+        [self openURLs:fileURL titleIndex:0];
     }
 }
 
@@ -864,9 +883,9 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     if (self.core.state != HBStateScanning)
     {
         [job refreshSecurityScopedResources];
-        self.fileToken = [HBSecurityAccessToken tokenWithObject:job.fileURL];
+        self.fileTokens = @[[HBSecurityAccessToken tokenWithObject:job.fileURL]];
 
-        [self scanURL:job.fileURL titleIndex:job.titleIdx completionHandler:^(NSArray<HBTitle *> *titles)
+        [self scanURLs:@[job.fileURL] titleIndex:job.titleIdx completionHandler:^(NSArray<HBTitle *> *titles)
         {
             if (titles.count)
             {
@@ -1018,7 +1037,7 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     }
 
     NSOpenPanel *panel = [NSOpenPanel openPanel];
-    [panel setAllowsMultipleSelection:NO];
+    [panel setAllowsMultipleSelection:YES];
     [panel setCanChooseFiles:YES];
     [panel setCanChooseDirectories:YES];
 
@@ -1042,7 +1061,7 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
         if (result == NSModalResponseOK)
          {
              NSInteger titleIdx = self.scanSpecificTitle ? self.scanSpecificTitleIdx : 0;
-             [self openURL:panel.URL titleIndex:titleIdx];
+             [self openURLs:panel.URLs titleIndex:titleIdx];
          }
      }];
 }

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -859,14 +859,6 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     }];
 }
 
-- (void)openURL:(NSURL *)fileURL
-{
-    if (self.core.state != HBStateScanning)
-    {
-        [self openURLs:@[fileURL] titleIndex:0];
-    }
-}
-
 - (void)openURLs:(NSArray<NSURL *> *)fileURL
 {
     if (self.core.state != HBStateScanning)

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -688,11 +688,11 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     // Clear the undo manager, we can't undo this action
     [self.window.undoManager removeAllActions];
 
-    NSArray<NSURL *> *mediaURLs = fileURLs;
+    NSMutableArray<NSURL *> *mediaURLs = [[NSMutableArray alloc] init];
 
-    if (fileURLs.count == 1)
+    for (NSURL *fileURL in fileURLs)
     {
-        mediaURLs = @[[HBUtilities mediaURLFromURL:fileURLs.firstObject]];
+        [mediaURLs addObject:[HBUtilities mediaURLFromURL:fileURL]];
     }
 
     // Check if we can scan the source and if there is any warning.
@@ -744,8 +744,6 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
                  {
                      [self.titlePopUp addItemWithTitle:title.description];
                  }
-                 self.window.representedURL = mediaURLs.firstObject;
-                 self.window.title = mediaURLs.firstObject.lastPathComponent;
              }
              else
              {
@@ -1004,6 +1002,9 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
         {
             self.sourceLabel.stringValue = [NSString stringWithFormat:@"%@, %@", title.name, title.shortFormatDescription];
         }
+
+        self.window.representedURL = job.fileURL;
+        self.window.title = job.fileURL.lastPathComponent;
     }
     else
     {

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -151,12 +151,12 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
 /**
  *  Determines whether the scan operation can scan a particular URL or whether an additional decryption lib is needed.
  *
- *  @param url   the URL of the input file.
+ *  @param urls   the URLs of the input files.
  *  @param error an error containing additional info.
  *
  *  @return YES is the file at URL is scannable.
  */
-- (BOOL)canScan:(NSArray<NSURL *> *)url error:(NSError * __autoreleasing *)error;
+- (BOOL)canScan:(NSArray<NSURL *> *)urls error:(NSError * __autoreleasing *)error;
 
 /**
  *  Initiates an asynchronous scan operation and returns immediately.

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -156,12 +156,12 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
  *
  *  @return YES is the file at URL is scannable.
  */
-- (BOOL)canScan:(NSURL *)url error:(NSError * __autoreleasing *)error;
+- (BOOL)canScan:(NSArray<NSURL *> *)url error:(NSError * __autoreleasing *)error;
 
 /**
  *  Initiates an asynchronous scan operation and returns immediately.
  *
- *  @param url                 the URL of the input file.
+ *  @param urls            the URLs of the input files.
  *  @param index            the index of the desired title. Use 0 to scan every title.
  *  @param previewsNum         the number of previews image to generate.
  *  @param seconds             the minimum duration of the wanted titles in seconds.
@@ -169,7 +169,7 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
  *  @param progressHandler     a block called periodically with the progress information.
  *  @param completionHandler   a block called with the scan result.
  */
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler;
+- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler;
 
 /**
  *  Cancels the scan execution.

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -184,7 +184,7 @@ HB_OBJC_DIRECT_MEMBERS
 
 - (BOOL)canScan:(NSArray<NSURL *> *)urls error:(NSError * __autoreleasing *)error
 {
-    NSAssert(url, @"[HBCore canScan:] called with nil url.");
+    NSAssert(urls, @"[HBCore canScan:] called with nil urls.");
 
     for (NSURL *url in urls)
     {
@@ -264,7 +264,7 @@ HB_OBJC_DIRECT_MEMBERS
 - (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler
 {
     NSAssert(self.state == HBStateIdle, @"[HBCore scanURL:] called while another scan or encode already in progress");
-    NSAssert(url, @"[HBCore scanURL:] called with nil url.");
+    NSAssert(urls, @"[HBCore scanURL:] called with nil url.");
 
 #ifdef __SANDBOX_ENABLED__
     __block NSMutableArray<HBSecurityAccessToken *> *tokens = [[NSMutableArray alloc] init];

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -182,88 +182,97 @@ HB_OBJC_DIRECT_MEMBERS
 
 #pragma mark - Scan
 
-- (BOOL)canScan:(NSURL *)url error:(NSError * __autoreleasing *)error
+- (BOOL)canScan:(NSArray<NSURL *> *)urls error:(NSError * __autoreleasing *)error
 {
     NSAssert(url, @"[HBCore canScan:] called with nil url.");
 
-#ifdef __SANDBOX_ENABLED__
-    __unused HBSecurityAccessToken *token = [HBSecurityAccessToken tokenWithObject:url];
-#endif
-
-    if (![[NSFileManager defaultManager] fileExistsAtPath:url.path]) {
-        if (error) {
-            *error = [NSError errorWithDomain:@"HBErrorDomain"
-                                         code:100
-                                     userInfo:@{ NSLocalizedDescriptionKey: @"Unable to find the file at the specified URL" }];
-        }
-
-        return NO;
-    }
-
-    HBDVDDetector *detector = [HBDVDDetector detectorForPath:url.path];
-
-    if (detector.isVideoDVD || detector.isVideoBluRay)
+    for (NSURL *url in urls)
     {
-        [HBUtilities writeToActivityLog:"%s trying to open a physical disc at: %s", self.name.UTF8String, url.path.UTF8String];
-        void *lib = NULL;
+#ifdef __SANDBOX_ENABLED__
+        __unused HBSecurityAccessToken *token = [HBSecurityAccessToken tokenWithObject:url];
+#endif
 
-        if (detector.isVideoDVD)
+        if (![NSFileManager.defaultManager fileExistsAtPath:url.path])
         {
-            lib = dlopen("libdvdcss.2.dylib", RTLD_LAZY);
-            if (!lib)
+            if (error)
             {
-                lib = dlopen("/usr/local/lib/libdvdcss.2.dylib", RTLD_LAZY);
-            }
-        }
-        else if (detector.isVideoBluRay)
-        {
-            lib = dlopen("libaacs.dylib", RTLD_LAZY);
-            if (!lib)
-            {
-                lib = dlopen("/usr/local/lib/libaacs.dylib", RTLD_LAZY);
-            }
-        }
-
-        if (lib)
-        {
-            dlclose(lib);
-            [HBUtilities writeToActivityLog:"%s library found for decrypting physical disc", self.name.UTF8String];
-        }
-        else
-        {
-            const char *dlError = dlerror();
-
-            if (dlError)
-            {
-                [HBUtilities writeToActivityLog:"dlopen error: %s", dlError];
-            }
-
-            // Notify the user that we don't support removal of copy protection.
-            [HBUtilities writeToActivityLog:"%s, library not found for decrypting physical disc", self.name.UTF8String];
-
-            if (error) {
                 *error = [NSError errorWithDomain:@"HBErrorDomain"
-                                             code:101
-                                         userInfo:@{ NSLocalizedDescriptionKey: @"library not found for decrypting physical disc" }];
+                                             code:100
+                                         userInfo:@{ NSLocalizedDescriptionKey: @"Unable to find the file at the specified URL" }];
+            }
+            
+            return NO;
+        }
+        
+        HBDVDDetector *detector = [HBDVDDetector detectorForPath:url.path];
+        
+        if (detector.isVideoDVD || detector.isVideoBluRay)
+        {
+            [HBUtilities writeToActivityLog:"%s trying to open a physical disc at: %s", self.name.UTF8String, url.path.UTF8String];
+            void *lib = NULL;
+            
+            if (detector.isVideoDVD)
+            {
+                lib = dlopen("libdvdcss.2.dylib", RTLD_LAZY);
+                if (!lib)
+                {
+                    lib = dlopen("/usr/local/lib/libdvdcss.2.dylib", RTLD_LAZY);
+                }
+            }
+            else if (detector.isVideoBluRay)
+            {
+                lib = dlopen("libaacs.dylib", RTLD_LAZY);
+                if (!lib)
+                {
+                    lib = dlopen("/usr/local/lib/libaacs.dylib", RTLD_LAZY);
+                }
+            }
+            
+            if (lib)
+            {
+                dlclose(lib);
+                [HBUtilities writeToActivityLog:"%s library found for decrypting physical disc", self.name.UTF8String];
+            }
+            else
+            {
+                const char *dlError = dlerror();
+                
+                if (dlError)
+                {
+                    [HBUtilities writeToActivityLog:"dlopen error: %s", dlError];
+                }
+                
+                // Notify the user that we don't support removal of copy protection.
+                [HBUtilities writeToActivityLog:"%s, library not found for decrypting physical disc", self.name.UTF8String];
+                
+                if (error) {
+                    *error = [NSError errorWithDomain:@"HBErrorDomain"
+                                                 code:101
+                                             userInfo:@{ NSLocalizedDescriptionKey: @"library not found for decrypting physical disc" }];
+                }
             }
         }
-    }
 
 #ifdef __SANDBOX_ENABLED__
-    token = nil;
+        token = nil;
 #endif
+    }
 
     return YES;
 }
 
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler
+- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler
 {
     NSAssert(self.state == HBStateIdle, @"[HBCore scanURL:] called while another scan or encode already in progress");
     NSAssert(url, @"[HBCore scanURL:] called with nil url.");
 
 #ifdef __SANDBOX_ENABLED__
-    __block HBSecurityAccessToken *token = [HBSecurityAccessToken tokenWithObject:url];
-    self.cleanupHandler = ^{ token = nil; };
+    __block NSMutableArray<HBSecurityAccessToken *> *tokens = [[NSMutableArray alloc] init];
+    for (NSURL *url in urls)
+    {
+        [tokens addObject:[HBSecurityAccessToken tokenWithObject:url]];
+    }
+    self.cleanupHandler = ^{ tokens = nil; };
 #endif
 
     // Reset the titles array
@@ -291,10 +300,18 @@ HB_OBJC_DIRECT_MEMBERS
 
     [self preventAutoSleep];
 
-    hb_scan(_hb_handle, url.fileSystemRepresentation,
+    hb_list_t *files_list = hb_list_init();
+    for (NSURL *url in urls)
+    {
+        hb_list_add(files_list, (char *)url.fileSystemRepresentation);
+    }
+
+    hb_scan_list(_hb_handle, files_list,
               (int)index, (int)previewsNum,
               keepPreviews, min_title_duration_ticks,
               0, 0, NULL);
+
+    hb_list_close(&files_list);
 
     // Start the timer to handle libhb state changes
     [self startUpdateTimerWithInterval:0.2];

--- a/macosx/HandBrakeXPCService/HandBrakeXPCService.m
+++ b/macosx/HandBrakeXPCService/HandBrakeXPCService.m
@@ -158,9 +158,12 @@ static void *HandBrakeXPCServiceContext = &HandBrakeXPCServiceContext;
     dispatch_sync(_queue, ^{
         self.reply = reply;
 
-        [self.core scanURL:url titleIndex:index previews:previewsNum minDuration:seconds keepPreviews:keepPreviews
-           progressHandler:self.progressHandler
-         completionHandler:self.completionHandler];
+        [self.core scanURLs:@[url] titleIndex:index
+                   previews:previewsNum
+                minDuration:seconds
+               keepPreviews:keepPreviews
+            progressHandler:self.progressHandler
+          completionHandler:self.completionHandler];
     });
 }
 

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -125,7 +125,7 @@ namespace HandBrake.Interop.Interop
         /// <summary>
         /// Starts a scan of the given path.
         /// </summary>
-        /// <param name="path">
+        /// <param name="paths">
         /// The path of the video to scan.
         /// </param>
         /// <param name="previewCount">
@@ -142,7 +142,7 @@ namespace HandBrake.Interop.Interop
         /// These should be the extension name only. No .
         /// Case Insensitive.
         /// </param>
-        public void StartScan(string path, int previewCount, TimeSpan minDuration, int titleIndex, List<string> excludedExtensions)
+        public void StartScan(List<string> paths, int previewCount, TimeSpan minDuration, int titleIndex, List<string> excludedExtensions)
         {
             this.PreviewCount = previewCount;
 
@@ -157,11 +157,16 @@ namespace HandBrake.Interop.Interop
                 }
             }
 
+            // Handle Scan Paths
+            NativeList scanPathsList = NativeList.CreateList();
+            foreach (string path in paths)
+            {
+                scanPathsList.Add(InteropUtilities.ToUtf8PtrFromString(path));
+            }
+
             // Start the Scan
-            IntPtr pathPtr = InteropUtilities.ToUtf8PtrFromString(path);
             IntPtr excludedExtensionsPtr = excludedExtensionsNative?.Ptr ?? IntPtr.Zero;
-            HBFunctions.hb_scan(this.Handle, pathPtr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr);
-            Marshal.FreeHGlobal(pathPtr);
+            HBFunctions.hb_scan_list(this.Handle, scanPathsList.Ptr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr);
 
             this.scanPollTimer = new Timer();
             this.scanPollTimer.Interval = ScanPollIntervalMs;

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -402,7 +402,7 @@ namespace HandBrake.Interop.Interop
                     this.ScanProgress(this, new ScanProgressEventArgs(state.Scanning.Progress, state.Scanning.Preview, state.Scanning.PreviewCount, state.Scanning.Title, state.Scanning.TitleCount));
                 }
             }
-            else if (taskState != null && (taskState == TaskState.ScanDone || taskState == TaskState.Idle))
+            else if (taskState != null && (taskState == TaskState.ScanDone))
             {
                 this.scanPollTimer.Stop();
 
@@ -420,7 +420,7 @@ namespace HandBrake.Interop.Interop
 
                 if (this.ScanCompleted != null)
                 {
-                    this.ScanCompleted(this, new System.EventArgs());
+                    this.ScanCompleted(this, EventArgs.Empty);
                 }
 
                 // Memory Management for the exclusion list.
@@ -441,6 +441,16 @@ namespace HandBrake.Interop.Interop
                 catch (Exception ex)
                 {
                     Debug.WriteLine(ex);
+                }
+            }
+            else if (taskState != null && (taskState == TaskState.Idle))
+            {
+                this.scanPollTimer.Stop();
+                this.Titles = null;
+
+                if (this.ScanCompleted != null)
+                {
+                    this.ScanCompleted(this, EventArgs.Empty);
                 }
             }
         }

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -402,7 +402,7 @@ namespace HandBrake.Interop.Interop
                     this.ScanProgress(this, new ScanProgressEventArgs(state.Scanning.Progress, state.Scanning.Preview, state.Scanning.PreviewCount, state.Scanning.Title, state.Scanning.TitleCount));
                 }
             }
-            else if (taskState != null && taskState == TaskState.ScanDone)
+            else if (taskState != null && (taskState == TaskState.ScanDone || taskState == TaskState.Idle))
             {
                 this.scanPollTimer.Stop();
 

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -51,7 +51,7 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
 
-        [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
+        [DllImport("hb", EntryPoint = "hb_scan_list", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
 
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -51,6 +51,9 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
 
+        [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
+
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_stop(IntPtr hbHandle);
 

--- a/win/CS/HandBrake.Interop/Interop/Interfaces/IScanInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/IScanInstance.cs
@@ -62,8 +62,8 @@ namespace HandBrake.Interop.Interop.Interfaces
         /// <summary>
         /// Starts a scan of the given path.
         /// </summary>
-        /// <param name="path">
-        /// The path of the video to scan.
+        /// <param name="paths">
+        /// A list of file paths to scan.
         /// </param>
         /// <param name="previewCount">
         /// The number of previews to make on each title.
@@ -79,7 +79,7 @@ namespace HandBrake.Interop.Interop.Interfaces
         /// These should be the extension name only. No .
         /// Case Insensitive.
         /// </param>
-        void StartScan(string path, int previewCount, TimeSpan minDuration, int titleIndex, List<string> excludedExtensions);
+        void StartScan(List<string> paths, int previewCount, TimeSpan minDuration, int titleIndex, List<string> excludedExtensions);
 
         /// <summary>
         /// Stop any running scans

--- a/win/CS/HandBrake.Worker/Routing/ApiRouter.cs
+++ b/win/CS/HandBrake.Worker/Routing/ApiRouter.cs
@@ -119,7 +119,7 @@ namespace HandBrake.Worker.Routing
 
                 this.Initialise(command.InitialiseCommand);
 
-                this.handbrakeInstance.StartScan(command.Path, command.PreviewCount, command.MinDuration, command.TitleIndex, command.InitialiseCommand.ExcludeExtnesionList);
+                this.handbrakeInstance.StartScan(command.Paths, command.PreviewCount, command.MinDuration, command.TitleIndex, command.InitialiseCommand.ExcludeExtnesionList);
 
                 return JsonSerializer.Serialize(new CommandResult() { WasSuccessful = true }, JsonSettings.Options);
             }

--- a/win/CS/HandBrake.Worker/Routing/Commands/ScanCommand.cs
+++ b/win/CS/HandBrake.Worker/Routing/Commands/ScanCommand.cs
@@ -16,7 +16,7 @@ namespace HandBrake.Worker.Routing.Commands
     {
         public InitCommand InitialiseCommand { get; set; }
 
-        public string Path { get; set; }
+        public List<string> Paths { get; set; }
 
         public int PreviewCount { get; set; }
 

--- a/win/CS/HandBrakeWPF/App.xaml.cs
+++ b/win/CS/HandBrakeWPF/App.xaml.cs
@@ -236,7 +236,7 @@ namespace HandBrakeWPF
             if (args.Any() && (File.Exists(args[0]) || Directory.Exists(args[0])))
             {
                 IMainViewModel mvm = IoCHelper.Get<IMainViewModel>();
-                mvm.StartScan(args[0], 0);
+                mvm.StartScan(new List<string> { args[0] }, 0);
             }
         }
 

--- a/win/CS/HandBrakeWPF/Controls/SourceSelection.xaml
+++ b/win/CS/HandBrakeWPF/Controls/SourceSelection.xaml
@@ -213,8 +213,9 @@
         </Grid>
 
         <Grid Grid.Column="1" Background="Black" Opacity="0.75" VerticalAlignment="Stretch" HorizontalAlignment="Stretch">
-            <Border BorderThickness="2" CornerRadius="4" BorderBrush="{StaticResource Ui.Light}" VerticalAlignment="Center" HorizontalAlignment="Center">
-                <TextBlock Text="{x:Static Properties:Resources.SourceSelection_DropFileHere}" TextWrapping="WrapWithOverflow" Foreground="White" Margin="100,125,100,125"  FontSize="30"  />
+            <Border BorderThickness="4" CornerRadius="4" BorderBrush="{StaticResource Ui.Light}" VerticalAlignment="Center" HorizontalAlignment="Center">
+                <TextBlock Text="{x:Static Properties:Resources.SourceSelection_DropFileHere}" TextWrapping="WrapWithOverflow" Foreground="White" 
+                           Margin="100,150,100,150"  FontSize="22"   />
             </Border>
         </Grid>
     </Grid>

--- a/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
+++ b/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
@@ -12,8 +12,6 @@ namespace HandBrakeWPF.Helpers
     using System;
     using System.IO;
     using System.Linq;
-    using System.Runtime.CompilerServices;
-    using System.Windows.Forms;
 
     using HandBrake.App.Core.Extensions;
 

--- a/win/CS/HandBrakeWPF/Instance/RemoteScanInstance.cs
+++ b/win/CS/HandBrakeWPF/Instance/RemoteScanInstance.cs
@@ -80,12 +80,12 @@ namespace HandBrakeWPF.Instance
             return null;
         }
 
-        public void StartScan(string path, int previewCount, TimeSpan minDuration, int titleIndex, List<string> fileExclusionList)
+        public void StartScan(List<string> paths, int previewCount, TimeSpan minDuration, int titleIndex, List<string> fileExclusionList)
         {
             if (this.IsServerRunning())
             {
                 scanCompleteFired = false;
-                Thread thread1 = new Thread(() => RunScanInitProcess(path, previewCount, minDuration, titleIndex));
+                Thread thread1 = new Thread(() => RunScanInitProcess(paths, previewCount, minDuration, titleIndex));
                 thread1.Start();
             }
             else
@@ -118,7 +118,7 @@ namespace HandBrakeWPF.Instance
             return state;
         }
 
-        private void RunScanInitProcess(string path, int previewCount, TimeSpan minDuration, int titleIndex)
+        private void RunScanInitProcess(List<string> paths, int previewCount, TimeSpan minDuration, int titleIndex)
         {
             if (this.IsServerRunning())
             {
@@ -136,7 +136,7 @@ namespace HandBrakeWPF.Instance
 
                 initCommand.LogFile = Path.Combine(initCommand.LogDirectory, string.Format("activity_log.worker.{0}.txt", GeneralUtilities.ProcessId));
 
-                string job = JsonSerializer.Serialize(new ScanCommand { InitialiseCommand = initCommand, Path = path, MinDuration = minDuration, PreviewCount = previewCount, TitleIndex = titleIndex}, JsonSettings.Options);
+                string job = JsonSerializer.Serialize(new ScanCommand { InitialiseCommand = initCommand, Paths = paths, MinDuration = minDuration, PreviewCount = previewCount, TitleIndex = titleIndex}, JsonSettings.Options);
 
                 var task = Task.Run(async () => await this.MakeHttpJsonPostRequest("StartScan", job));
                 task.Wait();

--- a/win/CS/HandBrakeWPF/Model/SelectionTitle.cs
+++ b/win/CS/HandBrakeWPF/Model/SelectionTitle.cs
@@ -53,7 +53,7 @@ namespace HandBrakeWPF.Model
         {
             get
             {
-                return !string.IsNullOrEmpty(Title.SourceName) ? Title.SourceName : sourceName;
+                return !string.IsNullOrEmpty(Title.SourcePath) ? Title.SourcePath : sourceName;
             }
         }
 
@@ -107,14 +107,14 @@ namespace HandBrakeWPF.Model
 
         private decimal? CalcFilesize()
         {
-            if (this.Title != null && !string.IsNullOrEmpty(this.Title.SourceName) && File.Exists(this.Title.SourceName))
+            if (this.Title != null && !string.IsNullOrEmpty(this.Title.SourcePath) && File.Exists(this.Title.SourcePath))
             {
-                if (Path.GetExtension(this.Title.SourceName)?.Contains("iso", StringComparison.InvariantCultureIgnoreCase) ?? false)
+                if (Path.GetExtension(this.Title.SourcePath)?.Contains("iso", StringComparison.InvariantCultureIgnoreCase) ?? false)
                 {
                     return null;
                 }
 
-                FileInfo info = new FileInfo(this.Title.SourceName);
+                FileInfo info = new FileInfo(this.Title.SourcePath);
                 return Math.Round((decimal)info.Length / 1024 / 1024, 1);
             }
 

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -6615,7 +6615,7 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Open a single video file..
+        ///   Looks up a localized string similar to Open video file(s)..
         /// </summary>
         public static string SourceSelection_SingleVideoFile {
             get {

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -6525,7 +6525,7 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Or drop a file or folder here ....
+        ///   Looks up a localized string similar to Or drop a file, set of files or folder here ....
         /// </summary>
         public static string SourceSelection_DropFileHere {
             get {

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -1702,7 +1702,7 @@ VLC and MPC-HC are supported. Other players may also work but are not validated.
     <value>About HandBrake</value>
   </data>
   <data name="SourceSelection_DropFileHere" xml:space="preserve">
-    <value>Or drop a file or folder here ...</value>
+    <value>Or drop a file, set of files or folder here ...</value>
   </data>
   <data name="SourceSelection_Help" xml:space="preserve">
     <value>Help</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -1549,7 +1549,7 @@ VLC and MPC-HC are supported. Other players may also work but are not validated.
     <value>A previous queue archive is available. </value>
   </data>
   <data name="SourceSelection_SingleVideoFile" xml:space="preserve">
-    <value>Open a single video file.</value>
+    <value>Open video file(s).</value>
   </data>
   <data name="SourceSelection_SourceSelection" xml:space="preserve">
     <value>Source Selection</value>

--- a/win/CS/HandBrakeWPF/Services/Scan/Factories/TitleFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Factories/TitleFactory.cs
@@ -10,6 +10,7 @@
 namespace HandBrakeWPF.Services.Scan.Factories
 {
     using System;
+    using System.IO;
 
     using HandBrake.App.Core.Model;
     using HandBrake.App.Core.Utilities;
@@ -38,6 +39,10 @@ namespace HandBrakeWPF.Services.Scan.Factories
                     }
                 }
             }
+            else if (title.Type == 0 || title.Type == 1)
+            {
+                driveLabel = Path.GetFileNameWithoutExtension(title.Path) ?? title.Path;
+            }
 
             Title converted = new Title
             {
@@ -61,7 +66,7 @@ namespace HandBrakeWPF.Services.Scan.Factories
                     Right = title.LooseCrop[3]
                 },
                 Fps = ((double)title.FrameRate.Num) / title.FrameRate.Den,
-                SourceName = title.Path,
+                SourcePath = title.Path,
                 DriveLabel = driveLabel,
                 MainTitle = mainFeature == title.Index,
                 Playlist = title.Type == 1 ? string.Format(" {0:d5}.MPLS", title.Playlist).Trim() : null,

--- a/win/CS/HandBrakeWPF/Services/Scan/Interfaces/IScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Interfaces/IScan.cs
@@ -10,6 +10,7 @@
 namespace HandBrakeWPF.Services.Scan.Interfaces
 {
     using System;
+    using System.Collections.Generic;
     using System.Windows.Media.Imaging;
 
     using HandBrakeWPF.Services.Encode.Model;
@@ -76,7 +77,7 @@ namespace HandBrakeWPF.Services.Scan.Interfaces
         /// <param name="postAction">
         /// The post Action.
         /// </param>
-        void Scan(string sourcePath, int title, Action<bool, Source> postAction);
+        void Scan(List<string> sourcePath, int title, Action<bool, Source> postAction);
 
         /// <summary>
         /// Cancel the current scan.

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -12,6 +12,7 @@ namespace HandBrakeWPF.Services.Scan
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Windows.Media.Imaging;
 
     using HandBrake.Interop.Interop;
@@ -42,7 +43,7 @@ namespace HandBrakeWPF.Services.Scan
         private readonly ILogInstanceManager logInstanceManager;
 
         private TitleFactory titleFactory = new TitleFactory();
-        private string currentSourceScanPath;
+        private List<string> currentSourceScanPath;
         private IScanInstance instance;
         private Action<bool, Source> postScanOperation;
         private bool isCancelled = false;
@@ -67,8 +68,8 @@ namespace HandBrakeWPF.Services.Scan
         /// Scan a Source Path.
         /// Title 0: scan all
         /// </summary>
-        /// <param name="sourcePath">
-        /// Path to the file to scan
+        /// <param name="sourcePaths">
+        /// Paths to the file to scan
         /// </param>
         /// <param name="title">
         /// int title number. 0 for scan all
@@ -76,7 +77,7 @@ namespace HandBrakeWPF.Services.Scan
         /// <param name="postAction">
         /// The post Action.
         /// </param>
-        public void Scan(string sourcePath, int title, Action<bool, Source> postAction)
+        public void Scan(List<string> sourcePaths, int title, Action<bool, Source> postAction)
         {
             if (this.IsScanning)
             {
@@ -110,7 +111,7 @@ namespace HandBrakeWPF.Services.Scan
             this.instance.ScanCompleted += this.InstanceScanCompleted;
 
             // Start the scan on a back
-            this.ScanSource(sourcePath, title, this.userSettingService.GetUserSetting<int>(UserSettingConstants.PreviewScanCount));
+            this.ScanSource(sourcePaths, title, this.userSettingService.GetUserSetting<int>(UserSettingConstants.PreviewScanCount));
         }
 
         /// <summary>
@@ -206,7 +207,7 @@ namespace HandBrakeWPF.Services.Scan
         /// <summary>
         /// Start a scan for a given source path and title
         /// </summary>
-        /// <param name="sourcePath">
+        /// <param name="sourcePaths">
         /// Path to the source file
         /// </param>
         /// <param name="title">
@@ -215,13 +216,11 @@ namespace HandBrakeWPF.Services.Scan
         /// <param name="previewCount">
         /// The preview Count.
         /// </param>
-        private void ScanSource(object sourcePath, int title, int previewCount)
+        private void ScanSource(List<string> sourcePaths, int title, int previewCount)
         {
             try
             {
-                string source = sourcePath.ToString().EndsWith("\\") ? string.Format("\"{0}\\\\\"", sourcePath.ToString().TrimEnd('\\'))
-                              : "\"" + sourcePath + "\"";
-                this.currentSourceScanPath = source;
+                this.currentSourceScanPath = sourcePaths;
 
                 this.IsScanning = true;
 
@@ -232,7 +231,7 @@ namespace HandBrakeWPF.Services.Scan
                 List<string> excludedExtensions = this.userSettingService.GetUserSetting<List<string>>(UserSettingConstants.ExcludedExtensions);
 
                 this.ServiceLogMessage("Starting Scan ...");
-                this.instance.StartScan(sourcePath.ToString(), previewCount, minDuration, title != 0 ? title : 0, excludedExtensions);
+                this.instance.StartScan(sourcePaths, previewCount, minDuration, title != 0 ? title : 0, excludedExtensions);
 
                 this.ScanStarted?.Invoke(this, System.EventArgs.Empty);
             }
@@ -259,18 +258,12 @@ namespace HandBrakeWPF.Services.Scan
                 bool cancelled = this.isCancelled;
                 this.isCancelled = false;
 
-                // TODO -> Might be a better place to fix this.
-                string path = this.currentSourceScanPath;
-                if (this.currentSourceScanPath.Contains("\""))
-                {
-                    path = this.currentSourceScanPath.Trim('\"');
-                }
-
                 // Process into internal structures.
                 Source sourceData = null;
                 if (this.instance?.Titles != null)
                 {
-                    sourceData = new Source(path, this.ConvertTitles(this.instance.Titles), null);
+                    // TODO -> Support handling multiple directories. 
+                    sourceData = new Source(this.currentSourceScanPath.FirstOrDefault(), this.ConvertTitles(this.instance.Titles), null);
                 }
 
                 this.IsScanning = false;

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -12,7 +12,6 @@ namespace HandBrakeWPF.Services.Scan
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Linq;
     using System.Windows.Media.Imaging;
 
     using HandBrake.Interop.Interop;
@@ -43,7 +42,6 @@ namespace HandBrakeWPF.Services.Scan
         private readonly ILogInstanceManager logInstanceManager;
 
         private TitleFactory titleFactory = new TitleFactory();
-        private List<string> currentSourceScanPath;
         private IScanInstance instance;
         private Action<bool, Source> postScanOperation;
         private bool isCancelled = false;
@@ -220,8 +218,6 @@ namespace HandBrakeWPF.Services.Scan
         {
             try
             {
-                this.currentSourceScanPath = sourcePaths;
-
                 this.IsScanning = true;
 
                 TimeSpan minDuration = TimeSpan.FromSeconds(this.userSettingService.GetUserSetting<int>(UserSettingConstants.MinScanDuration));
@@ -262,8 +258,7 @@ namespace HandBrakeWPF.Services.Scan
                 Source sourceData = null;
                 if (this.instance?.Titles != null)
                 {
-                    // TODO -> Support handling multiple directories. 
-                    sourceData = new Source(this.currentSourceScanPath.FirstOrDefault(), this.ConvertTitles(this.instance.Titles), null);
+                    sourceData = new Source(this.ConvertTitles(this.instance.Titles));
                 }
 
                 this.IsScanning = false;

--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Source.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Source.cs
@@ -33,57 +33,19 @@ namespace HandBrakeWPF.Services.Scan.Model
             this.Titles = new List<Title>();
         }
 
-        public Source(Source scannedSource) : this(scannedSource.ScanPath, scannedSource.Titles, scannedSource.SourceName)
+        public Source(Source scannedSource) : this(scannedSource.Titles)
         { 
         }
 
-        public Source(string scanPath, List<Title> titles, string sourceName)
+        public Source(List<Title> titles)
         {
-            this.ScanPath = scanPath;
             this.Titles = titles;
-            this.SourceName = sourceName;
-
-            if (string.IsNullOrEmpty(sourceName))
-            {
-                // Scan Path is a File.
-                if (File.Exists(this.ScanPath))
-                {
-                    this.SourceName = Path.GetFileNameWithoutExtension(this.ScanPath);
-                }
-
-                // Scan Path is a folder.
-                if (Directory.Exists(this.ScanPath))
-                {
-                    // Check to see if it's a Drive. If yes, use the volume label.
-                    foreach (DriveInformation item in DriveUtilities.GetDrives())
-                    {
-                        if (item.RootDirectory.Contains(this.ScanPath.Replace("\\\\", "\\")))
-                        {
-                            this.SourceName = item.VolumeLabel;
-                        }
-                    }
-
-                    // Otherwise, it may be a path of files.
-                    if (string.IsNullOrEmpty(this.SourceName))
-                    {
-                        this.SourceName = Path.GetFileName(this.ScanPath);
-                    }
-                }
-            }
         }
-
-        /// <summary>
-        /// Gets or sets ScanPath.
-        /// The Path used by the Scan Service.
-        /// </summary>
-        public string ScanPath { get; }
 
         /// <summary>
         /// Gets or sets Titles. A list of titles from the source
         /// </summary>
         [XmlIgnore]
         public List<Title> Titles { get; }
-
-        public string SourceName { get; }
     }
 }

--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Title.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Title.cs
@@ -125,7 +125,7 @@ namespace HandBrakeWPF.Services.Scan.Model
         /// <summary>
         /// Gets or sets the Source Name
         /// </summary>
-        public string SourceName { get; set; }
+        public string SourcePath { get; set; }
 
         public string DisplaySourceName
         {
@@ -139,9 +139,9 @@ namespace HandBrakeWPF.Services.Scan.Model
                         return DriveLabel;
                     case 2: // HB_STREAM_TYPE
                     case 3: // HB_FF_STREAM_TYPE
-                        if (!string.IsNullOrEmpty(this.SourceName))
+                        if (!string.IsNullOrEmpty(this.SourcePath))
                         {
-                            return Path.GetFileNameWithoutExtension(this.SourceName);
+                            return Path.GetFileNameWithoutExtension(this.SourcePath);
                         }
                         break;
                     default:
@@ -166,7 +166,7 @@ namespace HandBrakeWPF.Services.Scan.Model
                         return string.Empty;
                     case 2: // HB_STREAM_TYPE
                     case 3: // HB_FF_STREAM_TYPE
-                        return Path.GetFileNameWithoutExtension(this.SourceName);
+                        return Path.GetFileNameWithoutExtension(this.SourcePath);
                 }
             }
         }

--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Title.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Title.cs
@@ -36,7 +36,7 @@ namespace HandBrakeWPF.Services.Scan.Model
         }
 
         #region Properties
-
+        
         /// <summary>
         /// Gets or sets a Collection of chapters in this Title
         /// </summary>

--- a/win/CS/HandBrakeWPF/ViewModels/Interfaces/IMainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/Interfaces/IMainViewModel.cs
@@ -9,6 +9,7 @@
 
 namespace HandBrakeWPF.ViewModels.Interfaces
 {
+    using System.Collections.Generic;
     using System.Windows;
 
     using HandBrakeWPF.Model;
@@ -99,12 +100,12 @@ namespace HandBrakeWPF.ViewModels.Interfaces
         /// The start scan.
         /// </summary>
         /// <param name="filename">
-        /// The filename.
+        /// A list of files to scan
         /// </param>
         /// <param name="title">
         /// The title.
         /// </param>
-        void StartScan(string filename, int title);
+        void StartScan(List<string> filename, int title);
 
         /// <summary>
         /// Edit a Queue Task

--- a/win/CS/HandBrakeWPF/ViewModels/Interfaces/IStaticPreviewViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/Interfaces/IStaticPreviewViewModel.cs
@@ -24,7 +24,7 @@ namespace HandBrakeWPF.ViewModels.Interfaces
 
         BitmapSource PreviewImage { get; }
 
-        void UpdatePreviewFrame(EncodeTask task, Source scannedSource);
+        void UpdatePreviewFrame(Title title, EncodeTask task, Source scannedSource);
 
         void PreviousPreview();
 

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1245,7 +1245,7 @@ namespace HandBrakeWPF.ViewModels
 
         public void FileScan()
         {
-            OpenFileDialog dialog = new OpenFileDialog { Filter = "All files (*.*)|*.*" };
+            OpenFileDialog dialog = new OpenFileDialog { Filter = "All files (*.*)|*.*", Multiselect = true };
 
             string mruDir = this.GetMru(Constants.FileScanMru);
             if (!string.IsNullOrEmpty(mruDir) && Directory.Exists(mruDir))
@@ -1272,9 +1272,12 @@ namespace HandBrakeWPF.ViewModels
             
             if (dialogResult.HasValue && dialogResult.Value)
             {
-                this.SetMru(Constants.FileScanMru, Path.GetDirectoryName(dialog.FileName));
+                if (!string.IsNullOrEmpty(dialog.FileName))
+                {
+                    this.SetMru(Constants.FileScanMru, Path.GetDirectoryName(dialog.FileName));
+                }
 
-                this.StartScan(new List<string> { dialog.FileName }, this.TitleSpecificScan);
+                this.StartScan(dialog.FileNames.ToList(), this.TitleSpecificScan);
             }
         }
 

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1239,7 +1239,7 @@ namespace HandBrakeWPF.ViewModels
 
             if (dialogResult.HasValue && dialogResult.Value)
             {
-                this.StartScan(dialog.SelectedPath, this.TitleSpecificScan);
+                this.StartScan(new List<string> { dialog.SelectedPath }, this.TitleSpecificScan);
             }
         }
 
@@ -1274,7 +1274,7 @@ namespace HandBrakeWPF.ViewModels
             {
                 this.SetMru(Constants.FileScanMru, Path.GetDirectoryName(dialog.FileName));
 
-                this.StartScan(dialog.FileName, this.TitleSpecificScan);
+                this.StartScan(new List<string> { dialog.FileName }, this.TitleSpecificScan);
             }
         }
 
@@ -1330,7 +1330,7 @@ namespace HandBrakeWPF.ViewModels
             EncodeTask task = queueTask.Task;
 
             this.queueEditTask = queueTask;
-            this.scanService.Scan(task.Source, task.Title, QueueEditAction);
+            this.scanService.Scan(new List<string> { task.Source }, task.Title, QueueEditAction);
         }
 
         public void PauseEncode()
@@ -1484,8 +1484,8 @@ namespace HandBrakeWPF.ViewModels
                 string[] fileNames = e.Data.GetData(DataFormats.FileDrop, true) as string[];
                 if (fileNames != null && fileNames.Any() && (File.Exists(fileNames[0]) || Directory.Exists(fileNames[0])))
                 {
-                    string videoContent = fileNames.FirstOrDefault(f => Path.GetExtension(f)?.ToLower() != ".srt" && Path.GetExtension(f)?.ToLower() != ".ssa" && Path.GetExtension(f)?.ToLower() != ".ass");
-                    if (!string.IsNullOrEmpty(videoContent))
+                    List<string> videoContent = fileNames.Where(f => Path.GetExtension(f)?.ToLower() != ".srt" && Path.GetExtension(f)?.ToLower() != ".ssa" && Path.GetExtension(f)?.ToLower() != ".ass").ToList();
+                    if (videoContent.Count > 0)
                     {
                         this.StartScan(videoContent, 0);
                         return;
@@ -1880,12 +1880,12 @@ namespace HandBrakeWPF.ViewModels
             this.NotifyOfPropertyChange(() => this.IsPresetDescriptionVisible);
         }
 
-        public void StartScan(string filename, int title)
+        public void StartScan(List<string> filePaths, int title)
         {
-            if (!string.IsNullOrEmpty(filename))
+            if (filePaths != null && filePaths.Count > 0)
             {
                 ShowSourceSelection = false;
-                this.scanService.Scan(filename, title, null);
+                this.scanService.Scan(filePaths, title, null);
             }
         }
 
@@ -1898,7 +1898,9 @@ namespace HandBrakeWPF.ViewModels
                     string path = ((DriveInformation)item).RootDirectory;
                     string videoDir = Path.Combine(path, "VIDEO_TS");
 
-                    this.StartScan(Directory.Exists(videoDir) ? videoDir : path, this.TitleSpecificScan);
+                    List<string> scanPath = new List<string> { Directory.Exists(videoDir) ? videoDir : path };
+
+                    this.StartScan(scanPath, this.TitleSpecificScan);
                 }
                 else if (item.GetType() == typeof(SourceMenuItem))
                 {
@@ -1908,7 +1910,9 @@ namespace HandBrakeWPF.ViewModels
                         string path = driveInfo.RootDirectory;
                         string videoDir = Path.Combine(driveInfo.RootDirectory, "VIDEO_TS");
 
-                        this.StartScan(Directory.Exists(videoDir) ? videoDir : path, this.TitleSpecificScan);
+                        List<string> scanPath = new List<string> { Directory.Exists(videoDir) ? videoDir : path };
+
+                        this.StartScan(scanPath, this.TitleSpecificScan);
                     }
 
                     this.ShowSourceSelection = false;

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -432,7 +432,7 @@ namespace HandBrakeWPF.ViewModels
                                 return;
                             }
 
-                            if (value == this.ScannedSource.ScanPath)
+                            if (value == this.SelectedTitle.SourcePath)
                             {
                                 this.errorService.ShowMessageBox(Resources.Main_MatchingFileOverwriteWarning, Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
                                 return;
@@ -488,8 +488,8 @@ namespace HandBrakeWPF.ViewModels
                     }
 
                     // Use the Path on the Title, or the Source Scan path if one doesn't exist.
-                    this.SourceLabel = this.SelectedTitle?.DisplaySourceName ?? this.ScannedSource?.SourceName ;
-                    this.CurrentTask.Source = !string.IsNullOrEmpty(this.selectedTitle.SourceName) ? this.selectedTitle.SourceName : this.ScannedSource?.ScanPath;
+                    this.SourceLabel = this.SelectedTitle?.DisplaySourceName;
+                    this.CurrentTask.Source = this.selectedTitle.SourcePath;
                     this.CurrentTask.Title = value.TitleNumber;
                     this.NotifyOfPropertyChange(() => this.StartEndRangeItems);
                     this.NotifyOfPropertyChange(() => this.SelectedTitle);
@@ -510,7 +510,7 @@ namespace HandBrakeWPF.ViewModels
                     {
                         if (this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null)
                         {
-                            this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                            this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
                         }
                     }
 
@@ -547,12 +547,12 @@ namespace HandBrakeWPF.ViewModels
                 this.NotifyOfPropertyChange(() => this.SelectedStartPoint);
                 this.Duration = this.DurationCalculation();
 
-                if (this.userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming) && this.ScannedSource.ScanPath != null)
+                if (this.userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming) && this.SelectedTitle.SourcePath != null)
                 {
                     if (this.SelectedPointToPoint == PointToPointMode.Chapters && this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null &&
                         this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat).Contains(Constants.Chapters))
                     {
-                        this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                        this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
                     }
                 }
 
@@ -576,7 +576,7 @@ namespace HandBrakeWPF.ViewModels
                 if (this.SelectedPointToPoint == PointToPointMode.Chapters && this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null &&
                     this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat).Contains(Constants.Chapters))
                 {
-                    this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                    this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
                 }
 
                 if (this.SelectedStartPoint > this.SelectedEndPoint && this.SelectedPointToPoint == PointToPointMode.Chapters)
@@ -970,7 +970,7 @@ namespace HandBrakeWPF.ViewModels
             if (!string.IsNullOrEmpty(this.CurrentTask.Source) && !this.StaticPreviewViewModel.IsOpen)
             {
                 this.StaticPreviewViewModel.IsOpen = true;
-                this.StaticPreviewViewModel.UpdatePreviewFrame(this.CurrentTask, this.ScannedSource);
+                this.StaticPreviewViewModel.UpdatePreviewFrame(this.SelectedTitle, this.CurrentTask, this.ScannedSource);
                 this.windowManager.ShowWindow<StaticPreviewView>(this.StaticPreviewViewModel);
             }
             else if (this.StaticPreviewViewModel.IsOpen)
@@ -1037,7 +1037,7 @@ namespace HandBrakeWPF.ViewModels
 
         public AddQueueError AddToQueue(bool batch)
         {
-            if (this.ScannedSource == null || string.IsNullOrEmpty(this.ScannedSource.ScanPath) || this.ScannedSource.Titles.Count == 0)
+            if (this.ScannedSource == null || string.IsNullOrEmpty(this.SelectedTitle.SourcePath) || this.ScannedSource.Titles.Count == 0)
             {
                 return new AddQueueError(Resources.Main_ScanSource, Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -1047,7 +1047,7 @@ namespace HandBrakeWPF.ViewModels
                 return new AddQueueError(Resources.Main_SetDestination, Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
             }
 
-            if (this.Destination.ToLower() == this.ScannedSource.ScanPath.ToLower())
+            if (this.Destination.ToLower() == this.SelectedTitle.SourcePath.ToLower())
             {
                 return new AddQueueError(Resources.Main_MatchingFileOverwriteWarning, Resources.Error, MessageBoxButton.OK, MessageBoxImage.Error);
             }
@@ -1094,7 +1094,7 @@ namespace HandBrakeWPF.ViewModels
                 return new AddQueueError(Resources.Subtitles_WebmSubtitleIncompatibilityHeader, Resources.Main_PleaseFixSubtitleSettings, MessageBoxButton.OK, MessageBoxImage.Error);
             }
 
-            QueueTask task = new QueueTask(new EncodeTask(this.CurrentTask), this.ScannedSource.ScanPath, this.SelectedPreset, this.IsModifiedPreset, this.selectedTitle);
+            QueueTask task = new QueueTask(new EncodeTask(this.CurrentTask), this.SelectedTitle.SourcePath, this.SelectedPreset, this.IsModifiedPreset, this.selectedTitle);
 
             if (!this.queueProcessor.CheckForDestinationPathDuplicates(task.Task.Destination))
             {
@@ -1862,7 +1862,7 @@ namespace HandBrakeWPF.ViewModels
                     {
                         if (this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat).Contains(Constants.Preset))
                         {
-                            this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                            this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
                         }
                     }
 
@@ -1955,7 +1955,7 @@ namespace HandBrakeWPF.ViewModels
         {
             if (this.ScannedSource != null)
             {
-                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
             }
         }
 
@@ -2006,7 +2006,7 @@ namespace HandBrakeWPF.ViewModels
               
                 // Cleanup
                 this.ShowStatusWindow = false;
-                this.SourceLabel = this.SelectedTitle?.DisplaySourceName ?? this.ScannedSource?.SourceName;
+                this.SourceLabel = this.SelectedTitle?.DisplaySourceName ?? this.SelectedTitle?.DisplaySourceName;
                 this.StatusLabel = Resources.Main_ScanCompleted;
             });
         }
@@ -2041,7 +2041,7 @@ namespace HandBrakeWPF.ViewModels
             // Update Preview if needed
             if (e != null && e.TabKey != null && e.TabKey.Equals(TabStatusEventType.FilterType) && this.StaticPreviewViewModel.IsOpen)
             {
-                delayedPreviewprocessor.PerformTask(() => this.StaticPreviewViewModel.UpdatePreviewFrame(this.CurrentTask, this.ScannedSource), 1000);
+                delayedPreviewprocessor.PerformTask(() => this.StaticPreviewViewModel.UpdatePreviewFrame(this.SelectedTitle, this.CurrentTask, this.ScannedSource), 1000);
             }
 
             // Preset Check
@@ -2111,18 +2111,18 @@ namespace HandBrakeWPF.ViewModels
 
             if (autonameFormat.Contains(Constants.QualityBitrate) && (option == ChangedOption.Bitrate || option == ChangedOption.Quality))
             {
-                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
             }
 
             if (autonameFormat.Contains(Constants.EncoderBitDepth) && option == ChangedOption.Encoder)
             {
-                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
             }
 
 
             if ((autonameFormat.Contains(Constants.StorageWidth) || autonameFormat.Contains(Constants.StorageHeight)) && option == ChangedOption.Dimensions)
             {
-                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.ScannedSource?.SourceName, this.selectedPreset);
+                this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
             }
         }
 
@@ -2225,7 +2225,7 @@ namespace HandBrakeWPF.ViewModels
 
                 if (e.Successful)
                 {
-                    this.SourceLabel = this.SelectedTitle?.DisplaySourceName ?? this.ScannedSource?.SourceName;
+                    this.SourceLabel = this.SelectedTitle?.DisplaySourceName;
                     this.StatusLabel = Resources.Main_ScanCompleted;
                 }
                 else if (e.Cancelled)

--- a/win/CS/HandBrakeWPF/ViewModels/PictureSettingsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/PictureSettingsViewModel.cs
@@ -684,7 +684,7 @@ namespace HandBrakeWPF.ViewModels
             if (!string.IsNullOrEmpty(this.Task.Source) && !this.StaticPreviewViewModel.IsOpen)
             {
                 this.StaticPreviewViewModel.IsOpen = true;
-                this.StaticPreviewViewModel.UpdatePreviewFrame(this.Task, this.scannedSource);
+                this.StaticPreviewViewModel.UpdatePreviewFrame(this.currentTitle, this.Task, this.scannedSource);
                 this.windowManager.ShowWindow<StaticPreviewView>(this.StaticPreviewViewModel);
             }
             else if (this.StaticPreviewViewModel.IsOpen)
@@ -895,7 +895,7 @@ namespace HandBrakeWPF.ViewModels
             // Step 5, Update the Preview
             if (delayedPreviewprocessor != null && this.Task != null && this.StaticPreviewViewModel != null && this.StaticPreviewViewModel.IsOpen)
             {
-                delayedPreviewprocessor.PerformTask(() => this.StaticPreviewViewModel.UpdatePreviewFrame(this.Task, this.scannedSource), 800);
+                delayedPreviewprocessor.PerformTask(() => this.StaticPreviewViewModel.UpdatePreviewFrame(this.currentTitle, this.Task, this.scannedSource), 800);
             }
 
             this.OnTabStatusChanged(new TabStatusEventArgs("picture", ChangedOption.Dimensions));

--- a/win/CS/HandBrakeWPF/ViewModels/QueueSelectionViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/QueueSelectionViewModel.cs
@@ -129,11 +129,11 @@ namespace HandBrakeWPF.ViewModels
         {
             if (this.nameDesc)
             {
-                TitleList = new BindingList<SelectionTitle>(TitleList.OrderByDescending(o => o.Title.SourceName).ToList());
+                TitleList = new BindingList<SelectionTitle>(TitleList.OrderByDescending(o => o.Title.SourcePath).ToList());
             }
             else
             {
-                TitleList = new BindingList<SelectionTitle>(TitleList.OrderBy(o => o.Title.SourceName).ToList());
+                TitleList = new BindingList<SelectionTitle>(TitleList.OrderBy(o => o.Title.SourcePath).ToList());
             }
             
             this.NotifyOfPropertyChange(() => TitleList);
@@ -211,7 +211,7 @@ namespace HandBrakeWPF.ViewModels
 
                 foreach (Title item in titles)
                 {
-                    string srcName = item.DisplaySourceName ?? scannedSource.SourceName;
+                    string srcName = item.DisplaySourceName ?? item.SourcePath;
                     SelectionTitle title = new SelectionTitle(item, srcName) { IsSelected = true };
                     TitleList.Add(title);
                 }

--- a/win/CS/HandBrakeWPF/ViewModels/StaticPreviewViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/StaticPreviewViewModel.cs
@@ -155,6 +155,8 @@ namespace HandBrakeWPF.ViewModels
 
         public Source ScannedSource { get; set; }
 
+        public Title SelectedTitle { get; set; }
+
         public bool IsMediaPlayerVisible
         {
             get => this.isMediaPlayerVisible && !this.isEncoding;
@@ -334,9 +336,10 @@ namespace HandBrakeWPF.ViewModels
             }
         }
         
-        public void UpdatePreviewFrame(EncodeTask task, Source scannedSource)
+        public void UpdatePreviewFrame(Title selectedTitle, EncodeTask task, Source scannedSource)
         {
             this.Task = task;
+            this.SelectedTitle = selectedTitle;
 
             // The Built-in Player does not support WebM or Mpeg2
             if (this.Task != null && 
@@ -350,7 +353,7 @@ namespace HandBrakeWPF.ViewModels
             this.Title = Resources.StaticPreviewViewModel_Title;
             this.ScannedSource = scannedSource;
         }
-
+        
         public void NextPreview()
         {
             int maxPreview = this.userSettingService.GetUserSetting<int>(UserSettingConstants.PreviewScanCount);
@@ -533,7 +536,7 @@ namespace HandBrakeWPF.ViewModels
                 return;
             }
 
-            QueueTask task = new QueueTask(encodeTask, this.ScannedSource.ScanPath, null, false, null);
+            QueueTask task = new QueueTask(encodeTask, this.SelectedTitle.SourcePath, null, false, null);
             ThreadPool.QueueUserWorkItem(this.CreatePreview, task);
         }
 


### PR DESCRIPTION
**Description of Change:**

- Add an hb_scan_list method that takes a list of files to scan.  This allows a user to drag any arbitrary list of files onto the UI.
- Add a check for known file types during scan. When a known file type is detected, bypass the DVD / Bluray Probe.  Reduces some log spam. 
- Supported in Mac and Windows UIs

Maybe useful for those wanting #1310


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
