### PR TITLE
libhb: add Metal accelerated pad yadif bwdif chroma smooth unsharp lapsharp grayscale filters

### DIFF
--- a/contrib/bin2c/bin2c.c
+++ b/contrib/bin2c/bin2c.c
@@ -1,0 +1,76 @@
+/*
+ * This file is part of FFmpeg.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char **argv)
+{
+    const char *name;
+    FILE *input, *output;
+    unsigned int length = 0;
+    unsigned char data;
+
+    if (argc < 3 || argc > 4)
+        return 1;
+
+    input = fopen(argv[1], "rb");
+    if (!input)
+        return -1;
+
+    output = fopen(argv[2], "wb");
+    if (!output)
+        return -1;
+
+    if (argc == 4) {
+        name = argv[3];
+    } else {
+        size_t arglen = strlen(argv[1]);
+        name = argv[1];
+
+        for (int i = 0; i < arglen; i++) {
+            if (argv[1][i] == '.')
+                argv[1][i] = '_';
+            else if (argv[1][i] == '/')
+                name = &argv[1][i+1];
+        }
+    }
+
+    fprintf(output, "const unsigned char hb_%s_data[] = { ", name);
+
+    while (fread(&data, 1, 1, input) > 0) {
+        fprintf(output, "0x%02x, ", data);
+        length++;
+    }
+
+    fprintf(output, "0x00 };\n");
+    fprintf(output, "const unsigned int hb_%s_len = %u;\n", name, length);
+
+    fclose(output);
+
+    if (ferror(input) || !feof(input))
+        return -1;
+
+    fclose(input);
+
+    return 0;
+}

--- a/contrib/bin2c/module.defs
+++ b/contrib/bin2c/module.defs
@@ -1,0 +1,18 @@
+$(eval $(call import.MODULE.defs,BIN2C,bin2c))
+$(eval $(call import.GCC,BIN2C))
+
+BIN2C.src/ = $(SRC/)contrib/bin2c/
+BIN2C.build/ = $(BUILD/)contrib/bin2c/
+BIN2C.GCC.archs = $(BUILD.machine)
+
+BIN2C.c   = $(wildcard $(BIN2C.src/)*.c)
+BIN2C.c.o = $(patsubst $(SRC/)%.c,$(BUILD/)%.o,$(BIN2C.c))
+
+BIN2C.exe = $(BUILD/)$(call TARGET.exe,bin2c)
+
+###############################################################################
+
+BIN2C.out += $(BIN2C.c.o)
+BIN2C.out += $(BIN2C.exe)
+
+BUILD.out += $(BIN2C.out)

--- a/contrib/bin2c/module.rules
+++ b/contrib/bin2c/module.rules
@@ -1,0 +1,24 @@
+$(eval $(call import.MODULE.rules,BIN2C))
+
+build: bin2c.build
+clean: bin2c.clean
+xclean: bin2c.xclean
+
+bin2c.build: $(BIN2C.exe)
+
+########################################
+
+bin2c.clean:
+	$(RM.exe) -f $(BIN2C.out)
+
+bin2c.xclean: bin2c.clean
+
+########################################
+
+$(BIN2C.exe): | $(dir $(BIN2C.exe))
+$(BIN2C.exe): $(BIN2C.c.o)
+	$(call BIN2C.GCC.EXE++,$@,$^ $(BIN2C.libs))
+
+$(BIN2C.c.o): | $(dir $(BIN2C.c.o))
+$(BIN2C.c.o): $(BUILD/)%.o: $(SRC/)%.c
+	$(call BIN2C.GCC.C_O,$@,$<)

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -4674,12 +4674,40 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             filter = &hb_filter_prefilter_vt;
             break;
 
+        case HB_FILTER_YADIF_VT:
+            filter = &hb_filter_yadif_vt;
+            break;
+
+        case HB_FILTER_BWDIF_VT:
+            filter = &hb_filter_bwdif_vt;
+            break;
+
+        case HB_FILTER_CHROMA_SMOOTH_VT:
+            filter = &hb_filter_chroma_smooth_vt;
+            break;
+
         case HB_FILTER_CROP_SCALE_VT:
             filter = &hb_filter_crop_scale_vt;
             break;
 
+        case HB_FILTER_PAD_VT:
+            filter = &hb_filter_pad_vt;
+            break;
+
         case HB_FILTER_ROTATE_VT:
             filter = &hb_filter_rotate_vt;
+            break;
+
+        case HB_FILTER_GRAYSCALE_VT:
+            filter = &hb_filter_grayscale_vt;
+            break;
+
+        case HB_FILTER_LAPSHARP_VT:
+            filter = &hb_filter_lapsharp_vt;
+            break;
+
+        case HB_FILTER_UNSHARP_VT:
+            filter = &hb_filter_unsharp_vt;
             break;
 #endif
 
@@ -6020,6 +6048,30 @@ int hb_rgb2yuv_bt709(int rgb)
     return (y << 16) | (Cr << 8) | Cb;
 }
 
+int hb_rgb2yuv_bt2020(int rgb)
+{
+    double r, g, b;
+    int y, Cr, Cb;
+
+    r = (rgb >> 16) & 0xff;
+    g = (rgb >>  8) & 0xff;
+    b = (rgb      ) & 0xff;
+
+    y  =  16. + ( 0.2307 * r) + (0.5956 * g) + (0.0521 * b);
+    Cb = 128. + (-0.1227 * r) - (0.3166 * g) + (0.4392 * b);
+    Cr = 128. + ( 0.4392 * r) - (0.4039 * g) - (0.0353 * b);
+
+    y = (y < 0) ? 0 : y;
+    Cb = (Cb < 0) ? 0 : Cb;
+    Cr = (Cr < 0) ? 0 : Cr;
+
+    y = (y > 255) ? 255 : y;
+    Cb = (Cb > 255) ? 255 : Cb;
+    Cr = (Cr > 255) ? 255 : Cr;
+
+    return (y << 16) | (Cr << 8) | Cb;
+}
+
 const char * hb_subsource_name( int source )
 {
     switch (source)
@@ -6353,7 +6405,8 @@ static int pix_fmt_is_supported(hb_job_t *job, int pix_fmt)
             case HB_FILTER_LAPSHARP:
             case HB_FILTER_UNSHARP:
             case HB_FILTER_GRAYSCALE:
-               if (planes_count == 2)
+               if (planes_count == 2 &&
+                   job->hw_pix_fmt != AV_PIX_FMT_VIDEOTOOLBOX)
                {
                    return 0;
                }

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1490,7 +1490,9 @@ enum
     HB_FILTER_COMB_DETECT,
     HB_FILTER_DECOMB,
     HB_FILTER_YADIF,
+    HB_FILTER_YADIF_VT,
     HB_FILTER_BWDIF,
+    HB_FILTER_BWDIF_VT,
     HB_FILTER_VFR,
     // Filters that must operate on the original source image are next
     HB_FILTER_DEBLOCK,
@@ -1498,15 +1500,20 @@ enum
     HB_FILTER_HQDN3D = HB_FILTER_DENOISE,
     HB_FILTER_NLMEANS,
     HB_FILTER_CHROMA_SMOOTH,
+    HB_FILTER_CHROMA_SMOOTH_VT,
     HB_FILTER_ROTATE,
     HB_FILTER_ROTATE_VT,
     HB_FILTER_RENDER_SUB,
     HB_FILTER_CROP_SCALE,
     HB_FILTER_CROP_SCALE_VT,
     HB_FILTER_LAPSHARP,
+    HB_FILTER_LAPSHARP_VT,
     HB_FILTER_UNSHARP,
+    HB_FILTER_UNSHARP_VT,
     HB_FILTER_GRAYSCALE,
+    HB_FILTER_GRAYSCALE_VT,
     HB_FILTER_PAD,
+    HB_FILTER_PAD_VT,
     HB_FILTER_COLORSPACE,
     HB_FILTER_FORMAT,
     HB_FILTER_RPU,
@@ -1557,6 +1564,7 @@ char ** hb_str_vsplit( const char * str, char delem );
 int hb_yuv2rgb(int yuv);
 int hb_rgb2yuv(int rgb);
 int hb_rgb2yuv_bt709(int rgb);
+int hb_rgb2yuv_bt2020(int rgb);
 
 const char * hb_subsource_name( int source );
 

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -496,8 +496,15 @@ extern hb_filter_object_t hb_filter_format;
 
 #if defined(__APPLE__)
 extern hb_filter_object_t hb_filter_prefilter_vt;
+extern hb_filter_object_t hb_filter_yadif_vt;
+extern hb_filter_object_t hb_filter_bwdif_vt;
 extern hb_filter_object_t hb_filter_crop_scale_vt;
+extern hb_filter_object_t hb_filter_chroma_smooth_vt;
 extern hb_filter_object_t hb_filter_rotate_vt;
+extern hb_filter_object_t hb_filter_grayscale_vt;
+extern hb_filter_object_t hb_filter_pad_vt;
+extern hb_filter_object_t hb_filter_lapsharp_vt;
+extern hb_filter_object_t hb_filter_unsharp_vt;
 #endif
 
 extern hb_work_object_t * hb_objects;

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -12,6 +12,7 @@ endif
 
 $(eval $(call import.MODULE.defs,LIBHB,libhb,$(__deps__)))
 $(eval $(call import.GCC,LIBHB))
+$(eval $(call import.METAL,LIBHB))
 
 ###############################################################################
 
@@ -24,6 +25,7 @@ LIBHB.m4.out = $(patsubst $(LIBHB.src/)%.m4,$(LIBHB.build/)%,$(LIBHB.m4.in))
 LIBHB.c   = $(wildcard $(LIBHB.src/)*.c)
 LIBHB.c.o = $(patsubst $(SRC/)%.c,$(BUILD/)%.o,$(LIBHB.c))
 LIBHB.m.o = $(patsubst $(SRC/)%.m,$(BUILD/)%.o,$(LIBHB.m))
+LIBHB.metal.o = $(patsubst $(SRC/)%.metal,$(BUILD/)%.o,$(LIBHB.metal))
 LIBHB.d   = $(LIBHB.m4.out) $(LIBHB.h.out) \
     $(foreach n,$(LIBHB.prerequisites),$($n.INSTALL.target) )
 
@@ -40,6 +42,7 @@ LIBHB.a = $(LIBHB.build/)$(call TARGET.archive,handbrake)
 LIBHB.out += $(LIBHB.m4.out)
 LIBHB.out += $(LIBHB.c.o)
 LIBHB.out += $(LIBHB.m.o)
+LIBHB.out += $(LIBHB.metal.o)
 LIBHB.out += $(LIBHB.h.out)
 LIBHB.out += $(LIBHB.a)
 
@@ -81,6 +84,7 @@ else ifeq ($(HOST.system),darwin)
     LIBHB.GCC.D += SYS_DARWIN
     LIBHB.c += $(wildcard $(LIBHB.src/)platform/macosx/*.c)
     LIBHB.m += $(wildcard $(LIBHB.src/)platform/macosx/*.m)
+    LIBHB.metal += $(wildcard $(LIBHB.src/)platform/macosx/shaders/*.metal)
 else ifeq ($(HOST.system),linux)
     LIBHB.GCC.D += SYS_LINUX _LARGEFILE_SOURCE _FILE_OFFSET_BITS=64
 else ifeq ($(HOST.system),freebsd)

--- a/libhb/module.rules
+++ b/libhb/module.rules
@@ -3,16 +3,22 @@ $(eval $(call import.MODULE.rules,LIBHB))
 libhb.build: $(LIBHB.a)
 
 $(LIBHB.a): | $(dir $(LIBHB.a))
-$(LIBHB.a): $(LIBHB.c.o) $(LIBHB.m.o)
+$(LIBHB.a): $(LIBHB.metal.o) $(LIBHB.c.o) $(LIBHB.m.o)
 	$(AR.exe) rsu $@ $^
 
 $(LIBHB.c.o): $(LIBHB.d)
 $(LIBHB.c.o): | $(dir $(LIBHB.c.o))
 $(LIBHB.c.o): $(BUILD/)%.o: $(SRC/)%.c
 	$(call LIBHB.GCC.C_O,$@,$<)
+$(LIBHB.m.o): $(LIBHB.d)
 $(LIBHB.m.o): | $(dir $(LIBHB.m.o))
 $(LIBHB.m.o): $(BUILD/)%.o: $(SRC/)%.m
 	$(call LIBHB.GCC.C_O,$@,$<)
+
+$(LIBHB.metal.o): $(LIBHB.d)
+$(LIBHB.metal.o): | $(dir $(LIBHB.metal.o))
+$(LIBHB.metal.o): $(BUILD/)%.o: $(SRC/)%.metal
+	$(call LIBHB.METAL.C_O,$(patsubst %.o,%,$@),$<)
 
 $(LIBHB.m4.out): $(BUILD/)project/handbrake.m4
 $(LIBHB.m4.out): | $(dir $(LIBHB.m4.out))

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -1243,9 +1243,7 @@ hb_generate_filter_settings(int filter_id, const char *preset, const char *tune,
     {
         case HB_FILTER_PAD:
         case HB_FILTER_ROTATE:
-        case HB_FILTER_ROTATE_VT:
         case HB_FILTER_CROP_SCALE:
-        case HB_FILTER_CROP_SCALE_VT:
         case HB_FILTER_VFR:
         case HB_FILTER_RENDER_SUB:
         case HB_FILTER_GRAYSCALE:

--- a/libhb/platform/macosx/chroma_smooth_vt.m
+++ b/libhb/platform/macosx/chroma_smooth_vt.m
@@ -1,0 +1,396 @@
+/* unsharp_vt.m
+
+   Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_chroma_smooth_vt_metallib_data[];
+extern unsigned int hb_chroma_smooth_vt_metallib_len;
+
+#define CHROMA_SMOOTH_STRENGTH_DEFAULT 0.25
+#define CHROMA_SMOOTH_SIZE_DEFAULT 7
+#define CHROMA_SMOOTH_SIZE_MIN 3
+#define CHROMA_SMOOTH_SIZE_MAX 15
+
+typedef struct
+{
+    float      max_value;
+    float      min_value;
+    float      strength;  // amount
+    int        size;      // pixel context region width (must be odd)
+
+    id<MTLBuffer> matrix;
+    id<MTLBuffer> coef_x;
+    id<MTLBuffer> coef_y;
+} chroma_smooth_vt_plane_context_t;
+
+struct mtl_chroma_smooth_params
+{
+    uint       channels;
+    float      max_value;
+    float      min_value;
+    float      strength;
+    int        size;
+};
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    bool                        global;
+    chroma_smooth_vt_plane_context_t  plane_ctx[3];
+
+    hb_filter_init_t            input;
+    hb_filter_init_t            output;
+};
+
+static int chroma_smooth_vt_init(hb_filter_object_t *filter,
+                           hb_filter_init_t   *init);
+
+static int chroma_smooth_vt_work(hb_filter_object_t *filter,
+                           hb_buffer_t ** buf_in,
+                           hb_buffer_t ** buf_out);
+
+static void chroma_smooth_vt_close(hb_filter_object_t *filter);
+
+static const char chroma_smooth_vt_template[] =
+    "cb-strength=^"HB_FLOAT_REG"$:cb-size=^"HB_INT_REG"$:"
+    "cr-strength=^"HB_FLOAT_REG"$:cr-size=^"HB_INT_REG"$";
+
+hb_filter_object_t hb_filter_chroma_smooth_vt =
+{
+    .id                = HB_FILTER_CHROMA_SMOOTH_VT,
+    .enforce_order     = 1,
+    .name              = "Chroma Smooth (VideoToolbox)",
+    .settings          = NULL,
+    .init              = chroma_smooth_vt_init,
+    .work              = chroma_smooth_vt_work,
+    .close             = chroma_smooth_vt_close,
+    .settings_template = chroma_smooth_vt_template,
+};
+
+static int chroma_smooth_vt_init(hb_filter_object_t *filter,
+                        hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("chroma_smooth_vt: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t * pv = filter->private_data;
+    pv->input = *init;
+    pv->desc = av_pix_fmt_desc_get(init->pix_fmt);
+
+    // Mark parameters unset
+    for (int c = 0; c < 3; c++)
+    {
+        pv->plane_ctx[c].strength = -1;
+        pv->plane_ctx[c].size     = -1;
+    }
+
+    // Read user parameters
+    if (filter->settings != NULL)
+    {
+        hb_dict_t *dict = filter->settings;
+        double val;
+
+        hb_dict_extract_double(&val, dict, "cb-strength");
+        hb_dict_extract_int(&pv->plane_ctx[1].size, dict, "cb-size");
+        pv->plane_ctx[1].strength = val;
+
+        hb_dict_extract_double(&val, dict, "cr-strength");
+        hb_dict_extract_int(&pv->plane_ctx[2].size, dict, "cr-size");
+        pv->plane_ctx[2].strength = val;
+    }
+
+    char *function_name = "chroma_smooth_local";
+
+    // Cascade values
+    // Cr not set; inherit Cb. Cb not set; defaults.
+    for (int c = 2; c < 3; c++)
+    {
+        chroma_smooth_vt_plane_context_t *prev_ctx = &pv->plane_ctx[c - 1];
+        chroma_smooth_vt_plane_context_t *ctx      = &pv->plane_ctx[c];
+
+        if (ctx->strength == -1) ctx->strength = prev_ctx->strength;
+        if (ctx->size     == -1) ctx->size     = prev_ctx->size;
+        if (ctx->size > 17)
+        {
+            pv->global = true;
+            function_name = "chroma_smooth_global";
+        }
+    }
+
+    pv->mtl = hb_metal_context_init(hb_chroma_smooth_vt_metallib_data,
+                                    hb_chroma_smooth_vt_metallib_len,
+                                    function_name,
+                                    sizeof(struct mtl_chroma_smooth_params),
+                                    init->geometry.width, init->geometry.height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("chroma_smooth_vt: failed to create Metal device");
+        return -1;
+    }
+
+    for (int c = 0; c < 3; c++)
+    {
+        chroma_smooth_vt_plane_context_t *ctx = &pv->plane_ctx[c];
+
+        float max = 1.0f;
+        ctx->max_value = max - max / 16;
+        ctx->min_value = max / 16;
+
+        // Replace unset values with defaults
+        if (ctx->strength == -1)
+        {
+            ctx->strength = CHROMA_SMOOTH_STRENGTH_DEFAULT;
+        }
+        if (ctx->size     == -1)
+        {
+            ctx->size     = CHROMA_SMOOTH_SIZE_DEFAULT;
+        }
+
+        // Sanitize
+        if (ctx->strength < 0) ctx->strength = 0;
+        if (ctx->strength > 3) ctx->strength = 3;
+        if (ctx->size % 2 == 0) ctx->size--;
+        if (ctx->size < CHROMA_SMOOTH_SIZE_MIN) ctx->size = CHROMA_SMOOTH_SIZE_MIN;
+        if (ctx->size > CHROMA_SMOOTH_SIZE_MAX) ctx->size = CHROMA_SMOOTH_SIZE_MAX;
+
+        const NSUInteger length = CHROMA_SMOOTH_SIZE_MAX * sizeof(float);
+        ctx->coef_x = [pv->mtl->device newBufferWithLength:length
+                                                     options:MTLResourceStorageModeManaged];
+        ctx->coef_y = [pv->mtl->device newBufferWithLength:length
+                                                     options:MTLResourceStorageModeManaged];
+
+        float *blur_x = ctx->coef_x.contents;
+        float *blur_y = ctx->coef_y.contents;
+        double sum = 0.0;
+
+        for (int x = 0; x < ctx->size; x++)
+        {
+            double dx = (double)(x - ctx->size / 2) / ctx->size;
+            sum += blur_x[x] = exp(-16.0 * (dx * dx));
+        }
+        for (int x = 0; x < ctx->size; x++)
+        {
+            blur_x[x] /= sum;
+        }
+
+        sum = 0.0;
+        for (int y = 0; y < ctx->size; y++)
+        {
+            double dy = (double)(y - ctx->size / 2) / ctx->size;
+            sum += blur_y[y] = exp(-16.0 * (dy * dy));
+        }
+        for (int y = 0; y < ctx->size; y++)
+        {
+            blur_y[y] /= sum;
+        }
+
+        [ctx->coef_x didModifyRange:NSMakeRange(0, length)];
+        [ctx->coef_y didModifyRange:NSMakeRange(0, length)];
+
+        NSUInteger matrix_length = ctx->size * ctx->size * sizeof(float);
+        ctx->matrix = [pv->mtl->device newBufferWithLength:matrix_length
+                                                   options:MTLResourceStorageModeManaged];
+
+        float *matrix = ctx->matrix.contents;
+        for (int y = 0; y < ctx->size; y++)
+        {
+            for (int x = 0; x < ctx->size; x++)
+            {
+                double val = blur_x[x] * blur_y[y];
+                matrix[y * ctx->size + x] = val;
+            }
+        }
+
+        [ctx->matrix didModifyRange:NSMakeRange(0, matrix_length)];
+    }
+
+    pv->output = *init;
+
+    return 0;
+}
+
+static void chroma_smooth_vt_close(hb_filter_object_t *filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    for (int i = 0; i < 3; i++)
+    {
+        chroma_smooth_vt_plane_context_t *ctx = &pv->plane_ctx[i];
+        [ctx->matrix release];
+        [ctx->coef_x release];
+        [ctx->coef_y release];
+    }
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> src,
+                        int channels,
+                        int plane)
+{
+    chroma_smooth_vt_plane_context_t *ctx = &pv->plane_ctx[plane];
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    struct mtl_chroma_smooth_params *params = (struct mtl_chroma_smooth_params *)pv->mtl->params_buffer.contents;
+    *params = (struct mtl_chroma_smooth_params)
+    {
+        .channels = channels,
+        .max_value = ctx->max_value,
+        .min_value = ctx->min_value,
+        .strength  = ctx->strength,
+        .size      = ctx->size,
+    };
+
+    [encoder setTexture:dst atIndex:0];
+    [encoder setTexture:src atIndex:1];
+
+    int i = 0;
+    if (pv->global)
+    {
+        [encoder setBuffer:ctx->matrix offset:0 atIndex:i++];
+    }
+    else
+    {
+        [encoder setBuffer:ctx->coef_x offset:0 atIndex:i++];
+        [encoder setBuffer:ctx->coef_y offset:0 atIndex:i++];
+    }
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:i++];
+
+    if (pv->global)
+    {
+        hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+    }
+    else
+    {
+        hb_metal_compute_encoder_dispatch_fixed_threadgroup_size(pv->mtl->device, pv->mtl->pipeline, encoder,
+                                                                 dst.width, dst.height, 16, 16);
+    }
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_src = hb_cv_get_pixel_buffer(in);
+
+    if (cv_src == NULL)
+    {
+        hb_log("chroma_smooth_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("chroma_smooth_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        int channels;
+        const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        CVMetalTextureRef src  = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_src, i, format);
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format);
+
+        id<MTLTexture> tex_src  = CVMetalTextureGetTexture(src);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_src, channels, i);
+
+        CFRelease(src);
+        CFRelease(dest);
+    }
+
+    CVBufferPropagateAttachments(cv_src, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type      = COREMEDIA;
+    out->storage           = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, in);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static int chroma_smooth_vt_work(hb_filter_object_t *filter,
+                                 hb_buffer_t **buf_in,
+                                 hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    @autoreleasepool
+    {
+        *buf_out = filter_frame(pv, in);
+    }
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/cv_utils.c
+++ b/libhb/platform/macosx/cv_utils.c
@@ -1,0 +1,336 @@
+/* cv_utils.c
+
+   Copyright (c) 2003-2022 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "libavutil/avutil.h"
+#include "cv_utils.h"
+
+OSType hb_cv_get_pixel_format(enum AVPixelFormat pix_fmt, enum AVColorRange color_range)
+{
+    if (pix_fmt == AV_PIX_FMT_NV12)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_420YpCbCr8BiPlanarFullRange :
+                                kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_YUV420P)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_420YpCbCr8PlanarFullRange :
+                                kCVPixelFormatType_420YpCbCr8Planar;
+    }
+    else if (pix_fmt == AV_PIX_FMT_BGRA)
+    {
+        return kCVPixelFormatType_32BGRA;
+    }
+    else if (pix_fmt == AV_PIX_FMT_P010LE)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_420YpCbCr10BiPlanarFullRange :
+                                kCVPixelFormatType_420YpCbCr10BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_NV16)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_422YpCbCr8BiPlanarFullRange :
+                                kCVPixelFormatType_422YpCbCr8BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_P210)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_422YpCbCr10BiPlanarFullRange :
+                                kCVPixelFormatType_422YpCbCr10BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_NV24)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_444YpCbCr8BiPlanarFullRange :
+                                kCVPixelFormatType_444YpCbCr8BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_P410)
+    {
+        return color_range == AVCOL_RANGE_JPEG ?
+                                kCVPixelFormatType_444YpCbCr10BiPlanarFullRange :
+                                kCVPixelFormatType_444YpCbCr10BiPlanarVideoRange;
+    }
+    else if (pix_fmt == AV_PIX_FMT_P416)
+    {
+        return kCVPixelFormatType_444YpCbCr16BiPlanarVideoRange;
+    }
+    else
+    {
+        return 0;
+    }
+}
+
+CVPixelBufferRef hb_cv_get_pixel_buffer(const hb_buffer_t *buf)
+{
+    if (buf->storage_type == AVFRAME)
+    {
+        return (CVPixelBufferRef)((AVFrame *)buf->storage)->data[3];
+    }
+    else if (buf->storage_type == COREMEDIA)
+    {
+        return (CVPixelBufferRef)buf->storage;
+    }
+    else
+    {
+        hb_log("corevideo: unknown storage");
+    }
+    return NULL;
+}
+
+CVPixelBufferPoolRef hb_cv_create_pixel_buffer_pool(int width, int height, enum AVPixelFormat pix_fmt, enum AVColorRange color_range)
+{
+    // CVPixelBuffer pool
+    // Set the Metal compatibility key
+    // to keep the buffer on the GPU memory
+    OSType cv_pix_fmt = hb_cv_get_pixel_format(pix_fmt, color_range);
+    CFNumberRef pix_fmt_num = CFNumberCreate(kCFAllocatorDefault, kCFNumberSInt32Type, &cv_pix_fmt);
+    CFNumberRef width_num   = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &width);
+    CFNumberRef height_num  = CFNumberCreate(kCFAllocatorDefault, kCFNumberIntType, &height);
+
+    const void *attrs_keys[4] =
+    {
+        kCVPixelBufferWidthKey,
+        kCVPixelBufferHeightKey,
+        kCVPixelBufferPixelFormatTypeKey,
+        kCVPixelBufferMetalCompatibilityKey
+    };
+    const void *attrs_values[4] =
+    {
+        width_num,
+        height_num,
+        pix_fmt_num,
+        kCFBooleanTrue
+    };
+
+    CFDictionaryRef attrs = CFDictionaryCreate(kCFAllocatorDefault,
+                                               attrs_keys,
+                                               attrs_values,
+                                               4,
+                                               &kCFTypeDictionaryKeyCallBacks,
+                                               &kCFTypeDictionaryValueCallBacks);
+
+    CFRelease(width_num);
+    CFRelease(height_num);
+    CFRelease(pix_fmt_num);
+
+    CVPixelBufferPoolRef pool;
+    CVReturn ret = CVPixelBufferPoolCreate(kCFAllocatorDefault, NULL, attrs, &pool);
+    CFRelease(attrs);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("corevideo: CVPixelBufferPoolCreate failed");
+        return NULL;
+    }
+
+    return pool;
+}
+
+CFStringRef hb_cv_colr_pri_xlat(int color_prim)
+{
+    switch (color_prim)
+    {
+        case HB_COLR_PRI_BT2020:
+            return kCMFormatDescriptionColorPrimaries_ITU_R_2020;
+        case HB_COLR_PRI_BT709:
+            return kCMFormatDescriptionColorPrimaries_ITU_R_709_2;
+        case HB_COLR_PRI_EBUTECH:
+            return kCMFormatDescriptionColorPrimaries_EBU_3213;
+        case HB_COLR_PRI_SMPTEC:
+            return kCMFormatDescriptionColorPrimaries_SMPTE_C;
+        default:
+            return NULL;
+    }
+}
+
+CFStringRef hb_cv_colr_tra_xlat(int color_transfer)
+{
+    switch (color_transfer)
+    {
+        case HB_COLR_TRA_BT709:
+            return kCMFormatDescriptionTransferFunction_ITU_R_709_2;
+        case HB_COLR_TRA_SMPTE240M:
+            return kCMFormatDescriptionTransferFunction_SMPTE_240M_1995;
+        case HB_COLR_TRA_SMPTEST2084:
+            return kCVImageBufferTransferFunction_SMPTE_ST_2084_PQ;
+        case HB_COLR_TRA_LINEAR:
+            if (__builtin_available(macOS 10.14, *)) { return kCVImageBufferTransferFunction_Linear; }
+        case HB_COLR_TRA_IEC61966_2_1:
+            return kCVImageBufferTransferFunction_sRGB;
+        case HB_COLR_TRA_ARIB_STD_B67:
+            return kCVImageBufferTransferFunction_ITU_R_2100_HLG;
+        case HB_COLR_TRA_GAMMA22:
+            return kCVImageBufferTransferFunction_UseGamma;
+        case HB_COLR_TRA_GAMMA28:
+            return kCVImageBufferTransferFunction_UseGamma;
+        case HB_COLR_TRA_BT2020_10:
+        case HB_COLR_TRA_BT2020_12:
+            return kCVImageBufferTransferFunction_ITU_R_2020;
+        default:
+            return NULL;
+    }
+}
+
+CFNumberRef hb_cv_colr_gamma_xlat(int color_transfer)
+{
+    Float32 gamma = 0;
+    switch (color_transfer)
+    {
+        case HB_COLR_TRA_GAMMA22:
+            gamma = 2.2;
+        case HB_COLR_TRA_GAMMA28:
+            gamma = 2.8;
+    }
+
+    return gamma > 0 ? CFNumberCreate(NULL, kCFNumberFloat32Type, &gamma) : NULL;
+}
+
+CFStringRef hb_cv_colr_mat_xlat(int color_matrix)
+{
+    switch (color_matrix)
+    {
+        case HB_COLR_MAT_BT2020_NCL:
+            return kCMFormatDescriptionYCbCrMatrix_ITU_R_2020;
+        case HB_COLR_MAT_BT709:
+            return kCMFormatDescriptionYCbCrMatrix_ITU_R_709_2;
+        case HB_COLR_MAT_SMPTE170M:
+            return kCMFormatDescriptionYCbCrMatrix_ITU_R_601_4;
+        case HB_COLR_MAT_SMPTE240M:
+            return kCMFormatDescriptionYCbCrMatrix_SMPTE_240M_1995;
+        default:
+            return NULL;
+    }
+}
+
+CFStringRef hb_cv_chroma_loc_xlat(int chroma_location)
+{
+    switch (chroma_location)
+    {
+        case AVCHROMA_LOC_LEFT:
+            return kCVImageBufferChromaLocation_Left;
+        case AVCHROMA_LOC_CENTER:
+            return kCVImageBufferChromaLocation_Center;
+        case AVCHROMA_LOC_TOPLEFT:
+            return kCVImageBufferChromaLocation_TopLeft;
+        case AVCHROMA_LOC_TOP:
+            return kCVImageBufferChromaLocation_Top;
+        case AVCHROMA_LOC_BOTTOMLEFT:
+            return kCVImageBufferChromaLocation_BottomLeft;
+        case AVCHROMA_LOC_BOTTOM:
+            return kCVImageBufferChromaLocation_Bottom;
+        default:
+            return NULL;
+    }
+}
+
+void hb_cv_add_color_tag(CVPixelBufferRef pix_buf,
+                         int color_prim, int color_transfer,
+                         int color_matrix, int chroma_location)
+{
+    CFStringRef prim       = hb_cv_colr_pri_xlat(color_prim);
+    CFStringRef transfer   = hb_cv_colr_tra_xlat(color_transfer);
+    CFNumberRef gamma      = hb_cv_colr_gamma_xlat(color_transfer);
+    CFStringRef matrix     = hb_cv_colr_mat_xlat(color_matrix);
+    CFStringRef chroma_loc = hb_cv_chroma_loc_xlat(chroma_location);
+
+    CVBufferRemoveAllAttachments(pix_buf);
+
+    if (prim)
+    {
+        CVBufferSetAttachment(pix_buf, kCVImageBufferColorPrimariesKey, prim, kCVAttachmentMode_ShouldPropagate);
+    }
+    if (transfer)
+    {
+        CVBufferSetAttachment(pix_buf, kCVImageBufferTransferFunctionKey, transfer, kCVAttachmentMode_ShouldPropagate);
+    }
+    if (gamma)
+    {
+        CVBufferSetAttachment(pix_buf, kCVImageBufferGammaLevelKey, gamma, kCVAttachmentMode_ShouldPropagate);
+        CFRelease(gamma);
+    }
+    if (matrix)
+    {
+        CVBufferSetAttachment(pix_buf, kCVImageBufferYCbCrMatrixKey, matrix, kCVAttachmentMode_ShouldPropagate);
+    }
+    if (chroma_loc)
+    {
+        CVBufferSetAttachment(pix_buf, kCVImageBufferChromaLocationTopFieldKey, chroma_loc, kCVAttachmentMode_ShouldPropagate);
+        CVBufferSetAttachment(pix_buf, kCVImageBufferChromaLocationBottomFieldKey, chroma_loc, kCVAttachmentMode_ShouldPropagate);
+    }
+}
+
+int hb_cv_match_rgb_to_colorspace(int rgb,
+                                  int color_prim,
+                                  int color_transfer,
+                                  int color_matrix)
+{
+    const unsigned r = (rgb >> 16) & 0xff;
+    const unsigned g = (rgb >> 8) & 0xff;
+    const unsigned b = (rgb) & 0xff;
+
+    if (__builtin_available(macOS 10.15, *)) {
+
+        CGColorRef rgb_color = CGColorCreateSRGB(r / 255.f, g / 255.f, b / 255.f, 1.f);
+
+        CFStringRef prim     = CVColorPrimariesGetStringForIntegerCodePoint(color_prim);
+        CFStringRef transfer = CVTransferFunctionGetStringForIntegerCodePoint(color_transfer);
+        CFNumberRef gamma    = hb_cv_colr_gamma_xlat(color_transfer);
+        CFStringRef matrix   = CVYCbCrMatrixGetStringForIntegerCodePoint(color_matrix);
+
+        CGColorSpaceRef colorspace = NULL;
+        if (transfer == kCVImageBufferTransferFunction_UseGamma)
+        {
+            const void *keys[4] = { kCVImageBufferColorPrimariesKey, kCVImageBufferTransferFunctionKey,
+                kCVImageBufferYCbCrMatrixKey, kCVImageBufferGammaLevelKey };
+            const void *values[4] = { prim, transfer, matrix, gamma };
+            CFDictionaryRef attachments = CFDictionaryCreate(NULL, keys, values, 4, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+            colorspace = CVImageBufferCreateColorSpaceFromAttachments(attachments);
+            CFRelease(attachments);
+        }
+        else
+        {
+            const void *keys[3] = { kCVImageBufferColorPrimariesKey, kCVImageBufferTransferFunctionKey, kCVImageBufferYCbCrMatrixKey };
+            const void *values[3] = { prim, transfer, gamma };
+            CFDictionaryRef attachments = CFDictionaryCreate(NULL, keys, values, 3, &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+
+            colorspace = CVImageBufferCreateColorSpaceFromAttachments(attachments);
+            CFRelease(attachments);
+        }
+
+        if (colorspace == NULL)
+        {
+            CFRelease(rgb_color);
+            hb_log("cgcolor: unable to match color to colorspace");
+            return rgb;
+        }
+
+        CGColorRef matched_color = CGColorCreateCopyByMatchingToColorSpace(colorspace,
+                                                                           kCGRenderingIntentPerceptual,
+                                                                           rgb_color, NULL);
+        CFRelease(colorspace);
+        CFRelease(rgb_color);
+        if (matched_color == NULL)
+        {
+            hb_log("cgcolor: unable to match color to colorspace");
+            return rgb;
+        }
+
+        const CGFloat *components = CGColorGetComponents(matched_color);
+        const int color = ((int)(components[0] * 255) << 16) | ((int)(components[1] * 255) << 8) | (int)(components[2] * 255);
+        CFRelease(matched_color);
+        return color;
+    }
+    else
+    {
+        return rgb;
+    }
+}

--- a/libhb/platform/macosx/cv_utils.h
+++ b/libhb/platform/macosx/cv_utils.h
@@ -1,0 +1,40 @@
+/* cv_utils.h
+
+   Copyright (c) 2003-2022 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HB_COREVIDEO_UTILS_H
+#define HB_COREVIDEO_UTILS_H
+
+#include <CoreVideo/CoreVideo.h>
+#include <CoreMedia/CoreMedia.h>
+
+OSType hb_cv_get_pixel_format(enum AVPixelFormat pix_fmt,
+                              enum AVColorRange color_range);
+
+CVPixelBufferRef hb_cv_get_pixel_buffer(const hb_buffer_t *buf);
+
+CVPixelBufferPoolRef hb_cv_create_pixel_buffer_pool(int width, int height,
+                                                    enum AVPixelFormat pix_fmt,
+                                                    enum AVColorRange color_range);
+
+CFStringRef hb_cv_colr_pri_xlat(int color_prim);
+CFStringRef hb_cv_colr_tra_xlat(int color_transfer);
+CFNumberRef hb_cv_colr_gamma_xlat(int color_transfer);
+CFStringRef hb_cv_colr_mat_xlat(int color_matrix);
+CFStringRef hb_cv_chroma_loc_xlat(int chroma_location);
+
+void hb_cv_add_color_tag(CVPixelBufferRef pix_buf,
+                         int color_prim, int color_transfer,
+                         int color_matrix, int chroma_location);
+
+int hb_cv_match_rgb_to_colorspace(int rgb,
+                                  int color_prim,
+                                  int color_transfer,
+                                  int color_matrix);
+
+#endif /* HB_COREVIDEO_UTILS_H */

--- a/libhb/platform/macosx/deinterlace_vt.m
+++ b/libhb/platform/macosx/deinterlace_vt.m
@@ -1,0 +1,406 @@
+/* deinterlace_vt.m
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "handbrake/decomb.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_yadif_vt_metallib_data[];
+extern unsigned int hb_yadif_vt_metallib_len;
+
+extern char hb_bwdif_vt_metallib_data[];
+extern unsigned int hb_bwdif_vt_metallib_len;
+
+struct mtl_deint_params
+{
+    uint channels;
+    uint parity;
+    uint tff;
+    bool is_second_field;
+    bool skip_spatial_check;
+    bool is_field_end;
+};
+
+#define PREV 0
+#define CURR 1
+#define NEXT 2
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    int mode;
+    int parity;
+
+    hb_buffer_t        *ref[3];
+    hb_buffer_list_t    out_list;
+
+    hb_filter_init_t    input;
+    hb_filter_init_t    output;
+};
+
+static int yadif_vt_init(hb_filter_object_t *filter,
+                         hb_filter_init_t   *init);
+static int bwdif_vt_init(hb_filter_object_t *filter,
+                         hb_filter_init_t   *init);
+static int deinterlace_vt_init(hb_filter_object_t *filter,
+                               hb_filter_init_t   *init);
+
+static int deinterlace_vt_work(hb_filter_object_t *filter,
+                               hb_buffer_t **buf_in,
+                               hb_buffer_t **buf_out);
+
+static void deinterlace_vt_close(hb_filter_object_t *filter);
+
+/*
+ *  mode   - deinterlace mode
+ *  parity - field parity
+ *  Modes:
+ *      1 = Enabled ("send_frame")
+ *      2 = Spatial [Yadif only]
+ *      4 = Bob ("send_field")
+ *      8 = Selective
+ *  Parity:
+ *      0  = Top Field First
+ *      1  = Bottom Field First
+ *     -1  = Automatic detection of field parity
+ */
+
+const char deinterlace_vt_template[] = "mode=^"HB_INT_REG"$:parity=^([01])$";
+
+hb_filter_object_t hb_filter_yadif_vt =
+{
+    .id                = HB_FILTER_YADIF_VT,
+    .enforce_order     = 1,
+    .name              = "Yadif (VideoToolbox)",
+    .settings          = NULL,
+    .init              = yadif_vt_init,
+    .work              = deinterlace_vt_work,
+    .close             = deinterlace_vt_close,
+    .settings_template = deinterlace_vt_template,
+};
+
+hb_filter_object_t hb_filter_bwdif_vt =
+{
+    .id                = HB_FILTER_BWDIF_VT,
+    .enforce_order     = 1,
+    .name              = "Bwdif (VideoToolbox)",
+    .settings          = NULL,
+    .init              = bwdif_vt_init,
+    .work              = deinterlace_vt_work,
+    .close             = deinterlace_vt_close,
+    .settings_template = deinterlace_vt_template,
+};
+
+static int yadif_vt_init(hb_filter_object_t *filter,
+                         hb_filter_init_t   *init)
+{
+    return deinterlace_vt_init(filter, init);
+}
+
+static int bwdif_vt_init(hb_filter_object_t *filter,
+                         hb_filter_init_t   *init)
+{
+    return deinterlace_vt_init(filter, init);
+}
+
+static int deinterlace_vt_init(hb_filter_object_t *filter,
+                               hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("deinterlace_vt: calloc failed");
+        return -1;
+    }
+
+    hb_filter_private_t *pv = filter->private_data;
+    pv->input = *init;
+    hb_buffer_list_clear(&pv->out_list);
+
+    hb_dict_t *settings = filter->settings;
+    int mode = 3, parity = -1;
+
+    hb_dict_extract_int(&mode,   settings, "mode");
+    hb_dict_extract_int(&parity, settings, "parity");
+
+    pv->mode   = mode;
+    pv->parity = parity;
+    pv->desc   = av_pix_fmt_desc_get(init->pix_fmt);
+
+    if (filter->id == HB_FILTER_YADIF_VT)
+    {
+        pv->mtl = hb_metal_context_init(hb_yadif_vt_metallib_data,
+                                        hb_yadif_vt_metallib_len,
+                                        "deint",
+                                        sizeof(struct mtl_deint_params),
+                                        init->geometry.width, init->geometry.height,
+                                        init->pix_fmt, init->color_range);
+    }
+    else if (filter->id == HB_FILTER_BWDIF_VT)
+    {
+        pv->mtl = hb_metal_context_init(hb_bwdif_vt_metallib_data,
+                                        hb_bwdif_vt_metallib_len,
+                                        "deint",
+                                        sizeof(struct mtl_deint_params),
+                                        init->geometry.width, init->geometry.height,
+                                        init->pix_fmt, init->color_range);
+    }
+
+    if (pv->mtl == NULL)
+    {
+        hb_error("deinterlace_vt: failed to create Metal device");
+        return -1;
+    }
+
+    pv->output = *init;
+    return 0;
+}
+
+static void deinterlace_vt_close(hb_filter_object_t *filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    for (int i = 0; i < 3; i++)
+    {
+        hb_buffer_close(&pv->ref[i]);
+    }
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> prev,
+                        id<MTLTexture> cur,
+                        id<MTLTexture> next,
+                        int channels,
+                        int parity,
+                        int tff)
+{
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    struct mtl_deint_params *params = (struct mtl_deint_params *)pv->mtl->params_buffer.contents;
+    *params = (struct mtl_deint_params)
+    {
+        .channels = channels,
+        .parity = parity,
+        .tff = tff,
+        .is_second_field = !(parity ^ tff),
+        .skip_spatial_check = (pv->mode & MODE_YADIF_SPATIAL) == 0,
+        .is_field_end = false
+    };
+
+    [encoder setTexture:dst  atIndex:0];
+    [encoder setTexture:prev atIndex:1];
+    [encoder setTexture:cur  atIndex:2];
+    [encoder setTexture:next atIndex:3];
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:0];
+
+    hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static void store_buf(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    if (pv->ref[PREV])
+    {
+        hb_buffer_close(&pv->ref[PREV]);
+    }
+    pv->ref[PREV] = pv->ref[CURR];
+    pv->ref[CURR] = pv->ref[NEXT];
+    pv->ref[NEXT] = in;
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, int parity, int tff)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_prev = pv->ref[PREV] ? hb_cv_get_pixel_buffer(pv->ref[PREV]) : hb_cv_get_pixel_buffer(pv->ref[CURR]);
+    CVPixelBufferRef cv_cur = hb_cv_get_pixel_buffer(pv->ref[CURR]);
+    CVPixelBufferRef cv_next = pv->ref[NEXT] ? hb_cv_get_pixel_buffer(pv->ref[NEXT]) : hb_cv_get_pixel_buffer(pv->ref[CURR]);
+
+    if (cv_prev == NULL || cv_cur == NULL || cv_next == NULL)
+    {
+        hb_log("bwdif_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("bwdif_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        int channels;
+        const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        CVMetalTextureRef prev = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_prev, i, format);
+        CVMetalTextureRef cur  = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_cur,  i, format);
+        CVMetalTextureRef next = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_next, i, format);
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format);
+
+        id<MTLTexture> tex_prev = CVMetalTextureGetTexture(prev);
+        id<MTLTexture> tex_cur  = CVMetalTextureGetTexture(cur);
+        id<MTLTexture> tex_next = CVMetalTextureGetTexture(next);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_prev, tex_cur, tex_next, channels, parity, tff);
+
+        CFRelease(prev);
+        CFRelease(cur);
+        CFRelease(next);
+        CFRelease(dest);
+    }
+
+    CVBufferPropagateAttachments(cv_cur, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type      = COREMEDIA;
+    out->storage           = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, pv->ref[CURR]);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static void process_frame(hb_filter_private_t *pv)
+{
+    if ((pv->mode & MODE_DECOMB_SELECTIVE) &&
+         pv->ref[CURR]->s.combed == HB_COMB_NONE)
+    {
+        // Input buffer is not combed, just make a dup of it
+        hb_buffer_t *buf = hb_buffer_dup(pv->ref[CURR]);
+        hb_buffer_list_append(&pv->out_list, buf);
+    }
+    else
+    {
+        // Determine if top-field first layout
+        int tff;
+        if (pv->parity < 0)
+        {
+            uint16_t flags = pv->ref[CURR]->s.flags;
+            tff = ((flags & PIC_FLAG_PROGRESSIVE_FRAME) == 0) ?
+                  !!(flags & PIC_FLAG_TOP_FIELD_FIRST) : 1;
+        }
+        else
+        {
+            tff = (pv->parity & 1) ^ 1;
+        }
+
+        // Deinterlace both fields if Bob
+        int num_frames = 1;
+        if (pv->mode & MODE_XXDIF_BOB)
+        {
+            num_frames = 2;
+        }
+
+        // Perform filtering
+        for (int frame = 0; frame < num_frames; frame++)
+        {
+            hb_buffer_t *buf;
+            int parity = frame ^ tff ^ 1;
+
+            @autoreleasepool
+            {
+                buf = filter_frame(pv, parity, tff);
+            }
+            hb_buffer_list_append(&pv->out_list, buf);
+        }
+
+        // If this frame was deinterlaced and Bob mode is engaged,
+        // halve the duration of the saved timestamps
+        if (pv->mode & MODE_XXDIF_BOB)
+        {
+            hb_buffer_t *first  = hb_buffer_list_head(&pv->out_list);
+            hb_buffer_t *second = hb_buffer_list_tail(&pv->out_list);
+            first->s.stop  -= (first->s.stop - first->s.start) / 2LL;
+            second->s.start = first->s.stop;
+            second->s.new_chap = 0;
+        }
+    }
+}
+
+static int deinterlace_vt_work(hb_filter_object_t *filter,
+                               hb_buffer_t **buf_in,
+                               hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+    *buf_in = NULL;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        store_buf(pv, NULL);
+        process_frame(pv);
+        hb_buffer_list_append(&pv->out_list, in);
+        *buf_out = hb_buffer_list_clear(&pv->out_list);
+        return HB_FILTER_DONE;
+    }
+
+    store_buf(pv, in);
+
+    if (pv->ref[CURR] == NULL)
+    {
+        // Wait for next buffer
+        return HB_FILTER_DELAY;
+    }
+
+    process_frame(pv);
+    *buf_out = hb_buffer_list_clear(&pv->out_list);
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/grayscale_vt.m
+++ b/libhb/platform/macosx/grayscale_vt.m
@@ -1,0 +1,282 @@
+/* grayscale_vt.m
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "handbrake/decomb.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_grayscale_vt_metallib_data[];
+extern unsigned int hb_grayscale_vt_metallib_len;
+
+struct mtl_grayscale_params
+{
+    uint plane;
+    bool biplanar;
+    uint subw;
+    uint subh;
+    uint cb;
+    uint cr;
+    uint size;
+    uint high;
+};
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    int cb;
+    int cr;
+    int size;
+    int high;
+
+    hb_filter_init_t    input;
+    hb_filter_init_t    output;
+};
+
+static int grayscale_vt_init(hb_filter_object_t *filter,
+                             hb_filter_init_t   *init);
+
+static int grayscale_vt_work(hb_filter_object_t *filter,
+                             hb_buffer_t **buf_in,
+                             hb_buffer_t **buf_out);
+
+static void grayscale_vt_close(hb_filter_object_t *filter);
+
+const char grayscale_vt_template[] =
+    "cb=^"HB_FLOAT_REG"$:cr=^"HB_FLOAT_REG"$:size=^"HB_FLOAT_REG"$:high=^"HB_FLOAT_REG"$";
+
+hb_filter_object_t hb_filter_grayscale_vt =
+{
+    .id                = HB_FILTER_GRAYSCALE_VT,
+    .enforce_order     = 1,
+    .name              = "Grayscale (VideoToolbox)",
+    .settings          = NULL,
+    .init              = grayscale_vt_init,
+    .work              = grayscale_vt_work,
+    .close             = grayscale_vt_close,
+    .settings_template = grayscale_vt_template,
+};
+
+static int grayscale_vt_init(hb_filter_object_t *filter,
+                             hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("grayscale_vt: calloc failed");
+        return -1;
+    }
+
+    hb_filter_private_t *pv = filter->private_data;
+    pv->input = *init;
+    pv->desc  = av_pix_fmt_desc_get(init->pix_fmt);
+
+    hb_dict_t *settings = filter->settings;
+    double cb = 0, cr = 0, size = 1, high = 0;
+
+    hb_dict_extract_double(&cb, settings, "cb");
+    hb_dict_extract_double(&cr, settings, "cr");
+    hb_dict_extract_double(&size, settings, "size");
+    hb_dict_extract_double(&high, settings, "high");
+
+    pv->cb = cb;
+    pv->cr = cr;
+    pv->size = size;
+    pv->high = high;
+
+    pv->mtl = hb_metal_context_init(hb_grayscale_vt_metallib_data,
+                                    hb_grayscale_vt_metallib_len,
+                                    "monochrome",
+                                    sizeof(struct mtl_grayscale_params),
+                                    init->geometry.width, init->geometry.height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("grayscale_vt: failed to create Metal device");
+        return -1;
+    }
+
+    pv->output = *init;
+    return 0;
+}
+
+static void grayscale_vt_close(hb_filter_object_t *filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> src[3],
+                        int plane,
+                        int channels)
+{
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    struct mtl_grayscale_params *params = (struct mtl_grayscale_params *)pv->mtl->params_buffer.contents;
+    *params = (struct mtl_grayscale_params)
+    {
+        .plane = plane,
+        .biplanar = channels == 2,
+        .subw = pv->desc->log2_chroma_w,
+        .subh = pv->desc->log2_chroma_h,
+        .cb = pv->cb,
+        .cr = pv->cr,
+        .size = pv->size,
+        .high = pv->high,
+    };
+
+    [encoder setTexture:dst atIndex:0];
+    for (int i = 0; i < 3; i++)
+    {
+        if (src[i] != NULL)
+        {
+            [encoder setTexture:src[i] atIndex:i+1];
+        }
+    }
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:0];
+
+    hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_source = hb_cv_get_pixel_buffer(in);
+
+    if (cv_source == NULL)
+    {
+        hb_log("grayscale_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("grayscale_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    CVMetalTextureRef  src[3] = { NULL };
+    MTLPixelFormat  format[3] = { 0 };
+    id<MTLTexture> tex_src[3] = { NULL };
+    int channels;
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        format[i] = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format[i] == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        src[i]     = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_source, i, format[i]);
+        tex_src[i] = CVMetalTextureGetTexture(src[i]);
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format[i]);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_src, i, channels);
+
+        CFRelease(dest);
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        if (src[i] != NULL)
+        {
+            CFRelease(src[i]);
+        }
+    }
+
+    CVBufferPropagateAttachments(cv_source, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type      = COREMEDIA;
+    out->storage           = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, in);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static int grayscale_vt_work(hb_filter_object_t *filter,
+                             hb_buffer_t **buf_in,
+                             hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    @autoreleasepool
+    {
+        *buf_out = filter_frame(pv, in);
+    }
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/lapsharp_vt.m
+++ b/libhb/platform/macosx/lapsharp_vt.m
@@ -1,0 +1,408 @@
+/* lapsharp_vt.m
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_lapsharp_vt_metallib_data[];
+extern unsigned int hb_lapsharp_vt_metallib_len;
+
+#define LAPSHARP_STRENGTH_LUMA_DEFAULT   0.2
+#define LAPSHARP_STRENGTH_CHROMA_DEFAULT 0.2
+
+#define LAPSHARP_KERNELS 4
+#define LAPSHARP_KERNEL_LUMA_DEFAULT   2
+#define LAPSHARP_KERNEL_CHROMA_DEFAULT 2
+
+typedef struct
+{
+    uint   channels;
+    float  strength;  // strength
+    uint   size;
+    float  coef;
+    int    kernel;
+} lapsharp_plane_context_t;
+
+typedef struct {
+    const int   *mem;
+    const int    size;
+    const double coef;
+} kernel_t;
+
+// 4-neighbor Laplacian kernel (lap)
+// Sharpens vertical and horizontal edges, less effective on diagonals
+// size = 3, coef = 1.0
+static const int    kernel_lap[] =
+{
+ 0, -1,  0,
+-1,  5, -1,
+ 0, -1,  0
+};
+
+// Isotropic Laplacian kernel (isolap)
+// Minimal directionality, sharpens all edges similarly
+// size = 3, coef = 1.0 / 5
+static const int    kernel_isolap[] =
+{
+-1, -4, -1,
+-4, 25, -4,
+-1, -4, -1
+};
+
+// Laplacian of Gaussian kernel (log)
+// Slight noise and grain rejection
+// σ ~= 1
+// size = 5, coef = 1.0 / 5
+static const int    kernel_log[] =
+{
+ 0,  0, -1,  0,  0,
+ 0, -1, -2, -1,  0,
+-1, -2, 21, -2, -1,
+ 0, -1, -2, -1,  0,
+ 0,  0, -1,  0,  0
+};
+
+// Isotropic Laplacian of Gaussian kernel (isolog)
+// Minimal directionality, plus noise and grain rejection
+// σ ~= 1.2
+// size = 5, coef = 1.0 / 15
+static const int    kernel_isolog[] =
+{
+ 0, -1, -1, -1,  0,
+-1, -3, -4, -3, -1,
+-1, -4, 55, -4, -1,
+-1, -3, -4, -3, -1,
+ 0, -1, -1, -1,  0
+};
+
+static kernel_t kernels[] =
+{
+    { kernel_lap,    3, 1.0      },
+    { kernel_isolap, 3, 1.0 /  5 },
+    { kernel_log,    5, 1.0 /  5 },
+    { kernel_isolog, 5, 1.0 / 15 }
+};
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    lapsharp_plane_context_t    plane_ctx[3];
+    id<MTLBuffer>               mem[3];
+
+    hb_filter_init_t            input;
+    hb_filter_init_t            output;
+};
+
+static int lapsharp_vt_init(hb_filter_object_t *filter,
+                           hb_filter_init_t   *init);
+
+static int lapsharp_vt_work(hb_filter_object_t *filter,
+                           hb_buffer_t ** buf_in,
+                           hb_buffer_t ** buf_out);
+
+static void lapsharp_vt_close(hb_filter_object_t *filter);
+
+static const char lapsharp_vt_template[] =
+    "y-strength=^"HB_FLOAT_REG"$:y-size=^"HB_INT_REG"$:"
+    "cb-strength=^"HB_FLOAT_REG"$:cb-size=^"HB_INT_REG"$:"
+    "cr-strength=^"HB_FLOAT_REG"$:cr-size=^"HB_INT_REG"$";
+
+hb_filter_object_t hb_filter_lapsharp_vt =
+{
+    .id                = HB_FILTER_LAPSHARP_VT,
+    .enforce_order     = 1,
+    .name              = "Lapsharp (VideoToolbox)",
+    .settings          = NULL,
+    .init              = lapsharp_vt_init,
+    .work              = lapsharp_vt_work,
+    .close             = lapsharp_vt_close,
+    .settings_template = lapsharp_vt_template,
+};
+
+static int lapsharp_vt_init(hb_filter_object_t *filter,
+                        hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("lapsharp_vt: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t * pv = filter->private_data;
+    pv->input = *init;
+    pv->desc = av_pix_fmt_desc_get(init->pix_fmt);
+
+    pv->mtl = hb_metal_context_init(hb_lapsharp_vt_metallib_data,
+                                    hb_lapsharp_vt_metallib_len,
+                                    "lapsharp",
+                                    sizeof(lapsharp_plane_context_t),
+                                    init->geometry.width, init->geometry.height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("lapsharp_vt: failed to create Metal device");
+        return -1;
+    }
+
+    char *kernel_string[3];
+
+    // Mark parameters unset
+    for (int c = 0; c < 3; c++)
+    {
+        pv->plane_ctx[c].strength = -1;
+        pv->plane_ctx[c].kernel   = -1;
+        kernel_string[c]          = NULL;
+    }
+
+    // Read user parameters
+    if (filter->settings != NULL)
+    {
+        hb_dict_t *dict = filter->settings;
+        double val;
+        hb_dict_extract_double(&val, dict, "y-strength");
+        hb_dict_extract_string(&kernel_string[0], dict, "y-kernel");
+        pv->plane_ctx[0].strength = val;
+
+        hb_dict_extract_double(&val, dict, "cb-strength");
+        hb_dict_extract_string(&kernel_string[1], dict, "cb-kernel");
+        pv->plane_ctx[1].strength = val;
+
+        hb_dict_extract_double(&val, dict, "cr-strength");
+        hb_dict_extract_string(&kernel_string[2], dict, "cr-kernel");
+        pv->plane_ctx[2].strength = val;
+    }
+
+    for (int c = 0; c < 3; c++)
+    {
+        lapsharp_plane_context_t * ctx = &pv->plane_ctx[c];
+
+        ctx->kernel = -1;
+
+        if (kernel_string[c] == NULL)
+        {
+            continue;
+        }
+
+        if (!strcasecmp(kernel_string[c], "lap"))
+        {
+            ctx->kernel = 0;
+        }
+        else if (!strcasecmp(kernel_string[c], "isolap"))
+        {
+            ctx->kernel = 1;
+        }
+        else if (!strcasecmp(kernel_string[c], "log"))
+        {
+            ctx->kernel = 2;
+        }
+        else if (!strcasecmp(kernel_string[c], "isolog"))
+        {
+            ctx->kernel = 3;
+        }
+
+        free(kernel_string[c]);
+    }
+
+    // Cascade values
+    // Cr not set; inherit Cb. Cb not set; inherit Y. Y not set; defaults.
+    for (int c = 1; c < 3; c++)
+    {
+        lapsharp_plane_context_t * prev_ctx = &pv->plane_ctx[c - 1];
+        lapsharp_plane_context_t * ctx      = &pv->plane_ctx[c];
+
+        if (ctx->strength == -1) ctx->strength = prev_ctx->strength;
+        if (ctx->kernel   == -1) ctx->kernel   = prev_ctx->kernel;
+    }
+
+    for (int c = 0; c < 3; c++)
+    {
+        lapsharp_plane_context_t * ctx = &pv->plane_ctx[c];
+
+        // Replace unset values with defaults
+        if (ctx->strength == -1)
+        {
+            ctx->strength = c ? LAPSHARP_STRENGTH_CHROMA_DEFAULT :
+                                LAPSHARP_STRENGTH_LUMA_DEFAULT;
+        }
+        if (ctx->kernel   == -1)
+        {
+            ctx->kernel   = c ? LAPSHARP_KERNEL_CHROMA_DEFAULT :
+                                LAPSHARP_KERNEL_LUMA_DEFAULT;
+        }
+
+        // Sanitize
+        if (ctx->strength < 0)   ctx->strength = 0;
+        if (ctx->strength > 1.5) ctx->strength = 1.5;
+        if ((ctx->kernel < 0) || (ctx->kernel >= LAPSHARP_KERNELS))
+        {
+            ctx->kernel = c ? LAPSHARP_KERNEL_CHROMA_DEFAULT : LAPSHARP_KERNEL_LUMA_DEFAULT;
+        }
+
+        kernel_t *kernel = &kernels[ctx->kernel];
+        NSUInteger length = kernel->size * kernel->size * sizeof(int);
+
+        pv->mem[c] = [pv->mtl->device newBufferWithLength:length
+                                                  options:MTLResourceStorageModeManaged];
+        memcpy(pv->mem[c].contents, kernel->mem, length);
+        [pv->mem[c] didModifyRange:NSMakeRange(0, length)];
+
+        ctx->size = kernel->size;
+        ctx->coef = kernel->coef;
+    }
+
+    pv->output = *init;
+
+    return 0;
+}
+
+static void lapsharp_vt_close(hb_filter_object_t * filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    for (int i = 0; i < 3; i++)
+    {
+        [pv->mem[i] release];
+    }
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> src,
+                        int channels,
+                        int plane)
+{
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    lapsharp_plane_context_t *params = (lapsharp_plane_context_t *)pv->mtl->params_buffer.contents;
+    *params = pv->plane_ctx[plane];
+    params->channels = channels;
+
+    [encoder setTexture:dst atIndex:0];
+    [encoder setTexture:src atIndex:1];
+    [encoder setBuffer:pv->mem[plane] offset:0 atIndex:0];
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:1];
+
+    hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_src = hb_cv_get_pixel_buffer(in);
+
+    if (cv_src == NULL)
+    {
+        hb_log("lapsharp_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("lapsharp_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        int channels;
+        const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        CVMetalTextureRef src  = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_src, i, format);
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format);
+
+        id<MTLTexture> tex_src  = CVMetalTextureGetTexture(src);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_src, channels, i);
+
+        CFRelease(src);
+        CFRelease(dest);
+    }
+
+    CVBufferPropagateAttachments(cv_src, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type      = COREMEDIA;
+    out->storage           = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, in);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static int lapsharp_vt_work(hb_filter_object_t *filter,
+                            hb_buffer_t **buf_in,
+                            hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    @autoreleasepool
+    {
+        *buf_out = filter_frame(pv, in);
+    }
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/metal_utils.h
+++ b/libhb/platform/macosx/metal_utils.h
@@ -1,0 +1,58 @@
+/* utils.h
+
+   Copyright (c) 2003-2022 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HB_METAL_UTILS_H
+#define HB_METAL_UTILS_H
+
+#include <Metal/Metal.h>
+#include <CoreVideo/CoreVideo.h>
+#include "libavutil/avutil.h"
+
+struct hb_metal_context_s
+{
+    id<MTLDevice>               device;
+    id<MTLLibrary>              library;
+    id<MTLCommandQueue>         queue;
+    id<MTLComputePipelineState> pipeline;
+    id<MTLFunction>             function;
+    id<MTLBuffer>               params_buffer;
+
+    CVMetalTextureCacheRef   cache;
+    CVPixelBufferPoolRef     pool;
+};
+typedef struct hb_metal_context_s hb_metal_context_t;
+
+hb_metal_context_t * hb_metal_context_init(const char *metallib_data,
+                                           size_t metallib_len,
+                                           const char *function_name,
+                                           size_t params_buffer_len,
+                                           int width, int height,
+                                           int pix_fmt, int color_range);
+
+void hb_metal_context_close(hb_metal_context_t **_ctx);
+
+void hb_metal_compute_encoder_dispatch(id<MTLDevice> device,
+                                       id<MTLComputePipelineState> pipeline,
+                                       id<MTLComputeCommandEncoder> encoder,
+                                       NSUInteger width, NSUInteger height);
+
+void hb_metal_compute_encoder_dispatch_fixed_threadgroup_size(id<MTLDevice> device,
+                                                              id<MTLComputePipelineState> pipeline,
+                                                              id<MTLComputeCommandEncoder> encoder,
+                                                              NSUInteger width, NSUInteger height,
+                                                              NSUInteger w, NSUInteger h);
+
+MTLPixelFormat hb_metal_pix_fmt_from_component(const AVComponentDescriptor *comp, int *channels_out);
+
+CVMetalTextureRef hb_metal_texture_from_pixbuf(CVMetalTextureCacheRef textureCache,
+                                               CVPixelBufferRef pixbuf,
+                                               int plane,
+                                               MTLPixelFormat format);
+
+#endif /* HB_METAL_UTILS_H */

--- a/libhb/platform/macosx/metal_utils.m
+++ b/libhb/platform/macosx/metal_utils.m
@@ -1,0 +1,235 @@
+/* utils.m
+
+   Copyright (c) 2003-2022 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "metal_utils.h"
+#include "cv_utils.h"
+
+hb_metal_context_t * hb_metal_context_init(const char *metallib_data,
+                                           size_t metallib_len,
+                                           const char *function_name,
+                                           size_t params_buffer_len,
+                                           int width, int height,
+                                           int pix_fmt, int color_range)
+{
+    hb_metal_context_t *ctx = calloc(sizeof(struct hb_metal_context_s), 1);
+    if (ctx == NULL)
+    {
+        goto fail;
+    }
+
+    NSError *err = nil;
+
+    NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
+    ctx->device = [devices.lastObject retain];
+    [devices release];
+    if (!ctx->device)
+    {
+        hb_error("metal: unable to find Metal device");
+        goto fail;
+    }
+
+    if (@available(macOS 10.14, *))
+    {
+        NSUInteger maxBufferLength = ctx->device.maxBufferLength;
+        NSUInteger textureSize = width * height * sizeof(float);
+
+        if (textureSize > maxBufferLength || width > 16384 || height > 16384)
+        {
+            hb_error("metal: unsupported texture size: %d x %d", width, height);
+            goto fail;
+        }
+    }
+
+    dispatch_data_t libData = dispatch_data_create(metallib_data, metallib_len, nil, nil);
+    ctx->library = [ctx->device newLibraryWithData:libData error:&err];
+    dispatch_release(libData);
+    libData = nil;
+    if (err)
+    {
+        hb_error("metal: failed to load Metal library: %s", err.description.UTF8String);
+        goto fail;
+    }
+
+    ctx->function = [ctx->library newFunctionWithName:@(function_name)];
+    if (!ctx->function)
+    {
+        hb_error("metal: failed to create Metal function");
+        goto fail;
+    }
+
+    ctx->queue = ctx->device.newCommandQueue;
+    if (!ctx->queue)
+    {
+        hb_error("metal: failed to create Metal command queue");
+        goto fail;
+    }
+
+    ctx->pipeline = [ctx->device newComputePipelineStateWithFunction:ctx->function error:&err];
+    if (!ctx->pipeline)
+    {
+        hb_error("metal: failed to create Metal compute pipeline: %s", err.description.UTF8String);
+        goto fail;
+    }
+
+    ctx->params_buffer = [ctx->device newBufferWithLength:params_buffer_len
+                                                  options:MTLResourceStorageModeShared];
+    if (!ctx->params_buffer)
+    {
+        hb_error("metal: failed to create Metal buffer for parameters");
+        goto fail;
+    }
+
+    CVReturn ret = CVMetalTextureCacheCreate(NULL, NULL, ctx->device, NULL, &ctx->cache);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_error("metal: failed to create CVMetalTextureCache: %d", ret);
+        goto fail;
+    }
+
+    ctx->pool = hb_cv_create_pixel_buffer_pool(width, height, pix_fmt, color_range);
+    if (ctx->pool == NULL)
+    {
+        hb_log("metal: failed to create CVPixelBufferPool failed");
+        goto fail;
+    }
+
+    return ctx;
+
+fail:
+    if (ctx)
+    {
+        hb_metal_context_close(&ctx);
+    }
+    return NULL;
+}
+
+void hb_metal_context_close(hb_metal_context_t **_ctx)
+{
+    hb_metal_context_t *ctx = *_ctx;
+    if (ctx)
+    {
+        [ctx->params_buffer release];
+        [ctx->function release];
+        [ctx->pipeline release];
+        [ctx->queue release];
+        [ctx->library release];
+        [ctx->device release];
+
+        if (ctx->cache)
+        {
+            CFRelease(ctx->cache);
+        }
+        if (ctx->pool)
+        {
+            CVPixelBufferPoolRelease(ctx->pool);
+        }
+
+    }
+    free(ctx);
+    *_ctx = NULL;
+}
+
+void hb_metal_compute_encoder_dispatch(id<MTLDevice> device,
+                                       id<MTLComputePipelineState> pipeline,
+                                       id<MTLComputeCommandEncoder> encoder,
+                                       NSUInteger width, NSUInteger height)
+{
+    [encoder setComputePipelineState:pipeline];
+    NSUInteger w = pipeline.threadExecutionWidth;
+    NSUInteger h = pipeline.maxTotalThreadsPerThreadgroup / w;
+    MTLSize threadsPerThreadgroup = MTLSizeMake(w, h, 1);
+    BOOL fallback = YES;
+
+    if (@available(macOS 10.15, iOS 11, tvOS 14.5, *))
+    {
+        if ([device supportsFamily:MTLGPUFamilyCommon3])
+        {
+            MTLSize threadsPerGrid = MTLSizeMake(width, height, 1);
+            [encoder dispatchThreads:threadsPerGrid threadsPerThreadgroup:threadsPerThreadgroup];
+            fallback = NO;
+        }
+    }
+    if (fallback)
+    {
+        MTLSize threadgroups = MTLSizeMake((width + w - 1) / w,
+                                           (height + h - 1) / h,
+                                           1);
+        [encoder dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerThreadgroup];
+    }
+}
+
+void hb_metal_compute_encoder_dispatch_fixed_threadgroup_size(id<MTLDevice> device,
+                                                              id<MTLComputePipelineState> pipeline,
+                                                              id<MTLComputeCommandEncoder> encoder,
+                                                              NSUInteger width, NSUInteger height,
+                                                              NSUInteger w, NSUInteger h)
+{
+    [encoder setComputePipelineState:pipeline];
+    MTLSize threadsPerThreadgroup = MTLSizeMake(w, h, 1);
+    MTLSize threadgroups = MTLSizeMake((width + w - 1) / w,
+                                       (height + h - 1) / h,
+                                       1);
+    [encoder dispatchThreadgroups:threadgroups threadsPerThreadgroup:threadsPerThreadgroup];
+}
+
+MTLPixelFormat hb_metal_pix_fmt_from_component(const AVComponentDescriptor *comp, int *channels_out)
+{
+    MTLPixelFormat format;
+    int pixel_size = (comp->depth + comp->shift) / 8;
+    int channels = comp->step / pixel_size;
+    if (pixel_size > 2 || channels > 2)
+    {
+        hb_log("metal: unsupported pixel format");
+        return MTLPixelFormatInvalid;
+    }
+    switch (pixel_size)
+    {
+        case 1:
+            format = channels == 1 ? MTLPixelFormatR8Unorm : MTLPixelFormatRG8Unorm;
+            break;
+        case 2:
+            format = channels == 1 ? MTLPixelFormatR16Unorm : MTLPixelFormatRG16Unorm;
+            break;
+        default:
+            hb_log("metal: unsupported pixel format");
+            return MTLPixelFormatInvalid;
+    }
+
+    *channels_out = channels;
+    return format;
+}
+
+CVMetalTextureRef hb_metal_texture_from_pixbuf(CVMetalTextureCacheRef textureCache,
+                                               CVPixelBufferRef pixbuf,
+                                               int plane,
+                                               MTLPixelFormat format)
+{
+    CVMetalTextureRef tex = NULL;
+    CVReturn ret;
+
+    ret = CVMetalTextureCacheCreateTextureFromImage(
+        NULL,
+        textureCache,
+        pixbuf,
+        NULL,
+        format,
+        CVPixelBufferGetWidthOfPlane(pixbuf, plane),
+        CVPixelBufferGetHeightOfPlane(pixbuf, plane),
+        plane,
+        &tex
+    );
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("metal: failed to create CVMetalTexture from image: %d", ret);
+        return NULL;
+    }
+
+    return tex;
+}

--- a/libhb/platform/macosx/pad_vt.m
+++ b/libhb/platform/macosx/pad_vt.m
@@ -1,0 +1,334 @@
+/* pad_vt.m
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "handbrake/colormap.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_pad_vt_metallib_data[];
+extern unsigned int hb_pad_vt_metallib_len;
+
+struct mtl_pad_params
+{
+    uint    plane;
+    uint    channels;
+    float   color_y;
+    float   color_u;
+    float   color_v;
+    uint    x;
+    uint    y;
+};
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    float color[3];
+    int   x;
+    int   y;
+
+    hb_filter_init_t    input;
+    hb_filter_init_t    output;
+};
+
+static int pad_vt_init(hb_filter_object_t   *filter,
+                           hb_filter_init_t *init);
+
+static int pad_vt_work(hb_filter_object_t *filter,
+                           hb_buffer_t **buf_in,
+                           hb_buffer_t **buf_out);
+
+static void pad_vt_close(hb_filter_object_t *filter);
+
+const char pad_vt_template[] =
+    "width=^"HB_INT_REG"$:height=^"HB_INT_REG"$:color=^"HB_ALL_REG"$:"
+    "x=^"HB_INT_REG"$:y=^"HB_INT_REG"$:"
+    "top=^"HB_INT_REG"$:bottom=^"HB_INT_REG"$:"
+    "left=^"HB_INT_REG"$:right=^"HB_INT_REG"$";
+
+hb_filter_object_t hb_filter_pad_vt =
+{
+    .id                = HB_FILTER_PAD_VT,
+    .enforce_order     = 1,
+    .name              = "Pad (VideoToolbox)",
+    .settings          = NULL,
+    .init              = pad_vt_init,
+    .work              = pad_vt_work,
+    .close             = pad_vt_close,
+    .settings_template = pad_vt_template,
+};
+
+static int pad_vt_init(hb_filter_object_t *filter,
+                        hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("pad_vt: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t * pv = filter->private_data;
+    pv->input = *init;
+    pv->desc = av_pix_fmt_desc_get(init->pix_fmt);
+
+    hb_dict_t *settings = filter->settings;
+    int      width  = -1, height = -1;
+    int      top = -1, bottom = -1, left = -1, right = -1;
+    int      x = -1, y = -1;
+    char     *color = NULL;
+
+    hb_dict_extract_int(&top, settings, "top");
+    hb_dict_extract_int(&bottom, settings, "bottom");
+    hb_dict_extract_int(&left, settings, "left");
+    hb_dict_extract_int(&right, settings, "right");
+
+    hb_dict_extract_int(&width, settings, "width");
+    hb_dict_extract_int(&height, settings, "height");
+    hb_dict_extract_string(&color, settings, "color");
+    hb_dict_extract_int(&x, settings, "x");
+    hb_dict_extract_int(&y, settings, "y");
+
+    if (x < 0)
+    {
+        x = left;
+    }
+    if (y < 0)
+    {
+        y = top;
+    }
+    // Avoid odd offsets when chroma
+    // is half the luma
+    if (x % 2)
+    {
+        x -= pv->desc->log2_chroma_w;
+    }
+    if (y % 2)
+    {
+        y -= pv->desc->log2_chroma_h;
+    }
+    if (top >= 0 && bottom >= 0 && height < 0)
+    {
+        height = init->geometry.height + top + bottom;
+    }
+    if (left >= 0 && right >= 0 && width < 0)
+    {
+        width = init->geometry.width + left + right;
+    }
+    if (color != NULL)
+    {
+        char *end;
+        int rgb = strtol(color, &end, 0);
+        if (end == color)
+        {
+            // Not a numeric value, lookup by name
+            rgb = hb_rgb_lookup_by_name(color);
+        }
+        free(color);
+
+        rgb = hb_cv_match_rgb_to_colorspace(rgb, init->color_prim, init->color_transfer, init->color_matrix);
+
+        int yuv;
+        switch (init->color_matrix)
+        {
+            case HB_COLR_MAT_SMPTE170M:
+                yuv = hb_rgb2yuv(rgb);
+                break;
+            case HB_COLR_MAT_BT2020_NCL:
+            case HB_COLR_MAT_BT2020_CL:
+                yuv = hb_rgb2yuv_bt2020(rgb);
+                break;
+            case HB_COLR_MAT_BT709:
+            default:
+                yuv = hb_rgb2yuv_bt709(rgb);
+                break;
+        }
+
+        pv->color[0] = ((yuv >> 16) & 0xff) / 255.f;
+        pv->color[1] = ((yuv >> 8 ) & 0xff) / 255.f;
+        pv->color[2] = ((yuv >> 0 ) & 0xff) / 255.f;
+    }
+
+    if (width < init->geometry.width)
+    {
+        width = init->geometry.width;
+    }
+    if (height < init->geometry.height)
+    {
+        height = init->geometry.height;
+    }
+
+    pv->x = x;
+    pv->y = y;
+
+    pv->mtl = hb_metal_context_init(hb_pad_vt_metallib_data,
+                                    hb_pad_vt_metallib_len,
+                                    "pad",
+                                    sizeof(struct mtl_pad_params),
+                                    width, height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("pad_vt: failed to create Metal device");
+        return -1;
+    }
+
+    init->geometry.width = width;
+    init->geometry.height = height;
+    pv->output = *init;
+
+    return 0;
+}
+
+static void pad_vt_close(hb_filter_object_t * filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> src,
+                        int channels,
+                        int plane)
+{
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    struct mtl_pad_params *params = (struct mtl_pad_params *)pv->mtl->params_buffer.contents;
+    *params = (struct mtl_pad_params)
+    {
+        .plane = plane,
+        .channels = channels,
+        .color_y = pv->color[0],
+        .color_u = pv->color[1],
+        .color_v = pv->color[2],
+        .x = plane ? pv->x >> pv->desc->log2_chroma_w : pv->x,
+        .y = plane ? pv->y >> pv->desc->log2_chroma_h : pv->y,
+    };
+
+    [encoder setTexture:dst atIndex:0];
+    [encoder setTexture:src atIndex:1];
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:0];
+
+    hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_src = hb_cv_get_pixel_buffer(in);
+
+    if (cv_src == NULL)
+    {
+        hb_log("pad_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("pad_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        int channels;
+        const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        CVMetalTextureRef src  = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_src, i, format);
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format);
+
+        id<MTLTexture> tex_src  = CVMetalTextureGetTexture(src);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_src, channels, i);
+
+        CFRelease(src);
+        CFRelease(dest);
+    }
+
+    CVBufferPropagateAttachments(cv_src, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type      = COREMEDIA;
+    out->storage           = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, in);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static int pad_vt_work(hb_filter_object_t *filter,
+                        hb_buffer_t **buf_in,
+                        hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    @autoreleasepool
+    {
+        *buf_out = filter_frame(pv, in);
+    }
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/shaders/bwdif_vt.metal
+++ b/libhb/platform/macosx/shaders/bwdif_vt.metal
@@ -1,0 +1,269 @@
+/* bwdif.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2019 Philip Langdale <philipl@overt.org>
+
+   port of FFmpeg vf_bwdif_cuda.
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+/*
+ * Parameters
+ */
+
+struct params {
+    uint channels;
+    uint parity;
+    uint tff;
+    bool is_second_field;
+    bool skip_spatial_check;
+    bool is_field_end;
+};
+
+/*
+ * Texture access helpers
+ */
+
+#define accesstype access::sample
+constexpr sampler s(coord::pixel);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).xy;
+}
+
+template <typename T>
+T tex2D(texture2d<float, access::read> tex, uint x, uint y)
+{
+    return tex.read(uint2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::read> tex, uint x, uint y)
+{
+    return tex.read(uint2(x, y)).xy;
+}
+
+/*
+ * Bwdiff helpers
+ */
+
+constant static const float coef_lf[2] = { 4309, 213 };
+constant static const float coef_hf[3] = { 5570, 3801, 1016 };
+constant static const float coef_sp[2] = { 5077, 981 };
+
+template<typename T>
+T filter_intra(T cur_prefs3, T cur_prefs,
+               T cur_mrefs, T cur_mrefs3)
+{
+    T final = (coef_sp[0] * (cur_mrefs + cur_prefs) -
+                 coef_sp[1] * (cur_mrefs3 + cur_prefs3)) / (1 << 13);
+    return saturate(final);
+}
+
+template<typename T>
+T filter_temp(T cur_prefs3, T cur_prefs, T cur_mrefs, T cur_mrefs3,
+              T prev2_prefs4, T prev2_prefs2, T prev2_0, T prev2_mrefs2, T prev2_mrefs4,
+              T prev_prefs, T prev_mrefs, T next_prefs, T next_mrefs,
+              T next2_prefs4, T next2_prefs2, T next2_0, T next2_mrefs2, T next2_mrefs4)
+{
+    T final;
+
+    T c = cur_mrefs;
+    T d = (prev2_0 + next2_0) / 2;
+    T e = cur_prefs;
+
+    T temporal_diff0 = abs(prev2_0 - next2_0);
+    T temporal_diff1 = (abs(prev_mrefs - c) + abs(prev_prefs - e)) / 2;
+    T temporal_diff2 = (abs(next_mrefs - c) + abs(next_prefs - e)) / 2;
+    T diff = max3(temporal_diff0 / 2, temporal_diff1, temporal_diff2);
+
+    if (!diff) {
+        final = d;
+    } else {
+        T b = ((prev2_mrefs2 + next2_mrefs2) / 2) - c;
+        T f = ((prev2_prefs2 + next2_prefs2) / 2) - e;
+        T dc = d - c;
+        T de = d - e;
+        T mmax = max3(de, dc, min(b, f));
+        T mmin = min3(de, dc, max(b, f));
+        diff = max3(diff, mmin, -mmax);
+
+        float interpol;
+        if (abs(c - e) > temporal_diff0) {
+            interpol = (((coef_hf[0] * (prev2_0 + next2_0)
+                - coef_hf[1] * (prev2_mrefs2 + next2_mrefs2 + prev2_prefs2 + next2_prefs2)
+                + coef_hf[2] * (prev2_mrefs4 + next2_mrefs4 + prev2_prefs4 + next2_mrefs4)) / 4)
+                + coef_lf[0] * (c + e) - coef_lf[1] * (cur_mrefs3 + cur_prefs3)) / (1 << 13);
+        } else {
+            interpol = (coef_sp[0] * (c + e) - coef_sp[1] * (cur_mrefs3 + cur_prefs3)) / (1 << 13);
+        }
+
+        if (interpol > d + diff) {
+            interpol = d + diff;
+        } else if (interpol < d - diff) {
+            interpol = d - diff;
+        }
+        final = saturate(interpol);
+    }
+
+    return final;
+}
+
+template<typename T>
+T bwdif_single(texture2d<float, access::write> dst,
+               texture2d<float, accesstype> prev,
+               texture2d<float, accesstype> cur,
+               texture2d<float, accesstype> next,
+               int parity, int tff,
+               bool is_field_end, bool is_second_field,
+               ushort2 pos)
+{
+    // Don't modify the primary field
+    if (pos.y % 2 == parity) {
+        return tex2D<T>(cur, pos.x, pos.y);
+    }
+
+    T cur_prefs3 = tex2D<T>(cur, pos.x, pos.y + 3);
+    T cur_prefs  = tex2D<T>(cur, pos.x, pos.y + 1);
+    T cur_mrefs  = tex2D<T>(cur, pos.x, pos.y - 1);
+    T cur_mrefs3 = tex2D<T>(cur, pos.x, pos.y - 3);
+
+    if (is_field_end) {
+        return filter_intra(cur_prefs3, cur_prefs, cur_mrefs, cur_mrefs3);
+    }
+
+    // Calculate temporal prediction
+    texture2d<float, accesstype> prev2 = prev;
+    texture2d<float, accesstype> prev1 = is_second_field ? cur : prev;
+    texture2d<float, accesstype> next1 = is_second_field ? next : cur;
+    texture2d<float, accesstype> next2 = next;
+
+    T prev2_prefs4 = tex2D<T>(prev2, pos.x, pos.y+ 4);
+    T prev2_prefs2 = tex2D<T>(prev2, pos.x, pos.y + 2);
+    T prev2_0 = tex2D<T>(prev2, pos.x, pos.y + 0);
+    T prev2_mrefs2 = tex2D<T>(prev2, pos.x, pos.y - 2);
+    T prev2_mrefs4 = tex2D<T>(prev2, pos.x, pos.y - 4);
+    T prev_prefs = tex2D<T>(prev1, pos.x, pos.y + 1);
+    T prev_mrefs = tex2D<T>(prev1, pos.x, pos.y - 1);
+    T next_prefs = tex2D<T>(next1, pos.x, pos.y + 1);
+    T next_mrefs = tex2D<T>(next1, pos.x, pos.y - 1);
+    T next2_prefs4 = tex2D<T>(next2, pos.x, pos.y + 4);
+    T next2_prefs2 = tex2D<T>(next2, pos.x, pos.y + 2);
+    T next2_0 = tex2D<T>(next2, pos.x, pos.y + 0);
+    T next2_mrefs2 = tex2D<T>(next2, pos.x, pos.y - 2);
+    T next2_mrefs4 = tex2D<T>(next2, pos.x, pos.y - 4);
+
+    return filter_temp(cur_prefs3, cur_prefs, cur_mrefs, cur_mrefs3,
+                       prev2_prefs4, prev2_prefs2, prev2_0, prev2_mrefs2, prev2_mrefs4,
+                       prev_prefs, prev_mrefs, next_prefs, next_mrefs,
+                       next2_prefs4, next2_prefs2, next2_0, next2_mrefs2, next2_mrefs4);
+}
+
+template<typename T>
+T bwdif_double(texture2d<float, access::write> dst,
+               texture2d<float, accesstype> prev,
+               texture2d<float, accesstype> cur,
+               texture2d<float, accesstype> next,
+               int parity, int tff,
+               bool is_field_end, bool is_second_field,
+               ushort2 pos)
+{
+    // Don't modify the primary field
+    if (pos.y % 2 == parity) {
+        return tex2D<T>(cur, pos.x, pos.y);
+    }
+
+    T cur_prefs3 = tex2D<T>(cur, pos.x, pos.y + 3);
+    T cur_prefs  = tex2D<T>(cur, pos.x, pos.y + 1);
+    T cur_mrefs  = tex2D<T>(cur, pos.x, pos.y - 1);
+    T cur_mrefs3 = tex2D<T>(cur, pos.x, pos.y - 3);
+
+    if (is_field_end) {
+        T final;
+        final.x = filter_intra(cur_prefs3.x, cur_prefs.x, cur_mrefs.x, cur_mrefs3.x);
+        final.y = filter_intra(cur_prefs3.y, cur_prefs.y, cur_mrefs.y, cur_mrefs3.y);
+        return final;
+    }
+
+    // Calculate temporal prediction
+    texture2d<float, accesstype> prev2 = prev;
+    texture2d<float, accesstype> prev1 = is_second_field ? cur : prev;
+    texture2d<float, accesstype> next1 = is_second_field ? next : cur;
+    texture2d<float, accesstype> next2 = next;
+
+    T prev2_prefs4 = tex2D<T>(prev2, pos.x, pos.y+ 4);
+    T prev2_prefs2 = tex2D<T>(prev2, pos.x, pos.y + 2);
+    T prev2_0 = tex2D<T>(prev2, pos.x, pos.y + 0);
+    T prev2_mrefs2 = tex2D<T>(prev2, pos.x, pos.y - 2);
+    T prev2_mrefs4 = tex2D<T>(prev2, pos.x, pos.y - 4);
+    T prev_prefs = tex2D<T>(prev1, pos.x, pos.y + 1);
+    T prev_mrefs = tex2D<T>(prev1, pos.x, pos.y - 1);
+    T next_prefs = tex2D<T>(next1, pos.x, pos.y + 1);
+    T next_mrefs = tex2D<T>(next1, pos.x, pos.y - 1);
+    T next2_prefs4 = tex2D<T>(next2, pos.x, pos.y + 4);
+    T next2_prefs2 = tex2D<T>(next2, pos.x, pos.y + 2);
+    T next2_0 = tex2D<T>(next2, pos.x, pos.y + 0);
+    T next2_mrefs2 = tex2D<T>(next2, pos.x, pos.y - 2);
+    T next2_mrefs4 = tex2D<T>(next2, pos.x, pos.y - 4);
+
+    T final;
+    final.x = filter_temp(cur_prefs3.x, cur_prefs.x, cur_mrefs.x, cur_mrefs3.x,
+                          prev2_prefs4.x, prev2_prefs2.x, prev2_0.x, prev2_mrefs2.x, prev2_mrefs4.x,
+                          prev_prefs.x, prev_mrefs.x, next_prefs.x, next_mrefs.x,
+                          next2_prefs4.x, next2_prefs2.x, next2_0.x, next2_mrefs2.x, next2_mrefs4.x);
+    final.y = filter_temp(cur_prefs3.y, cur_prefs.y, cur_mrefs.y, cur_mrefs3.y,
+                          prev2_prefs4.y, prev2_prefs2.y, prev2_0.y, prev2_mrefs2.y, prev2_mrefs4.y,
+                          prev_prefs.y, prev_mrefs.y, next_prefs.y, next_mrefs.y,
+                          next2_prefs4.y, next2_prefs2.y, next2_0.y, next2_mrefs2.y, next2_mrefs4.y);
+    return final;
+}
+
+
+/*
+ * Kernel dispatch
+ */
+
+kernel void deint(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype> prev [[texture(1)]],
+    texture2d<float, accesstype> cur  [[texture(2)]],
+    texture2d<float, accesstype> next [[texture(3)]],
+    constant params& p [[buffer(0)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) || (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    float2 pred;
+    if (p.channels == 1) {
+        pred = float2(bwdif_single<float>(dst, prev, cur, next,
+                                   p.parity, p.tff,
+                                   p.is_field_end, p.is_second_field,
+                                   pos));
+    } else {
+        pred = bwdif_double<float2>(dst, prev, cur, next,
+                                    p.parity, p.tff,
+                                    p.is_field_end, p.is_second_field,
+                                    pos);
+    }
+    dst.write(pred.xyyy, pos);
+}

--- a/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
+++ b/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
@@ -1,0 +1,190 @@
+/* chroma_smooth.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+
+   port of FFmpeg unsharp.cl.
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+struct params {
+    uint       channels;
+    float      max;
+    float      min;
+    float      strength;  // strength
+    int        size;      // pixel context region width (must be odd)
+};
+
+#define accesstype access::sample
+constexpr sampler s(coord::pixel);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).xy;
+}
+
+template <typename T>
+T filter_global(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype> src,
+    const short size_x,
+    const short size_y,
+    const float amount,
+    constant float *coef_matrix,
+    ushort2 pos)
+{
+    ushort2 center = ushort2(size_x / 2, size_y / 2);
+    T val = tex2D<T>(src, pos.x, pos.y);
+    T sum = 0.0f;
+    short x, y;
+
+    for (y = 0; y < size_y; y++) {
+        for (x = 0; x < size_x; x++) {
+            ushort2 posl = pos + ushort2(x, y) - center;
+            sum += coef_matrix[y * size_x + x] *
+                tex2D<T>(src, posl.x, posl.y);
+        }
+    }
+
+    return val + (val - sum) * amount;
+}
+
+kernel void chroma_smooth_global(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype>    src [[texture(1)]],
+    constant float *coef_matrix [[buffer(0)]],
+    constant params& params     [[buffer(1)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) || (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    if (params.strength == 0) {
+        float2 value;
+        if (params.channels == 1) {
+            value = float2(tex2D<float>(src, pos.x, pos.y));
+        } else {
+            value = tex2D<float2>(src, pos.x, pos.y);
+        }
+        dst.write(value.xyyy, pos);
+    } else {
+        float2 value;
+        if (params.channels == 1) {
+            value = float2(filter_global<float>(dst, src,
+                                                params.size, params.size,
+                                                params.strength,
+                                                coef_matrix, pos));
+        } else {
+            value = filter_global<float2>(dst, src,
+                                          params.size, params.size,
+                                          params.strength,
+                                          coef_matrix, pos);
+        }
+        dst.write(value.xyyy, pos);
+    }
+}
+
+template <typename T, size_t S>
+T filter_local(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype> src,
+    const short size_x,
+    const short size_y,
+    const float max,
+    const float min,
+    const float amount,
+    constant float *coef_x,
+    constant float *coef_y,
+    threadgroup T tmp[S][S],
+    ushort2 gid,
+    ushort2 lid)
+{
+    constexpr short s = S / 2;
+    constexpr short h = S / 4;
+
+    gid *= s;
+
+    short rad_x = size_x / 2;
+    short rad_y = size_y / 2;
+    short x, y;
+
+    for (y = 0; y <= 1; y++) {
+        for (x = 0; x <= 1; x++) {
+            tmp[lid.y + s * y][lid.x + s * x] =
+                tex2D<T>(src,
+                         gid.x + lid.x + (s * x - h),
+                         gid.y + lid.y + (s * y - h));
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    T val = tmp[lid.y + h][lid.x + h];
+
+    T horiz[2];
+    for (y = 0; y <= 1; y++) {
+        horiz[y] = 0.0f;
+        for (x = 0; x < size_x; x++)
+            horiz[y] += coef_x[x] * tmp[lid.y + y * s][lid.x + h + x - rad_x];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (y = 0; y <= 1; y++) {
+        tmp[lid.y + y * s][lid.x + h] = horiz[y];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    T sum = 0.0f;
+    for (y = 0; y < size_y; y++) {
+        sum += coef_y[y] * tmp[lid.y + h + y - rad_y][lid.x + h];
+    }
+
+    return clamp(val - (val - sum) * amount, min, max);
+}
+
+kernel void chroma_smooth_local(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype>    src [[texture(1)]],
+    constant float *coef_x [[buffer(0)]],
+    constant float *coef_y [[buffer(1)]],
+    constant params& p     [[buffer(2)]],
+    ushort2 pos   [[thread_position_in_grid]],
+    ushort2 gid   [[threadgroup_position_in_grid]],
+    ushort2 lid   [[thread_position_in_threadgroup]])
+{
+    if (p.strength == 0) {
+        float2 value = tex2D<float2>(src, pos.x, pos.y);
+        dst.write(value.xyyy, pos);
+    } else {
+        float2 value;
+        constexpr size_t size = 32;
+        threadgroup float2 tmp[size][size];
+        value = filter_local<float2>(dst, src,
+                                     p.size, p.size,
+                                     p.max, p.min,
+                                     p.strength,
+                                     coef_x, coef_y,
+                                     tmp, gid, lid);
+        dst.write(value.xyyy, pos);
+    }
+}

--- a/libhb/platform/macosx/shaders/grayscale_vt.metal
+++ b/libhb/platform/macosx/shaders/grayscale_vt.metal
@@ -1,0 +1,140 @@
+/* grayscale.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2021 Paul B Mahol
+
+   port of vf_monochrome FFmpeg.
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+/*
+ * Parameters
+ */
+
+struct params {
+    uint plane;
+    uint biplanar;
+    uint subw;
+    uint subh;
+    uint cb;
+    uint cr;
+    uint size;
+    uint high;
+};
+
+/*
+ * Texture access helpers
+ */
+
+template <typename T>
+T tex2D(texture2d<float, access::read> tex, ushort x, ushort y)
+{
+    return tex.read(ushort2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::read> tex, ushort x, ushort y)
+{
+    return tex.read(ushort2(x, y)).xy;
+}
+
+float2 tex2D(texture2d<float, access::read> tex1,
+             texture2d<float, access::read> tex2,
+             ushort x, ushort y, bool biplanar)
+{
+    if (biplanar) {
+        return tex1.read(ushort2(x, y)).xy;
+    } else {
+        float2 value;
+        value.x = tex2D<float>(tex1, x, y);
+        value.y = tex2D<float>(tex2, x, y);
+        return value;
+    }
+}
+
+/*
+ * Monochrome helpers
+ */
+
+float envelope(const float x)
+{
+    const float beta = 0.6f;
+
+    if (x < beta) {
+        const float tmp = fabs(x / beta - 1.f);
+        return 1.f - tmp * tmp;
+    } else {
+        const float tmp = (1.f - x) / (1.f - beta);
+        return tmp * tmp * (3.f - 2.f * tmp);
+    }
+}
+
+float filter_sample(float b, float r, float u, float v, float size)
+{
+    return exp(-saturate(((b - u) * (b - u) + (r - v) * (r - v)) * size));
+}
+
+float filter_pixel(
+    texture2d<float, access::write> dst,
+    texture2d<float, access::read> src_y,
+    texture2d<float, access::read> src_u,
+    texture2d<float, access::read> src_v,
+    constant params& p,
+    ushort2 pos)
+{
+    const float ihigh = 1.f - p.high;
+    const float size = 1.f / p.size;
+    const float b = p.cb * .5f;
+    const float r = p.cr * .5f;
+
+    const int cx = pos.x >> p.subw;
+    const int cy = pos.y >> p.subh;
+
+    float  y  = tex2D<float>(src_y, pos.x, pos.y);
+    float2 uv = tex2D(src_u, src_v, cx, cy, p.biplanar) - .5f;
+
+    float tt, t, ny;
+
+    ny = filter_sample(b, r, uv.x, uv.y, size);
+    tt = envelope(y);
+    t = tt + (1.f - tt) * ihigh;
+    ny = (1.f - t) * y + t * ny * y;
+
+    return saturate(ny);
+}
+
+/*
+ * Kernel dispatch
+ */
+
+kernel void monochrome(
+    texture2d<float, access::write> dst   [[texture(0)]],
+    texture2d<float, access::read>  src_y [[texture(1)]],
+    texture2d<float, access::read>  src_u [[texture(2)]],
+    texture2d<float, access::read>  src_v [[texture(3)]],
+    constant params& p [[buffer(0)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) || (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    if (p.plane == 0) {
+        float value = filter_pixel(dst, src_y, src_u, src_v, p, pos);
+        dst.write(value, pos);
+    } else {
+        float half_value = 0.5;
+        dst.write(half_value, pos);
+    }
+}

--- a/libhb/platform/macosx/shaders/lapsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/lapsharp_vt.metal
@@ -1,0 +1,116 @@
+/* lapsharp.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+struct params {
+    uint   channels;
+    float  strength;
+    uint   size;
+    float  coef;
+    int    kernel_id;
+};
+
+/*
+ * Texture access helpers
+ */
+
+#define accesstype access::sample
+constexpr sampler s(coord::pixel);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).xy;
+}
+
+template <typename T>
+T filter_global(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype>    src,
+    const float strength,
+    const uint size,
+    const float coef,
+    constant int *mem,
+    ushort2 pos)
+{
+    const int offset_min = -((size - 1) / 2);
+    const int offset_max =   (size + 1) / 2;
+
+    T val = tex2D<T>(src, pos.x, pos.y);
+
+    if ((int(pos.y) < offset_max) ||
+        (pos.y > dst.get_height() - offset_max) ||
+        (int(pos.x) < offset_max) ||
+        (pos.x > dst.get_width() - offset_max)) {
+        return val;
+    }
+
+    T sum = 0;
+    for (int x = offset_min; x < offset_max; x++) {
+        for (int y = offset_min; y < offset_max; y++) {
+            sum += tex2D<T>(src, pos.x + x, pos.y + y) *
+                    mem[((y - offset_min) * size) + x - offset_min];
+        }
+    }
+
+    return saturate(((sum * coef) - val) * strength + val);
+}
+
+kernel void lapsharp(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype>    src [[texture(1)]],
+    constant int *mem  [[buffer(0)]],
+    constant params& p [[buffer(1)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) || (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    if (p.strength == 0) {
+        float2 value;
+        if (p.channels == 1) {
+            value = float2(tex2D<float>(src, pos.x, pos.y));
+        } else {
+            value = tex2D<float2>(src, pos.x, pos.y);
+        }
+        dst.write(value.xyyy, pos);
+    } else {
+        float2 value;
+        if (p.channels == 1) {
+            value = float2(filter_global<float>(dst, src,
+                                                p.strength,
+                                                p.size,
+                                                p.coef,
+                                                mem,
+                                                pos));
+        } else {
+            value = filter_global<float2>(dst, src,
+                                          p.strength,
+                                          p.size,
+                                          p.coef,
+                                          mem,
+                                          pos);
+        }
+        dst.write(value.xyyy, pos);
+    }
+}

--- a/libhb/platform/macosx/shaders/pad_vt.metal
+++ b/libhb/platform/macosx/shaders/pad_vt.metal
@@ -1,0 +1,95 @@
+/* pad.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+
+   port of FFmpeg pad.cl.
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+/*
+ * Parameters
+ */
+
+struct params {
+    uint    plane;
+    uint    channels;
+    float   color_y;
+    float   color_u;
+    float   color_v;
+    uint    x;
+    uint    y;
+};
+
+/*
+ * Texture access helpers
+ */
+
+template <typename T>
+T tex2D(texture2d<float, access::read> tex, ushort x, ushort y)
+{
+    return tex.read(ushort2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::read> tex, ushort x, ushort y)
+{
+    return tex.read(ushort2(x, y)).xy;
+}
+
+/*
+ * Pad helpers
+ */
+
+template <typename T>
+T filter_pixel(
+    texture2d<float, access::write> dst,
+    texture2d<float, access::read>  src,
+    T color,
+    ushort2 pos,
+    ushort2 src_pos,
+    ushort2 offset)
+{
+    ushort2 src_size = ushort2(src.get_width(), src.get_height());
+
+    T pixel = pos.x >= src_size.x + offset.x ||
+              pos.y >= src_size.y + offset.y ||
+              pos.x < offset.x ||
+              pos.y < offset.y ? color : tex2D<T>(src, src_pos.x, src_pos.y);
+    return pixel;
+}
+
+/*
+ * Kernel dispatch
+ */
+
+kernel void pad(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, access::read>  src [[texture(1)]],
+    constant params& p [[buffer(0)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) || (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    ushort2 offset = ushort2(p.x, p.y);
+    ushort2 src_pos = pos - offset;
+
+    float2 value = p.channels == 1 ?
+        float2(filter_pixel<float>(dst, src, p.color_y,
+                                   pos, src_pos, offset)) :
+        filter_pixel<float2>(dst, src, float2(p.color_v, p.color_u),
+                             pos, src_pos, offset);
+    dst.write(value.xyyy, pos);
+}

--- a/libhb/platform/macosx/shaders/unsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/unsharp_vt.metal
@@ -1,0 +1,181 @@
+/* unsharp.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+
+   port of FFmpeg unsharp.cl.
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+struct params {
+    uint       channels;
+    float      strength;
+    int        size;
+};
+
+#define accesstype access::sample
+constexpr sampler s(coord::pixel);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).xy;
+}
+
+template <typename T>
+T filter_global(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype> src,
+    const short size_x,
+    const short size_y,
+    const float amount,
+    constant float *coef_matrix,
+    ushort2 pos)
+{
+    ushort2 center = ushort2(size_x / 2, size_y / 2);
+    T val = tex2D<T>(src, pos.x, pos.y);
+    T sum = 0.0f;
+    short x, y;
+
+    for (y = 0; y < size_y; y++) {
+        for (x = 0; x < size_x; x++) {
+            ushort2 posl = pos + ushort2(x, y) - center;
+            sum += coef_matrix[y * size_x + x] *
+                tex2D<T>(src, posl.x, posl.y);
+        }
+    }
+
+    return val + (val - sum) * amount;
+}
+
+kernel void unsharp_global(
+    texture2d<float, access::write> dst  [[texture(0)]],
+    texture2d<float, accesstype>    src [[texture(1)]],
+    constant float *coef_matrix [[buffer(0)]],
+    constant params& p          [[buffer(1)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if (p.strength == 0) {
+        float2 value;
+        if (p.channels == 1) {
+            value = float2(tex2D<float>(src, pos.x, pos.y));
+        } else {
+            value = tex2D<float2>(src, pos.x, pos.y);
+        }
+        dst.write(value.xyyy, pos);
+    } else {
+        float2 value;
+        if (p.channels == 1) {
+            value = float2(filter_global<float>(dst, src,
+                                                p.size, p.size,
+                                                p.strength,
+                                                coef_matrix, pos));
+        } else {
+            value = filter_global<float2>(dst, src,
+                                          p.size, p.size,
+                                          p.strength,
+                                          coef_matrix, pos);
+        }
+        dst.write(value.xyyy, pos);
+    }
+}
+
+template <typename T, size_t S>
+T filter_local(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype> src,
+    const short size_x,
+    const short size_y,
+    const float amount,
+    constant float *coef_x,
+    constant float *coef_y,
+    threadgroup T tmp[S][S],
+    ushort2 gid,
+    ushort2 lid)
+{
+    constexpr short s = S / 2;
+    constexpr short h = S / 4;
+
+    gid *= s;
+
+    short rad_x = size_x / 2;
+    short rad_y = size_y / 2;
+    short x, y;
+
+    for (y = 0; y <= 1; y++) {
+        for (x = 0; x <= 1; x++) {
+            tmp[lid.y + s * y][lid.x + s * x] =
+                tex2D<T>(src,
+                         gid.x + lid.x + (s * x - h),
+                         gid.y + lid.y + (s * y - h));
+        }
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    T val = tmp[lid.y + h][lid.x + h];
+
+    T horiz[2];
+    for (y = 0; y <= 1; y++) {
+        horiz[y] = 0.0f;
+        for (x = 0; x < size_x; x++)
+            horiz[y] += coef_x[x] * tmp[lid.y + y * s][lid.x + h + x - rad_x];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    for (y = 0; y <= 1; y++) {
+        tmp[lid.y + s * y][lid.x + h] = horiz[y];
+    }
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    T sum = 0.0f;
+    for (y = 0; y < size_y; y++) {
+        sum += coef_y[y] * tmp[lid.y + h + y - rad_y][lid.x + h];
+    }
+
+    return val + (val - sum) * amount;
+}
+
+kernel void unsharp_local(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype>    src [[texture(1)]],
+    constant float *coef_x    [[buffer(0)]],
+    constant float *coef_y    [[buffer(1)]],
+    constant params& p        [[buffer(2)]],
+    ushort2 pos [[thread_position_in_grid]],
+    ushort2 gid [[threadgroup_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]])
+{
+    if (p.strength == 0) {
+        float2 value = tex2D<float2>(src, pos.x, pos.y);
+        dst.write(value.xyyy, pos);
+    } else {
+        float2 value;
+        constexpr size_t size = 32;
+        threadgroup float2 tmp[size][size];
+        value = filter_local<float2>(dst, src,
+                                     p.size, p.size,
+                                     p.strength,
+                                     coef_x, coef_y,
+                                     tmp, gid, lid);
+        dst.write(value.xyyy, pos);
+    }
+}

--- a/libhb/platform/macosx/shaders/yadif_vt.metal
+++ b/libhb/platform/macosx/shaders/yadif_vt.metal
@@ -1,0 +1,278 @@
+/*
+ * Copyright (C) 2018 Philip Langdale <philipl@overt.org>
+ *               2020 Aman Karmani <aman@tmm1.net>
+ *               2020 Stefan Dyulgerov <stefan.dyulgerov@gmail.com>
+ *
+ * This file is part of FFmpeg.
+ *
+ * FFmpeg is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * FFmpeg is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with FFmpeg; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+/*
+ * Version compat shims
+ */
+
+#if __METAL_VERSION__ < 210
+#define max3(x, y, z) max(x, max(y, z))
+#define min3(x, y, z) min(x, min(y, z))
+#endif
+
+/*
+ * Parameters
+ */
+
+struct deintParams {
+    uint channels;
+    uint parity;
+    uint tff;
+    bool is_second_field;
+    bool skip_spatial_check;
+    bool is_field_end;
+};
+
+/*
+ * Texture access helpers
+ */
+
+#define accesstype access::sample
+constexpr sampler s(coord::pixel);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::sample> tex, int x, int y)
+{
+    return tex.sample(s, float2(x, y)).xy;
+}
+
+template <typename T>
+T tex2D(texture2d<float, access::read> tex, uint x, uint y)
+{
+    return tex.read(uint2(x, y)).x;
+}
+
+template <>
+float2 tex2D<float2>(texture2d<float, access::read> tex, uint x, uint y)
+{
+    return tex.read(uint2(x, y)).xy;
+}
+
+/*
+ * YADIF helpers
+ */
+
+template<typename T>
+T spatial_predictor(T a, T b, T c, T d, T e, T f, T g,
+                    T h, T i, T j, T k, T l, T m, T n)
+{
+    T spatial_pred = (d + k)/2;
+    T spatial_score = abs(c - j) + abs(d - k) + abs(e - l);
+
+    T score = abs(b - k) + abs(c - l) + abs(d - m);
+    if (score < spatial_score) {
+        spatial_pred = (c + l)/2;
+        spatial_score = score;
+        score = abs(a - l) + abs(b - m) + abs(c - n);
+        if (score < spatial_score) {
+            spatial_pred = (b + m)/2;
+            spatial_score = score;
+        }
+    }
+    score = abs(d - i) + abs(e - j) + abs(f - k);
+    if (score < spatial_score) {
+        spatial_pred = (e + j)/2;
+        spatial_score = score;
+        score = abs(e - h) + abs(f - i) + abs(g - j);
+        if (score < spatial_score) {
+            spatial_pred = (f + i)/2;
+            spatial_score = score;
+        }
+    }
+    return spatial_pred;
+}
+
+template<typename T>
+T temporal_predictor(T A, T B, T C, T D, T E, T F,
+                     T G, T H, T I, T J, T K, T L,
+                     T spatial_pred, bool skip_check)
+{
+    T p0 = (C + H) / 2;
+    T p1 = F;
+    T p2 = (D + I) / 2;
+    T p3 = G;
+    T p4 = (E + J) / 2;
+
+    T tdiff0 = abs(D - I);
+    T tdiff1 = (abs(A - F) + abs(B - G)) / 2;
+    T tdiff2 = (abs(K - F) + abs(G - L)) / 2;
+
+    T diff = max3(tdiff0, tdiff1, tdiff2);
+
+    if (!skip_check) {
+        T maxi = max3(p2 - p3, p2 - p1, min(p0 - p1, p4 - p3));
+        T mini = min3(p2 - p3, p2 - p1, max(p0 - p1, p4 - p3));
+        diff = max3(diff, mini, -maxi);
+    }
+
+    return clamp(spatial_pred, p2 - diff, p2 + diff);
+}
+
+#define T float2
+template <>
+T spatial_predictor<T>(T a, T b, T c, T d, T e, T f, T g,
+                       T h, T i, T j, T k, T l, T m, T n)
+{
+    return T(
+        spatial_predictor(a.x, b.x, c.x, d.x, e.x, f.x, g.x,
+                          h.x, i.x, j.x, k.x, l.x, m.x, n.x),
+        spatial_predictor(a.y, b.y, c.y, d.y, e.y, f.y, g.y,
+                          h.y, i.y, j.y, k.y, l.y, m.y, n.y)
+    );
+}
+
+template <>
+T temporal_predictor<T>(T A, T B, T C, T D, T E, T F,
+                        T G, T H, T I, T J, T K, T L,
+                        T spatial_pred, bool skip_check)
+{
+    return T(
+        temporal_predictor(A.x, B.x, C.x, D.x, E.x, F.x,
+                           G.x, H.x, I.x, J.x, K.x, L.x,
+                           spatial_pred.x, skip_check),
+        temporal_predictor(A.y, B.y, C.y, D.y, E.y, F.y,
+                           G.y, H.y, I.y, J.y, K.y, L.y,
+                           spatial_pred.y, skip_check)
+    );
+}
+#undef T
+
+/*
+ * YADIF compute
+ */
+
+template <typename T>
+T yadif_compute_spatial(
+    texture2d<float, accesstype> cur,
+    uint2 pos)
+{
+    // Calculate spatial prediction
+    T a = tex2D<T>(cur, pos.x - 3, pos.y - 1);
+    T b = tex2D<T>(cur, pos.x - 2, pos.y - 1);
+    T c = tex2D<T>(cur, pos.x - 1, pos.y - 1);
+    T d = tex2D<T>(cur, pos.x - 0, pos.y - 1);
+    T e = tex2D<T>(cur, pos.x + 1, pos.y - 1);
+    T f = tex2D<T>(cur, pos.x + 2, pos.y - 1);
+    T g = tex2D<T>(cur, pos.x + 3, pos.y - 1);
+
+    T h = tex2D<T>(cur, pos.x - 3, pos.y + 1);
+    T i = tex2D<T>(cur, pos.x - 2, pos.y + 1);
+    T j = tex2D<T>(cur, pos.x - 1, pos.y + 1);
+    T k = tex2D<T>(cur, pos.x - 0, pos.y + 1);
+    T l = tex2D<T>(cur, pos.x + 1, pos.y + 1);
+    T m = tex2D<T>(cur, pos.x + 2, pos.y + 1);
+    T n = tex2D<T>(cur, pos.x + 3, pos.y + 1);
+
+    return spatial_predictor(a, b, c, d, e, f, g,
+                             h, i, j, k, l, m, n);
+}
+
+template <typename T>
+T yadif_compute_temporal(
+    texture2d<float, accesstype> cur,
+    texture2d<float, accesstype> prev2,
+    texture2d<float, accesstype> prev1,
+    texture2d<float, accesstype> next1,
+    texture2d<float, accesstype> next2,
+    T spatial_pred,
+    bool skip_spatial_check,
+    uint2 pos)
+{
+    // Calculate temporal prediction
+    T A = tex2D<T>(prev2, pos.x, pos.y - 1);
+    T B = tex2D<T>(prev2, pos.x, pos.y + 1);
+    T C = tex2D<T>(prev1, pos.x, pos.y - 2);
+    T D = tex2D<T>(prev1, pos.x, pos.y + 0);
+    T E = tex2D<T>(prev1, pos.x, pos.y + 2);
+    T F = tex2D<T>(cur,   pos.x, pos.y - 1);
+    T G = tex2D<T>(cur,   pos.x, pos.y + 1);
+    T H = tex2D<T>(next1, pos.x, pos.y - 2);
+    T I = tex2D<T>(next1, pos.x, pos.y + 0);
+    T J = tex2D<T>(next1, pos.x, pos.y + 2);
+    T K = tex2D<T>(next2, pos.x, pos.y - 1);
+    T L = tex2D<T>(next2, pos.x, pos.y + 1);
+
+    return temporal_predictor(A, B, C, D, E, F, G, H, I, J, K, L,
+                              spatial_pred, skip_spatial_check);
+}
+
+template <typename T>
+T yadif(
+    texture2d<float, access::write> dst,
+    texture2d<float, accesstype> prev,
+    texture2d<float, accesstype> cur,
+    texture2d<float, accesstype> next,
+    constant deintParams& params,
+    uint2 pos)
+{
+    T spatial_pred = yadif_compute_spatial<T>(cur, pos);
+
+    if (params.is_second_field) {
+        return yadif_compute_temporal(cur, prev, cur, next, next, spatial_pred, params.skip_spatial_check, pos);
+    } else {
+        return yadif_compute_temporal(cur, prev, prev, cur, next, spatial_pred, params.skip_spatial_check, pos);
+    }
+}
+
+/*
+ * Kernel dispatch
+ */
+
+kernel void deint(
+    texture2d<float, access::write> dst [[texture(0)]],
+    texture2d<float, accesstype> prev [[texture(1)]],
+    texture2d<float, accesstype> cur  [[texture(2)]],
+    texture2d<float, accesstype> next [[texture(3)]],
+    constant deintParams& params [[buffer(0)]],
+    uint2 pos [[thread_position_in_grid]])
+{
+    if ((pos.x >= dst.get_width()) ||
+        (pos.y >= dst.get_height())) {
+        return;
+    }
+
+    // Don't modify the primary field
+    if (pos.y % 2 == params.parity) {
+        float4 in = cur.read(pos);
+        dst.write(in, pos);
+        return;
+    }
+
+    float2 pred;
+    if (params.channels == 1)
+        pred = float2(yadif<float>(dst, prev, cur, next, params, pos));
+    else
+        pred = yadif<float2>(dst, prev, cur, next, params, pos);
+    dst.write(pred.xyyy, pos);
+}

--- a/libhb/platform/macosx/unsharp_vt.m
+++ b/libhb/platform/macosx/unsharp_vt.m
@@ -1,0 +1,394 @@
+/* unsharp_vt.m
+
+   Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_unsharp_vt_metallib_data[];
+extern unsigned int hb_unsharp_vt_metallib_len;
+
+#define UNSHARP_STRENGTH_LUMA_DEFAULT 0.25
+#define UNSHARP_SIZE_LUMA_DEFAULT 7
+#define UNSHARP_STRENGTH_CHROMA_DEFAULT 0.25
+#define UNSHARP_SIZE_CHROMA_DEFAULT 7
+#define UNSHARP_SIZE_MIN 3
+#define UNSHARP_SIZE_MAX 15
+
+typedef struct
+{
+    float         strength;  // amount
+    int           size;      // pixel context region width (must be odd)
+    
+    id<MTLBuffer> matrix;
+    id<MTLBuffer> coef_x;
+    id<MTLBuffer> coef_y;
+} unsharp_vt_plane_context_t;
+
+struct mtl_unsharp_params
+{
+    uint       channels;
+    float      strength;
+    int        size;
+};
+
+struct hb_filter_private_s
+{
+    hb_metal_context_t       *mtl;
+    const AVPixFmtDescriptor *desc;
+
+    bool                        global;
+    unsharp_vt_plane_context_t  plane_ctx[3];
+
+    hb_filter_init_t            input;
+    hb_filter_init_t            output;
+};
+
+static int unsharp_vt_init(hb_filter_object_t *filter,
+                           hb_filter_init_t   *init);
+
+static int unsharp_vt_work(hb_filter_object_t *filter,
+                           hb_buffer_t ** buf_in,
+                           hb_buffer_t ** buf_out);
+
+static void unsharp_vt_close(hb_filter_object_t *filter);
+
+static const char unsharp_vt_template[] =
+    "y-strength=^"HB_FLOAT_REG"$:y-size=^"HB_INT_REG"$:"
+    "cb-strength=^"HB_FLOAT_REG"$:cb-size=^"HB_INT_REG"$:"
+    "cr-strength=^"HB_FLOAT_REG"$:cr-size=^"HB_INT_REG"$";
+
+hb_filter_object_t hb_filter_unsharp_vt =
+{
+    .id                = HB_FILTER_UNSHARP_VT,
+    .enforce_order     = 1,
+    .name              = "Unsharp (VideoToolbox)",
+    .settings          = NULL,
+    .init              = unsharp_vt_init,
+    .work              = unsharp_vt_work,
+    .close             = unsharp_vt_close,
+    .settings_template = unsharp_vt_template,
+};
+
+static int unsharp_vt_init(hb_filter_object_t *filter,
+                        hb_filter_init_t   *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("unsharp_vt: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t * pv = filter->private_data;
+    pv->input = *init;
+    pv->desc = av_pix_fmt_desc_get(init->pix_fmt);
+
+    // Mark parameters unset
+    for (int c = 0; c < 3; c++)
+    {
+        pv->plane_ctx[c].strength = -1;
+        pv->plane_ctx[c].size     = -1;
+    }
+
+    // Read user parameters
+    if (filter->settings != NULL)
+    {
+        hb_dict_t *dict = filter->settings;
+        double val;
+        hb_dict_extract_double(&val, dict, "y-strength");
+        hb_dict_extract_int(&pv->plane_ctx[0].size, dict, "y-size");
+        pv->plane_ctx[0].strength = val;
+
+        hb_dict_extract_double(&val, dict, "cb-strength");
+        hb_dict_extract_int(&pv->plane_ctx[1].size, dict, "cb-size");
+        pv->plane_ctx[1].strength = val;
+
+        hb_dict_extract_double(&val, dict, "cr-strength");
+        hb_dict_extract_int(&pv->plane_ctx[2].size, dict, "cr-size");
+        pv->plane_ctx[2].strength = val;
+    }
+
+    char *function_name = "unsharp_local";
+
+    // Cascade values
+    // Cr not set; inherit Cb. Cb not set; inherit Y. Y not set; defaults.
+    for (int c = 1; c < 3; c++)
+    {
+        unsharp_vt_plane_context_t *prev_ctx = &pv->plane_ctx[c - 1];
+        unsharp_vt_plane_context_t *ctx      = &pv->plane_ctx[c];
+
+        if (ctx->strength == -1) ctx->strength = prev_ctx->strength;
+        if (ctx->size     == -1) ctx->size     = prev_ctx->size;
+        if (ctx->size > 17)
+        {
+            pv->global = true;
+            function_name = "unsharp_global";
+        }
+    }
+
+    pv->mtl = hb_metal_context_init(hb_unsharp_vt_metallib_data,
+                                    hb_unsharp_vt_metallib_len,
+                                    function_name,
+                                    sizeof(struct mtl_unsharp_params),
+                                    init->geometry.width, init->geometry.height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("unsharp_vt: failed to create Metal device");
+        return -1;
+    }
+
+    for (int c = 0; c < 3; c++)
+    {
+        unsharp_vt_plane_context_t *ctx = &pv->plane_ctx[c];
+
+        // Replace unset values with defaults
+        if (ctx->strength == -1)
+        {
+            ctx->strength = c ? UNSHARP_STRENGTH_CHROMA_DEFAULT :
+                                UNSHARP_STRENGTH_LUMA_DEFAULT;
+        }
+        if (ctx->size     == -1)
+        {
+            ctx->size     = c ? UNSHARP_SIZE_CHROMA_DEFAULT :
+                                UNSHARP_SIZE_LUMA_DEFAULT;
+        }
+
+        // Sanitize
+        if (ctx->strength < 0)   ctx->strength = 0;
+        if (ctx->strength > 1.5) ctx->strength = 1.5;
+        if (ctx->size % 2 == 0) ctx->size--;
+        if (ctx->size < UNSHARP_SIZE_MIN) ctx->size = UNSHARP_SIZE_MIN;
+        if (ctx->size > UNSHARP_SIZE_MAX) ctx->size = UNSHARP_SIZE_MAX;
+
+        const NSUInteger length = UNSHARP_SIZE_MAX * sizeof(float);
+        ctx->coef_x = [pv->mtl->device newBufferWithLength:length
+                                                     options:MTLResourceStorageModeManaged];
+        ctx->coef_y = [pv->mtl->device newBufferWithLength:length
+                                                     options:MTLResourceStorageModeManaged];
+
+        float *blur_x = ctx->coef_x.contents;
+        float *blur_y = ctx->coef_y.contents;
+        double sum = 0.0;
+
+        for (int x = 0; x < ctx->size; x++)
+        {
+            double dx = (double)(x - ctx->size / 2) / ctx->size;
+            sum += blur_x[x] = exp(-16.0 * (dx * dx));
+        }
+        for (int x = 0; x < ctx->size; x++)
+        {
+            blur_x[x] /= sum;
+        }
+
+        sum = 0.0;
+        for (int y = 0; y < ctx->size; y++)
+        {
+            double dy = (double)(y - ctx->size / 2) / ctx->size;
+            sum += blur_y[y] = exp(-16.0 * (dy * dy));
+        }
+        for (int y = 0; y < ctx->size; y++)
+        {
+            blur_y[y] /= sum;
+        }
+
+        [ctx->coef_x didModifyRange:NSMakeRange(0, length)];
+        [ctx->coef_y didModifyRange:NSMakeRange(0, length)];
+
+        NSUInteger matrix_length = ctx->size * ctx->size * sizeof(float);
+        ctx->matrix = [pv->mtl->device newBufferWithLength:matrix_length
+                                                   options:MTLResourceStorageModeManaged];
+
+        float *matrix = ctx->matrix.contents;
+        for (int y = 0; y < ctx->size; y++)
+        {
+            for (int x = 0; x < ctx->size; x++)
+            {
+                double val = blur_x[x] * blur_y[y];
+                matrix[y * ctx->size + x] = val;
+            }
+        }
+
+        [ctx->matrix didModifyRange:NSMakeRange(0, matrix_length)];
+    }
+
+    pv->output = *init;
+
+    return 0;
+}
+
+static void unsharp_vt_close(hb_filter_object_t * filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    hb_metal_context_close(&pv->mtl);
+
+    for (int i = 0; i < 3; i++)
+    {
+        unsharp_vt_plane_context_t *ctx = &pv->plane_ctx[i];
+        [ctx->matrix release];
+        [ctx->coef_x release];
+        [ctx->coef_y release];
+    }
+
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void call_kernel(hb_filter_private_t *pv,
+                        id<MTLTexture> dst,
+                        id<MTLTexture> src,
+                        int channels,
+                        int plane)
+{
+    unsharp_vt_plane_context_t *ctx = &pv->plane_ctx[plane];
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+    struct mtl_unsharp_params *params = (struct mtl_unsharp_params *)pv->mtl->params_buffer.contents;
+    *params = (struct mtl_unsharp_params)
+    {
+        .channels = channels,
+        .strength = ctx->strength,
+        .size     = ctx->size,
+    };
+
+    [encoder setTexture:dst atIndex:0];
+    [encoder setTexture:src atIndex:1];
+
+    int i = 0;
+    if (pv->global)
+    {
+        [encoder setBuffer:ctx->matrix offset:0 atIndex:i++];
+    }
+    else
+    {
+        [encoder setBuffer:ctx->coef_x offset:0 atIndex:i++];
+        [encoder setBuffer:ctx->coef_y offset:0 atIndex:i++];
+    }
+    [encoder setBuffer:pv->mtl->params_buffer offset:0 atIndex:i++];
+
+    if (pv->global)
+    {
+        hb_metal_compute_encoder_dispatch(pv->mtl->device, pv->mtl->pipeline, encoder, dst.width, dst.height);
+    }
+    else
+    {
+        hb_metal_compute_encoder_dispatch_fixed_threadgroup_size(pv->mtl->device, pv->mtl->pipeline, encoder,
+                                                                 dst.width, dst.height, 16, 16);
+    }
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static hb_buffer_t * filter_frame(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    CVReturn ret = kCVReturnSuccess;
+    hb_buffer_t *out = NULL;
+
+    CVPixelBufferRef cv_src = hb_cv_get_pixel_buffer(in);
+
+    if (cv_src == NULL)
+    {
+        hb_log("unsharp_vt: extract_buf failed");
+        goto fail;
+    }
+
+    CVPixelBufferRef cv_dest = NULL;
+    ret = CVPixelBufferPoolCreatePixelBuffer(kCFAllocatorDefault, pv->mtl->pool, &cv_dest);
+    if (ret != kCVReturnSuccess)
+    {
+        hb_log("unsharp_vt: CVPixelBufferPoolCreatePixelBuffer failed");
+        goto fail;
+    }
+
+    for (int i = 0; i < pv->desc->nb_components; i++)
+    {
+        const AVComponentDescriptor *comp = &pv->desc->comp[i];
+        if (comp->plane < i)
+        {
+            continue;
+        }
+
+        int channels;
+        const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+        if (format == MTLPixelFormatInvalid)
+        {
+            goto fail;
+        }
+
+        CVMetalTextureRef src  = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_src, i, format);
+        CVMetalTextureRef dest = hb_metal_texture_from_pixbuf(pv->mtl->cache, cv_dest, i, format);
+
+        id<MTLTexture> tex_src  = CVMetalTextureGetTexture(src);
+        id<MTLTexture> tex_dest = CVMetalTextureGetTexture(dest);
+
+        call_kernel(pv, tex_dest, tex_src, channels, i);
+
+        CFRelease(src);
+        CFRelease(dest);
+    }
+
+    CVBufferPropagateAttachments(cv_src, cv_dest);
+
+    out = hb_buffer_wrapper_init();
+    out->storage_type = COREMEDIA;
+    out->storage      = cv_dest;
+    out->f.width           = pv->output.geometry.width;
+    out->f.height          = pv->output.geometry.height;
+    out->f.fmt             = pv->output.pix_fmt;
+    out->f.color_prim      = pv->output.color_prim;
+    out->f.color_transfer  = pv->output.color_transfer;
+    out->f.color_matrix    = pv->output.color_matrix;
+    out->f.color_range     = pv->output.color_range;
+    out->f.chroma_location = pv->output.chroma_location;
+    hb_buffer_copy_props(out, in);
+
+    return out;
+
+fail:
+    if (out != NULL)
+    {
+        hb_buffer_close(&out);
+    }
+    else if (cv_dest)
+    {
+        CVPixelBufferRelease(cv_dest);
+    }
+    return NULL;
+}
+
+static int unsharp_vt_work(hb_filter_object_t *filter,
+                        hb_buffer_t **buf_in,
+                        hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    @autoreleasepool
+    {
+        *buf_out = filter_frame(pv, in);
+    }
+
+    return *buf_out == NULL ? HB_FILTER_FAILED : HB_FILTER_OK;
+}

--- a/libhb/platform/macosx/vt_common.h
+++ b/libhb/platform/macosx/vt_common.h
@@ -19,7 +19,6 @@ const char * const * hb_vt_preset_get_names(int encoder);
 const char * const * hb_vt_profile_get_names(int encoder);
 const char * const * hb_vt_level_get_names(int encoder);
 
-unsigned int hb_vt_get_cv_pixel_format(int pix_fmt, int color_range);
 hb_buffer_t * hb_vt_copy_video_buffer_to_hw_video_buffer(const hb_job_t *job, hb_buffer_t **buf);
 hb_buffer_t * hb_vt_buffer_dup(const hb_buffer_t *src);
 

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		A91119A21C7DD58B001C463C /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F203B14ADBC210021BE6D /* Cocoa.framework */; };
 		A91119A31C7DD591001C463C /* IOKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 273F202214ADB8650021BE6D /* IOKit.framework */; };
 		A91119A41C7DD614001C463C /* HBSubtitlesDefaults.h in Headers */ = {isa = PBXBuildFile; fileRef = A9F4728B1976BAA70009EC65 /* HBSubtitlesDefaults.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A913DDFC2AAB828D004D2C5E /* Metal.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A99B989F27957FCE00DCD062 /* Metal.framework */; };
 		A91485FE1F61296100374C12 /* HBFiltersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = A91485FD1F61296100374C12 /* HBFiltersViewController.m */; };
 		A914BCB31BC441C700157917 /* HBPreviewView.m in Sources */ = {isa = PBXBuildFile; fileRef = A914BCB21BC441C700157917 /* HBPreviewView.m */; };
 		A9150DAE243F7BE200694870 /* HBQueueDockTileController.m in Sources */ = {isa = PBXBuildFile; fileRef = A9150DAD243F7BE200694870 /* HBQueueDockTileController.m */; };
@@ -1131,6 +1132,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A913DDFC2AAB828D004D2C5E /* Metal.framework in Frameworks */,
 				A9998605278868220019E76F /* QuickLookUI.framework in Frameworks */,
 				273F203C14ADBC210021BE6D /* Cocoa.framework in Frameworks */,
 				A96E461B278D99840016DCBB /* Sparkle in Frameworks */,

--- a/make/include/base.rules
+++ b/make/include/base.rules
@@ -1,4 +1,4 @@
-.PHONY: report.main report.gcc report.modules report.var report.true report.help
+.PHONY: report.main report.gcc report.metal report.modules report.var report.true report.help
 .PHONY: shell.run
 
 report.modules::
@@ -8,6 +8,9 @@ report.main:
 
 report.gcc:
 	@$(MAKE) report.true REPORT=gcc
+
+report.metal:
+	@$(MAKE) report.true REPORT=metal
 
 report.var:
 	@$(MAKE) report.true REPORT=var
@@ -28,12 +31,13 @@ endef
 
 REPORT.help.main = global general vars
 REPORT.help.gcc  = global gcc vars (inherited by module GCC)
+REPORT.help.metal = global metal vars (inherited by module Metal)
 REPORT.help.var  = usage: make report.var name=VARNAME
 
 report.help:
 	@echo "  AVAILABLE MAKEFILE VARS REPORTS"
 	@echo "  ----------------------------------------------------------------"
-	$(foreach n,main gcc var,$(call REPORT.help.item.global,$n))
+	$(foreach n,main gcc metal var,$(call REPORT.help.item.global,$n))
 	$(foreach n,$(MODULES.NAMES),$(call REPORT.help.item.module,$n))
 
 ## diagnostic aid when troubleshooting build issues

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -2,6 +2,7 @@ include $(SRC/)make/include/base.defs
 include $(SRC/)make/include/contrib.defs
 include $(SRC/)make/include/function.defs
 include $(SRC/)make/include/gcc.defs
+include $(SRC/)make/include/metal.defs
 include $(SRC/)make/include/target.defs
 include $(SRC/)make/include/tool.defs
 
@@ -76,6 +77,7 @@ endif
 
 ifneq (,$(filter $(HOST.system),darwin))
     MODULES += contrib/xz
+    MODULES += contrib/bin2c
 endif
 
 ifneq (,$(filter $(HOST.machine),arm64 aarch64))

--- a/make/include/metal.defs
+++ b/make/include/metal.defs
@@ -1,0 +1,42 @@
+METAL.cc = xcrun metal
+METAL.ar = xcrun metal-ar
+METAL.ld = xcrun metallib
+METAL.bin2c = ./bin2c
+
+METAL.args.extra = -O2 -std=macos-metal2.4
+
+###############################################################################
+
+define import.METAL
+    $(1).METAL.cc = $$(METAL.cc)
+    $(1).METAL.ar = $$(METAL.ar)
+    $(1).METAL.ld = $$(METAL.ld)
+    $(1).METAL.bin2c = $$(METAL.bin2c)
+
+    $(1).METAL.args.extra = $$(METAL.args.extra)
+
+    ###########################################################################
+
+    $(1).METAL.c = -c -frecord-sources $$(4)
+    $(1).METAL.o = -o $$(3);
+
+    $(1).METAL.ld.c = $$(4)
+    $(1).METAL.ld.o = -o $$(3);
+    $(1).METAL.C_METALLIB.args = !ld !ld.c !ld.o
+
+    $(1).METAL.bin2c.c = $$(4)
+    $(1).METAL.bin2c.o = $$(3);
+    $(1).METAL.C_BIN2C.args = !bin2c !bin2c.c !bin2c.o
+
+    # FUNCTION: Metal compile source
+    $(1).METAL.C_O.args = !cc !args.extra !c !o
+    define $(1).METAL.C_O
+        $$(call fn.ARGS,$(1).METAL,$$($(1).METAL.C_O.args),$$(1).air,$$(2))
+        $$(call fn.ARGS,$(1).METAL,$$($(1).METAL.C_METALLIB.args),$$(1).metallib,$$(1).air)
+        $$(call fn.ARGS,$(1).METAL,$$($(1).METAL.C_BIN2C.args),$$(1).c,$$(1).metallib)
+        $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.C_O.args),$$(1).o,$$(1).c)
+    endef
+
+    ###########################################################################
+
+endef

--- a/make/include/report.defs
+++ b/make/include/report.defs
@@ -54,6 +54,18 @@ $(info $(foreach v,$(sort $(filter GCC.%,$(.VARIABLES))),$(call fn.PRINTVAR,$v))
 $(info )
 endif
 
+## report: metal
+##
+ifeq (metal,$(REPORT))
+$(info ###############################################################################)
+$(info ##)
+$(info ## METAL)
+$(info ##)
+$(info ###############################################################################)
+$(info $(foreach v,$(sort $(filter METAL.%,$(.VARIABLES))),$(call fn.PRINTVAR,$v)))
+$(info )
+endif
+
 ## report: var
 ##
 ifeq (var,$(REPORT))

--- a/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
@@ -18,7 +18,9 @@ namespace HandBrake.Interop.Interop.HbLib
         HB_FILTER_COMB_DETECT,
         HB_FILTER_DECOMB,
         HB_FILTER_YADIF,
+        HB_FILTER_YADIF_VT,
         HB_FILTER_BWDIF,
+        HB_FILTER_BWDIF_VT,
         HB_FILTER_VFR,
         // Filters that must operate on the original source image are next
         HB_FILTER_DEBLOCK,
@@ -26,16 +28,23 @@ namespace HandBrake.Interop.Interop.HbLib
         HB_FILTER_HQDN3D = HB_FILTER_DENOISE,
         HB_FILTER_NLMEANS,
         HB_FILTER_CHROMA_SMOOTH,
+        HB_FILTER_CHROMA_SMOOTH_VT,
         HB_FILTER_ROTATE,
         HB_FILTER_ROTATE_VT,
         HB_FILTER_RENDER_SUB,
         HB_FILTER_CROP_SCALE,
         HB_FILTER_CROP_SCALE_VT,
         HB_FILTER_LAPSHARP,
+        HB_FILTER_LAPSHARP_VT,
         HB_FILTER_UNSHARP,
+        HB_FILTER_UNSHARP_VT,
         HB_FILTER_GRAYSCALE,
+        HB_FILTER_GRAYSCALE_VT,
         HB_FILTER_PAD,
+        HB_FILTER_PAD_VT,
         HB_FILTER_COLORSPACE,
+        HB_FILTER_FORMAT,
+        HB_FILTER_RPU,
 
         // Finally filters that don't care what order they are in,
         // except that they must be after the above filters
@@ -43,6 +52,6 @@ namespace HandBrake.Interop.Interop.HbLib
 
         HB_FILTER_LAST,
         // wrapper filter for frame based multi-threading of simple filters
-        HB_FILTER_MT_FRAME,
+        HB_FILTER_MT_FRAME
     }
 }


### PR DESCRIPTION
Insert the <I have no idea what I'm doing> dog meme here.
I was playing around porting FFmpeg Metal yadif filter, and ported some more too. They mostly work, sharper filters need to be fixed to use the separate parameters for u and v channels.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 13
- [ ] Ubuntu Linux
