### PR TITLE
SVT-AV1: Add native march

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -32,6 +32,12 @@ else ifeq (off,$(GCC.lto))
     SVT-AV1.CONFIGURE.extra += -DSVT_AV1_LTO=OFF
 endif
 
+ifeq (native,$(GCC.cpu))
+    SVT-AV1.CONFIGURE.extra += -DNATIVE=ON
+else ifeq (none,$(GCC.cpu))
+    SVT-AV1.CONFIGURE.extra += -DNATIVE=OFF
+endif
+
 ifeq (1,$(HOST.cross))
     ifeq (mingw,$(HOST.system))
         SVT-AV1.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON


### PR DESCRIPTION
This commit adds native march support to SVT-AV1 when `--cpu=native` is specified during configure.