### PR TITLE
libhb: Define missing quality limits for VCN H.264 and H.265.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1408,6 +1408,9 @@ void hb_video_quality_get_limits(uint32_t codec, float *low, float *high,
          */
         case HB_VCODEC_X264_8BIT:
         case HB_VCODEC_X265_8BIT:
+        case HB_VCODEC_FFMPEG_VCE_H264:
+        case HB_VCODEC_FFMPEG_VCE_H265:
+        case HB_VCODEC_FFMPEG_VCE_H265_10BIT:
         case HB_VCODEC_FFMPEG_NVENC_H264:
         case HB_VCODEC_FFMPEG_NVENC_H265:
         case HB_VCODEC_FFMPEG_NVENC_AV1:


### PR DESCRIPTION
These codecs support quality levels 0-51 and would otherwise be restricted; e.g., the Windows GUI currently only shows 1-31 on both 1.6.1 and latest master.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux