### PR TITLE
libhb: use the hwaccel decoders in scan, and enable VideoToolbox in the UI.

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3554,7 +3554,7 @@ void ghb_backend_scan_stop (void)
 void
 ghb_backend_scan(const gchar *path, gint titleindex, gint preview_count, uint64_t min_duration)
 {
-    hb_scan( h_scan, path, titleindex, preview_count, 1, min_duration, 0, 0, NULL );
+    hb_scan( h_scan, path, titleindex, preview_count, 1, min_duration, 0, 0, NULL, 0 );
     hb_status.scan.state |= GHB_STATE_SCANNING;
     // initialize count and cur to something that won't cause FPE
     // when computing progress
@@ -3569,7 +3569,7 @@ void
 ghb_backend_queue_scan(const gchar *path, gint titlenum)
 {
     ghb_log_func();
-    hb_scan( h_queue, path, titlenum, -1, 0, 0, 0, 0, NULL );
+    hb_scan( h_queue, path, titlenum, -1, 0, 0, 0, 0, NULL, 0 );
     hb_status.queue.state |= GHB_STATE_SCANNING;
 }
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4655,6 +4655,10 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             break;
 
 #if defined(__APPLE__)
+        case HB_FILTER_PRE_VT:
+            filter = &hb_filter_prefilter_vt;
+            break;
+
         case HB_FILTER_CROP_SCALE_VT:
             filter = &hb_filter_crop_scale_vt;
             break;

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1426,6 +1426,12 @@ int reinit_video_filters(hb_work_private_t * pv)
         return 0;
     }
 
+    if (pv->job && pv->job->hw_pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
+    {
+        // Filtering is done in a separate filter
+        return 0;
+    }
+
     pv->video_filters.width       = pv->frame->width;
     pv->video_filters.height      = pv->frame->height;
     pv->video_filters.color_range = pv->frame->color_range;

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1693,13 +1693,26 @@ static int decodeFrame( hb_work_private_t * pv, packet_info_t * packet_info )
 
         if (pv->hw_frame)
         {
-            ret = av_hwframe_transfer_data(pv->frame, pv->hw_frame, 0);
-            av_frame_copy_props(pv->frame, pv->hw_frame);
-            av_frame_unref(pv->hw_frame);
-            if (ret < 0)
+            if (pv->hw_frame->hw_frames_ctx)
             {
-                hb_error("decavcodec: error transferring data to system memory");
-                break;
+                ret = av_hwframe_transfer_data(pv->frame, pv->hw_frame, 0);
+                av_frame_copy_props(pv->frame, pv->hw_frame);
+                av_frame_unref(pv->hw_frame);
+                if (ret < 0)
+                {
+                    hb_error("decavcodec: error transferring data to system memory");
+                    break;
+                }
+            }
+            else
+            {
+                // HWAccel falled back to the software decoder
+                av_frame_ref(pv->frame, pv->hw_frame);
+                av_frame_unref(pv->hw_frame);
+                if (ret < 0)
+                {
+                    hb_error("decavcodec: error hwaccel copying frame");
+                }
             }
         }
 
@@ -1811,13 +1824,14 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
     pv->context->err_recognition = AV_EF_CRCCHECK;
     pv->context->error_concealment = FF_EC_GUESS_MVS|FF_EC_DEBLOCK;
 
-    if (pv->job && job->hw_device_ctx)
+    if (w->hw_device_ctx)
     {
         pv->context->get_format = hw_hwaccel_get_hw_format;
         pv->context->opaque = job;
-        av_buffer_replace(&pv->context->hw_device_ctx, pv->job->hw_device_ctx);
+        av_buffer_replace(&pv->context->hw_device_ctx, w->hw_device_ctx);
 
-        if (job->hw_pix_fmt == AV_PIX_FMT_NONE && job->hw_decode & HB_DECODE_SUPPORT_FORCE_HW)
+        if (job == NULL ||
+            (job->hw_pix_fmt == AV_PIX_FMT_NONE && job->hw_decode & HB_DECODE_SUPPORT_FORCE_HW))
         {
             pv->hw_frame = av_frame_alloc();
         }
@@ -2042,9 +2056,9 @@ static int decodePacket( hb_work_object_t * w )
         pv->context->err_recognition   = AV_EF_CRCCHECK;
         pv->context->error_concealment = FF_EC_GUESS_MVS|FF_EC_DEBLOCK;
 
-        if (pv->job && pv->job->hw_device_ctx)
+        if (w->hw_device_ctx)
         {
-            int ret = av_buffer_replace(&pv->context->hw_device_ctx, pv->job->hw_device_ctx);
+            int ret = av_buffer_replace(&pv->context->hw_device_ctx, w->hw_device_ctx);
             if (ret < 0)
             {
                 return HB_WORK_ERROR;
@@ -2426,7 +2440,7 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
     info->level = pv->context->level;
     info->name = pv->context->codec->name;
 
-    info->pix_fmt        = pv->context->pix_fmt;
+    info->pix_fmt        = pv->context->sw_pix_fmt;
     info->color_prim     = pv->context->color_primaries;
     info->color_transfer = pv->context->color_trc;
     info->color_matrix   = pv->context->colorspace;
@@ -2445,17 +2459,14 @@ static int decavcodecvInfo( hb_work_object_t *w, hb_work_info_t *info )
     }
 #endif
 
-#if HB_PROJECT_FEATURE_NVDEC
-    if (hb_hwaccel_available(w->title->video_codec_param, "cuda"))
+    if (pv->context->pix_fmt == AV_PIX_FMT_CUDA)
     {
         info->video_decode_support |= HB_DECODE_SUPPORT_NVDEC;
     }
-#elif defined( __APPLE__ )
-    if (hb_hwaccel_available(w->title->video_codec_param, "videotoolbox"))
+    else if (pv->context->pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
     {
         info->video_decode_support |= HB_DECODE_SUPPORT_VIDEOTOOLBOX;
     }
-#endif
 
     return 1;
 }

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1369,6 +1369,7 @@ struct hb_work_object_s
     int                 status;
     int                 frame_count;
     int                 codec_param;
+    void              * hw_device_ctx;
     hb_title_t        * title;
 
     hb_work_object_t  * next;

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1483,6 +1483,7 @@ enum
     HB_FILTER_INVALID = 0,
     HB_FILTER_FIRST = 1,
 
+    HB_FILTER_PRE_VT,
     // First, filters that may change the framerate (drop or dup frames)
     HB_FILTER_DETELECINE,
     HB_FILTER_COMB_DETECT,

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -49,11 +49,13 @@ void          hb_dvd_set_dvdnav( int enable );
 void          hb_scan( hb_handle_t *, const char * path,
                        int title_index, int preview_count,
                        int store_previews, uint64_t min_duration,
-                       int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions);
+                       int crop_auto_switch_threshold, int crop_median_threshold,
+                       hb_list_t * exclude_extensions, int hw_decode);
                        
 void          hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
                       int preview_count, int store_previews, uint64_t min_duration,
-                      int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions);
+                      int crop_threshold_frames, int crop_threshold_pixels,
+                      hb_list_t * exclude_extensions, int hw_decode);
 
 void          hb_scan_stop( hb_handle_t * );
 void          hb_force_rescan( hb_handle_t * );

--- a/libhb/handbrake/hwaccel.h
+++ b/libhb/handbrake/hwaccel.h
@@ -14,8 +14,8 @@
 
 enum AVPixelFormat hw_hwaccel_get_hw_format(AVCodecContext *ctx, const enum AVPixelFormat *pix_fmts);
 
-int hb_hwaccel_hw_ctx_init(hb_job_t *job);
-void hb_hwaccel_hw_ctx_close(hb_job_t *job);
+int hb_hwaccel_hw_ctx_init(int codec_id, int hw_decode, void **hw_device_ctx);
+void hb_hwaccel_hw_ctx_close(void **hw_device_ctx);
 
 int hb_hwaccel_hwframes_ctx_init(struct AVCodecContext *ctx, hb_job_t *job);
 AVBufferRef *hb_hwaccel_init_hw_frames_ctx(AVBufferRef *hw_device_ctx,
@@ -29,7 +29,6 @@ hb_buffer_t * hb_hwaccel_copy_video_buffer_to_hw_video_buffer(hb_job_t *job, hb_
 const char * hb_hwaccel_get_codec_name(enum AVCodecID codec_id);
 
 int hb_hwaccel_available(int codec_id, const char *device_name);
-int hb_hwaccel_is_enabled(hb_job_t *job);
 int hb_hwaccel_decode_is_enabled(hb_job_t *job);
 int hb_hwaccel_is_full_hardware_pipeline_enabled(hb_job_t *job);
 

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -283,7 +283,8 @@ hb_thread_t * hb_scan_init( hb_handle_t *, volatile int * die,
                             hb_list_t * paths, int title_index,
                             hb_title_set_t * title_set, int preview_count,
                             int store_previews, uint64_t min_duration,
-                            int crop_auto_switch_threshold, int crop_median_threshold, hb_list_t * exclude_extensions );
+                            int crop_auto_switch_threshold, int crop_median_threshold,
+                            hb_list_t * exclude_extensions, int hw_decode);
 hb_thread_t * hb_work_init( hb_list_t * jobs,
                             volatile int * die, hb_error_code * error, hb_job_t ** job );
 void ReadLoop( void * _w );
@@ -292,7 +293,7 @@ hb_work_object_t * hb_muxer_init( hb_job_t * );
 hb_work_object_t * hb_get_work( hb_handle_t *, int );
 hb_work_object_t * hb_audio_decoder( hb_handle_t *, int );
 hb_work_object_t * hb_audio_encoder( hb_handle_t *, int );
-hb_work_object_t * hb_video_decoder( hb_handle_t *, int, int );
+hb_work_object_t * hb_video_decoder( hb_handle_t *, int, int, void *);
 hb_work_object_t * hb_video_encoder( hb_handle_t *, int );
 
 /***********************************************************************

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -495,6 +495,7 @@ extern hb_filter_object_t hb_filter_colorspace;
 extern hb_filter_object_t hb_filter_format;
 
 #if defined(__APPLE__)
+extern hb_filter_object_t hb_filter_prefilter_vt;
 extern hb_filter_object_t hb_filter_crop_scale_vt;
 extern hb_filter_object_t hb_filter_rotate_vt;
 #endif

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -361,13 +361,14 @@ void hb_remove_previews( hb_handle_t * h )
 
 void hb_scan( hb_handle_t * h, const char * path, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
-              int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
+              int crop_threshold_frames, int crop_threshold_pixels,
+              hb_list_t * exclude_extensions, int hw_decode)
 {
     // TODO: Compatibility later for the other UI's.  Remove when they are updated.
     hb_list_t *file_paths = hb_list_init();
     hb_list_add(file_paths, (char *)path);
 
-    hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
+    hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions, hw_decode);
 
     hb_list_close(&file_paths);
 }
@@ -383,10 +384,12 @@ void hb_scan( hb_handle_t * h, const char * path, int title_index,
  * @param crop_threshold_frames The number of frames to trigger smart crop
  * @param crop_threshold_pixels The variance in pixels detected that are allowed for.
  * @param exclude_extensions A list of extensions to exclude for this scan.
+ * @param hw_decode  The preferred hardware decoder to use..
  */
 void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
-              int crop_threshold_frames, int crop_threshold_pixels, hb_list_t * exclude_extensions)
+              int crop_threshold_frames, int crop_threshold_pixels,
+              hb_list_t * exclude_extensions, int hw_decode)
 {
     hb_title_t * title;
 
@@ -473,7 +476,8 @@ void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
     h->scan_thread = hb_scan_init( h, &h->scan_die, paths, title_index,
                                    &h->title_set, preview_count,
                                    store_previews, min_duration,
-                                   crop_threshold_frames, crop_threshold_pixels, exclude_extensions);
+                                   crop_threshold_frames, crop_threshold_pixels,
+                                   exclude_extensions, hw_decode);
 }
 
 void hb_force_rescan( hb_handle_t * h )

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -594,8 +594,8 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
     // Destination {Mux, InlineParameterSets, AlignAVStart,
     //              ChapterMarkers, ChapterList}
     "s:{s:o, s:o, s:o, s:o, s:[]},"
-    // Source {Path, Title, Angle}
-    "s:{s:o, s:o, s:o,},"
+    // Source {Path, Title, Angle, HWDecode}
+    "s:{s:o, s:o, s:o, s:o},"
     // PAR {Num, Den}
     "s:{s:o, s:o},"
     // Video {Encoder, HardwareDecode, QSV {Decode, AsyncDepth, AdapterIndex}}
@@ -620,6 +620,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
             "Path",             hb_value_string(job->title->path),
             "Title",            hb_value_int(job->title->index),
             "Angle",            hb_value_int(job->angle),
+            "HWDecode",         hb_value_int(job->hw_decode),
         "PAR",
             "Num",              hb_value_int(job->par.num),
             "Den",              hb_value_int(job->par.den),
@@ -1013,13 +1014,14 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
 
     dict = hb_value_json(json_job);
 
-    int title_index;
+    int title_index, hw_decode;
     const char *path = NULL;
 
-    result = json_unpack_ex(dict, &error, 0, "{s:{s:s, s:i}}",
+    result = json_unpack_ex(dict, &error, 0, "{s:{s:s, s:i, s?i}}",
                             "Source",
                                 "Path",     unpack_s(&path),
-                                "Title",    unpack_i(&title_index)
+                                "Title",    unpack_i(&title_index),
+                                "HWDecode", unpack_i(&hw_decode)
                            );
     if (result < 0)
     {
@@ -1030,7 +1032,7 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
 
     // If the job wants to use Hardware decode, it must also be
     // enabled during scan.  So enable it here.                      
-    hb_scan(h, path, title_index, -1, 0, 0, 0, 0, NULL);
+    hb_scan(h, path, title_index, -1, 0, 0, 0, 0, NULL, hw_decode);
 
     // Wait for scan to complete
     hb_state_t state;

--- a/libhb/platform/macosx/prefilter_vt.c
+++ b/libhb/platform/macosx/prefilter_vt.c
@@ -1,0 +1,324 @@
+/* prefilter_vt.c
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "handbrake/hbffmpeg.h"
+#include "vt_common.h"
+
+struct hb_filter_private_s
+{
+    hb_filter_init_t input;
+    hb_filter_init_t output;
+
+    hb_list_t *list_filter;
+    hb_fifo_t *fifo_first;
+    hb_fifo_t *fifo_last;
+
+    struct
+    {
+        int width;
+        int height;
+        int rotation;
+    } resample;
+
+    int resample_needed;
+    int done;
+};
+
+static int prefilter_vt_init(hb_filter_object_t *filter,
+                              hb_filter_init_t   *init);
+
+static int prefilter_vt_work(hb_filter_object_t *filter,
+                              hb_buffer_t **buf_in,
+                              hb_buffer_t **buf_out);
+
+static void prefilter_vt_close(hb_filter_object_t *filter);
+
+static const char prefilter_vt_template[] = "";
+
+
+hb_filter_object_t hb_filter_prefilter_vt =
+{
+    .id                = HB_FILTER_PRE_VT,
+    .enforce_order     = 1,
+    .name              = "Prefilter (VideoToolbox)",
+    .settings          = NULL,
+    .init              = prefilter_vt_init,
+    .work              = prefilter_vt_work,
+    .close             = prefilter_vt_close,
+    .settings_template = prefilter_vt_template,
+};
+
+static int prefilter_vt_init(hb_filter_object_t *filter, hb_filter_init_t *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("prefilter_vt: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t *pv = filter->private_data;
+
+    pv->input = *init;
+    pv->output = *init;
+
+    return 0;
+}
+
+static void close_filters(hb_filter_private_t *pv)
+{
+    if (pv->list_filter)
+    {
+        hb_filter_object_t *filter;
+        while ((filter = hb_list_item(pv->list_filter, 0)))
+        {
+            if (filter->thread != NULL)
+            {
+                hb_thread_close(&filter->thread);
+            }
+            filter->close(filter);
+
+            if (!filter->skip)
+            {
+                hb_fifo_close(&filter->fifo_out);
+            }
+
+            hb_list_rem(pv->list_filter, filter);
+            hb_filter_close(&filter);
+        }
+    }
+
+    hb_fifo_close(&pv->fifo_first);
+    hb_list_close(&pv->list_filter);
+}
+
+static void prefilter_vt_close(hb_filter_object_t *filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    close_filters(pv);
+    free(pv);
+    filter->private_data = NULL;
+}
+
+void set_properties(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    AVFrame *frame = (AVFrame *)in->storage;
+    if (pv->input.job->title->rotation == HB_ROTATION_90 ||
+        pv->input.job->title->rotation == HB_ROTATION_270)
+    {
+        pv->input.geometry.width   = frame->height;
+        pv->input.geometry.height  = frame->width;
+    }
+    else
+    {
+        pv->input.geometry.width   = frame->width;
+        pv->input.geometry.height  = frame->height;
+    }
+}
+
+static void process_filter(hb_filter_object_t *filter)
+{
+    hb_buffer_t *in, *out;
+
+    in = hb_fifo_get_wait(filter->fifo_in);
+    if (in == NULL)
+    {
+        return;
+    }
+
+    out = NULL;
+    filter->status = filter->work(filter, &in, &out);
+    if (in != NULL)
+    {
+        hb_buffer_close(&in);
+    }
+    if (out != NULL)
+    {
+        hb_fifo_push(filter->fifo_out, out);
+    }
+}
+
+static hb_buffer_t * filter_buf(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    // Feed preview frame to filter chain
+    hb_fifo_push(pv->fifo_first, in);
+
+    // Process the preview frame through all filters
+    for (int ii = 0; ii < hb_list_count(pv->list_filter); ii++)
+    {
+        hb_filter_object_t *filter = hb_list_item(pv->list_filter, ii);
+        if (!filter->skip)
+        {
+            process_filter(filter);
+        }
+    }
+    // Retrieve the filtered preview frame
+    return hb_fifo_get(pv->fifo_last);
+}
+
+static int update(hb_filter_private_t *pv)
+{
+    int resample_changed;
+    hb_job_t *job = pv->input.job;
+
+    pv->resample_needed =
+        (pv->output.geometry.width != pv->input.geometry.width ||
+         pv->output.geometry.height != pv->input.geometry.height ||
+         job->title->rotation != HB_ROTATION_0);
+
+    resample_changed =
+        (pv->resample_needed &&
+         (pv->resample.width != pv->input.geometry.width ||
+          pv->resample.height != pv->input.geometry.height ||
+          pv->resample.rotation != job->title->rotation));
+
+    if (resample_changed || (pv->resample_needed &&
+                             pv->list_filter == NULL))
+    {
+        close_filters(pv);
+        hb_list_t *list_filter  = hb_list_init();
+        hb_filter_init_t init = pv->input;
+
+        hb_filter_object_t *filter;
+
+        // Rotate
+        if (job->title->rotation != HB_ROTATION_0)
+        {
+            filter = hb_filter_init(HB_FILTER_ROTATE_VT);
+            filter->settings = hb_dict_init();
+
+            switch (job->title->rotation)
+            {
+                case HB_ROTATION_90:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("270"));
+                    hb_log("prefilter_vt: auto-rotating video 90 degrees");
+                    break;
+                case HB_ROTATION_180:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("180"));
+                    hb_log("prefilter_vt: auto-rotating video 180 degrees");
+                    break;
+                case HB_ROTATION_270:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("90"));
+                    hb_log("prefilter_vt: auto-rotating video 270 degrees");
+                    break;
+                default:
+                    hb_log("prefilter_vt: reinit_video_filters: unknown rotation, failed");
+            }
+
+            hb_list_add(list_filter, filter);
+            if (filter->init != NULL && filter->init(filter, &init))
+            {
+                hb_error("prefilter_vt: failure to initialize filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+            }
+        }
+
+        // Crop Scale
+        if (pv->output.geometry.width != pv->input.geometry.width ||
+            pv->output.geometry.height != pv->input.geometry.height)
+        {
+            filter = hb_filter_init(HB_FILTER_CROP_SCALE_VT);
+            filter->settings = hb_dict_init();
+
+            hb_dict_set_int(filter->settings, "width", pv->output.geometry.width);
+            hb_dict_set_int(filter->settings, "height", pv->output.geometry.height);
+
+            hb_log("prefilter_vt: auto-scaling video from %d x %d",
+                   pv->input.geometry.width,
+                   pv->input.geometry.height);
+
+            hb_list_add(list_filter, filter);
+            if (filter->init != NULL && filter->init(filter, &init))
+            {
+                hb_error("prefilter_vt: failure to initialize filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+            }
+        }
+
+        for (int ii = 0; ii < hb_list_count(list_filter);)
+        {
+            filter = hb_list_item(list_filter, ii);
+            filter->done = &pv->done;
+            if (filter->post_init != NULL && filter->post_init(filter, job))
+            {
+                hb_log("prefilter_vt: failure to initialise filter '%s'", filter->name );
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+                continue;
+            }
+            ii++;
+        }
+
+        // Set up filter fifos
+        hb_fifo_t *fifo_in, *fifo_first, *fifo_last;
+
+        fifo_last = fifo_in = fifo_first = hb_fifo_init(1, 1);
+        for (int ii = 0; ii < hb_list_count(list_filter); ii++)
+        {
+            filter = hb_list_item(list_filter, ii);
+            if (!filter->skip)
+            {
+                filter->fifo_in = fifo_in;
+                filter->fifo_out = hb_fifo_init(1, 1);
+                fifo_last = fifo_in = filter->fifo_out;
+            }
+        }
+        pv->fifo_first = fifo_first;
+        pv->fifo_last  = fifo_last;
+        pv->list_filter = list_filter;
+
+        pv->resample.width        = pv->input.geometry.width;
+        pv->resample.height       = pv->input.geometry.height;
+        pv->resample.rotation     = pv->output.job->title->rotation;
+    }
+
+    return 0;
+}
+
+static int prefilter_vt_work(hb_filter_object_t *filter,
+                             hb_buffer_t **buf_in,
+                             hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        if (pv->resample_needed)
+        {
+            filter_buf(pv, in);
+        }
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    set_properties(pv, in);
+    update(pv);
+
+    if (pv->resample_needed)
+    {
+        *buf_out = filter_buf(pv, in);
+    }
+    else
+    {
+        *buf_out = in;
+    }
+    *buf_in = NULL;
+
+    return HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -366,6 +366,7 @@ int hb_vt_are_filters_supported(hb_list_t *filters)
         {
             case HB_FILTER_CROP_SCALE:
             case HB_FILTER_CROP_SCALE_VT:
+            case HB_FILTER_PRE_VT:
                 break;
             case HB_FILTER_ROTATE:
             case HB_FILTER_ROTATE_VT:
@@ -402,8 +403,12 @@ void hb_vt_setup_hw_filters(hb_job_t *job)
     if (job->hw_pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
     {
         hb_list_t *list = job->list_filter;
+        hb_filter_object_t *filter;
 
-        hb_filter_object_t *filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
+        filter = hb_filter_init(HB_FILTER_PRE_VT);
+        hb_add_filter(job, filter, NULL);
+
+        filter = hb_filter_find(list, HB_FILTER_CROP_SCALE);
         if (filter != NULL)
         {
             hb_dict_t *settings = filter->settings;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -222,7 +222,7 @@ hb_work_object_t* hb_audio_decoder(hb_handle_t *h, int codec)
     return w;
 }
 
-hb_work_object_t* hb_video_decoder(hb_handle_t *h, int vcodec, int param)
+hb_work_object_t* hb_video_decoder(hb_handle_t *h, int vcodec, int param, void *hw_device_ctx)
 {
     hb_work_object_t * w;
 
@@ -233,6 +233,7 @@ hb_work_object_t* hb_video_decoder(hb_handle_t *h, int vcodec, int param)
         return NULL;
     }
     w->codec_param = param;
+    w->hw_device_ctx = hw_device_ctx;
 
     return w;
 }
@@ -1627,6 +1628,13 @@ static void do_job(hb_job_t *job)
         hb_log( "Starting Task: Encoding Pass" );
     }
 
+    // Allow the usage of the hardware decoder
+    // only if it was marked as supported in the scan
+    if ((title->video_decode_support & job->hw_decode) == 0)
+    {
+        job->hw_decode = 0;
+    }
+
     // This must be performed before initializing filters because
     // it can add the subtitle render filter.
     result = sanitize_subtitles(job);
@@ -1651,7 +1659,9 @@ static void do_job(hb_job_t *job)
         // Init hwaccel context if needed
         if (hb_hwaccel_decode_is_enabled(job))
         {
-            hb_hwaccel_hw_ctx_init(job);
+            hb_hwaccel_hw_ctx_init(job->title->video_codec_param,
+                                   job->hw_decode,
+                                   &job->hw_device_ctx);
         }
 
         sanitize_dynamic_hdr_metadata_passthru(job);
@@ -1850,7 +1860,7 @@ static void do_job(hb_job_t *job)
     }
 
     // Video decoder
-    w = hb_video_decoder(job->h, title->video_codec, title->video_codec_param);
+    w = hb_video_decoder(job->h, title->video_codec, title->video_codec_param, job->hw_device_ctx);
     if (w == NULL)
     {
         *job->done_error = HB_ERROR_WRONG_INPUT;
@@ -2096,7 +2106,7 @@ cleanup:
     }
 
     hb_buffer_pool_free();
-    hb_hwaccel_hw_ctx_close(job);
+    hb_hwaccel_hw_ctx_close(&job->hw_device_ctx);
 
 #if HB_PROJECT_FEATURE_QSV
     if (!job->indepth_scan &&

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1630,10 +1630,13 @@ static void do_job(hb_job_t *job)
 
     // Allow the usage of the hardware decoder
     // only if it was marked as supported in the scan
+    // TODO: remove the ifdef after WinUI is updated
+#ifdef __APPLE__
     if ((title->video_decode_support & job->hw_decode) == 0)
     {
         job->hw_decode = 0;
     }
+#endif
 
     // This must be performed before initializing filters because
     // it can add the subtitle render filter.

--- a/macosx/Base.lproj/Preferences.xib
+++ b/macosx/Base.lproj/Preferences.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22152" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22152"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -44,7 +44,7 @@
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="F3c-q6-MdR">
                             <rect key="frame" x="0.0" y="399" width="313" height="34"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="275">
+                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="275">
                                     <rect key="frame" x="-2" y="0.0" width="81" height="34"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="At Launch:" id="307">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -101,7 +101,7 @@
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Aee-4F-nXp">
                             <rect key="frame" x="0.0" y="286" width="274" height="76"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="248" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="242">
+                                <textField focusRingType="none" horizontalHuggingPriority="248" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="242">
                                     <rect key="frame" x="-2" y="0.0" width="81" height="76"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="When Done:" id="304">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -167,7 +167,7 @@
                                                         <binding destination="61" name="value" keyPath="values.HBSendToAppEnabled" id="Kff-6m-jt9"/>
                                                     </connections>
                                                 </button>
-                                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="448">
+                                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="448">
                                                     <rect key="frame" x="89" y="0.0" width="32" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="None" id="449">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -237,7 +237,7 @@
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4pr-s0-FuJ">
                             <rect key="frame" x="0.0" y="235" width="490" height="14"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="PPY-fd-mVq">
+                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="PPY-fd-mVq">
                                     <rect key="frame" x="-2" y="0.0" width="81" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Destination:" id="lo9-Hk-I6l">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -282,7 +282,7 @@
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cgC-1f-KdT">
                             <rect key="frame" x="0.0" y="0.0" width="490" height="198"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="276">
+                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="749" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="276">
                                     <rect key="frame" x="-2" y="0.0" width="81" height="198"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="File Name: " id="308">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -296,7 +296,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qlP-Qk-4OU">
                                             <rect key="frame" x="0.0" y="184" width="181" height="14"/>
                                             <subviews>
-                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="486">
+                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="486">
                                                     <rect key="frame" x="-2" y="0.0" width="126" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Default MP4 Extension:" id="487">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -345,7 +345,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" horizontalHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eM6-W0-cC4">
                                             <rect key="frame" x="16" y="120" width="389" height="38"/>
                                             <subviews>
-                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="150" translatesAutoresizingMaskIntoConstraints="NO" id="fF9-Q1-vYr">
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="150" translatesAutoresizingMaskIntoConstraints="NO" id="fF9-Q1-vYr">
                                                     <rect key="frame" x="-2" y="0.0" width="45" height="38"/>
                                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Format:" id="3dN-MN-DcP">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -356,7 +356,7 @@
                                                         <binding destination="61" name="enabled" keyPath="values.DefaultAutoNaming" id="RQc-sb-xRW"/>
                                                     </connections>
                                                 </textField>
-                                                <tokenField horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6aa-GX-TuM">
+                                                <tokenField focusRingType="none" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6aa-GX-TuM">
                                                     <rect key="frame" x="49" y="0.0" width="340" height="38"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="340" id="PN0-BF-dcA"/>
@@ -389,7 +389,7 @@
                                                 <real value="3.4028234663852886e+38"/>
                                             </customSpacing>
                                         </stackView>
-                                        <tokenField toolTip="Drag labels to the Format field to compose a naming format." horizontalHuggingPriority="1000" verticalHuggingPriority="249" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tk3-Ig-fFI">
+                                        <tokenField toolTip="Drag labels to the Format field to compose a naming format." focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="249" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tk3-Ig-fFI">
                                             <rect key="frame" x="63" y="100" width="304" height="14"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="300" id="GPI-Do-VPV"/>
@@ -404,7 +404,7 @@
                                                 <outlet property="delegate" destination="-2" id="P3H-mA-QsB"/>
                                             </connections>
                                         </tokenField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LKY-ui-YVw">
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="751" verticalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LKY-ui-YVw">
                                             <rect key="frame" x="63" y="80" width="274" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Drag labels to Format to compose a naming format." id="dQ6-Dh-9sD">
                                                 <font key="font" metaFont="menu" size="11"/>
@@ -535,19 +535,19 @@
                 <constraint firstAttribute="bottom" secondItem="TQb-nF-3BD" secondAttribute="bottom" constant="20" symbolic="YES" id="czc-wV-7ee"/>
                 <constraint firstItem="TQb-nF-3BD" firstAttribute="top" secondItem="233" secondAttribute="top" constant="20" symbolic="YES" id="u4A-xM-w8P"/>
             </constraints>
-            <point key="canvasLocation" x="48" y="-129.5"/>
+            <point key="canvasLocation" x="-44" y="-137"/>
         </customView>
         <customView id="236" userLabel="Advanced">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="424"/>
+            <rect key="frame" x="0.0" y="0.0" width="580" height="489"/>
             <autoresizingMask key="autoresizingMask"/>
             <subviews>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OVb-Af-BVd">
-                    <rect key="frame" x="79" y="20" width="422" height="387"/>
+                    <rect key="frame" x="45" y="20" width="490" height="452"/>
                     <subviews>
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vWO-gM-Ipq">
-                            <rect key="frame" x="0.0" y="326" width="410" height="61"/>
+                            <rect key="frame" x="0.0" y="391" width="410" height="61"/>
                             <subviews>
-                                <textField horizontalHuggingPriority="248" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="IV7-SY-HLR">
+                                <textField focusRingType="none" horizontalHuggingPriority="248" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="IV7-SY-HLR">
                                     <rect key="frame" x="-2" y="44" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Scan:" id="c0L-TU-WML">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -561,7 +561,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="250" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WJs-Wy-S1o">
                                             <rect key="frame" x="0.0" y="42" width="331" height="19"/>
                                             <subviews>
-                                                <textField toolTip="Minimum DVD and Blu-ray title duration in seconds. Shorter titles will be skipped." verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="463">
+                                                <textField toolTip="Minimum DVD and Blu-ray title duration in seconds. Shorter titles will be skipped." focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="463">
                                                     <rect key="frame" x="-2" y="2" width="228" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Ignore DVD and Blu-ray titles shorter than:" id="464">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -569,7 +569,7 @@
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                     </textFieldCell>
                                                 </textField>
-                                                <textField toolTip="Minimum title duration in seconds. Shorter titles will be skipped." verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="480">
+                                                <textField toolTip="Minimum title duration in seconds. Shorter titles will be skipped." focusRingType="none" verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="480">
                                                     <rect key="frame" x="230" y="0.0" width="50" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="DCn-qW-TPY"/>
@@ -584,7 +584,7 @@
                                                         <binding destination="61" name="value" keyPath="values.MinTitleScanSeconds" id="483"/>
                                                     </connections>
                                                 </textField>
-                                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="UXr-op-aKN">
+                                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="UXr-op-aKN">
                                                     <rect key="frame" x="284" y="2" width="49" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="seconds" id="klQ-DW-Kc6">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -607,7 +607,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="O8F-xH-gTY">
                                             <rect key="frame" x="0.0" y="20" width="238" height="16"/>
                                             <subviews>
-                                                <textField toolTip="Number of picture previews to scan. Higher values may increase automatic cropping accuracy at the expense of title scan time." verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="359">
+                                                <textField toolTip="Number of picture previews to scan. Higher values may increase automatic cropping accuracy at the expense of title scan time." focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="359">
                                                     <rect key="frame" x="-2" y="1" width="195" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Number of picture previews to scan:" id="360">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -699,72 +699,55 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
-                        <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ETV-cg-RgU">
-                            <rect key="frame" x="0.0" y="307" width="422" height="5"/>
+                        <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="hr4-Pm-Vz2">
+                            <rect key="frame" x="0.0" y="372" width="490" height="5"/>
                         </box>
-                        <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tQh-6O-iM2">
-                            <rect key="frame" x="0.0" y="277" width="422" height="16"/>
+                        <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eyN-bD-QR9">
+                            <rect key="frame" x="0.0" y="324" width="366" height="34"/>
                             <subviews>
-                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="jPa-4p-Y29">
-                                    <rect key="frame" x="-2" y="1" width="75" height="14"/>
-                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Encoder:" id="cqp-xU-GOe">
+                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="251" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="v13-p6-eJ2">
+                                    <rect key="frame" x="-2" y="20" width="75" height="14"/>
+                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Decoder:" id="j6w-xf-tC0">
                                         <font key="font" metaFont="menu" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jxx-8p-Riz">
-                                    <rect key="frame" x="79" y="0.0" width="343" height="16"/>
+                                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="etI-4Z-e5w">
+                                    <rect key="frame" x="79" y="0.0" width="287" height="34"/>
                                     <subviews>
-                                        <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="249" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hdb-ng-C9T">
-                                            <rect key="frame" x="0.0" y="0.0" width="260" height="16"/>
-                                            <subviews>
-                                                <textField toolTip="Determines the granularity of the x264 Constant Quality control. Smaller values allow for finer quality increments." verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="395">
-                                                    <rect key="frame" x="-2" y="1" width="208" height="14"/>
-                                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Constant Quality fractional granularity:" id="396">
-                                                        <font key="font" metaFont="menu" size="11"/>
-                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                    </textFieldCell>
-                                                </textField>
-                                                <popUpButton toolTip="Determines the granularity of the x264 Constant Quality control. Smaller values allow for finer quality increments." horizontalHuggingPriority="750" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="387">
-                                                    <rect key="frame" x="208" y="-4" width="56" height="22"/>
-                                                    <popUpButtonCell key="cell" type="push" title="0.25" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="4" imageScaling="proportionallyDown" inset="2" selectedItem="391" id="388">
-                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                        <font key="font" metaFont="menu" size="11"/>
-                                                        <menu key="menu" title="OtherViews" id="389">
-                                                            <items>
-                                                                <menuItem title="1.0" tag="1" id="394"/>
-                                                                <menuItem title="0.50" tag="2" id="393"/>
-                                                                <menuItem title="0.25" state="on" tag="4" id="391">
-                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                </menuItem>
-                                                                <menuItem title="0.20" tag="5" id="390">
-                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                </menuItem>
-                                                            </items>
-                                                        </menu>
-                                                    </popUpButtonCell>
-                                                    <connections>
-                                                        <accessibilityConnection property="title" destination="395" id="NVF-jL-QpH"/>
-                                                        <binding destination="61" name="selectedTag" keyPath="values.HBx264CqSliderFractional" id="XKV-6r-lP5"/>
-                                                    </connections>
-                                                </popUpButton>
-                                            </subviews>
-                                            <visibilityPriorities>
-                                                <integer value="1000"/>
-                                                <integer value="1000"/>
-                                            </visibilityPriorities>
-                                            <customSpacing>
-                                                <real value="3.4028234663852886e+38"/>
-                                                <real value="3.4028234663852886e+38"/>
-                                            </customSpacing>
-                                        </stackView>
+                                        <button verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="Doh-Ja-Gh7">
+                                            <rect key="frame" x="-1" y="19" width="254" height="16"/>
+                                            <string key="toolTip">Hardware decoder will reduce CPU usage and lower battery usage when combined with an hardware encoder. Depending on the CPU speed, they could either improve or decrese encoding speed.</string>
+                                            <buttonCell key="cell" type="check" title="Enable the VideoToolbox hardware decoders" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="BHK-QU-DwS">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="menu" size="11"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="61" name="value" keyPath="values.HBUseHardwareDecoder" id="dxI-cp-QOL"/>
+                                            </connections>
+                                        </button>
+                                        <button verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="6Tx-U9-QG9">
+                                            <rect key="frame" x="15" y="-1" width="272" height="16"/>
+                                            <buttonCell key="cell" type="check" title="Also use in combination with software encoders" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="d9B-Vd-jMM">
+                                                <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                                <font key="font" metaFont="menu" size="11"/>
+                                            </buttonCell>
+                                            <connections>
+                                                <binding destination="61" name="value" keyPath="values.HBAlwaysUseHardwareDecoder" id="tie-OI-x9E"/>
+                                                <binding destination="61" name="enabled" keyPath="values.HBUseHardwareDecoder" id="PZ6-3c-zRc"/>
+                                            </connections>
+                                        </button>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="6Tx-U9-QG9" firstAttribute="leading" secondItem="Doh-Ja-Gh7" secondAttribute="leading" constant="16" id="o50-wu-cG2"/>
+                                    </constraints>
                                     <visibilityPriorities>
+                                        <integer value="1000"/>
                                         <integer value="1000"/>
                                     </visibilityPriorities>
                                     <customSpacing>
+                                        <real value="3.4028234663852886e+38"/>
                                         <real value="3.4028234663852886e+38"/>
                                     </customSpacing>
                                 </stackView>
@@ -778,13 +761,84 @@
                                 <real value="3.4028234663852886e+38"/>
                             </customSpacing>
                         </stackView>
+                        <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ETV-cg-RgU">
+                            <rect key="frame" x="0.0" y="305" width="490" height="5"/>
+                        </box>
+                        <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tQh-6O-iM2">
+                            <rect key="frame" x="0.0" y="277" width="339" height="14"/>
+                            <subviews>
+                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="jPa-4p-Y29">
+                                    <rect key="frame" x="-2" y="0.0" width="75" height="14"/>
+                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Encoder:" id="cqp-xU-GOe">
+                                        <font key="font" metaFont="menu" size="11"/>
+                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    </textFieldCell>
+                                </textField>
+                                <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jxx-8p-Riz">
+                                    <rect key="frame" x="79" y="0.0" width="260" height="14"/>
+                                    <subviews>
+                                        <textField toolTip="Determines the granularity of the x264 Constant Quality control. Smaller values allow for finer quality increments." focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="395">
+                                            <rect key="frame" x="-2" y="0.0" width="208" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Constant Quality fractional granularity:" id="396">
+                                                <font key="font" metaFont="menu" size="11"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <popUpButton toolTip="Determines the granularity of the x264 Constant Quality control. Smaller values allow for finer quality increments." horizontalHuggingPriority="750" verticalHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="387">
+                                            <rect key="frame" x="208" y="-4" width="56" height="20"/>
+                                            <popUpButtonCell key="cell" type="push" title="0.25" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="4" imageScaling="proportionallyDown" inset="2" selectedItem="391" id="388">
+                                                <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                <font key="font" metaFont="menu" size="11"/>
+                                                <menu key="menu" title="OtherViews" id="389">
+                                                    <items>
+                                                        <menuItem title="1.0" tag="1" id="394"/>
+                                                        <menuItem title="0.50" tag="2" id="393"/>
+                                                        <menuItem title="0.25" state="on" tag="4" id="391">
+                                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                                        </menuItem>
+                                                        <menuItem title="0.20" tag="5" id="390">
+                                                            <modifierMask key="keyEquivalentModifierMask"/>
+                                                        </menuItem>
+                                                    </items>
+                                                </menu>
+                                            </popUpButtonCell>
+                                            <connections>
+                                                <accessibilityConnection property="title" destination="395" id="NVF-jL-QpH"/>
+                                                <binding destination="61" name="selectedTag" keyPath="values.HBx264CqSliderFractional" id="XKV-6r-lP5"/>
+                                            </connections>
+                                        </popUpButton>
+                                    </subviews>
+                                    <visibilityPriorities>
+                                        <integer value="1000"/>
+                                        <integer value="1000"/>
+                                    </visibilityPriorities>
+                                    <customSpacing>
+                                        <real value="3.4028234663852886e+38"/>
+                                        <real value="3.4028234663852886e+38"/>
+                                    </customSpacing>
+                                </stackView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="395" firstAttribute="firstBaseline" secondItem="jPa-4p-Y29" secondAttribute="firstBaseline" id="vdw-mi-3oC"/>
+                            </constraints>
+                            <visibilityPriorities>
+                                <integer value="1000"/>
+                                <integer value="1000"/>
+                            </visibilityPriorities>
+                            <customSpacing>
+                                <real value="3.4028234663852886e+38"/>
+                                <real value="3.4028234663852886e+38"/>
+                            </customSpacing>
+                        </stackView>
                         <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="VIv-34-shj">
-                            <rect key="frame" x="0.0" y="258" width="422" height="5"/>
+                            <rect key="frame" x="0.0" y="258" width="490" height="5"/>
                         </box>
                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="FOD-gy-lzc">
                             <rect key="frame" x="0.0" y="230" width="331" height="14"/>
                             <subviews>
-                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="ufI-Bw-KRl">
+                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="ufI-Bw-KRl">
                                     <rect key="frame" x="-2" y="0.0" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Preset:" id="wiP-Ia-DfB">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -813,12 +867,12 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="0OI-K4-nd9">
-                            <rect key="frame" x="0.0" y="211" width="422" height="5"/>
+                            <rect key="frame" x="0.0" y="211" width="490" height="5"/>
                         </box>
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SV2-pU-Zy5">
                             <rect key="frame" x="0.0" y="136" width="399" height="61"/>
                             <subviews>
-                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="251" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="sRQ-Oe-1xH">
+                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="251" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="sRQ-Oe-1xH">
                                     <rect key="frame" x="-2" y="44" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Queue:" id="FKi-zh-5gc">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -842,7 +896,7 @@
                                                         <binding destination="61" name="value" keyPath="values.HBQueuePauseIfLowSpace" id="GWr-Dv-XBh"/>
                                                     </connections>
                                                 </button>
-                                                <textField toolTip="Minimum free space on destination disk." horizontalHuggingPriority="1000" verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PaR-zw-opS">
+                                                <textField toolTip="Minimum free space on destination disk." focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PaR-zw-opS">
                                                     <rect key="frame" x="236" y="0.0" width="50" height="19"/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="QfS-RV-sxI"/>
@@ -857,7 +911,7 @@
                                                         <binding destination="61" name="value" keyPath="values.HBQueueMinFreeSpace" id="xrN-DJ-ihe"/>
                                                     </connections>
                                                 </textField>
-                                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="Koh-5H-cdo">
+                                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="Koh-5H-cdo">
                                                     <rect key="frame" x="290" y="2" width="20" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="GB" id="FZE-ZR-g93">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -890,7 +944,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ExZ-Gs-Uis">
                                             <rect key="frame" x="0.0" y="0.0" width="220" height="16"/>
                                             <subviews>
-                                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="qkp-nA-8ES">
+                                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="qkp-nA-8ES">
                                                     <rect key="frame" x="-2" y="1" width="184" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="left" title="Number of simultaneous encodes:" id="iGS-b5-ip7">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -952,12 +1006,12 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="I0X-1x-9qe">
-                            <rect key="frame" x="0.0" y="117" width="422" height="5"/>
+                            <rect key="frame" x="0.0" y="117" width="490" height="5"/>
                         </box>
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ywq-ob-I2a">
                             <rect key="frame" x="0.0" y="47" width="418" height="56"/>
                             <subviews>
-                                <textField verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="350">
+                                <textField focusRingType="none" verticalHuggingPriority="1000" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="400" translatesAutoresizingMaskIntoConstraints="NO" id="350">
                                     <rect key="frame" x="-2" y="41" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Activity Logs:" id="351">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -971,7 +1025,7 @@
                                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" spacing="6" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Id7-c4-iCn">
                                             <rect key="frame" x="0.0" y="40" width="168" height="16"/>
                                             <subviews>
-                                                <textField toolTip="Verbosity Level. Extended verbosity records more technical information to the Activity Log. Minimal verbosity records less." verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="371">
+                                                <textField toolTip="Verbosity Level. Extended verbosity records more technical information to the Activity Log. Minimal verbosity records less." focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="371">
                                                     <rect key="frame" x="-2" y="1" width="88" height="14"/>
                                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Verbosity Level:" id="372">
                                                         <font key="font" metaFont="menu" size="11"/>
@@ -1050,12 +1104,12 @@
                             </customSpacing>
                         </stackView>
                         <box verticalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="756-9v-KSX">
-                            <rect key="frame" x="0.0" y="28" width="422" height="5"/>
+                            <rect key="frame" x="0.0" y="28" width="490" height="5"/>
                         </box>
                         <stackView distribution="fill" orientation="horizontal" alignment="firstBaseline" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" verticalHuggingPriority="1000" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7c9-5I-bdX">
                             <rect key="frame" x="0.0" y="0.0" width="213" height="14"/>
                             <subviews>
-                                <textField verticalHuggingPriority="1000" horizontalCompressionResistancePriority="251" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="6NP-6w-Wa6">
+                                <textField focusRingType="none" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="251" allowsCharacterPickerTouchBarItem="YES" preferredMaxLayoutWidth="300" translatesAutoresizingMaskIntoConstraints="NO" id="6NP-6w-Wa6">
                                     <rect key="frame" x="-2" y="0.0" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" alignment="right" title="Summary:" id="GQJ-go-PoN">
                                         <font key="font" metaFont="menu" size="11"/>
@@ -1085,22 +1139,28 @@
                         </stackView>
                     </subviews>
                     <constraints>
+                        <constraint firstItem="756-9v-KSX" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="2d7-LB-G90"/>
                         <constraint firstItem="IV7-SY-HLR" firstAttribute="width" secondItem="350" secondAttribute="width" id="4Bz-gv-uid"/>
-                        <constraint firstItem="I0X-1x-9qe" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="4Uo-Zn-IQY"/>
-                        <constraint firstAttribute="trailing" secondItem="I0X-1x-9qe" secondAttribute="trailing" id="98y-iP-aJm"/>
+                        <constraint firstItem="I0X-1x-9qe" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="73U-eZ-vXY"/>
+                        <constraint firstItem="hr4-Pm-Vz2" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="FoE-0M-4Ul"/>
                         <constraint firstItem="ufI-Bw-KRl" firstAttribute="width" secondItem="jPa-4p-Y29" secondAttribute="width" id="Isc-qn-kaM"/>
-                        <constraint firstItem="tQh-6O-iM2" firstAttribute="trailing" secondItem="I0X-1x-9qe" secondAttribute="trailing" id="NsF-aU-gLY"/>
-                        <constraint firstAttribute="trailing" secondItem="ETV-cg-RgU" secondAttribute="trailing" id="SDr-k0-JBP"/>
-                        <constraint firstAttribute="trailing" secondItem="VIv-34-shj" secondAttribute="trailing" id="cyy-bN-Avo"/>
-                        <constraint firstItem="ETV-cg-RgU" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="kCm-uu-XAz"/>
+                        <constraint firstAttribute="trailing" secondItem="0OI-K4-nd9" secondAttribute="trailing" id="PaO-Ro-qUs"/>
+                        <constraint firstItem="ETV-cg-RgU" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="Uyv-N4-egN"/>
+                        <constraint firstItem="IV7-SY-HLR" firstAttribute="width" secondItem="v13-p6-eJ2" secondAttribute="width" id="eIJ-b1-6Km"/>
+                        <constraint firstAttribute="trailing" secondItem="VIv-34-shj" secondAttribute="trailing" id="h5R-hV-tff"/>
+                        <constraint firstItem="VIv-34-shj" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="huZ-Yb-kNo"/>
+                        <constraint firstItem="0OI-K4-nd9" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="jOd-a4-tKC"/>
+                        <constraint firstAttribute="trailing" secondItem="hr4-Pm-Vz2" secondAttribute="trailing" id="kyL-nH-L6M"/>
+                        <constraint firstAttribute="trailing" secondItem="I0X-1x-9qe" secondAttribute="trailing" id="mEn-n3-Qrp"/>
                         <constraint firstItem="350" firstAttribute="width" secondItem="sRQ-Oe-1xH" secondAttribute="width" id="mhs-ln-Axe"/>
-                        <constraint firstAttribute="trailing" secondItem="756-9v-KSX" secondAttribute="trailing" id="mnl-VH-8Jc"/>
-                        <constraint firstItem="756-9v-KSX" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="nE5-gC-Etm"/>
-                        <constraint firstItem="VIv-34-shj" firstAttribute="leading" secondItem="OVb-Af-BVd" secondAttribute="leading" id="oCQ-Ko-ZX7"/>
                         <constraint firstItem="jPa-4p-Y29" firstAttribute="width" secondItem="IV7-SY-HLR" secondAttribute="width" id="wfJ-1q-hrR"/>
+                        <constraint firstAttribute="trailing" secondItem="ETV-cg-RgU" secondAttribute="trailing" id="ysh-2j-xxI"/>
                         <constraint firstItem="sRQ-Oe-1xH" firstAttribute="width" secondItem="6NP-6w-Wa6" secondAttribute="width" id="zDM-j8-4YX"/>
+                        <constraint firstAttribute="trailing" secondItem="756-9v-KSX" secondAttribute="trailing" id="zNT-GR-J6L"/>
                     </constraints>
                     <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
@@ -1125,6 +1185,8 @@
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
             </subviews>
@@ -1135,7 +1197,7 @@
                 <constraint firstAttribute="bottom" secondItem="OVb-Af-BVd" secondAttribute="bottom" constant="20" symbolic="YES" id="rfw-rz-rC5"/>
                 <constraint firstItem="OVb-Af-BVd" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="236" secondAttribute="leading" id="ws0-YM-nwc"/>
             </constraints>
-            <point key="canvasLocation" x="64" y="-632"/>
+            <point key="canvasLocation" x="-44" y="-671.5"/>
         </customView>
         <customObject id="410" userLabel="Updater" customClass="SPUStandardUpdaterController"/>
     </objects>

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -722,7 +722,9 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 
         [self.core scanURLs:fileURLs
                  titleIndex:index
-                   previews:hb_num_previews minDuration:min_title_duration_seconds keepPreviews:YES
+                   previews:hb_num_previews minDuration:min_title_duration_seconds
+               keepPreviews:YES
+            hardwareDecoder:[NSUserDefaults.standardUserDefaults boolForKey:HBUseHardwareDecoder]
             progressHandler:^(HBState state, HBProgress progress, NSString *info)
          {
              self.sourceLabel.stringValue = info;

--- a/macosx/HBCore.h
+++ b/macosx/HBCore.h
@@ -169,7 +169,7 @@ typedef void (^HBCoreCompletionHandler)(HBCoreResult result);
  *  @param progressHandler     a block called periodically with the progress information.
  *  @param completionHandler   a block called with the scan result.
  */
-- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler;
+- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler;
 
 /**
  *  Cancels the scan execution.

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -309,7 +309,7 @@ HB_OBJC_DIRECT_MEMBERS
     hb_scan_list(_hb_handle, files_list,
               (int)index, (int)previewsNum,
               keepPreviews, min_title_duration_ticks,
-              0, 0, NULL);
+              0, 0, NULL, 0);
 
     hb_list_close(&files_list);
 

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -261,7 +261,7 @@ HB_OBJC_DIRECT_MEMBERS
     return YES;
 }
 
-- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler
+- (void)scanURLs:(NSArray<NSURL *> *)urls titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder progressHandler:(HBCoreProgressHandler)progressHandler completionHandler:(HBCoreCompletionHandler)completionHandler
 {
     NSAssert(self.state == HBStateIdle, @"[HBCore scanURL:] called while another scan or encode already in progress");
     NSAssert(urls, @"[HBCore scanURL:] called with nil url.");
@@ -309,7 +309,7 @@ HB_OBJC_DIRECT_MEMBERS
     hb_scan_list(_hb_handle, files_list,
               (int)index, (int)previewsNum,
               keepPreviews, min_title_duration_ticks,
-              0, 0, NULL, 0);
+              0, 0, NULL, hardwareDecoder ? HB_DECODE_SUPPORT_VIDEOTOOLBOX : 0);
 
     hb_list_close(&files_list);
 

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -50,6 +50,15 @@
 
     hb_job_set_file(job, self.destinationURL.fileSystemRepresentation);
 
+    if (self.hwDecodeUsage == HBJobHardwareDecoderUsageFullPathOnly)
+    {
+        job->hw_decode = HB_DECODE_SUPPORT_VIDEOTOOLBOX;
+    }
+    else if (self.hwDecodeUsage == HBJobHardwareDecoderUsageAlways)
+    {
+        job->hw_decode = HB_DECODE_SUPPORT_VIDEOTOOLBOX | HB_DECODE_SUPPORT_FORCE_HW;
+    }
+
     // Title Angle for dvdnav
     job->angle = self.angle;
 

--- a/macosx/HBJob.h
+++ b/macosx/HBJob.h
@@ -24,6 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString *HBContainerChangedNotification;
 extern NSString *HBChaptersChangedNotification;
 
+typedef NS_ENUM(NSUInteger, HBJobHardwareDecoderUsage) {
+    HBJobHardwareDecoderUsageNone,
+    HBJobHardwareDecoderUsageAlways,
+    HBJobHardwareDecoderUsageFullPathOnly
+};
+
 /**
  * HBJob
  */
@@ -72,6 +78,7 @@ extern NSString *HBChaptersChangedNotification;
 @property (nonatomic, readonly) NSArray<HBChapter *> *chapterTitles;
 
 @property (nonatomic, readwrite) BOOL metadataPassthru;
+@property (nonatomic, readwrite) HBJobHardwareDecoderUsage hwDecodeUsage;
 
 @property (nonatomic, readwrite, weak, nullable) NSUndoManager *undo;
 

--- a/macosx/HBJob.m
+++ b/macosx/HBJob.m
@@ -413,6 +413,7 @@ NSString *HBChaptersChangedNotification  = @"HBChaptersChangedNotification";
         copy->_chapterTitles = [[NSArray alloc] initWithArray:_chapterTitles copyItems:YES];
 
         copy->_metadataPassthru = _metadataPassthru;
+        copy->_hwDecodeUsage = _hwDecodeUsage;
     }
 
     return copy;
@@ -477,6 +478,7 @@ NSString *HBChaptersChangedNotification  = @"HBChaptersChangedNotification";
     encodeObject(_chapterTitles);
 
     encodeBool(_metadataPassthru);
+    encodeInteger(_hwDecodeUsage);
 }
 
 - (instancetype)initWithCoder:(NSCoder *)decoder
@@ -521,6 +523,7 @@ NSString *HBChaptersChangedNotification  = @"HBChaptersChangedNotification";
         decodeCollectionOfObjectsOrFail(_chapterTitles, NSArray, HBChapter);
 
         decodeBool(_metadataPassthru);
+        decodeInteger(_hwDecodeUsage); if (_hwDecodeUsage != HBJobHardwareDecoderUsageNone && _hwDecodeUsage != HBJobHardwareDecoderUsageAlways && _hwDecodeUsage != HBJobHardwareDecoderUsageFullPathOnly) { goto fail; }
 
         return self;
     }

--- a/macosx/HBPreferencesController.m
+++ b/macosx/HBPreferencesController.m
@@ -34,6 +34,8 @@ NSString * const HBAutoNamingISODateFormat       = @"HBAutoNamingISODateFormat";
 
 NSString * const HBCqSliderFractional            = @"HBx264CqSliderFractional";
 NSString * const HBUseDvdNav                     = @"UseDvdNav";
+NSString * const HBUseHardwareDecoder            = @"HBUseHardwareDecoder";
+NSString * const HBAlwaysUseHardwareDecoder      = @"HBAlwaysUseHardwareDecoder";
 NSString * const HBMinTitleScanSeconds           = @"MinTitleScanSeconds";
 NSString * const HBPreviewsNumber                = @"PreviewsNumber";
 
@@ -92,6 +94,8 @@ NSString * const HBKeepPresetEdits               = @"HBKeepPresetEdits";
         HBShowSummaryPreview:               @YES,
         HBDefaultMpegExtension:             @".mp4",
         HBUseDvdNav:                        @YES,
+        HBUseHardwareDecoder:               @NO,
+        HBAlwaysUseHardwareDecoder:         @NO,
         HBRecursiveScan:                    @NO,
         HBLastDestinationDirectoryURL:      [NSKeyedArchiver archivedDataWithRootObject:moviesURL],
         HBLastSourceDirectoryURL:           [NSKeyedArchiver archivedDataWithRootObject:moviesURL],

--- a/macosx/HBPreferencesKeys.h
+++ b/macosx/HBPreferencesKeys.h
@@ -44,6 +44,8 @@ extern NSString * const HBAutoNamingISODateFormat;
 
 extern NSString * const HBCqSliderFractional;
 extern NSString * const HBUseDvdNav;
+extern NSString * const HBUseHardwareDecoder;
+extern NSString * const HBAlwaysUseHardwareDecoder;
 extern NSString * const HBMinTitleScanSeconds;
 extern NSString * const HBPreviewsNumber;
 

--- a/macosx/HBPreviewGenerator.m
+++ b/macosx/HBPreviewGenerator.m
@@ -260,6 +260,20 @@
     // this should suffice for a fairly accurate short preview and cuts our preview generation time in half.
     job.video.multiPass = NO;
 
+    if ([NSUserDefaults.standardUserDefaults boolForKey:HBUseHardwareDecoder])
+    {
+        job.hwDecodeUsage = HBJobHardwareDecoderUsageFullPathOnly;
+
+        if ([NSUserDefaults.standardUserDefaults boolForKey:HBAlwaysUseHardwareDecoder])
+        {
+            job.hwDecodeUsage = HBJobHardwareDecoderUsageAlways;
+        }
+    }
+    else
+    {
+        job.hwDecodeUsage = HBJobHardwareDecoderUsageNone;
+    }
+
     // Init the libhb core
     NSInteger level = [NSUserDefaults.standardUserDefaults integerForKey:HBLoggingLevel];
     self.core = [[HBCore alloc] initWithLogLevel:level name:@"PreviewCore"];

--- a/macosx/HBQueueWorker.m
+++ b/macosx/HBQueueWorker.m
@@ -198,6 +198,7 @@ NSString * const HBQueueWorkerItemNotificationItemKey = @"HBQueueWorkerItemNotif
               previews:10
            minDuration:0
           keepPreviews:NO
+       hardwareDecoder:[NSUserDefaults.standardUserDefaults boolForKey:HBUseHardwareDecoder]
        progressHandler:progressHandler
      completionHandler:completionHandler];
 }
@@ -208,6 +209,20 @@ NSString * const HBQueueWorkerItemNotificationItemKey = @"HBQueueWorkerItemNotif
 - (void)realEncodeItem:(HBQueueJobItem *)item
 {
     HBJob *job = item.job;
+
+    if ([NSUserDefaults.standardUserDefaults boolForKey:HBUseHardwareDecoder])
+    {
+        job.hwDecodeUsage = HBJobHardwareDecoderUsageFullPathOnly;
+
+        if ([NSUserDefaults.standardUserDefaults boolForKey:HBAlwaysUseHardwareDecoder])
+        {
+            job.hwDecodeUsage = HBJobHardwareDecoderUsageAlways;
+        }
+    }
+    else
+    {
+        job.hwDecodeUsage = HBJobHardwareDecoderUsageNone;
+    }
 
     // Progress handler
     void (^progressHandler)(HBState state, HBProgress progress, NSString *info) = ^(HBState state, HBProgress progress, NSString *info)

--- a/macosx/HBRemoteCore.h
+++ b/macosx/HBRemoteCore.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)preventSleep;
 - (void)allowSleep;
 
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(nonnull HBCoreProgressHandler)progressHandler completionHandler:(nonnull HBCoreCompletionHandler)completionHandler;
+- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder progressHandler:(nonnull HBCoreProgressHandler)progressHandler completionHandler:(nonnull HBCoreCompletionHandler)completionHandler;
 
 - (void)cancelScan;
 

--- a/macosx/HBRemoteCore.m
+++ b/macosx/HBRemoteCore.m
@@ -150,7 +150,7 @@
     [_proxy preventSleep];
 }
 
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews progressHandler:(nonnull HBCoreProgressHandler)progressHandler completionHandler:(nonnull HBCoreCompletionHandler)completionHandler
+- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder progressHandler:(nonnull HBCoreProgressHandler)progressHandler completionHandler:(nonnull HBCoreCompletionHandler)completionHandler
 {
     if (!_connection)
     {
@@ -174,7 +174,7 @@
 
     __weak HBRemoteCore *weakSelf = self;
 
-    [_proxy scanURL:url titleIndex:index previews:previewsNum minDuration:seconds keepPreviews:keepPreviews withReply:^(HBCoreResult result) {
+    [_proxy scanURL:url titleIndex:index previews:previewsNum minDuration:seconds keepPreviews:keepPreviews hardwareDecoder:(BOOL)hardwareDecoder withReply:^(HBCoreResult result) {
         dispatch_sync(dispatch_get_main_queue(), ^{
             HBCoreCompletionHandler handler = weakSelf.completionHandler;
             weakSelf.completionHandler = nil;

--- a/macosx/HandBrakeXPCService/HBRemoteCoreProtocol.h
+++ b/macosx/HandBrakeXPCService/HBRemoteCoreProtocol.h
@@ -24,7 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)preventSleep;
 - (void)allowSleep;
 
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews withReply:(void (^)(HBCoreResult))reply;
+- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder withReply:(void (^)(HBCoreResult))reply;
 - (void)cancelScan;
 
 - (void)encodeJob:(HBJob *)job withReply:(void (^)(HBCoreResult))reply;

--- a/macosx/HandBrakeXPCService/HandBrakeXPCService.m
+++ b/macosx/HandBrakeXPCService/HandBrakeXPCService.m
@@ -153,7 +153,7 @@ static void *HandBrakeXPCServiceContext = &HandBrakeXPCServiceContext;
     });
 }
 
-- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews withReply:(void (^)(HBCoreResult))reply
+- (void)scanURL:(NSURL *)url titleIndex:(NSUInteger)index previews:(NSUInteger)previewsNum minDuration:(NSUInteger)seconds keepPreviews:(BOOL)keepPreviews hardwareDecoder:(BOOL)hardwareDecoder withReply:(void (^)(HBCoreResult))reply
 {
     dispatch_sync(_queue, ^{
         self.reply = reply;
@@ -162,6 +162,7 @@ static void *HandBrakeXPCServiceContext = &HandBrakeXPCServiceContext;
                    previews:previewsNum
                 minDuration:seconds
                keepPreviews:keepPreviews
+            hardwareDecoder:hardwareDecoder
             progressHandler:self.progressHandler
           completionHandler:self.completionHandler];
     });

--- a/test/test.c
+++ b/test/test.c
@@ -595,7 +595,9 @@ int main( int argc, char ** argv )
         hb_system_sleep_prevent(h);
 
         hb_scan(h, input, titleindex, preview_count, store_previews,
-                min_title_duration * 90000LL, crop_threshold_frames, crop_threshold_pixels, NULL);
+                min_title_duration * 90000LL,
+                crop_threshold_frames, crop_threshold_pixels,
+                NULL, hw_decode);
 
         EventLoop(h, preset_dict);
         hb_value_free(&preset_dict);

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -166,7 +166,7 @@ namespace HandBrake.Interop.Interop
 
             // Start the Scan
             IntPtr excludedExtensionsPtr = excludedExtensionsNative?.Ptr ?? IntPtr.Zero;
-            HBFunctions.hb_scan_list(this.Handle, scanPathsList.Ptr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr);
+            HBFunctions.hb_scan_list(this.Handle, scanPathsList.Ptr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr, 0);
 
             this.scanPollTimer = new Timer();
             this.scanPollTimer.Interval = ScanPollIntervalMs;

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -49,10 +49,10 @@ namespace HandBrake.Interop.Interop.HbLib
         public static extern void hb_dvd_set_dvdnav(int enable);
 
         [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
+        public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
 
         [DllImport("hb", EntryPoint = "hb_scan_list", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions);
+        public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
 
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_stop(IntPtr hbHandle);

--- a/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
@@ -10,10 +10,9 @@ namespace HandBrake.Interop.Interop.HbLib
     public enum hb_filter_ids
     {
         HB_FILTER_INVALID = 0,
-        // for QSV - important to have before other filters
         HB_FILTER_FIRST = 1,
-        HB_FILTER_QSV_PRE = 1,
 
+        HB_FILTER_PRE_VT,
         // First, filters that may change the framerate (drop or dup frames)
         HB_FILTER_DETELECINE,
         HB_FILTER_COMB_DETECT,
@@ -42,12 +41,7 @@ namespace HandBrake.Interop.Interop.HbLib
         // except that they must be after the above filters
         HB_FILTER_AVFILTER,
 
-        // for QSV - important to have as a last one
-        HB_FILTER_QSV_POST,
-        // default MSDK VPP filter
-        HB_FILTER_QSV,
-        HB_FILTER_LAST = HB_FILTER_QSV,
-
+        HB_FILTER_LAST,
         // wrapper filter for frame based multi-threading of simple filters
         HB_FILTER_MT_FRAME,
     }


### PR DESCRIPTION
…n actually decode the video or not. Hwaccel will fall back automatically to software, and we need to know if it will before starting a job.

win ui and linux ui will need to hook up the option for nvdec in hb_scan if they want to allow it.

QSV uses a separate decoder, and not hwaccel, so it might not require this and has not been modified yet.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux