### PR TITLE
libhb: avoid copying frames when converting from avframe to hb_buffer.

### DIFF
--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -232,7 +232,7 @@ void hb_avfilter_alias_close( hb_filter_object_t * filter )
     filter->private_data = NULL;
 }
 
-static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
+static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t ** buf_in )
 {
     hb_buffer_list_t   list;
     hb_buffer_t      * buf = NULL, * next = NULL;
@@ -240,8 +240,9 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
     mfxFrameSurface1 *surface = NULL;
     HBQSVFramesContext *frames_ctx = NULL;
-    if (hb_qsv_hw_filters_are_enabled(pv->input.job))
+    if (hb_qsv_hw_filters_are_enabled(pv->input.job) && buf_in != NULL)
     {
+        hb_buffer_t      *in = *buf_in;
         if (in && in->qsv_details.frame)
         {
             // We need to keep surface pointer because hb_avfilter_add_buf set it to 0 after in ffmpeg call
@@ -256,7 +257,7 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t * in )
 #endif
     if (av_frame_is_not_null)
     {
-        hb_avfilter_add_buf(pv->graph, in);
+        hb_avfilter_add_buf(pv->graph, buf_in);
         buf = hb_avfilter_get_buf(pv->graph);
     }
     while (buf != NULL)
@@ -305,7 +306,7 @@ static int avfilter_work( hb_filter_object_t * filter,
         return HB_FILTER_DONE;
     }
 
-    *buf_out = filterFrame(pv, in);
+    *buf_out = filterFrame(pv, buf_in);
 
     return HB_FILTER_OK;
 }

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -236,30 +236,27 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t ** buf_in
 {
     hb_buffer_list_t   list;
     hb_buffer_t      * buf = NULL, * next = NULL;
-    int av_frame_is_not_null = 1; // TODO: find the reason for empty input av_frame for ffmpeg filters
+
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
     mfxFrameSurface1 *surface = NULL;
     HBQSVFramesContext *frames_ctx = NULL;
+
     if (hb_qsv_hw_filters_are_enabled(pv->input.job) && buf_in != NULL)
     {
-        hb_buffer_t      *in = *buf_in;
-        if (in && in->qsv_details.frame)
+        hb_buffer_t *in = *buf_in;
+        AVFrame *frame = (AVFrame *)in->storage;
+        if (frame)
         {
             // We need to keep surface pointer because hb_avfilter_add_buf set it to 0 after in ffmpeg call
-            surface = (mfxFrameSurface1 *)in->qsv_details.frame->data[3];
+            surface = (mfxFrameSurface1 *)frame->data[3];
             frames_ctx = in->qsv_details.qsv_frames_ctx;
-        }
-        else
-        {
-            av_frame_is_not_null = 0;
         }
     }
 #endif
-    if (av_frame_is_not_null)
-    {
-        hb_avfilter_add_buf(pv->graph, buf_in);
-        buf = hb_avfilter_get_buf(pv->graph);
-    }
+
+    hb_avfilter_add_buf(pv->graph, buf_in);
+    buf = hb_avfilter_get_buf(pv->graph);
+
     while (buf != NULL)
     {
         hb_buffer_list_append(&pv->list, buf);

--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -88,7 +88,8 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                                  uint8_t *frame_dst,                                                        \
                            const int width,                                                                 \
                            const int height,                                                                \
-                           int stride,                                                                      \
+                           int stride_src,                                                                  \
+                           int stride_dst,                                                                  \
                            chroma_smooth_plane_context_t * ctx,                                             \
                            chroma_smooth_thread_context_t * tctx)                                           \
 {                                                                                                           \
@@ -112,7 +113,20 @@ static void name##_##nbits(const uint8_t *frame_src,                            
     {                                                                                                       \
         if (src != dst)                                                                                     \
         {                                                                                                   \
-            memcpy(dst, src, stride*height);                                                                \
+            if (stride_src == stride_dst)                                                                   \
+            {                                                                                               \
+                memcpy(dst, src, stride_dst * height);                                                      \
+            }                                                                                               \
+            else                                                                                            \
+            {                                                                                               \
+                const int size = stride_src < stride_dst ? ABS(stride_src) : stride_dst;                    \
+                for (int yy = 0; yy < height; yy++)                                                         \
+                {                                                                                           \
+                    memcpy(dst, src, size);                                                                 \
+                    dst += stride_dst;                                                                      \
+                    src += stride_src;                                                                      \
+                }                                                                                           \
+            }                                                                                               \
         }                                                                                                   \
                                                                                                             \
         return;                                                                                             \
@@ -123,7 +137,8 @@ static void name##_##nbits(const uint8_t *frame_src,                            
         memset(SC[y], 0, sizeof(SC[y][0]) * (width + 2 * steps));                                           \
     }                                                                                                       \
                                                                                                             \
-    stride /= ctx->bps;                                                                                     \
+    stride_src /= ctx->bps;                                                                                 \
+    stride_dst /= ctx->bps;                                                                                 \
                                                                                                             \
     for (y = -steps; y < height + steps; y++)                                                               \
     {                                                                                                       \
@@ -152,8 +167,8 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                                                                                                             \
             if (x >= steps && y >= steps)                                                                   \
             {                                                                                               \
-                const uint##nbits##_t *srx = src - steps * stride + x - steps;                              \
-                uint##nbits##_t       *dsx = dst - steps * stride + x - steps;                              \
+                const uint##nbits##_t *srx = src - steps * stride_src + x - steps;                          \
+                uint##nbits##_t       *dsx = dst - steps * stride_dst + x - steps;                          \
                                                                                                             \
                 res = (int32_t)*srx - ((((int32_t)*srx -                                                    \
                       (int32_t)((Tmp1 + halfscale) >> scalebits)) * amount) >> 16);                         \
@@ -163,8 +178,8 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                                                                                                             \
         if (y >= 0)                                                                                         \
         {                                                                                                   \
-            dst += stride;                                                                                  \
-            src += stride;                                                                                  \
+            dst += stride_dst;                                                                              \
+            src += stride_src;                                                                              \
         }                                                                                                   \
     }                                                                                                       \
 }                                                                                                           \
@@ -386,6 +401,7 @@ static int chroma_smooth_work_thread(hb_filter_object_t *filter,
                       in->plane[c].width,
                       in->plane[c].height,
                       in->plane[c].stride,
+                      out->plane[c].stride,
                       ctx, tctx);
     }
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -6306,7 +6306,7 @@ static int pix_fmt_is_supported(hb_job_t *job, int pix_fmt)
     {
         if (hb_hwaccel_decode_is_enabled(job) == 0
 #if HB_PROJECT_FEATURE_QSV
-            && hb_qsv_decode_is_enabled(job) == 0
+            && hb_qsv_full_path_is_enabled(job) == 0
 #endif
             )
         {

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1153,7 +1153,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
     if (pv->qsv.decode &&
         pv->qsv.config.io_pattern == MFX_IOPATTERN_OUT_VIDEO_MEMORY)
     {
-        out = hb_qsv_copy_avframe_to_video_buffer(pv->job, pv->frame, 0);
+        out = hb_qsv_copy_avframe_to_video_buffer(pv->job, pv->frame, (AVRational){1,1}, 0);
     }
     else
 #endif

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1158,7 +1158,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
     else
 #endif
     {
-        out = hb_avframe_to_video_buffer(pv->frame, (AVRational){1,1});
+        out = hb_avframe_to_video_buffer(pv->frame, (AVRational){1,1}, 1);
     }
 
     if (pv->frame->pts != AV_NOPTS_VALUE)

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -573,6 +573,15 @@ static int hb_decomb_work(hb_filter_object_t *filter,
     hb_filter_private_t *pv = filter->private_data;
     hb_buffer_t *in = *buf_in;
 
+    // TODO: eliminate extra buffer copies in decomb
+    if (in->plane[0].height_stride - in->plane[0].height < 3)
+    {
+        // Decomb requires some additional rows
+        // to work on.
+        in = hb_buffer_dup(in);
+        hb_buffer_close(buf_in);
+    }
+
     // Input buffer is always consumed.
     *buf_in = NULL;
     if (in->s.flags & HB_BUF_FLAG_EOF)

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1044,9 +1044,30 @@ static int hb_detelecine_work( hb_filter_object_t * filter,
     }
 
     /* Copy input buffer into pullup buffer */
-    memcpy( buf->planes[0], in->plane[0].data, buf->size[0] );
-    memcpy( buf->planes[1], in->plane[1].data, buf->size[1] );
-    memcpy( buf->planes[2], in->plane[2].data, buf->size[2] );
+    /* Copy pullup frame buffer into output buffer */
+    for (int pp = 0; pp < 3; pp++)
+    {
+        if (in->plane[pp].stride == ctx->stride[pp])
+        {
+            memcpy(buf->planes[pp], in->plane[pp].data, buf->size[pp]);
+        }
+        else
+        {
+            const int stride_src = in->plane[pp].stride;
+            const int stride_dst = ctx->stride[pp];
+            const int height = in->f.height;
+            const int size = stride_src < stride_dst ? ABS(stride_src) : stride_dst;
+            uint8_t *dst = buf->planes[pp];
+            uint8_t *src = in->plane[pp].data;
+
+            for (int yy = 0; yy < height; yy++)
+            {
+                memcpy(dst, src, size);
+                dst += stride_dst;
+                src += stride_src;
+            }
+        }
+    }
 
     /* Submit buffer fields based on buffer flags.
        Detelecine assumes BFF when the TFF flag isn't present. */

--- a/libhb/enc_qsv.c
+++ b/libhb/enc_qsv.c
@@ -2285,9 +2285,10 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
     else
     {
         QSVMid *mid = NULL;
-        if (in->qsv_details.frame && in->qsv_details.frame->data[3])
+        AVFrame *frame = (AVFrame *)in->storage;
+        if (frame && frame->data[3])
         {
-            surface = ((mfxFrameSurface1*)in->qsv_details.frame->data[3]);
+            surface = ((mfxFrameSurface1*)frame->data[3]);
             frames_ctx = in->qsv_details.qsv_frames_ctx;
             hb_qsv_get_mid_by_surface_from_pool(frames_ctx, surface, &mid);
             hb_qsv_replace_surface_mid(frames_ctx, mid, surface);
@@ -2399,9 +2400,11 @@ int encqsvWork(hb_work_object_t *w, hb_buffer_t **buf_in, hb_buffer_t **buf_out)
         goto fail;
     }
 
-    if (in->qsv_details.frame)
+    if (in->storage)
     {
-        in->qsv_details.frame->data[3] = 0;
+        // FIXME: This looks weird
+        AVFrame *frame = (AVFrame *)in->storage;
+        frame->data[3] = 0;
     }
 
     *buf_out = hb_buffer_list_clear(&pv->encoded_frames);

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -598,70 +598,118 @@ void hb_buffer_copy_props(hb_buffer_t *dst, const hb_buffer_t *src)
     hb_buffer_copy_side_data(dst, src);
 }
 
-hb_buffer_t * hb_buffer_dup( const hb_buffer_t * src )
+static int copy_hwframe_to_video_buffer(const AVFrame *frame, hb_buffer_t *buf)
 {
+    int ret;
+    AVFrame *hw_frame = av_frame_alloc();
 
-    hb_buffer_t * buf;
-
-    if ( src == NULL )
-        return NULL;
-
-    buf = hb_buffer_init( src->size );
-    if ( buf )
+    ret = av_frame_copy_props(hw_frame, frame);
+    if (ret < 0)
     {
-        buf->f = src->f;
-        hb_buffer_copy_props(buf, src);
+        hb_log("fifo: av_frame_copy_props");
+    }
+    ret = av_hwframe_get_buffer(frame->hw_frames_ctx, hw_frame, 0);
+    if (ret < 0)
+    {
+        hb_log("fifo: av_hwframe_get_buffer failed");
+    }
+    ret = av_hwframe_transfer_data(hw_frame, frame, 0);
+    if (ret < 0)
+    {
+        hb_log("fifo: av_hwframe_transfer_data failed");
+    }
 
-        if (buf->s.type == FRAME_BUF)
+    buf->storage = hw_frame;
+    buf->storage_type = AVFRAME;
+
+    return ret;
+}
+
+static void copy_avframe_to_video_buffer(const AVFrame *frame, hb_buffer_t *buf)
+{
+    for (int pp = 0; pp <= buf->f.max_plane; pp++)
+    {
+        if (buf->plane[pp].stride == frame->linesize[pp])
         {
-            hb_buffer_init_planes(buf);
-        }
-
-        if (src->storage_type == AVFRAME)
-        {
-            AVBufferRef *hw_frames_ctx = ((AVFrame *)src->storage)->hw_frames_ctx;
-            if (hw_frames_ctx)
-            {
-                AVFrame *hw_frame = av_frame_alloc();
-
-                int ret;
-
-                ret = av_frame_copy_props(hw_frame, (AVFrame *)src->storage);
-                if (ret < 0)
-                {
-                    hb_log("fifo: av_frame_copy_props");
-                }
-                ret = av_hwframe_get_buffer(hw_frames_ctx, hw_frame, 0);
-                if (ret < 0)
-                {
-                    hb_log("fifo: av_hwframe_get_buffer failed");
-                }
-                ret = av_hwframe_transfer_data(hw_frame, (AVFrame *)src->storage, 0);
-                if (ret < 0)
-                {
-                    hb_log("fifo: av_hwframe_transfer_data failed");
-                }
-
-                buf->storage = hw_frame;
-                buf->storage_type = AVFRAME;
-            }
-            else
-            {
-                for (int pp = 0; pp <= src->f.max_plane; pp++)
-                {
-                    memcpy(buf->plane[pp].data, src->plane[pp].data, src->plane[pp].size);
-                }
-            }
+            memcpy(buf->plane[pp].data, frame->data[pp], frame->linesize[pp] * buf->plane[pp].height);
         }
         else
         {
-            memcpy( buf->data, src->data, src->size );
+            const int width     = buf->plane[pp].width;
+            const int height    = buf->plane[pp].height;
+            const int stride    = buf->plane[pp].stride;
+            const int linesize  = frame->linesize[pp];
+            uint8_t *dst = buf->plane[pp].data;
+            uint8_t *src = frame->data[pp];
+            for (int yy = 0; yy < height; yy++)
+            {
+                memcpy(dst, src, width);
+                dst += stride;
+                src += linesize;
+            }
         }
+    }
+}
 
+hb_buffer_t * hb_buffer_dup(const hb_buffer_t *src)
+{
+    hb_buffer_t *buf = NULL;
+
+    if (src == NULL)
+    {
+        return NULL;
+    }
+
+    if (src->storage_type == STANDARD)
+    {
+        buf = hb_buffer_init(src->size);
+        if (buf)
+        {
+            buf->f = src->f;
+            hb_buffer_copy_props(buf, src);
+
+            if (buf->s.type == FRAME_BUF)
+            {
+                hb_buffer_init_planes(buf);
+            }
+
+            memcpy(buf->data, src->data, src->size);
+        }
+    }
+    else if (src->storage_type == AVFRAME)
+    {
+        const AVFrame *frame = (AVFrame *)src->storage;
+
+        // If it's an hardware frame, make a copy
+        // into another hardware AVFrame.
+        if (frame->hw_frames_ctx)
+        {
+            buf = hb_buffer_wrapper_init();
+            if (buf)
+            {
+                buf->f = src->f;
+                hb_buffer_copy_props(buf, src);
+                copy_hwframe_to_video_buffer(frame, buf);
+            }
+        }
+        // If not, copy the content to a standard hb_buffer
+        else
+        {
+            buf = hb_frame_buffer_init(src->f.fmt, src->f.width, src->f.height);
+            if (buf)
+            {
+                buf->f = src->f;
+                hb_buffer_copy_props(buf, src);
+                copy_avframe_to_video_buffer(frame, buf);
+            }
+        }
     }
 
 #if HB_PROJECT_FEATURE_QSV
-    memcpy(&buf->qsv_details, &src->qsv_details, sizeof(src->qsv_details));
+    if (buf)
+    {
+        memcpy(&buf->qsv_details, &src->qsv_details, sizeof(src->qsv_details));
+    }
 #endif
 
     return buf;

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -939,15 +939,15 @@ void hb_buffer_close( hb_buffer_t ** _b )
 #if HB_PROJECT_FEATURE_QSV
         // Reclaim QSV resources before dropping the buffer.
         // when decoding without QSV, the QSV atom will be NULL.
-        if(b->qsv_details.frame && b->qsv_details.ctx != NULL)
+        if (b->storage != NULL && b->qsv_details.ctx != NULL)
         {
-            mfxFrameSurface1 *surface = (mfxFrameSurface1*)b->qsv_details.frame->data[3];
-            if(surface)
+            AVFrame *frame = (AVFrame *)b->storage;
+            mfxFrameSurface1 *surface = (mfxFrameSurface1 *)frame->data[3];
+            if (surface)
             {
                 hb_qsv_release_surface_from_pool_by_surface_pointer(b->qsv_details.qsv_frames_ctx, surface);
-                b->qsv_details.frame->data[3] = 0;
+                frame->data[3] = 0;
             }
-            av_frame_unref(b->qsv_details.frame);
         }
         if (b->qsv_details.qsv_atom != NULL && b->qsv_details.ctx != NULL)
         {

--- a/libhb/handbrake/hbavfilter.h
+++ b/libhb/handbrake/hbavfilter.h
@@ -30,7 +30,7 @@ int     hb_avfilter_add_frame(hb_avfilter_graph_t * graph, AVFrame * frame);
 
 int     hb_avfilter_get_frame(hb_avfilter_graph_t * graph, AVFrame * frame);
 
-int     hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in);
+int     hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t ** in);
 
 hb_buffer_t *
 hb_avfilter_get_buf(hb_avfilter_graph_t * graph);

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -61,9 +61,10 @@ hb_sws_get_context(int srcW, int srcH, enum AVPixelFormat srcFormat, int srcRang
 
 static const char* const hb_vce_preset_names[] = { "speed", "balanced", "quality", NULL, };
 
-void            hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t * buf);
+void            hb_video_buffer_to_avframe(AVFrame *frame, hb_buffer_t **buf);
 hb_buffer_t   * hb_avframe_to_video_buffer(AVFrame *frame,
-                                           AVRational time_base);
+                                           AVRational time_base,
+                                           int zero_copy);
 void            hb_avframe_set_video_buffer_flags(hb_buffer_t * buf,
                                            AVFrame *frame,
                                            AVRational time_base);

--- a/libhb/handbrake/hwaccel.h
+++ b/libhb/handbrake/hwaccel.h
@@ -24,7 +24,7 @@ AVBufferRef *hb_hwaccel_init_hw_frames_ctx(AVBufferRef *hw_device_ctx,
                                        int width,
                                        int height);
 int hb_hwaccel_hwframe_init(hb_job_t *job, struct AVFrame **frame);
-hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t *buf);
+hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t **buf);
 
 const char * hb_hwaccel_get_codec_name(enum AVCodecID codec_id);
 

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -232,9 +232,8 @@ static inline int hb_image_stride( int pix_fmt, int width, int plane )
     int linesize = av_image_get_linesize( pix_fmt, width, plane );
 
     // Make buffer SIMD friendly.
-    // Decomb requires stride aligned to 32 bytes
-    // TODO: eliminate extra buffer copies in decomb
-    linesize = MULTIPLE_MOD_UP( linesize, 32 );
+    // Zscale requires stride aligned to 64 bytes
+    linesize = MULTIPLE_MOD_UP(linesize, 64);
     return linesize;
 }
 

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -156,7 +156,6 @@ struct hb_buffer_s
     struct qsv
     {
         void               * qsv_atom;
-        AVFrame            * frame;
         hb_qsv_context     * ctx;
         HBQSVFramesContext * qsv_frames_ctx;
     } qsv_details;

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -254,9 +254,9 @@ int hb_create_ffmpeg_pool(hb_job_t *job, int coded_width, int coded_height, enum
 int hb_qsv_hw_filters_are_enabled(hb_job_t *job);
 int hb_qsv_full_path_is_enabled(hb_job_t *job);
 AVBufferRef *hb_qsv_create_mids(AVBufferRef *hw_frames_ref);
-int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int is_vpp);
-int hb_qsv_copy_video_buffer_to_video_buffer(hb_job_t *job, hb_buffer_t* in, hb_buffer_t* out, int is_vpp);
-hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, int is_vpp);
+hb_buffer_t * hb_qsv_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t *in, const int is_vpp);
+hb_buffer_t * hb_qsv_buffer_dup(hb_job_t *job, hb_buffer_t *in, const int is_vpp);
+hb_buffer_t * hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, AVRational time_base, const int is_vpp);
 int hb_qsv_get_free_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, AVFrame* frame, QSVMid** out_mid);
 void hb_qsv_get_free_surface_from_pool_with_range(HBQSVFramesContext* hb_enc_qsv_frames_ctx, const int start_index, const int end_index, QSVMid** out_mid, mfxFrameSurface1** out_surface);
 int hb_qsv_get_mid_by_surface_from_pool(HBQSVFramesContext* hb_enc_qsv_frames_ctx, mfxFrameSurface1 *surface, QSVMid **out_mid);

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -310,23 +310,12 @@ int hb_avfilter_get_frame(hb_avfilter_graph_t * graph, AVFrame * frame)
 int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t ** buf_in)
 {
     int ret;
+
     if (buf_in != NULL && *buf_in != NULL)
     {
-#if HB_PROJECT_FEATURE_QSV
-        if (hb_qsv_hw_filters_are_enabled(graph->job))
-        {
-            hb_buffer_t      *in = *buf_in;
-
-            hb_video_buffer_to_avframe(in->qsv_details.frame, buf_in);
-            ret = hb_avfilter_add_frame(graph, in->qsv_details.frame);
-        }
-        else
-#endif
-        {
-            hb_video_buffer_to_avframe(graph->frame, buf_in);
-            ret = av_buffersrc_add_frame(graph->input, graph->frame);
-            av_frame_unref(graph->frame);
-        }
+        hb_video_buffer_to_avframe(graph->frame, buf_in);
+        ret = av_buffersrc_add_frame(graph->input, graph->frame);
+        av_frame_unref(graph->frame);
     }
     else
     {
@@ -347,8 +336,7 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
 #if HB_PROJECT_FEATURE_QSV
         if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
-            buf = hb_qsv_copy_avframe_to_video_buffer(graph->job, graph->frame, 1);
-            hb_avframe_set_video_buffer_flags(buf, graph->frame, graph->out_time_base);
+            buf = hb_qsv_copy_avframe_to_video_buffer(graph->job, graph->frame, graph->out_time_base, 1);
         }
         else
 #endif

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -307,21 +307,23 @@ int hb_avfilter_get_frame(hb_avfilter_graph_t * graph, AVFrame * frame)
     return av_buffersink_get_frame(graph->output, frame);
 }
 
-int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t * in)
+int hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t ** buf_in)
 {
     int ret;
-    if (in != NULL)
+    if (buf_in != NULL && *buf_in != NULL)
     {
 #if HB_PROJECT_FEATURE_QSV
         if (hb_qsv_hw_filters_are_enabled(graph->job))
         {
-            hb_video_buffer_to_avframe(in->qsv_details.frame, in);
+            hb_buffer_t      *in = *buf_in;
+
+            hb_video_buffer_to_avframe(in->qsv_details.frame, buf_in);
             ret = hb_avfilter_add_frame(graph, in->qsv_details.frame);
         }
         else
 #endif
         {
-            hb_video_buffer_to_avframe(graph->frame, in);
+            hb_video_buffer_to_avframe(graph->frame, buf_in);
             ret = av_buffersrc_add_frame(graph->input, graph->frame);
             av_frame_unref(graph->frame);
         }
@@ -351,7 +353,7 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
         else
 #endif
         {
-            buf = hb_avframe_to_video_buffer(graph->frame, graph->out_time_base);
+            buf = hb_avframe_to_video_buffer(graph->frame, graph->out_time_base, 1);
         }
         av_frame_unref(graph->frame);
         return buf;

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -194,14 +194,14 @@ static int hb_hwaccel_hwframe_init(hb_job_t *job, AVFrame **frame)
     return av_hwframe_get_buffer(hw_frames_ctx, *frame, 0);
 }
 
-hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t *buf)
+hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t **buf_in)
 {
     AVFrame frame = {{0}};
     AVFrame *hw_frame = NULL;
 
     int ret;
 
-    hb_video_buffer_to_avframe(&frame, buf);
+    hb_video_buffer_to_avframe(&frame, buf_in);
 
     ret = hb_hwaccel_hwframe_init(job, &hw_frame);
     if (ret < 0)
@@ -221,9 +221,7 @@ hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_
         goto fail;
     }
 
-    hb_buffer_close(&buf);
-
-    hb_buffer_t *out = hb_avframe_to_video_buffer(hw_frame, (AVRational){1,1});
+    hb_buffer_t *out = hb_avframe_to_video_buffer(hw_frame, (AVRational){1,1}, 1);
 
     av_frame_unref(&frame);
     av_frame_unref(hw_frame);

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -126,7 +126,8 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                                  uint8_t *frame_dst,                                             \
                            const int width,                                                      \
                            const int height,                                                     \
-                           int stride,                                                           \
+                           int stride_src,                                                       \
+                           int stride_dst,                                                       \
                            lapsharp_plane_context_t *ctx)                                        \
 {                                                                                                \
     const kernel_t *kernel = &kernels[ctx->kernel];                                              \
@@ -134,12 +135,13 @@ static void name##_##nbits(const uint8_t *frame_src,                            
     const uint##nbits##_t *src = (const uint##nbits##_t *)frame_src;                             \
     uint##nbits##_t       *dst = (uint##nbits##_t *)frame_dst;                                   \
                                                                                                  \
-    stride /= ctx->bps;                                                                          \
+    stride_src /= ctx->bps;                                                                      \
+    stride_dst /= ctx->bps;                                                                      \
                                                                                                  \
     /* Sharpen using selected kernel */                                                          \
     const int offset_min    = -((kernel->size - 1) / 2);                                         \
     const int offset_max    =   (kernel->size + 1) / 2;                                          \
-    const int stride_border =   (stride - width) / 2;                                            \
+    const int stride_border =   (stride_src - width) / 2;                                        \
     const int max_value     = ctx->max_value;                                                    \
                                                                                                  \
     int##pixelbits##_t pixel;                                                                    \
@@ -153,7 +155,7 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                 (x < stride_border + offset_max) ||                                              \
                 (x > width + stride_border - offset_max))                                        \
             {                                                                                    \
-                *(dst + stride*y + x) = *(src + stride*y + x);                                   \
+                *(dst + stride_dst*y + x) = *(src + stride_src*y + x);                           \
                 continue;                                                                        \
             }                                                                                    \
                                                                                                  \
@@ -163,14 +165,14 @@ static void name##_##nbits(const uint8_t *frame_src,                            
                 for (int j = offset_min; j < offset_max; j++)                                    \
                 {                                                                                \
                     pixel += kernel->mem[((j - offset_min) * kernel->size) +                     \
-                             k - offset_min] * *(src + stride*(y + j) + (x + k));                \
+                             k - offset_min] * *(src + stride_src*(y + j) + (x + k));            \
                 }                                                                                \
             }                                                                                    \
-            pixel = (int##pixelbits##_t)(((pixel * kernel->coef) - *(src + stride*y + x)) *      \
-                        ctx->strength) + *(src + stride*y + x);                                  \
+            pixel = (int##pixelbits##_t)(((pixel * kernel->coef) - *(src + stride_src*y + x)) *  \
+                        ctx->strength) + *(src + stride_src*y + x);                              \
             pixel = pixel < 0 ? 0 : pixel;                                                       \
             pixel = pixel > max_value ? max_value : pixel;                                       \
-            *(dst + stride*y + x) = (uint##nbits##_t)(pixel);                                    \
+            *(dst + stride_dst*y + x) = (uint##nbits##_t)(pixel);                                \
         }                                                                                        \
     }                                                                                            \
 }                                                                                                \
@@ -339,6 +341,7 @@ static int hb_lapsharp_work(hb_filter_object_t *filter,
                     in->plane[c].width,
                     in->plane[c].height,
                     in->plane[c].stride,
+                    out->plane[c].stride,
                     ctx);
     }
 

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4004,8 +4004,44 @@ static int hb_qsv_copy_surface(hb_qsv_context *ctx, void* output_surface, int ou
     return 0;
 }
 
-int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int is_vpp)
+hb_buffer_t * hb_qsv_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t *in, const int is_vpp)
 {
+    hb_buffer_t *out = hb_buffer_wrapper_init();
+
+    if (out == NULL)
+    {
+        goto fail;
+    }
+
+    // Alloc new frame
+    AVFrame *frame = av_frame_alloc();
+
+    if (frame == NULL)
+    {
+        hb_error("hb_qsv_copy_video_buffer_to_hw_video_buffer: av_frame_alloc() failed");
+        goto fail;
+    }
+
+    frame->pts              = in->s.start;
+    frame->duration         = in->s.duration;
+    frame->width            = in->f.width;
+    frame->height           = in->f.height;
+    frame->format           = in->f.fmt;
+    frame->interlaced_frame = !!in->s.combed;
+    frame->top_field_first  = !!(in->s.flags & PIC_FLAG_TOP_FIELD_FIRST);
+
+    frame->format          = in->f.fmt;
+    frame->color_primaries = hb_colr_pri_hb_to_ff(in->f.color_prim);
+    frame->color_trc       = hb_colr_tra_hb_to_ff(in->f.color_transfer);
+    frame->colorspace      = hb_colr_mat_hb_to_ff(in->f.color_matrix);
+    frame->color_range     = in->f.color_range;
+    frame->chroma_location = in->f.chroma_location;
+
+    out->storage_type = AVFRAME;
+    out->storage = frame;
+    out->f = in->f;
+    hb_buffer_copy_props(out, in);
+
     QSVMid *mid = NULL;
     mfxFrameSurface1 *surface = NULL;
     HBQSVFramesContext *hb_qsv_frames_ctx = NULL;
@@ -4034,74 +4070,89 @@ int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int i
         }
         else
         {
-            hb_error("hb_qsv_attach_surface_to_video_buffer: unsupported texture_format=%d", job->input_pix_fmt);
-            return -1;
+            hb_error("hb_qsv_copy_video_buffer_to_hw_video_buffer: unsupported texture_format=%d", job->input_pix_fmt);
+            goto fail;
         }
         hb_qsv_get_free_surface_from_pool_with_range(hb_qsv_frames_ctx, 0, HB_QSV_POOL_SURFACE_SIZE, &mid, &surface);
         output_surface = mid->handle_pair->first;
         ID3D11Texture2D_GetDesc(output_surface, &desc);
-        ID3D11Texture2D* blank_surface = hb_qsv_create_dx11_texture_with_bytes(job->qsv.ctx->device_manager_handle, buf->data, buf->plane[0].stride, desc.Width, desc.Height, texture_format);
+        ID3D11Texture2D* blank_surface = hb_qsv_create_dx11_texture_with_bytes(job->qsv.ctx->device_manager_handle,
+            in->data, in->plane[0].stride, desc.Width, desc.Height, texture_format);
         if (!blank_surface)
         {
-            hb_error("hb_qsv_attach_surface_to_video_buffer: hb_qsv_create_dx11_texture_with_bytes() failed");
-            return -1;
+            hb_error("hb_qsv_copy_video_buffer_to_hw_video_buffer: hb_qsv_create_dx11_texture_with_bytes() failed");
+            goto fail;
         }
         mfxHDLPair* output_pair = (mfxHDLPair*)surface->Data.MemId;
         int output_index = (int)(intptr_t)output_pair->second == MFX_INFINITE ? 0 : (int)(intptr_t)output_pair->second;
         int ret = hb_qsv_copy_surface(job->qsv.ctx, output_surface, output_index, blank_surface, 0);
         if (ret < 0)
         {
-            hb_error("hb_qsv_attach_surface_to_video_buffer: hb_qsv_copy_surface() failed");
-            return -1;
+            hb_error("hb_qsv_copy_video_buffer_to_hw_video_buffer: hb_qsv_copy_surface() failed");
+            goto fail;
         }
         ID3D11Texture2D_Release(blank_surface);
     }
 
-    // alloc new frame
-    buf->qsv_details.frame = av_frame_alloc();
-    if (!buf->qsv_details.frame) {
-        hb_error("hb_qsv_attach_surface_to_video_buffer: av_frame_alloc() failed");
-        return -1;
-    }
+    frame->data[3] = (uint8_t *)surface;
 
-    buf->qsv_details.frame->data[3] = (uint8_t*)surface;
-    buf->qsv_details.qsv_frames_ctx = hb_qsv_frames_ctx;
-    buf->qsv_details.qsv_atom       = 0;
-    buf->qsv_details.ctx            = job->qsv.ctx;
-    return 0;
+    out->qsv_details.qsv_frames_ctx = hb_qsv_frames_ctx;
+    out->qsv_details.qsv_atom       = NULL;
+    out->qsv_details.ctx            = job->qsv.ctx;
+
+    return out;
+
+fail:
+    hb_buffer_close(&out);
+    av_frame_free(&frame);
+    return NULL;
 }
 
-int hb_qsv_copy_video_buffer_to_video_buffer(hb_job_t *job, hb_buffer_t* in, hb_buffer_t* out, int is_vpp)
+hb_buffer_t * hb_qsv_buffer_dup(hb_job_t *job, hb_buffer_t *in, const int is_vpp)
 {
-    // alloc new frame
-    out->qsv_details.frame = av_frame_alloc();
-    if (!out->qsv_details.frame)
+    if (in->storage == NULL || in->storage_type != AVFRAME)
     {
-        hb_error("hb_qsv_copy_video_buffer_to_video_buffer: av_frame_alloc() failed");
-        return -1;
+        hb_error("hb_qsv_buffer_dup: in->storage is NULL");
+        goto fail;
     }
 
-    if (!in->qsv_details.frame)
+    hb_buffer_t *out = hb_buffer_wrapper_init();
+
+    if (out == NULL)
     {
-        hb_error("hb_qsv_copy_video_buffer_to_video_buffer: in->qsv_details.frame is NULL");
-        return -1;
+        goto fail;
     }
 
-    mfxFrameSurface1* input_surface = (mfxFrameSurface1*)in->qsv_details.frame->data[3];
-    mfxHDLPair* input_pair = (mfxHDLPair*)input_surface->Data.MemId;
+    // Alloc new frame
+    AVFrame *frame_copy = av_frame_alloc();
 
-    out->qsv_details.frame->format         = in->qsv_details.frame->format;
-    out->qsv_details.frame->width          = in->qsv_details.frame->width;
-    out->qsv_details.frame->height         = in->qsv_details.frame->height;
-    out->qsv_details.frame->ch_layout      = in->qsv_details.frame->ch_layout;
-    out->qsv_details.frame->nb_samples     = in->qsv_details.frame->nb_samples;
+    if (frame_copy == NULL)
+    {
+        hb_error("hb_qsv_buffer_dup: av_frame_alloc() failed");
+        goto fail;
+    }
 
-    int ret = av_frame_copy_props(out->qsv_details.frame, in->qsv_details.frame);
+    AVFrame *frame = (AVFrame *)in->storage;
+    frame_copy->format     = frame->format;
+    frame_copy->width      = frame->width;
+    frame_copy->height     = frame->height;
+    frame_copy->ch_layout  = frame->ch_layout;
+    frame_copy->nb_samples = frame->nb_samples;
+
+    mfxFrameSurface1 *input_surface = (mfxFrameSurface1 *)frame->data[3];
+    mfxHDLPair *input_pair = (mfxHDLPair*)input_surface->Data.MemId;
+
+    int ret = av_frame_copy_props(frame_copy, frame);
     if (ret < 0)
     {
-        hb_error("hb_qsv_copy_video_buffer_to_video_buffer: av_frame_copy_props error %d", ret);
-        return -1;
+        hb_error("hb_qsv_buffer_dup: av_frame_copy_props error %d", ret);
+        goto fail;
     }
+
+    out->storage_type = AVFRAME;
+    out->storage = frame_copy;
+    out->f = in->f;
+    hb_buffer_copy_props(out, in);
 
     QSVMid *mid = NULL;
     mfxFrameSurface1 *surface = NULL;
@@ -4125,49 +4176,73 @@ int hb_qsv_copy_video_buffer_to_video_buffer(hb_job_t *job, hb_buffer_t* in, hb_
         int ret = hb_qsv_copy_surface(job->qsv.ctx, mid->handle_pair->first, output_index, input_pair->first, input_index);
         if (ret < 0)
         {
-            hb_error("hb_qsv_copy_video_buffer_to_video_buffer: hb_qsv_copy_surface() failed");
-            return -1;
+            hb_error("hb_qsv_buffer_dup: hb_qsv_copy_surface() failed");
+            goto fail;
         }
     }
     else
     {
-        hb_error("hb_qsv_copy_video_buffer_to_video_buffer: device_manager_handle_type unsupported=%d", job->qsv.ctx->device_manager_handle_type);
+        hb_error("hb_qsv_buffer_dup: device_manager_handle_type unsupported=%d", job->qsv.ctx->device_manager_handle_type);
+        goto fail;
     }
 
-    out->qsv_details.frame->data[3] = (uint8_t*)surface;
+    frame_copy->data[3] = (uint8_t *)surface;
+
     out->qsv_details.qsv_frames_ctx = hb_qsv_frames_ctx;
-    out->qsv_details.qsv_atom       = 0;
+    out->qsv_details.qsv_atom       = NULL;
     out->qsv_details.ctx            = job->qsv.ctx;
-    return 0;
+
+    return out;
+
+fail:
+    hb_buffer_close(&out);
+    av_frame_free(&frame_copy);
+    return NULL;
 }
 
-hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, const int is_vpp)
+hb_buffer_t * hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, AVRational time_base, const int is_vpp)
 {
-    hb_buffer_t *out;
-    out = hb_frame_buffer_init(frame->format, frame->width, frame->height);
-    hb_avframe_set_video_buffer_flags(out, frame, (AVRational){1,1});
+    hb_buffer_t *out = hb_buffer_wrapper_init();
 
-    // alloc new frame
-    out->qsv_details.frame = av_frame_alloc();
-    if (!out->qsv_details.frame) {
-        return out;
+    if (out == NULL)
+    {
+        return NULL;
     }
 
-    out->qsv_details.frame->format         = frame->format;
-    out->qsv_details.frame->width          = frame->width;
-    out->qsv_details.frame->height         = frame->height;
-    out->qsv_details.frame->ch_layout      = frame->ch_layout;
-    out->qsv_details.frame->nb_samples     = frame->nb_samples;
+    // Alloc new frame
+    AVFrame *frame_copy = av_frame_alloc();
+    if (frame_copy == NULL)
+    {
+        goto fail;
+    }
 
-    int ret = av_frame_copy_props(out->qsv_details.frame, frame);
+    frame_copy->format         = frame->format;
+    frame_copy->width          = frame->width;
+    frame_copy->height         = frame->height;
+    frame_copy->ch_layout      = frame->ch_layout;
+    frame_copy->nb_samples     = frame->nb_samples;
+
+    int ret = av_frame_copy_props(frame_copy, frame);
     if (ret < 0)
     {
         hb_error("hb_qsv_copy_avframe_to_video_buffer: av_frame_copy_props error %d", ret);
+        goto fail;
     }
-    
+
+    out->storage_type = AVFRAME;
+    out->storage = frame_copy;
+
+    out->s.type = FRAME_BUF;
+    out->f.width  = frame_copy->width;
+    out->f.height = frame_copy->height;
+    hb_avframe_set_video_buffer_flags(out, frame, time_base);
+
+    out->side_data = (void **)frame_copy->side_data;
+    out->nb_side_data = frame_copy->nb_side_data;
+
     QSVMid *mid = NULL;
-    mfxFrameSurface1* output_surface = NULL;
-    HBQSVFramesContext* hb_qsv_frames_ctx = NULL;
+    mfxFrameSurface1 *output_surface = NULL;
+    HBQSVFramesContext *hb_qsv_frames_ctx = NULL;
 
     if (is_vpp)
     {
@@ -4180,10 +4255,13 @@ hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, 
 
     if (!is_vpp && hb_qsv_hw_filters_are_enabled(job))
     {
-        ret = hb_qsv_get_free_surface_from_pool(hb_qsv_frames_ctx, out->qsv_details.frame, &mid);
+        ret = hb_qsv_get_free_surface_from_pool(hb_qsv_frames_ctx, frame_copy, &mid);
         if (ret < 0)
-            return out;
-        output_surface = (mfxFrameSurface1*)out->qsv_details.frame->data[3];
+        {
+            hb_error("hb_qsv_copy_avframe_to_video_buffer: hb_qsv_get_free_surface_from_pool error %d", ret);
+            goto fail;
+        }
+        output_surface = (mfxFrameSurface1 *)frame_copy->data[3];
     }
     else
     {
@@ -4192,15 +4270,18 @@ hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, 
 
     if (job->qsv.ctx->device_manager_handle_type == MFX_HANDLE_D3D11_DEVICE)
     {
-        mfxFrameSurface1* input_surface = (mfxFrameSurface1*)frame->data[3];
-        mfxHDLPair* input_pair = (mfxHDLPair*)input_surface->Data.MemId;
+        mfxFrameSurface1 *input_surface = (mfxFrameSurface1 *)frame->data[3];
+        mfxHDLPair *input_pair = (mfxHDLPair *)input_surface->Data.MemId;
+
         // Need to pass 0 instead of MFX_INFINITE to DirectX as index of surface
         int input_index = (int)(intptr_t)input_pair->second == MFX_INFINITE ? 0 : (int)(intptr_t)input_pair->second;
         int output_index = (int)(intptr_t)mid->handle_pair->second == MFX_INFINITE ? 0 : (int)(intptr_t)mid->handle_pair->second;
-        // copy all surface fields
+
+        // Copy all surface fields
         *output_surface = *input_surface;
         output_surface->Info.CropW = frame->width;
         output_surface->Info.CropH = frame->height;
+
         if (hb_qsv_hw_filters_are_enabled(job))
         {
             // Make sure that we pass handle_pair to scale_qsv
@@ -4211,24 +4292,34 @@ hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, 
             // Make sure that we pass QSVMid to QSV encoder
             output_surface->Data.MemId = mid;
         }
-        // copy input surface to surface from the pool
+
+        // Copy input surface to surface from the pool
         ret = hb_qsv_copy_surface(job->qsv.ctx, mid->handle_pair->first, output_index, input_pair->first, input_index);
+
         if (ret < 0)
         {
             hb_error("hb_qsv_copy_avframe_to_video_buffer: hb_qsv_copy_surface() failed");
-            return NULL;
+            goto fail;
         }
     }
     else
     {
         hb_error("hb_qsv_copy_avframe_to_video_buffer: incorrect mfx impl");
-        return out;
+        goto fail;
     }
-    out->qsv_details.frame->data[3] = (uint8_t*)output_surface;
+
+    frame_copy->data[3] = (uint8_t *)output_surface;
+
     out->qsv_details.qsv_frames_ctx = hb_qsv_frames_ctx;
-    out->qsv_details.qsv_atom       = 0;
+    out->qsv_details.qsv_atom       = NULL;
     out->qsv_details.ctx            = job->qsv.ctx;
+
     return out;
+
+fail:
+    hb_buffer_close(&out);
+    av_frame_free(&frame_copy);
+    return NULL;
 }
 
 static int qsv_get_buffer(AVCodecContext *s, AVFrame *frame, int flags)
@@ -4601,17 +4692,17 @@ int hb_qsv_hw_frames_init(AVCodecContext *s)
     return -1;
 }
 
-int hb_qsv_attach_surface_to_video_buffer(hb_job_t *job, hb_buffer_t* buf, int is_vpp)
+hb_buffer_t * hb_qsv_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_buffer_t *in, const int is_vpp)
 {
-    return -1;
+    return NULL;
 }
 
-int hb_qsv_copy_video_buffer_to_video_buffer(hb_job_t *job, hb_buffer_t* in, hb_buffer_t* out, int is_vpp)
+hb_buffer_t * hb_qsv_buffer_dup(hb_job_t *job, hb_buffer_t *in, const int is_vpp)
 {
-    return -1;
+    return NULL;
 }
 
-hb_buffer_t* hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, const int is_vpp)
+hb_buffer_t * hb_qsv_copy_avframe_to_video_buffer(hb_job_t *job, AVFrame *frame, AVRational time_base, const int is_vpp)
 {
     return NULL;
 }

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3776,7 +3776,7 @@ int hb_qsv_release_surface_from_pool_by_surface_pointer(HBQSVFramesContext* hb_e
     for(int i = 0; i < hb_enc_qsv_frames_ctx->nb_mids; i++)
     {
         mfxFrameSurface1 *pool_surface = &frames_hwctx->surfaces[i];
-        if(surface == pool_surface)
+        if(surface == pool_surface && hb_enc_qsv_frames_ctx->pool[i] > 0)
         {
             ff_qsv_atomic_dec(&hb_enc_qsv_frames_ctx->pool[i]);
             return 0;

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -392,7 +392,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
 #if HB_PROJECT_FEATURE_QSV
             if (hb_qsv_full_path_is_enabled(stream->common->job) && !hb_qsv_hw_filters_are_enabled(stream->common->job))
             {
-                hb_qsv_attach_surface_to_video_buffer(stream->common->job, buf, 0);
+                buf = hb_qsv_copy_video_buffer_to_hw_video_buffer(stream->common->job, buf, 0);
             }
 #endif
             if (hb_hwaccel_is_full_hardware_pipeline_enabled(stream->common->job))
@@ -405,9 +405,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
 #if HB_PROJECT_FEATURE_QSV
             if (hb_qsv_full_path_is_enabled(stream->common->job) && !hb_qsv_hw_filters_are_enabled(stream->common->job))
             {
-                hb_buffer_t *temp = hb_buffer_dup(buf);
-                hb_qsv_copy_video_buffer_to_video_buffer(stream->common->job, buf, temp, 0);
-                buf = temp;
+                buf = hb_qsv_buffer_dup(stream->common->job, buf, 0);
             }
             else
 #endif

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -397,8 +397,7 @@ static hb_buffer_t * CreateBlackBuf( sync_stream_t * stream,
 #endif
             if (hb_hwaccel_is_full_hardware_pipeline_enabled(stream->common->job))
             {
-                hb_buffer_t *temp = buf;
-                buf = hb_hwaccel_copy_video_buffer_to_hw_video_buffer(stream->common->job, temp);
+                buf = hb_hwaccel_copy_video_buffer_to_hw_video_buffer(stream->common->job, &buf);
             }
         }
         else


### PR DESCRIPTION
Reduce the number of memcpy. At the moment a copy of each frame is always made in decavcodec.c, another each time a frame has to be transferred from an avfilter to a built-in filter or to the encoder, another when going passing a hb_buffer to avfilters, and another again when zscale is used and and the stride is not aligned to 64 bytes.

This PR enables the wrapping of avframes inside hb_buffers for frames on the cpu memory, it was previously enabled only for hw frames used by nvdec and videotoolbox.

Avframes buffer have a different height stride (I guess 0?), I have a vague memory that a filter or two required a 16 height stride, but I looked around and run it thru address sanitiser and found nothing.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
