### PR TITLE
decavsub: Remove arbitrary sub delay added whenever AV-PG PTS grid mismatch.

### DIFF
--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -479,7 +479,8 @@ int decavsubWork( hb_avsub_context_t * ctx,
             hb_log("decavsub: track %d, non-monotonically increasing PTS, last %"PRId64" current %"PRId64"",
                    ctx->subtitle->out_track,
                    ctx->last_pts, pts);
-            pts = ctx->last_pts + 1 * 90000LL;
+            //PGS PTS may not be always aligned to AV PTS. To not mess up animations, add only a single tick.
+            pts = ctx->last_pts + (ctx->subtitle->source == PGSSUB ? 1 : 90000LL);
         }
         ctx->last_pts = pts;
 


### PR DESCRIPTION
**Description of Change:**
HandBrake expects one subtitle packet alongside an audio or video packet. Else, it purposely delays the current subtitle by at least one second. For PGS, groups of segments may be closely tied together to perform animations like fades, karaoke, and so on. Delaying a packet (a group of segments) breaks animations as all subsequent packets gets delayed, and eventually dropped.`ApplyPGSSubs` performs sufficient packet filtering: it discards segments that predates the AV PTS. The arbitrary delay of 1-3 seconds is, as far as I understand, futile for this subtitle format.

**Motivation:**
Different softwares can be used to generate a variety of AV assets. Those may be combined despite mismatched framerates, for example. Some combinations may produce files where assets have mismatched PTS grids. HandBrake ought to accept these situations.

**Tested on:**
- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Sample**
[tetsu.sup.zip](https://github.com/HandBrake/HandBrake/files/13323819/tetsu.sup.zip)
Muxing and burning this 29.97 BD SUP to a video should result in erratic and delayed burned in subtitles.
And, before you ask, yes this file complies with the Blu-ray PGS format and has strictly monotonic PTS.
