### PR TITLE
LinGUI: Clean up code

### DIFF
--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -215,7 +215,7 @@ audio_deps(signal_user_data_t *ud, GhbValue *asettings, GtkWidget *widget)
     if (widget != NULL)
         ghb_check_dependency(ud, widget, NULL);
 
-    int track = -1, title_id, mix = 0, acodec = 0, sr = 0;
+    int title_id, mix = 0, acodec = 0, sr = 0;
     hb_audio_config_t *aconfig = NULL;
     const hb_title_t *title;
     gboolean qe;
@@ -225,7 +225,7 @@ audio_deps(signal_user_data_t *ud, GhbValue *asettings, GtkWidget *widget)
 
     if (asettings != NULL)
     {
-        track = ghb_dict_get_int(asettings, "Track");
+        int track = ghb_dict_get_int(asettings, "Track");
         acodec = ghb_settings_audio_encoder_codec(asettings, "Encoder");
         aconfig = ghb_get_audio_info(title, track);
         mix = ghb_settings_mixdown_mix(asettings, "Mixdown");

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -676,6 +676,10 @@ get_dvd_volume_name(gpointer gd)
     gchar *drive;
 
     drive = get_dvd_device_name(gd);
+
+    if (drive == NULL)
+        return NULL;
+
     g_mutex_lock(volname_mutex);
     label = g_strdup(g_hash_table_lookup(volname_hash, drive));
     g_mutex_unlock(volname_mutex);
@@ -4992,12 +4996,15 @@ ghb_file_menu_add_dvd(signal_user_data_t *ud)
             gchar *action = g_strdup_printf("app.dvd-open('%s')", get_dvd_device_name(link->data));
             gchar *name = get_dvd_volume_name(link->data);
 
-            GMenuItem *item = g_menu_item_new_from_model(dvd_template, 0);
-            g_menu_item_set_label(item, name);
-            g_menu_item_set_detailed_action(item, action);
-            g_menu_append_item(dvd_menu, item);
+            if (name != NULL)
+            {
+                GMenuItem *item = g_menu_item_new_from_model(dvd_template, 0);
+                g_menu_item_set_label(item, name);
+                g_menu_item_set_detailed_action(item, action);
+                g_menu_append_item(dvd_menu, item);
+                g_free(name);
+            }
 
-            g_free(name);
             g_free(action);
             free_drive(link->data);
             link = link->next;

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -813,7 +813,7 @@ parse_datestring(const char *src, struct tm *tm)
 
     datemap maps[1] = { ymdThmsZ };
 
-    for (int i = 0; i < sizeof(maps); i++)
+    for (guint i = 0; i < sizeof(maps); i++)
     {
         if (hb_validate_param_string(maps[i].pattern, src))
         {
@@ -3264,7 +3264,7 @@ ptop_read_value_cb (GtkWidget *widget, gdouble *val, signal_user_data_t *ud)
         return FALSE;
     if (result == 1)
     {
-        result = sscanf(text, "%lf", val);
+        sscanf(text, "%lf", val);
         return TRUE;
     }
     *val = hh * 3600 + mm * 60 + ss;
@@ -4688,6 +4688,9 @@ ghb_browse_uri(signal_user_data_t *ud, const gchar *uri)
     argv[2] = NULL;
     result = g_spawn_async(NULL, argv, NULL, G_SPAWN_SEARCH_PATH, NULL,
                 NULL, NULL, NULL);
+
+    if (!result)
+        g_warning("No application to open URI was found");
 #endif
 }
 
@@ -5066,7 +5069,7 @@ ghb_is_cd(GDrive *gd)
 {
     GIcon *gicon;
     gboolean ret = FALSE;
-    char **names, **iter;
+    char **names;
 
     if (!g_drive_is_media_removable (gd))
         return ret;
@@ -5081,7 +5084,7 @@ ghb_is_cd(GDrive *gd)
     }
 
     g_object_get (gicon, "names", &names, NULL);
-    ret = g_strv_contains (names, "drive-optical");
+    ret = g_strv_contains ((const char * const *) names, "drive-optical");
     g_strfreev (names);
     g_object_unref (gicon);
 

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -123,7 +123,7 @@ gint ghb_get_scan_state(void);
 gint ghb_get_queue_state(void);
 void ghb_get_status(ghb_status_t *status);
 void ghb_track_status(void);
-void ghb_backend_scan(const gchar *path, gint titleindex, gint preview_count, guint64 min_duration);
+void ghb_backend_scan(const char *path, int titleindex, int preview_count, uint64_t min_duration);
 void ghb_backend_scan_stop(void);
 void ghb_backend_queue_scan(const gchar *path, gint titleindex);
 hb_list_t * ghb_get_title_list(void);

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -545,12 +545,6 @@ IoRedirect(signal_user_data_t *ud)
         g_io_add_watch(channel, G_IO_IN, ghb_log_cb, (gpointer)ud );
 }
 
-typedef struct
-{
-    gchar *filename;
-    gchar *iconname;
-} icon_map_t;
-
 static gchar *dvd_device = NULL;
 static gchar *arg_preset = NULL;
 static gboolean ghb_debug = FALSE;
@@ -1323,9 +1317,9 @@ main(int argc, char *argv[])
         // Enable console logging
         if(AttachConsole(ATTACH_PARENT_PROCESS) || AllocConsole()){
             close(STDOUT_FILENO);
-            freopen("CONOUT$", "w", stdout);
+            (void) freopen("CONOUT$", "w", stdout);
             close(STDERR_FILENO);
-            freopen("CONOUT$", "w", stderr);
+            (void) freopen("CONOUT$", "w", stderr);
         }
     }
     else

--- a/gtk/src/plist.c
+++ b/gtk/src/plist.c
@@ -104,7 +104,7 @@ start_element(
         gint id;
         gpointer pid;
     } id;
-    gint ii;
+    guint ii;
 
     // Check to see if the first element found has been closed
     // If so, ignore any junk following it.
@@ -216,7 +216,7 @@ end_element(
         gint id;
         gpointer pid;
     } start_id;
-    gint ii;
+    guint ii;
 
     // Check to see if the first element found has been closed
     // If so, ignore any junk following it.

--- a/gtk/src/power-manager.c
+++ b/gtk/src/power-manager.c
@@ -11,11 +11,6 @@ static const char *battery_widgets[] = {
     "PauseEncodingOnLowBattery",
     NULL,
 };
-static const char *power_save_widgets[] = {
-    "pause_encoding_label",
-    "PauseEncodingOnPowerSave",
-    NULL,
-};
 
 static GDBusProxy *upower_proxy;
 static GDBusProxy *battery_proxy;
@@ -26,9 +21,14 @@ static GhbPowerState power_state;
  * level first drops from normal to low, so the user can resume encoding
  * without it being paused again. So this variable tracks the previous
  * battery level, and if it was low already, we don't do anything. */
-static guint prev_battery_level;
+static int prev_battery_level;
 
 #if GLIB_CHECK_VERSION(2, 70, 0)
+static const char *power_save_widgets[] = {
+    "pause_encoding_label",
+    "PauseEncodingOnPowerSave",
+    NULL,
+};
 static GPowerProfileMonitor *power_monitor;
 #endif
 
@@ -185,12 +185,12 @@ device_get_battery_proxy (const char *path)
     return NULL;
 }
 
-static void
+static gpointer
 devices_thread (signal_user_data_t *ud)
 {
     GDBusProxy *proxy;
 
-    for (int i = 0; i < g_strv_length(upower_devices); i++)
+    for (guint i = 0; i < g_strv_length(upower_devices); i++)
     {
         proxy = device_get_battery_proxy(upower_devices[i]);
         if (proxy != NULL)
@@ -205,6 +205,7 @@ devices_thread (signal_user_data_t *ud)
     }
     g_strfreev(upower_devices);
     g_thread_exit(0);
+    return NULL;
 }
 
 static void

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -856,7 +856,7 @@ ghb_write_pid_file (void)
     fd = open(path, O_RDWR|O_CREAT, S_IRUSR|S_IWUSR);
     if (fd >= 0)
     {
-        lockf(fd, F_TLOCK, 0);
+        (void) !!lockf(fd, F_TLOCK, 0);
     }
 
     g_free(config);
@@ -1459,10 +1459,10 @@ ghb_presets_list_init(signal_user_data_t *ud, const hb_preset_index_t *path)
             ghb_presets_list_init(ud, next_path);
             if (ghb_dict_get_bool(dict, "FolderOpen"))
             {
-                GtkTreePath *path;
-                path = gtk_tree_model_get_path(GTK_TREE_MODEL(store), &iter);
-                gtk_tree_view_expand_to_path(treeview, path);
-                gtk_tree_path_free(path);
+                GtkTreePath *tpath;
+                tpath = gtk_tree_model_get_path(GTK_TREE_MODEL(store), &iter);
+                gtk_tree_view_expand_to_path(treeview, tpath);
+                gtk_tree_path_free(tpath);
             }
         }
     }
@@ -1927,7 +1927,6 @@ settings_save(signal_user_data_t *ud, const char * category,
               const char *name, const char * desc, gboolean set_def)
 {
     GhbValue          * preset, * new_preset;
-    gboolean            def = FALSE;
     hb_preset_index_t * folder_path, * path;
     char              * fullname;
 
@@ -1965,7 +1964,7 @@ settings_save(signal_user_data_t *ud, const char * category,
     if (preset != NULL)
     {
         // Replacing an existing preset
-        def = ghb_dict_get_bool(preset, "Default");
+        gboolean def = ghb_dict_get_bool(preset, "Default");
 
         // If we are replacing the default preset, re-mark it as default
         ghb_dict_set_bool(new_preset, "Default", def);
@@ -2454,7 +2453,7 @@ preset_remove_action_cb(GSimpleAction *action, GVariant *param,
                         signal_user_data_t *ud)
 {
     hb_preset_index_t * path;
-    GhbValue          * preset;
+    GhbValue          * preset = NULL;
 
     path = get_selected_path(ud);
     if (path != NULL)
@@ -2707,7 +2706,6 @@ presets_drag_motion_cb(
             return TRUE;
         }
 
-        dst_ptype = ghb_dict_get_int(dst_preset, "Type");
         dst_folder = ghb_dict_get_bool(dst_preset, "Folder");
         drop_pos = GTK_TREE_VIEW_DROP_AFTER;
     }
@@ -2775,8 +2773,7 @@ presets_drag_data_received_cb(
 
     dst_model    = gtk_tree_view_get_model(tv);
     dst_treepath = g_object_get_data(G_OBJECT(tv), "dst-tree-path");
-    drop_pos     = (GtkTreeViewDropPosition)g_object_get_data(G_OBJECT(tv),
-                                                              "dst-drop-pos");
+    g_object_get(G_OBJECT(tv), "dst-drop-pos", &drop_pos, NULL);
     g_object_set_data(G_OBJECT(tv), "dst-tree-path", NULL);
     if (dst_treepath == NULL)
     {
@@ -3116,5 +3113,3 @@ preset_widget_changed_cb(GtkWidget *widget, signal_user_data_t *ud)
     ghb_widget_to_setting(ud->settings, widget);
     ghb_check_dependency(ud, widget, NULL);
 }
-
-

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -212,7 +212,7 @@ ghb_preview_init(signal_user_data_t *ud)
     if (ud->preview->play == NULL || ud->preview->vsink == NULL)
     {
         g_warning("Couldn't initialize gstreamer. Disabling live preview.");
-        GtkWidget *widget = GHB_WIDGET(ud->builder, "live_preview_box");
+        widget = GHB_WIDGET(ud->builder, "live_preview_box");
         gtk_widget_hide (widget);
         widget = GHB_WIDGET(ud->builder, "live_preview_duration_box");
         gtk_widget_hide (widget);

--- a/gtk/src/renderer_button.c
+++ b/gtk/src/renderer_button.c
@@ -27,8 +27,10 @@
 #define MyGdkRectangle const GdkRectangle
 
 /* Some boring function declarations: GObject type system stuff */
-static void     custom_cell_renderer_button_init       (CustomCellRendererButton      *cellprogress);
-static void     custom_cell_renderer_button_class_init (CustomCellRendererButtonClass *klass);
+static void     custom_cell_renderer_button_init       (CustomCellRendererButton      *cellprogress,
+                                                        gpointer                       class_data);
+static void     custom_cell_renderer_button_class_init (CustomCellRendererButtonClass *klass,
+                                                        gpointer                       class_data);
 static void     custom_cell_renderer_button_get_property  (GObject                    *object,
                                                              guint                       param_id,
                                                              GValue                     *value,
@@ -104,7 +106,8 @@ custom_cell_renderer_button_get_type (void)
  *
  ***************************************************************************/
 static void
-custom_cell_renderer_button_init (CustomCellRendererButton *cellbutton)
+custom_cell_renderer_button_init (CustomCellRendererButton *cellbutton,
+                                  gpointer class_data)
 {
     g_object_set(cellbutton, "mode", GTK_CELL_RENDERER_MODE_ACTIVATABLE, NULL);
     g_object_set(cellbutton, "xpad", 2, NULL);
@@ -123,7 +126,8 @@ custom_cell_renderer_button_init (CustomCellRendererButton *cellbutton)
  *
  ***************************************************************************/
 static void
-custom_cell_renderer_button_class_init (CustomCellRendererButtonClass *klass)
+custom_cell_renderer_button_class_init (CustomCellRendererButtonClass *klass,
+                                        gpointer class_data)
 {
     GtkCellRendererClass *cell_class   = GTK_CELL_RENDERER_CLASS(klass);
     GObjectClass         *object_class = G_OBJECT_CLASS(klass);

--- a/gtk/src/subtitlehandler.c
+++ b/gtk/src/subtitlehandler.c
@@ -556,30 +556,6 @@ set_pref_subtitle(signal_user_data_t *ud)
     subtitle_refresh_list_ui(ud);
 }
 
-static gint
-selected_subtitle_row (signal_user_data_t *ud)
-{
-    GtkTreeView *tv;
-    GtkTreePath *tp;
-    GtkTreeSelection *ts;
-    GtkTreeModel *tm;
-    GtkTreeIter iter;
-    gint *indices;
-    gint row = -1;
-
-    tv = GTK_TREE_VIEW(GHB_WIDGET(ud->builder, "subtitle_list_view"));
-    ts = gtk_tree_view_get_selection(tv);
-    if (gtk_tree_selection_get_selected(ts, &tm, &iter))
-    {
-        // Get the row number
-        tp = gtk_tree_model_get_path(tm, &iter);
-        indices = gtk_tree_path_get_indices(tp);
-        row = indices[0];
-        gtk_tree_path_free(tp);
-    }
-    return row;
-}
-
 static GhbValue*
 subtitle_get_selected_settings(signal_user_data_t *ud, int *index)
 {
@@ -1560,10 +1536,10 @@ subtitle_remove_lang_iter(GtkTreeModel *tm, GtkTreeIter *iter,
     {
         if (ghb_array_len(slang_list) > 0)
         {
-            const iso639_lang_t *lang;
+            const iso639_lang_t *lang_id;
             GhbValue *entry = ghb_array_get(slang_list, 0);
-            lang = ghb_iso639_lookup_by_int(ghb_lookup_lang(entry));
-            subtitle_update_pref_lang(ud, lang);
+            lang_id = ghb_iso639_lookup_by_int(ghb_lookup_lang(entry));
+            subtitle_update_pref_lang(ud, lang_id);
         }
         else
         {

--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -797,7 +797,6 @@ title_add_multiple_action_cb (GSimpleAction *action, GVariant *param,
         max_title_len = 60;
     for (ii = 0; ii < count; ii++)
     {
-        GtkWidget *row;
         GtkLabel *label;
 
         row = GTK_WIDGET(gtk_list_box_get_row_at_index(list, ii));

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -357,7 +357,8 @@ format_vquality_cb(GtkScale *scale, gdouble val, signal_user_data_t *ud)
                                        vqname, val);
                 break;
             }
-        } // Falls through to default
+            G_GNUC_FALLTHROUGH; // Falls through to default
+        }
         case HB_VCODEC_X264_10BIT:
         default:
         {

--- a/libhb/handbrake/lang.h
+++ b/libhb/handbrake/lang.h
@@ -27,7 +27,7 @@ extern "C" {
 const iso639_lang_t * lang_lookup( const char * str );
 
 /* find language table index, match any of names in lang struct */
-const int lang_lookup_index( const char * str );
+int lang_lookup_index( const char * str );
 
 /* return language for an index into the language table */
 const iso639_lang_t * lang_for_index( int index );

--- a/libhb/lang.c
+++ b/libhb/lang.c
@@ -206,7 +206,7 @@ static const iso639_lang_t languages[] =
 
 static const int lang_count = sizeof(languages) / sizeof(languages[0]);
 
-const int lang_lookup_index( const char * str )
+int lang_lookup_index( const char * str )
 {
     int             ii = 0;
     const iso639_lang_t * lang;


### PR DESCRIPTION
Cleans up a number of warnings across various platforms, including some which are only seen when compiling with -Wextra.
Also fixes some issues identified with cppcheck.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
