### PR TITLE
libhb: fix hw_pix_fmt init value for preview

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -927,6 +927,7 @@ hb_image_t * hb_get_preview3(hb_handle_t * h, int picture,
     init.time_base.den = 90000;
     init.job = job;
     init.pix_fmt = AV_PIX_FMT_YUV420P;
+    init.hw_pix_fmt = AV_PIX_FMT_NONE;
     init.color_range = AVCOL_RANGE_MPEG;
 
     init.color_prim = title->color_prim;


### PR DESCRIPTION
memset set value to 0 which is AV_PIX_FMT_YUV420P. I don't think this is expected for hw_pix_fmt as default value according to 
https://github.com/HandBrake/HandBrake/blob/8bdc8340f60b3abc8b8a8cbb0adce3098fc59d75/libhb/common.c#L6411

AV_PIX_FMT_NONE is -1.
https://github.com/FFmpeg/FFmpeg/blob/1bcb8a73382a253cee8b2b9e704e5a2fa3369593/libavutil/pixfmt.h#L65C1-L65C1