### PR TITLE
Update libdovi to 3.2.0

### DIFF
--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,7 +1,8 @@
 $(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
 $(eval $(call import.CONTRIB.defs,LIBDOVI))
 
-LIBDOVI.FETCH.url      = https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.2.0.tar.gz
+LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdovi-3.2.0.tar.gz
+LIBDOVI.FETCH.url     += https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.2.0.tar.gz
 LIBDOVI.FETCH.sha256   = 23c339b08bf32b66144b8fe17bf9a39f2dc810a37f081e5bc50207af9ae99922
 LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.2.0.tar.gz
 

--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
 $(eval $(call import.CONTRIB.defs,LIBDOVI))
 
-LIBDOVI.FETCH.url      = https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.1.2.tar.gz
-LIBDOVI.FETCH.sha256   = 3c74f8f6afdb7d4be97210df201a28a48676b2ebe10c20961176e81e2fd98c36
-LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.1.2.tar.gz
+LIBDOVI.FETCH.url      = https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.2.0.tar.gz
+LIBDOVI.FETCH.sha256   = 23c339b08bf32b66144b8fe17bf9a39f2dc810a37f081e5bc50207af9ae99922
+LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.2.0.tar.gz
 
 define LIBDOVI.CONFIGURE
      $(CARGO.exe) fetch $(LIBDOVI.manifest)


### PR DESCRIPTION
Update libdovi to 3.2.0.

[3.2.0](https://github.com/HandBrake/HandBrake/compare/master...Nomis101:libdovi?expand=1#320)

- Deprecated RpuDataHeader.rpu_nal_prefix.
- Added av1 module for handling AV1 Dolby Vision ITU-T T.35 metadata OBU payloads.
- AV1 RPU bytes can now be encoded with write_av1_rpu_metadata_obu_t35_payload.
- The payload is meant to be used for itu_t_t35_payload_bytes.