### PR TITLE
libhb: Fix content light query in macOS

### DIFF
--- a/libhb/platform/macosx/encvt.c
+++ b/libhb/platform/macosx/encvt.c
@@ -1088,7 +1088,7 @@ static OSStatus init_vtsession(hb_work_object_t *w, hb_job_t *job, hb_work_priva
         }
     }
 
-    if (CFDictionaryContainsKey(supportedProps, kVTCompressionPropertyKey_MasteringDisplayColorVolume) &&
+    if (CFDictionaryContainsKey(supportedProps, kVTCompressionPropertyKey_ContentLightLevelInfo) &&
         pv->settings.color.contentLightLevel != NULL)
     {
         err = VTSessionSetProperty(pv->session,


### PR DESCRIPTION
Fix the content light query in macOS

it's  a copy & paste code issue

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
