### PR TITLE
Fix CanApplyDrc

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -466,6 +466,26 @@ namespace HandBrake.Interop.Interop
         }
 
         /// <summary>
+        /// Determines if DRC can be applied to the given track with the given encoder.
+        /// </summary>
+        /// <param name="codecId">
+        /// The source audio codec.
+        /// </param>
+        /// <param name="codecParam">
+        /// The source audio codec parameters.
+        /// </param>
+        /// <param name="encoder">
+        /// The encoder that will be used.
+        /// </param>
+        /// <returns>
+        /// True if DRC can be applied to the track with the given encoder.
+        /// </returns>
+        public static bool CanApplyDrc(int codecId, int codecParam, HBAudioEncoder encoder)
+        {
+            return HBFunctions.hb_audio_can_apply_drc((uint)codecId, (uint)codecParam, encoder.Id) > 0;
+        }
+
+        /// <summary>
         /// Determines if the given input audio codec can be passed through.
         /// </summary>
         /// <param name="codecId">

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -466,29 +466,6 @@ namespace HandBrake.Interop.Interop
         }
 
         /// <summary>
-        /// Determines if DRC can be applied to the given track with the given encoder.
-        /// </summary>
-        /// <param name="handle">
-        /// The handle.
-        /// </param>
-        /// <param name="trackNumber">
-        /// The track Number.
-        /// </param>
-        /// <param name="encoder">
-        /// The encoder to use for DRC.
-        /// </param>
-        /// <param name="title">
-        /// The title.
-        /// </param>
-        /// <returns>
-        /// True if DRC can be applied to the track with the given encoder.
-        /// </returns>
-        public static bool CanApplyDrc(IntPtr handle, int trackNumber, HBAudioEncoder encoder, int title)
-        {
-            return HBFunctions.hb_audio_can_apply_drc2(handle, title, trackNumber, encoder.Id) > 0; 
-        }
-
-        /// <summary>
         /// Determines if the given input audio codec can be passed through.
         /// </summary>
         /// <param name="codecId">

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -239,18 +239,6 @@ namespace HandBrake.Interop.Interop
         }
 
         /// <summary>
-        /// Determines if DRC can be applied to the given track with the given encoder.
-        /// </summary>
-        /// <param name="trackNumber">The track Number.</param>
-        /// <param name="encoder">The encoder to use for DRC.</param>
-        /// <param name="title">The title.</param>
-        /// <returns>True if DRC can be applied to the track with the given encoder.</returns>
-        public bool CanApplyDrc(int trackNumber, HBAudioEncoder encoder, int title)
-        {
-            return HBFunctions.hb_audio_can_apply_drc2(this.Handle, title, trackNumber, encoder.Id) > 0;
-        }
-
-        /// <summary>
         /// Starts an encode with the given job.
         /// </summary>
         /// <param name="encodeObject">

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -20,7 +20,6 @@ namespace HandBrake.Interop.Interop
     using HandBrake.Interop.Interop.Helpers;
     using HandBrake.Interop.Interop.Interfaces;
     using HandBrake.Interop.Interop.Interfaces.EventArgs;
-    using HandBrake.Interop.Interop.Interfaces.Model.Encoders;
     using HandBrake.Interop.Interop.Interfaces.Model.Preview;
     using HandBrake.Interop.Interop.Json.Encode;
     using HandBrake.Interop.Interop.Json.Scan;

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -20,6 +20,7 @@ namespace HandBrake.Interop.Interop
     using HandBrake.Interop.Interop.Helpers;
     using HandBrake.Interop.Interop.Interfaces;
     using HandBrake.Interop.Interop.Interfaces.EventArgs;
+    using HandBrake.Interop.Interop.Interfaces.Model.Encoders;
     using HandBrake.Interop.Interop.Interfaces.Model.Preview;
     using HandBrake.Interop.Interop.Json.Encode;
     using HandBrake.Interop.Interop.Json.Scan;
@@ -235,6 +236,18 @@ namespace HandBrake.Interop.Interop
             Marshal.FreeHGlobal(nativeJobPtrPtr);
 
             return preview;
+        }
+
+        /// <summary>
+        /// Determines if DRC can be applied to the given track with the given encoder.
+        /// </summary>
+        /// <param name="trackNumber">The track Number.</param>
+        /// <param name="encoder">The encoder to use for DRC.</param>
+        /// <param name="title">The title.</param>
+        /// <returns>True if DRC can be applied to the track with the given encoder.</returns>
+        public bool CanApplyDrc(int trackNumber, HBAudioEncoder encoder, int title)
+        {
+            return HBFunctions.hb_audio_can_apply_drc2(this.Handle, title, trackNumber, encoder.Id) > 0;
         }
 
         /// <summary>

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -171,8 +171,8 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_audio_compression_get_default", CallingConvention = CallingConvention.Cdecl)]
         public static extern float hb_audio_compression_get_default(uint codec);
 
-        [DllImport("hb", EntryPoint = "hb_audio_can_apply_drc2", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_audio_can_apply_drc2(IntPtr handle, int title_index, int audio_index, int encoder);
+        [DllImport("hb", EntryPoint = "hb_audio_can_apply_drc", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_audio_can_apply_drc(uint codec, uint codec_param, int encoder);
 
         [DllImport("hb", EntryPoint = "hb_autopassthru_get_encoder", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_autopassthru_get_encoder(int in_codec, int copy_mask, int fallback, int muxer);

--- a/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
+++ b/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
@@ -54,6 +54,11 @@ namespace HandBrake.Interop.Interop.Json.Scan
         /// </summary>
         public int Codec { get; set; }
 
+        /// <summary>
+        /// Parameters for the codec.
+        /// </summary>
+        public int CodecParam { get; set; }
+
         public string CodecName { get; set; }
 
         public long LFECount { get; set; }


### PR DESCRIPTION
Removed the public static HandBrakeEncoderHelpers.CanApplyDrc, since it requires use of an internal Handle IntPtr and has no references. Re-added the removed, working version on HandBrakeInstance.