### PR TITLE
qsv: fix device enumeration order

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -533,10 +533,12 @@ int hb_str_ends_with(const char *base, const char *str)
 
 static void hb_common_global_hw_init()
 {
+#if HB_PROJECT_FEATURE_NVENC
     hb_nvenc_h264_available();
-
+#endif
+#if HB_PROJECT_FEATURE_VCE
     hb_vce_h264_available();
-
+#endif
     // first initialization and QSV adapters list collection should happen after other hw vendors initializations to prevent device order issues
 #if HB_PROJECT_FEATURE_QSV
     hb_qsv_available();

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -275,7 +275,7 @@ hb_encoder_internal_t hb_video_encoders[]  =
     { { "AV1 10-bit (Intel QSV)",      "qsv_av1_10bit",    "AV1 10-bit (Intel Media SDK)",   HB_VCODEC_QSV_AV1_10BIT,     HB_MUX_MASK_MP4|HB_MUX_MASK_WEBM|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_AV1_QSV,    },
     { { "AV1 (NVEnc)",                 "nvenc_av1",        "AV1 (NVEnc)",                    HB_VCODEC_FFMPEG_NVENC_AV1,                   HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_AV1_NVENC,  },
     { { "AV1 10-bit (NVEnc)",          "nvenc_av1_10bit",  "AV1 10-bit (NVEnc)",             HB_VCODEC_FFMPEG_NVENC_AV1_10BIT,             HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_AV1_NVENC,  },
-    { { "AV1 (AMD VCE)",               "vce_av1",          "AV1 (AMD VCE)",                  HB_VCODEC_FFMPEG_VCE_AV1,    				   HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_AV1_VCE,   },
+    { { "AV1 (AMD VCE)",               "vce_av1",          "AV1 (AMD VCE)",                  HB_VCODEC_FFMPEG_VCE_AV1,    				   HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_AV1_VCE,    },
     { { "H.264 (x264)",                "x264",             "H.264 (libx264)",                HB_VCODEC_X264_8BIT,                          HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_H264_X264,  },
     { { "H.264 10-bit (x264)",         "x264_10bit",       "H.264 10-bit (libx264)",         HB_VCODEC_X264_10BIT,                         HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_H264_X264,  },
     { { "H.264 (Intel QSV)",           "qsv_h264",         "H.264 (Intel Media SDK)",        HB_VCODEC_QSV_H264,                           HB_MUX_MASK_MP4|HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_H264_QSV,   },
@@ -531,11 +531,26 @@ int hb_str_ends_with(const char *base, const char *str)
     return (blen >= slen) && (0 == strcasecmp(base + blen - slen, str));
 }
 
+static void hb_common_global_hw_init()
+{
+    hb_nvenc_h264_available();
+
+    hb_vce_h264_available();
+
+    // first initialization and QSV adapters list collection should happen after other hw vendors initializations to prevent device order issues
+    hb_qsv_available();
+}
+
 void hb_common_global_init(int disable_hardware)
 {
     static int common_init_done = 0;
     if (common_init_done)
         return;
+
+    if (!disable_hardware)
+    {
+        hb_common_global_hw_init();
+    }
 
     int i, j;
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -538,7 +538,9 @@ static void hb_common_global_hw_init()
     hb_vce_h264_available();
 
     // first initialization and QSV adapters list collection should happen after other hw vendors initializations to prevent device order issues
+#if HB_PROJECT_FEATURE_QSV
     hb_qsv_available();
+#endif
 }
 
 void hb_common_global_init(int disable_hardware)

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -2267,7 +2267,6 @@ int hb_global_init()
 #if HB_PROJECT_FEATURE_QSV
     if (!disable_hardware)
     {
-        hb_qsv_available();
         hb_register(&hb_encqsv);
     }
 #endif

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -419,7 +419,15 @@ void hb_avfilter_combine( hb_list_t * list)
                 hb_dict_t *cur_settings_dict_qsv = hb_dict_get(cur_settings_dict, "vpp_qsv");
                 if (avfilter_settings_dict_qsv && cur_settings_dict_qsv)
                 {
-                    hb_dict_merge(avfilter_settings_dict_qsv, cur_settings_dict_qsv);
+                    // transpose filter should be applied first separately, then other merged filters
+                    if (hb_dict_get(avfilter_settings_dict_qsv, "transpose"))
+                    {
+                        hb_value_array_concat(avfilter->settings, settings);
+                    }
+                    else
+                    {
+                        hb_dict_merge(avfilter_settings_dict_qsv, cur_settings_dict_qsv);
+                    }
                 }
             }
             else

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -18,6 +18,7 @@
 
 static int is_nvenc_available = -1;
 static int is_nvenc_av1_available = -1;
+static int is_nvenc_h264_available = -1;
 static int is_nvenc_hevc_available = -1;
 
 static double cuda_version = -1;
@@ -138,7 +139,27 @@ int hb_check_nvenc_available()
 
 int hb_nvenc_h264_available()
 {
-    return hb_check_nvenc_available();
+    if (is_nvenc_h264_available != -1)
+    {
+        return is_nvenc_h264_available;
+    }
+
+    if (!hb_check_nvenc_available())
+    {
+        is_nvenc_h264_available = 0;
+        return is_nvenc_h264_available;
+    }
+
+    if (hb_nvenc_get_cuda_version() > 0)
+    {
+        is_nvenc_h264_available = 1;
+    } 
+    else 
+    {
+        is_nvenc_h264_available = 0;
+    }
+
+    return is_nvenc_h264_available;
 }
 
 int hb_nvenc_h265_available()

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4441,7 +4441,7 @@ static int hb_qsv_ffmpeg_set_options(hb_job_t *job, AVDictionary** dict)
     int err;
     AVDictionary* out_dict = *dict;
 
-    if (job->qsv.ctx && job->qsv.ctx->dx_index > 0)
+    if (job->qsv.ctx && job->qsv.ctx->dx_index >= 0)
     {
         char device[32];
         snprintf(device, 32, "%u", job->qsv.ctx->dx_index);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -4451,10 +4451,7 @@ static int hb_qsv_ffmpeg_set_options(hb_job_t *job, AVDictionary** dict)
             return err;
         }
     }
-    else
-    {
-        av_dict_set(&out_dict, "vendor", "0x8086", 0);
-    }
+
     av_dict_set(&out_dict, "child_device_type", "d3d11va", 0);
 
     *dict = out_dict;


### PR DESCRIPTION
It should fix https://github.com/HandBrake/HandBrake/issues/5317 and https://github.com/HandBrake/HandBrake/issues/5177 where system contains more than one GPU card.

[UPD] reverted back encoders array values and created dedicated function for hw init 
call of hb_nvenc_get_cuda_version() is needed for correct adapter order for Windows