### PR TITLE
Update zimg to 3.0.5

### DIFF
--- a/contrib/zimg/module.defs
+++ b/contrib/zimg/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,ZIMG,zimg))
 $(eval $(call import.CONTRIB.defs,ZIMG))
 
-ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zimg-3.0.4.tar.gz
-ZIMG.FETCH.url    += https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.4.tar.gz
-ZIMG.FETCH.sha256  = 219d1bc6b7fde1355d72c9b406ebd730a4aed9c21da779660f0a4c851243e32f
-ZIMG.EXTRACT.tarbase = zimg-release-3.0.4
+ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zimg-3.0.5.tar.gz
+ZIMG.FETCH.url    += https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.5.tar.gz
+ZIMG.FETCH.sha256  = a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf
+ZIMG.EXTRACT.tarbase = zimg-release-3.0.5
 
 ZIMG.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;
 


### PR DESCRIPTION
Update zimg to version 3.0.5. Tested on macOS.

> 3.0.5
> colorspace: add ST.428-1 (gamma 2.6) transfer function
> depth: fix AVX-512 integer to float border handling (introduced in 2.6)
> depth: fix NEON dither border handling (introduced in 3.0)
> graph: fix clipping in alpha premultiplication (introduced in 3.0)
> x86: optimizations for AMD Zen4 processors