### PR TITLE
contrib: update to SVT-AV1 1.7.0.

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -3,9 +3,9 @@ __deps__ :=
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v1.6.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.6.0/SVT-AV1-v1.6.0.tar.gz
-SVT-AV1.FETCH.sha256  = 3bc207247568ac713245063555082bfc905edc31df3bf6355e3b194cb73ad817
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v1.7.0.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v1.7.0/SVT-AV1-v1.7.0.tar.gz
+SVT-AV1.FETCH.sha256  = ce0973584f1a187aa4abf63f509ff8464397120878e322a3153f87e9c161fc4f
 
 SVT-AV1.build_dir             = build
 SVT-AV1.CONFIGURE.exe         = cmake

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -183,7 +183,11 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
         }
     }
 
-    if (job->encoder_tune != NULL && strstr("psnr", job->encoder_tune) != NULL)
+    if (job->encoder_tune != NULL && strstr("ssim", job->encoder_tune) != NULL)
+    {
+        param->tune = 2;
+    }
+    else if (job->encoder_tune != NULL && strstr("psnr", job->encoder_tune) != NULL)
     {
         param->tune = 1;
     }

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -26,12 +26,12 @@ static const int          hb_av1_level_values[] = {
 
 static const char * const av1_svt_preset_names[] =
 {
-    "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", NULL
+    "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL
 };
 
 static const char * const av1_svt_tune_names[] =
 {
-    "psnr", "fastdecode", NULL
+    "psnr", "ssim", "fastdecode", NULL
 };
 
 static const char * const av1_svt_profile_names[] =


### PR DESCRIPTION
> Encoder
> - Improve the tradeoffs for the random access mode across presets MR-M13:
>  - Quality improvements across all presets and metrics ranging from 0.3% to 4.5% in BD-rate (!2129)
>  - Spacing between presets [M1-M6] has been adjusted to account for the tradeoff improvements achieved
>   - As a user guidance when comparing v1.7 vs v1.6 in a convexhull encoding setup:
>    - v1.7.0 M2 is now at similar quality levels as v1.6.0 M1 while being ~50% faster
>    - v1.7.0 M3 is now at similar quality levels as v1.6.0 M2 while being ~50% faster
>    - v1.7.0 M4 is now at similar quality levels as v1.6.0 M3 while being ~40% faster
>    - v1.7.0 M5 is now at similar quality levels as v1.6.0 M4 while being ~30% faster
>    - v1.7.0 M6 is now at similar quality levels as v1.6.0 M5 while being ~25% faster
> - Added an experimental tune SSIM mode yielding ~3-4% additional SSIM BD-rate gains (!2109)

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
