### PR TITLE
Fix a xcodebuild warning

### DIFF
--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 		A9F217E61E2F934C00C10C6E /* container-migration.plist in Resources */ = {isa = PBXBuildFile; fileRef = A9F217E51E2F934C00C10C6E /* container-migration.plist */; };
 		A9F472891976B7F30009EC65 /* HBSubtitlesDefaultsController.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F472871976B7F30009EC65 /* HBSubtitlesDefaultsController.m */; };
 		A9F7102619A475EC00F61301 /* HBDockTile.m in Sources */ = {isa = PBXBuildFile; fileRef = A9F7102519A475EC00F61301 /* HBDockTile.m */; };
+		D0AAA60F2ADF15260020A025 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D0AAA60D2ADF15260020A025 /* Localizable.strings */; };
 		D0DC8F682331573500C12A24 /* libdav1d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0DC8F672331573500C12A24 /* libdav1d.a */; };
 		D0DC8F69233159C700C12A24 /* libdav1d.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D0DC8F672331573500C12A24 /* libdav1d.a */; };
 		D86C9DD51C6D372500F06F1B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D86C9DD41C6D372500F06F1B /* Assets.xcassets */; };
@@ -1032,7 +1033,7 @@
 		D0A185FE2AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Video.strings; sourceTree = "<group>"; };
 		D0A185FF2AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D0A186002AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-        D0A186012AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D0A186012AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D0A186022AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = "ko.lproj/HandBrakeXPCService1-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0A186032AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = "ko.lproj/HandBrakeXPCService2-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0A186042AD5BDE60056C7BD /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = "ko.lproj/HandBrakeXPCService3-InfoPlist.strings"; sourceTree = "<group>"; };
@@ -1140,7 +1141,7 @@
 		D0E25A722AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Video.strings; sourceTree = "<group>"; };
 		D0E25A732AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D0E25A742AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-        D0E25A752AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D0E25A752AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D0E25A762AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = "bg.lproj/HandBrakeXPCService1-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0E25A772AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = "bg.lproj/HandBrakeXPCService2-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0E25A782AD5BE3600D1B3F5 /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = "bg.lproj/HandBrakeXPCService3-InfoPlist.strings"; sourceTree = "<group>"; };
@@ -1355,6 +1356,7 @@
 		273F1FDE14AD9DA40021BE6D = {
 			isa = PBXGroup;
 			children = (
+				D0AAA60D2ADF15260020A025 /* Localizable.strings */,
 				273F204114ADBC210021BE6D /* HandBrake */,
 				273F200214ADAE950021BE6D /* HandBrakeCLI */,
 				A9736F031C7DA5FE008F1D18 /* HandBrakeKit */,
@@ -2239,6 +2241,7 @@
 				A94DC2DE20CADA2C00EAC8FD /* MainWindow.xib in Resources */,
 				D86C9DD51C6D372500F06F1B /* Assets.xcassets in Resources */,
 				A9A96BCE20CAD61F00A39AFB /* SubtitlesDefaults.xib in Resources */,
+				D0AAA60F2ADF15260020A025 /* Localizable.strings in Resources */,
 				A9A96BDA20CAD64B00A39AFB /* PicturePreview.xib in Resources */,
 				A958EAC222E24D6400D83AF4 /* HBQueueTableViewController.xib in Resources */,
 				A95BC1E71CD2548A008D6A33 /* volHighTemplate.pdf in Resources */,
@@ -2641,10 +2644,8 @@
 				A919992D23003D730037F526 /* de */,
 				A9D3E315234A11E600F39385 /* ru */,
 				A9D2DDE524B3B1C2009C92DA /* pt_BR */,
-                A91CAB55270726B300006BEA /* co */,
+				A91CAB55270726B300006BEA /* co */,
 				A91CAB54270726B000006BEA /* zh */,
-                D0A185FF2AD5BDE60056C7BD /* ko */,
-                D0E25A732AD5BE3600D1B3F5 /* bg */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";


### PR DESCRIPTION
This PR fixes a warning of xcodebuild while building:

```
2023-10-17 21:44:57.060 xcodebuild[59255:1877608] warning:  The file reference for "ko.lproj/Localizable.strings" is a member of multiple groups ("Localizable.strings" and "Localizable.strings"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
2023-10-17 21:44:57.060 xcodebuild[59255:1877608] warning:  The file reference for "bg.lproj/Localizable.strings" is a member of multiple groups ("Localizable.strings" and "Localizable.strings"); this indicates a malformed project.  Only the membership in one of the groups will be preserved (but membership in targets will be unaffected).  If you want a reference to the same file in more than one group, please add another reference to the same path.
Resolve Package Graph
```

This was introduced with my last Mac PR, sorry for that (but it was building fine). Now this warning is also fixed.