### PR TITLE
Flatpak: Update to GNOME 45 and fix Intel plugin

### DIFF
--- a/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
+++ b/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.HandBrakeCLI",
     "runtime": "org.freedesktop.Platform",
-    "runtime-version": "21.08",
+    "runtime-version": "23.08",
     "sdk": "org.freedesktop.Sdk",
     "command": "HandBrakeCLI",
     "finish-args": [

--- a/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
+++ b/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
@@ -25,6 +25,8 @@
             "config-opts": ["--flatpak", "--disable-gtk"],
             "builddir": true,
             "post-install": ["rm -rf /app/share"],
+            "build-options":{
+            },
             "sources": [
                 {
                     "type": "archive",

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -3,7 +3,7 @@
     "branch": "1",
     "runtime": "fr.handbrake.ghb",
     "runtime-version": "development",
-    "sdk": "org.gnome.Sdk//43",
+    "sdk": "org.gnome.Sdk//45",
     "build-extension": true,
     "separate-locales": false,
     "appstream-compose": false,
@@ -13,8 +13,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.3.3.tar.gz",
-                    "sha256": "86651bd2803c9f0afd82471bec784e65d2b418dee315a053d22215eb2a679be7"
+                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.3.12.tar.gz",
+                    "sha256": "14ec859936aea696a65e6b9488e95a0ac26b15126ef65b20956ef219004dd9a6"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -37,8 +37,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva/archive/refs/tags/2.17.0.tar.gz",
-                    "sha256": "8940541980ef998a36cd8f6ad905e81838ea4ddf56dc479ed2bebd12711e6001"
+                    "url": "https://github.com/intel/libva/archive/refs/tags/2.19.0.tar.gz",
+                    "sha256": "8cb5e2a9287a76b12c0b6cb96f4f27a0321bbe693df43cd950e5d4542db7f227"
                 }
             ],
             "no-autogen": false,
@@ -52,8 +52,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva-utils/archive/refs/tags/2.17.1.tar.gz",
-                    "sha256": "6ea5993c3eba230a979fa9d35b4cad8df06d4474a773dc0918033bf50353f966"
+                    "url": "https://github.com/intel/libva-utils/archive/refs/tags/2.19.0.tar.gz",
+                    "sha256": "4135992ab534d0cfd71a93c28e1a22f79c0003cf8d157ffd4621e5e482191b4f"
                 }
             ],
             "no-autogen": false,
@@ -67,8 +67,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-23.1.0.tar.gz",
-                    "sha256": "edae1bdc07b694bd6e42099feddcf875e3b5d7254894f4b3fb292128577baf82"
+                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-23.2.4.tar.gz",
+                    "sha256": "dfcf2facc4f8bf3df6b147222786032be195874adacc2f4071fc6c91a0abdf0a"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -110,6 +110,10 @@
                     "sha256": "3a671cc692da5111c041088f5e32528b4346e122e8a134fad71310c572705106"
                 },
                 {
+                    "type": "patch",
+                    "path": "intel-mediasdk-gcc13.patch"
+                },
+                {
                     "type": "file",
                     "path": "fr.handbrake.ghb.Plugin.IntelMediaSDK.metainfo.xml"
                 }
@@ -129,8 +133,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/refs/tags/intel-onevpl-23.1.0.tar.gz",
-                    "sha256": "4a4437f2ec09f80431807f6031751b586c6353f3c11f1b2d92c10a9a6906acd8"
+                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/refs/tags/intel-onevpl-23.2.4.tar.gz",
+                    "sha256": "77a768645c323dfd3e395e6e7e1aff886a7d3af75fb9f38ee9e7014d11e6356f"
                 },
                 {
                     "type": "file",

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -29,7 +29,8 @@
                 ],
                 "make-install-args": [
                     "-v"
-                ]
+                ],
+                "strip": true
             }
         },
         {
@@ -44,7 +45,8 @@
             "no-autogen": false,
             "config-opts": ["--with-drivers-path=/app/extensions/IntelMediaSDK/lib/dri"],
             "build-options": {
-                "prefix" : "/app/extensions/IntelMediaSDK"
+                "prefix" : "/app/extensions/IntelMediaSDK",
+                "strip": true
             }
         },
         {
@@ -59,7 +61,8 @@
             "no-autogen": false,
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
-                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig",
+                "strip": true
             }
         },
         {
@@ -80,7 +83,8 @@
             ],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
-                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig",
+                "strip": true
             }
         },
         {
@@ -97,7 +101,8 @@
             ],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
-                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig",
+                "strip": true
             },
             "post-install": [
                 "install -Dp -m 644 ${FLATPAK_BUILDER_BUILDDIR}/fr.handbrake.ghb.Plugin.IntelMediaSDK.metainfo.xml --target-directory=${FLATPAK_DEST}/share/metainfo",
@@ -128,7 +133,8 @@
             ],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
-                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig"
+                "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig",
+                "strip": true
             },
             "sources": [
                 {

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "43",
+    "runtime-version": "45",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [
@@ -63,6 +63,8 @@
             "config-opts": [
                 "--flatpak"
             ],
+            "build-options": {
+            },
             "builddir": true,
             "post-install": ["install -d /app/extensions"],
             "sources": [

--- a/pkg/linux/flatpak/intel-mediasdk-gcc13.patch
+++ b/pkg/linux/flatpak/intel-mediasdk-gcc13.patch
@@ -1,0 +1,11 @@
+diff -up MediaSDK-intel-mediasdk-22.6.4/api/mfx_dispatch/linux/mfxparser.cpp.gcc13 MediaSDK-intel-mediasdk-22.6.4/api/mfx_dispatch/linux/mfxparser.cpp
+--- MediaSDK-intel-mediasdk-22.6.4/api/mfx_dispatch/linux/mfxparser.cpp.gcc13	2022-11-18 09:02:59.000000000 +0100
++++ MediaSDK-intel-mediasdk-22.6.4/api/mfx_dispatch/linux/mfxparser.cpp	2023-01-17 21:26:56.794562323 +0100
+@@ -23,6 +23,7 @@
+ #include <stdlib.h>
+ #include <string.h>
+
++#include <cstdint>
+ #include <list>
+
+ #include "mfxloader.h"

--- a/pkg/linux/module.defs
+++ b/pkg/linux/module.defs
@@ -64,11 +64,15 @@ RPMROOT.out/ = $(RPMROOT.out)/
 ###############################################################################
 
 ifeq (1,$(FEATURE.qsv))
-    FPQSV = -q
+    FPFLAGS += -q
 endif
 
 ifeq (1,$(FEATURE.nvenc))
-    FPNVENC = -e
+    FPFLAGS += -e
+endif
+
+ifeq (1,$(FEATURE.libdovi))
+    FPFLAGS += -d
 endif
 
 ifneq ($(FP_RUNTIME),)

--- a/pkg/linux/module.defs
+++ b/pkg/linux/module.defs
@@ -108,6 +108,7 @@ PKG.mediasdk.manifest.flathub = $(PKG.out.flatpak/)$(PKG.mediasdk.name.flatpak).
 PKG.mediasdk.metainfo.flatpak = $(PKG.flatpak/)$(PKG.mediasdk.name.flatpak).metainfo.xml
 PKG.mediasdk.template.flatpak = $(PKG.flatpak/)$(PKG.mediasdk.name.flatpak).json
 PKG.mediasdk.manifest.flatpak = $(STAGE.out.flatpak/)$(PKG.mediasdk.name.flatpak).json
+PKG.mediasdk.patch.flatpak = $(PKG.flatpak/)intel-mediasdk-gcc13.patch
 PKG.mediasdk.build.flatpak = $(STAGE.out.flatpak/)$(PKG.mediasdk.name.flatpak)-$(HB.version)-$(HOST.machine).build
 PKG.mediasdk.flatpak = $(PKG.out.flatpak/)$(PKG.mediasdk.name.flatpak)-$(HB.version)-$(HOST.machine).flatpak
 

--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -96,6 +96,7 @@ $(PKG.mediasdk.flatpak): GNUmakefile $(PKG.mediasdk.template.flatpak) $(PKG.gui.
 	-flatpak --user remove --noninteractive $(PKG.gui.name.flatpak)//$(PKG.branch.flatpak)
 	flatpak --user install --noninteractive $(PKG.gui.flatpak)
 	$(CP.exe) $(PKG.mediasdk.metainfo.flatpak) $(STAGE.out.flatpak/)
+	$(CP.exe) $(PKG.mediasdk.patch.flatpak) $(STAGE.out.flatpak/)
 	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.mediasdk.build.flatpak) $(PKG.mediasdk.manifest.flatpak)
 	flatpak build-bundle --runtime $(PKG.repo.flatpak) $(PKG.mediasdk.flatpak) $(PKG.mediasdk.name.flatpak) $(PKG.plugin.version.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 	-flatpak --user remove --noninteractive $(PKG.gui.name.flatpak)//$(PKG.branch.flatpak)

--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -67,17 +67,17 @@ $(PKG.rpm.stamp): $(PKG.native.rpm.stamp)
 #
 $(PKG.gui.manifest.flathub):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) $(FPNVENC) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))" -b "$(word 1,$($m.FETCH.basename))") $(FPRUNTIME) $(PKG.gui.manifest.flathub)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))" -b "$(word 1,$($m.FETCH.basename))") $(FPRUNTIME) $(PKG.gui.manifest.flathub)
 
 $(PKG.cli.manifest.flathub):
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) $(FPNVENC) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))" -b "$(word 1,$($m.FETCH.basename))") $(FPRUNTIME) $(PKG.cli.manifest.flathub)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(HB_URL)" -s "$(HB_SHA256)" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(word 1,$($m.FETCH.url))" -s "$(word 1,$($m.FETCH.sha256))" -b "$(word 1,$($m.FETCH.basename))") $(FPRUNTIME) $(PKG.cli.manifest.flathub)
 
 $(PKG.gui.flatpak): GNUmakefile $(PKG.gui.template.flatpak) $(PKG.src.tar.bz2)
 	make contrib.fetch
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) $(FPNVENC) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.gui.manifest.flatpak)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.gui.manifest.flatpak)
 	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(PKG.gui.manifest.flatpak)
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) $(PKG.gui.name.flatpak) $(PKG.branch.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
@@ -85,7 +85,7 @@ $(PKG.cli.flatpak): GNUmakefile $(PKG.cli.template.flatpak) $(PKG.src.tar.bz2)
 	make contrib.fetch
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
-	$(SRC/)scripts/create_flatpak_manifest.py $(FPQSV) $(FPNVENC) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.cli.manifest.flatpak)
+	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.cli.manifest.flatpak)
 	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(PKG.cli.manifest.flatpak)
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) $(PKG.cli.name.flatpak) $(PKG.branch.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 


### PR DESCRIPTION
Updates the GUI Flatpak to GNOME 45 and the CLI to freedesktop 23.08, and adds a patch to fix the IntelMediaSDK. Also adds the rust-stable extension in order to build libdovi.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
