### PR TITLE
LinGUI: More detailed notifications

### DIFF
--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -108,6 +108,7 @@
         "version": "0.1",
         "PreferredLanguage": "und",
         "WhenComplete": "notify",
+        "NotifyOnEncodeDone": false,
         "SrtDir": "",
         "window_width": 1,
         "window_height": 1,

--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -109,6 +109,7 @@
         "PreferredLanguage": "und",
         "WhenComplete": "notify",
         "NotifyOnEncodeDone": false,
+        "NotifyOnQueueDone": true,
         "SrtDir": "",
         "window_width": 1,
         "window_height": 1,

--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -110,6 +110,7 @@
         "WhenComplete": "notify",
         "NotifyOnEncodeDone": false,
         "NotifyOnQueueDone": true,
+        "CustomNotificationMessage": "",
         "SrtDir": "",
         "window_width": 1,
         "window_height": 1,

--- a/gtk/po/POTFILES.in
+++ b/gtk/po/POTFILES.in
@@ -8,6 +8,7 @@ src/chapters.c
 src/ghb-dvd.c
 src/hb-backend.c
 src/main.c
+src/notifications.c
 src/presets.c
 src/preview.c
 src/queuehandler.c

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -311,7 +311,8 @@ inhibit_suspend (signal_user_data_t *ud)
         return;
     }
     suspend_cookie = gtk_application_inhibit(ud->app, NULL,
-                            GTK_APPLICATION_INHIBIT_SUSPEND, "Encoding");
+            GTK_APPLICATION_INHIBIT_SUSPEND | GTK_APPLICATION_INHIBIT_LOGOUT,
+            _("An encode is in progress."));
     if (suspend_cookie != 0)
     {
         suspend_inhibited = GHB_SUSPEND_INHIBITED_GTK;

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -5252,12 +5252,12 @@ static void
 queue_done_action (signal_user_data_t *ud)
 {
     switch (ud->when_complete)    {
-	    case 2:
+        case 1:
             ghb_countdown_dialog_show(_("Your encode is complete."),
                                       _("Quitting HandBrake"),
                                       (GSourceFunc)quit_cb, 60, ud);
             break;
-        case 3:
+        case 2:
             if (can_suspend_logind())
             {
                 ghb_countdown_dialog_show(_("Your encode is complete."),
@@ -5265,7 +5265,7 @@ queue_done_action (signal_user_data_t *ud)
                                           (GSourceFunc)suspend_cb, 60, ud);
             }
             break;
-	    case 4:
+        case 3:
             if (can_shutdown_logind())
             {
                 ghb_countdown_dialog_show(_("Your encode is complete."),

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -97,6 +97,5 @@ void ghb_break_duration(gint64 duration, gint *hh, gint *mm, gint *ss);
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    signal_user_data_t *ud,
                                    const char *name, const char *id);
-void ghb_notify_done(signal_user_data_t *ud);
 
 #endif // _CALLBACKS_H_

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -107,8 +107,7 @@ combo_opts_t point_to_point_opts =
 static options_map_t d_when_complete_opts[] =
 {
     {N_("Do Nothing"),            "nothing",  0},
-    {N_("Show Notification"),     "notify",   1},
-    {N_("Quit Handbrake"),        "quit",     4},
+    {N_("Quit Handbrake"),        "quit",     1},
     {N_("Put Computer To Sleep"), "sleep",    2},
     {N_("Shutdown Computer"),     "shutdown", 3},
 };

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -13,6 +13,7 @@ ghb_src = files(
   'icons.c',
   'jobdict.c',
   'main.c',
+  'notifications.c',
   'plist.c',
   'power-manager.c',
   'presets.c',

--- a/gtk/src/notifications.c
+++ b/gtk/src/notifications.c
@@ -91,7 +91,7 @@ notify_done (gboolean final, gboolean success, gint idx, signal_user_data_t *ud)
     gboolean notify_item, notify_queue;
 
     notify_item = ghb_dict_get_bool(ud->prefs, "NotifyOnEncodeDone");
-    notify_queue = ud->when_complete;
+    notify_queue = ghb_dict_get_bool(ud->prefs, "NotifyOnQueueDone");
 
     if (notify_queue && final)
     {

--- a/gtk/src/notifications.c
+++ b/gtk/src/notifications.c
@@ -1,0 +1,217 @@
+/* notifications.c
+ *
+ * Copyright (C) HandBrake Team 2023
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+#include "notifications.h"
+#include <glib/gi18n.h>
+
+static int n_succeeded = 0;
+static int n_failed = 0;
+
+static char *
+item_complete_name (const char *filename)
+{
+    if (filename == NULL)
+        return NULL;
+
+    g_autofree char *name = g_filename_display_basename(filename);
+
+    if (g_utf8_strlen(name, -1) > 64)
+    {
+        g_autofree char *shortname = g_utf8_substring(name, 0, 64);
+        return g_strdup_printf("%s…", shortname);
+    }
+    else
+    {
+        return g_steal_pointer(&name);
+    }
+}
+
+static char *
+queue_complete_message (int n_succeeded, int n_failed)
+{
+    char *msg;
+
+    if (n_failed > 0)
+    {
+        msg = g_strdup_printf((const char *)ngettext("%d encode completed, %d failed",
+                                                     "%d encodes completed, %d failed",
+                                                     n_succeeded), n_succeeded, n_failed);
+    }
+    else
+    {
+       msg = g_strdup_printf((const char *)ngettext("%d item has finished encoding.",
+                                                    "%d items have finished encoding.",
+                                                    n_succeeded), n_succeeded);
+    }
+    return msg;
+}
+
+static void
+send_notification (const char *title, const char *body, const char *category)
+{
+    g_autoptr(GNotification) notification = g_notification_new(title);
+    g_autoptr(GIcon) icon = g_themed_icon_new("fr.handbrake.ghb");
+    if (body != NULL)
+    {
+        g_notification_set_body(notification, body);
+    }
+    g_notification_set_icon(notification, icon);
+    g_application_send_notification(g_application_get_default(), category, notification);
+}
+
+static void
+notify_done (gboolean final, gboolean success, gint idx, signal_user_data_t *ud)
+{
+    if (!final)
+    {
+        if (success) n_succeeded += 1;
+        else n_failed += 1;
+    }
+
+    GhbValue *queueDict, *jobDict, *destDict;
+    const char *title;
+    g_autofree char *body = NULL;
+    gboolean notify_item, notify_queue;
+
+    notify_item = ghb_dict_get_bool(ud->prefs, "NotifyOnEncodeDone");
+    notify_queue = ud->when_complete;
+
+    if (notify_queue && final)
+    {
+        title = _("Queue Complete");
+        body = queue_complete_message(n_succeeded, n_failed);
+    }
+    else if (notify_item && !final)
+    {
+        queueDict = ghb_array_get(ud->queue, idx);
+        jobDict = ghb_dict_get(queueDict, "Job");
+        destDict = ghb_dict_get(jobDict, "Destination");
+        body = item_complete_name(ghb_dict_get_string(destDict, "File"));
+        title = success ? _("Encode Complete") : _("Encode Failed");
+    }
+    else
+    {
+        return;
+    }
+    send_notification(title, body, "hb-done");
+}
+
+static void
+notify_paused (GhbNotification type, int value, signal_user_data_t *ud)
+{
+    g_autofree char *body = NULL;
+    int gigabyte, decimal;
+
+    if (!ud->when_complete && !ghb_dict_get_bool(ud->prefs, "NotifyOnEncodeDone"))
+        return;
+
+    switch (type)
+    {
+        case GHB_NOTIFY_PAUSED_LOW_BATTERY:
+            body = g_strdup(_("Battery level is low."));
+            break;
+        case GHB_NOTIFY_PAUSED_ON_BATTERY:
+            body = g_strdup(_("Charger has been disconnected."));
+            break;
+        case GHB_NOTIFY_PAUSED_POWER_SAVE:
+            body = g_strdup(_("Power Saver mode has been activated."));
+            break;
+        case GHB_NOTIFY_PAUSED_LOW_DISK_SPACE:
+            gigabyte = value / 1000;
+            decimal = (value % 1000) / 100;
+            if (gigabyte != 0)
+            {
+                body = g_strdup_printf(_("%d.%d GB free space remaining."),
+                                       gigabyte, decimal);
+            }
+            else
+            {
+                body = g_strdup_printf(("%d MB free space remaining."), value);
+            }
+            break;
+        default:
+            body = NULL;
+    }
+
+    send_notification(_("Encoding Paused"), body, "hb-paused");
+}
+
+/*
+ * Sends a notification of the specified type. If a notification of the same or
+ * a related type is already displayed, it will be replaced.
+ * The value parameter will be used to determine the content of the message,
+ * depending on the type. In some cases it will be displayed directly, in others
+ * it is used as the index of the item to look up.
+ */
+void
+ghb_send_notification (GhbNotification type, int value, signal_user_data_t *ud)
+{
+    switch (type)
+    {
+    case GHB_NOTIFY_ITEM_DONE:
+        notify_done (FALSE, TRUE, value, ud);
+        break;
+    case GHB_NOTIFY_ITEM_FAILED:
+        notify_done (FALSE, FALSE, value, ud);
+        break;
+    case GHB_NOTIFY_QUEUE_DONE:
+        notify_done (TRUE, TRUE, value, ud);
+        // Reset the counters
+        n_succeeded = 0;
+        n_failed = 0;
+        break;
+    case GHB_NOTIFY_PAUSED_LOW_DISK_SPACE:
+    case GHB_NOTIFY_PAUSED_POWER_SAVE:
+    case GHB_NOTIFY_PAUSED_LOW_BATTERY:
+    case GHB_NOTIFY_PAUSED_ON_BATTERY:
+        notify_paused (type, value, ud);
+        break;
+    default:
+        g_debug("Notification not implemented");
+        break;
+    }
+}
+
+/*
+ * Withdraws all notifications of the specified type. If there is a notification
+ * of a different type which would otherwise replace this type, it will also be
+ * withdrawn.
+ */
+void
+ghb_withdraw_notification (GhbNotification type)
+{
+    switch (type)
+    {
+    case GHB_NOTIFY_ITEM_FAILED:
+    case GHB_NOTIFY_ITEM_DONE:
+    case GHB_NOTIFY_QUEUE_DONE:
+        g_application_withdraw_notification(g_application_get_default(), "hb-done");
+        break;
+    case GHB_NOTIFY_PAUSED_LOW_DISK_SPACE:
+    case GHB_NOTIFY_PAUSED_POWER_SAVE:
+    case GHB_NOTIFY_PAUSED_LOW_BATTERY:
+    case GHB_NOTIFY_PAUSED_ON_BATTERY:
+        g_application_withdraw_notification(g_application_get_default(), "hb-paused");
+        break;
+    default:
+        g_debug("Notification not implemented");
+        break;
+    }
+}

--- a/gtk/src/notifications.h
+++ b/gtk/src/notifications.h
@@ -1,0 +1,31 @@
+/* notifications.h
+ * Copyright (C) HandBrake Team 2023
+ * SPDX-License-Identifier: GPL-2.0-or-later */
+
+#ifndef _NOTIFICATIONS_H_
+#define _NOTIFICATIONS_H_
+
+#include <gtk/gtk.h>
+#include "handbrake/handbrake.h"
+#include "values.h"
+#include "settings.h"
+
+G_BEGIN_DECLS
+
+typedef enum {
+    GHB_NOTIFY_ITEM_DONE,
+    GHB_NOTIFY_ITEM_FAILED,
+    GHB_NOTIFY_QUEUE_DONE,
+    GHB_NOTIFY_PAUSED_LOW_DISK_SPACE,
+    GHB_NOTIFY_PAUSED_LOW_BATTERY,
+    GHB_NOTIFY_PAUSED_ON_BATTERY,
+    GHB_NOTIFY_PAUSED_POWER_SAVE,
+} GhbNotification;
+
+void ghb_send_notification(GhbNotification type, gint value,
+                            signal_user_data_t *ud);
+void ghb_withdraw_notification(GhbNotification type);
+
+G_END_DECLS
+
+#endif  // _NOTIFICATIONS_H_

--- a/gtk/src/power-manager.c
+++ b/gtk/src/power-manager.c
@@ -4,6 +4,7 @@
 #include "power-manager.h"
 #include "queuehandler.h"
 #include "callbacks.h"
+#include "notifications.h"
 
 #define UPOWER_PATH "org.freedesktop.UPower"
 #define UPOWER_OBJECT "/org/freedesktop/UPower"
@@ -88,6 +89,7 @@ battery_level_cb (GDBusProxy *proxy, GVariant *changed_properties,
     {
         power_state = GHB_POWER_PAUSED_LOW_BATTERY;
         ghb_log("Battery level %d%%: pausing encode", battery_level);
+        ghb_send_notification(GHB_NOTIFY_PAUSED_LOW_BATTERY, 0, ud);
         ghb_pause_queue();
     }
     else if (battery_level > low_battery_level
@@ -98,6 +100,7 @@ battery_level_cb (GDBusProxy *proxy, GVariant *changed_properties,
         {
             ghb_resume_queue();
             ghb_log("Battery level %d%%: resuming encode", battery_level);
+            ghb_withdraw_notification(GHB_NOTIFY_PAUSED_LOW_BATTERY);
         }
         power_state = GHB_POWER_OK;
     }
@@ -165,6 +168,7 @@ upower_status_cb (GDBusProxy *proxy, GVariant *changed_properties,
     {
         power_state = GHB_POWER_PAUSED_ON_BATTERY;
         ghb_log("Charger disconnected: pausing encode");
+        ghb_send_notification(GHB_NOTIFY_PAUSED_ON_BATTERY, 0, ud);
         ghb_pause_queue();
     }
     else if (!on_battery && (power_state == GHB_POWER_PAUSED_ON_BATTERY))
@@ -173,6 +177,7 @@ upower_status_cb (GDBusProxy *proxy, GVariant *changed_properties,
         {
             ghb_resume_queue();
             ghb_log("Charger connected: resuming encode");
+            ghb_withdraw_notification(GHB_NOTIFY_PAUSED_ON_BATTERY);
         }
         power_state = GHB_POWER_OK;
     }
@@ -225,6 +230,7 @@ power_save_cb (GPowerProfileMonitor *monitor, GParamSpec *pspec,
         power_state = GHB_POWER_PAUSED_POWER_SAVE;
         ghb_log("Power saver enabled: pausing encode");
         ghb_pause_queue();
+        ghb_send_notification(GHB_NOTIFY_PAUSED_POWER_SAVE, 0, ud);
     }
     else if (!power_save && (power_state == GHB_POWER_PAUSED_POWER_SAVE))
     {
@@ -232,6 +238,7 @@ power_save_cb (GPowerProfileMonitor *monitor, GParamSpec *pspec,
         {
             ghb_resume_queue();
             ghb_log("Power saver disabled: resuming encode");
+            ghb_withdraw_notification(GHB_NOTIFY_PAUSED_POWER_SAVE);
         }
         power_state = GHB_POWER_OK;
     }

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -40,6 +40,7 @@
 #include "queuehandler.h"
 #include "title-add.h"
 #include "power-manager.h"
+#include "notifications.h"
 
 void ghb_queue_buttons_grey (signal_user_data_t *ud);
 
@@ -1771,6 +1772,7 @@ low_disk_check_response_cb (GtkDialog *dialog, int response,
 {
     g_signal_handlers_disconnect_by_data(dialog, ud);
     gtk_widget_destroy(GTK_WIDGET(dialog));
+    ghb_withdraw_notification(GHB_NOTIFY_PAUSED_LOW_DISK_SPACE);
     switch (response)
     {
         case 1:
@@ -1835,6 +1837,8 @@ void ghb_low_disk_check (signal_user_data_t *ud)
     }
 
     ghb_pause_queue();
+    ghb_send_notification(GHB_NOTIFY_PAUSED_LOW_DISK_SPACE,
+                          free_size / (1024 * 1024), ud);
     dest      = ghb_dict_get_string(settings, "destination");
     hb_window = GTK_WINDOW(GHB_WIDGET(ud->builder, "hb_window"));
     dialog    = gtk_message_dialog_new(hb_window, GTK_DIALOG_MODAL,

--- a/gtk/src/ui-gtk3/ghb.ui
+++ b/gtk/src/ui-gtk3/ghb.ui
@@ -7764,138 +7764,206 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                 <property name="hexpand">True</property>
                 <child>
                   <object class="GtkBox" id="vbox42">
-                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">5</property>
                     <child>
-                      <object class="GtkBox" id="hbox82">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="spacing">4</property>
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin-start">12</property>
-                        <property name="margin-end">12</property>
-                        <child>
-                          <object class="GtkComboBox" id="WhenComplete">
-                            <property name="visible">True</property>
-                            <property name="valign">GTK_ALIGN_CENTER</property>
-                            <property name="can-focus">False</property>
-                            <signal name="changed" handler="when_complete_changed_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="labela1">
-                            <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Default action when all encodes are complete</property>
-                            <property name="use-markup">True</property>
-                          </object>
-                          <packing>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="halign">start</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-top">4</property>
+                        <property name="margin-bottom">4</property>
+                        <property name="label" translatable="yes">When Done</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
                       </object>
                       <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">1</property>
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="vbox5">
-                        <property name="orientation">vertical</property>
+                      <object class="GtkBox" id="hbox82">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin-start">12</property>
+                        <property name="spacing">4</property>
                         <child>
-                          <object class="GtkCheckButton" id="auto_name">
-                            <property name="label" translatable="yes">Use automatic naming (uses modified source name)</property>
-                            <property name="tooltip-text" translatable="yes">Create destination filename from source filename or volume label</property>
+                          <object class="GtkLabel" id="labela1">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="halign">start</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
+                            <property name="can-focus">False</property>
+                            <property name="margin-start">4</property>
+                            <property name="label" translatable="yes">Default action when queue is completed:</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="autoname_box">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkComboBox" id="WhenComplete">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="spacing">4</property>
-                            <property name="margin-start">18</property>
-                            <property name="margin-end">8</property>
-                            <child>
-                              <object class="GtkLabel" id="auto_name_template_label">
-                                <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label" translatable="yes">Auto-Name Template</property>
-                                <property name="use-markup">True</property>
-
-                                <property name="halign">end</property>
-                              </object>
-                              <packing>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkEntry" id="auto_name_template">
-                                <property name="tooltip-text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {modification-date} {modification-time} {codec} {bit-depth} {quality} {bitrate} {width} {height}</property>
-                                <property name="visible">True</property>
-                                <property name="can-focus">True</property>
-                                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                <property name="activates-default">True</property>
-                                <property name="width-chars">40</property>
-                                <property name="truncate-multiline">True</property>
-                                <signal name="changed" handler="pref_changed_cb" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <signal name="changed" handler="when_complete_changed_cb" swapped="no"/>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkCheckButton" id="UseM4v">
-                            <property name="label" translatable="yes">Use iPod/iTunes friendly (.m4v) file extension for MP4</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">False</property>
-                            <property name="halign">start</property>
-                            <property name="draw-indicator">True</property>
-                            <signal name="toggled" handler="use_m4v_changed_cb" swapped="no"/>
-                          </object>
-                          <packing>
-                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="position">2</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">3</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="NotifyOnEncodeDone">
+                        <property name="label" translatable="yes">Show notification when each item is completed</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">5</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="RemoveFinishedJobs">
+                        <property name="label" translatable="yes">Remove completed items from queue</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">By default, completed jobs remain in the queue and are marked as complete.
+Check this if you want the queue to clean itself up by deleting completed jobs.</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">6</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="margin-left">4</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-top">4</property>
+                        <property name="margin-bottom">4</property>
+                        <property name="label" translatable="yes">General</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">7</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="auto_name">
+                        <property name="label" translatable="yes">Use automatic naming (uses modified source name)</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="tooltip-text" translatable="yes">Create destination filename from source filename or volume label</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">8</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox" id="autoname_box">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-left">18</property>
+                        <property name="margin-right">8</property>
+                        <property name="margin-start">18</property>
+                        <property name="margin-end">8</property>
+                        <property name="spacing">4</property>
+                        <child>
+                          <object class="GtkLabel" id="auto_name_template_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Auto-Name Template</property>
+                            <property name="use-markup">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="auto_name_template">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                            <property name="tooltip-text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {modification-date} {modification-time} {codec} {bit-depth} {quality} {bitrate} {width} {height}</property>
+                            <property name="activates-default">True</property>
+                            <property name="width-chars">40</property>
+                            <property name="truncate-multiline">True</property>
+                            <signal name="changed" handler="pref_changed_cb" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">9</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkCheckButton" id="UseM4v">
+                        <property name="label" translatable="yes">Use iPod/iTunes friendly (.m4v) file extension for MP4</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="use_m4v_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">10</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="hbox66">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="spacing">4</property>
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin-start">12</property>
                         <child>
                           <object class="GtkSpinButton" id="preview_count">
                             <property name="visible">True</property>
@@ -7906,6 +7974,8 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             <signal name="value-changed" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
@@ -7917,23 +7987,23 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             <property name="use-markup">True</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="position">3</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">11</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="hbox60">
-                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="spacing">4</property>
-                        <property name="margin-top">6</property>
-                        <property name="margin-bottom">6</property>
-                        <property name="margin-start">12</property>
                         <child>
                           <object class="GtkSpinButton" id="MinTitleDuration">
                             <property name="visible">True</property>
@@ -7944,6 +8014,8 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             <signal name="value-changed" handler="pref_changed_cb" swapped="no"/>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
@@ -7955,29 +8027,16 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                             <property name="use-markup">True</property>
                           </object>
                           <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
                       <packing>
-                        <property name="position">4</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkCheckButton" id="RemoveFinishedJobs">
-                        <property name="label" translatable="yes">Clear completed queue items after an encode completes</property>
-                        <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">False</property>
-                        <property name="tooltip-text" translatable="yes">By default, completed jobs remain in the queue and are marked as complete.
-Check this if you want the queue to clean itself up by deleting completed jobs.</property>
-                        <property name="halign">start</property>
-                        <property name="margin-start">12</property>
-                        <property name="draw-indicator">True</property>
-                        <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="position">5</property>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">12</property>
                       </packing>
                     </child>
                     <child>
@@ -7986,16 +8045,17 @@ Check this if you want the queue to clean itself up by deleting completed jobs.<
                         <property name="visible">False</property>
                         <property name="can-focus">False</property>
                         <property name="receives-default">False</property>
-                        <property name="margin-start">12</property>
-                        <property name="margin-top">3</property>
-                        <property name="margin-bottom">3</property>
+                        <property name="margin-left">4</property>
+                        <property name="margin-start">4</property>
+                        <property name="margin-top">4</property>
+                        <property name="margin-bottom">4</property>
                         <property name="halign">start</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
                         </attributes>
                       </object>
                       <packing>
-                        <property name="position">6</property>
+                        <property name="position">13</property>
                       </packing>
                     </child>
                     <child>
@@ -8005,14 +8065,13 @@ Check this if you want the queue to clean itself up by deleting completed jobs.<
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-start">12</property>
                         <property name="tooltip-text" translatable="yes">If checked, encoding will be paused when the device
 enters Power Saver mode. Encoding will resume when
 Power Saver mode is disabled.</property>
                         <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="position">7</property>
+                        <property name="position">14</property>
                       </packing>
                     </child>
                     <child>
@@ -8022,14 +8081,13 @@ Power Saver mode is disabled.</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-start">12</property>
                         <property name="tooltip-text" translatable="yes">If checked, encoding will be paused when charger is
 unplugged. Encoding will resume when reconnected to
 a mains power source.</property>
                         <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="position">8</property>
+                        <property name="position">15</property>
                       </packing>
                     </child>
                     <child>
@@ -8039,14 +8097,13 @@ a mains power source.</property>
                         <property name="can-focus">True</property>
                         <property name="receives-default">False</property>
                         <property name="halign">start</property>
-                        <property name="margin-start">12</property>
                         <property name="tooltip-text" translatable="yes">If checked, encoding will be paused when the battery
 level is low. Encoding will resume when the
 battery is charged.</property>
                         <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                       </object>
                       <packing>
-                        <property name="position">9</property>
+                        <property name="position">16</property>
                       </packing>
                     </child>
                   </object>
@@ -8190,11 +8247,10 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                             <property name="spacing">2</property>
                             <child>
                               <object class="GtkCheckButton" id="DiskFreeCheck">
-                                <property name="label" translatable="yes">Monitor destination disk free space</property>
+                                <property name="label" translatable="yes">Pause encoding if free disk space drops below:</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
                                 <property name="receives-default">False</property>
-                                <property name="tooltip-text" translatable="yes">Pause encoding if free disk space drops below limit</property>
                                 <property name="halign">start</property>
                                 <property name="draw-indicator">True</property>
                                 <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
@@ -8216,7 +8272,6 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
-                                    <property name="tooltip-text" translatable="yes">Pause encoding if free disk space drops below limit</property>
                                     <property name="valign">GTK_ALIGN_CENTER</property>
                                     <property name="adjustment">DiskFreeLimitAdjustment</property>
                                     <property name="width-request">55</property>
@@ -8231,7 +8286,7 @@ Flatpak users may need to set this for certain workflows to work properly. The d
                                     <property name="visible">True</property>
                                     <property name="can-focus">False</property>
                                     <property name="halign">start</property>
-                                    <property name="label" translatable="yes">MB Limit</property>
+                                    <property name="label" translatable="yes">MB</property>
                                     <property name="hexpand">True</property>
                                   </object>
                                   <packing>

--- a/gtk/src/ui-gtk3/ghb.ui
+++ b/gtk/src/ui-gtk3/ghb.ui
@@ -8152,6 +8152,7 @@ battery is charged.</property>
                                 <property name="label" translatable="yes">Set a custom directory for Handbrake temporary files</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
+                                <property name="has-focus">True</property>
                                 <property name="receives-default">False</property>
                                 <property name="tooltip-text" translatable="yes">Temporary files that HandBrake creates will be placed under this directory.
 
@@ -8530,6 +8531,34 @@ Uncheck this if you want to allow changing each title's settings independently.<
                           </object>
                           <packing>
                             <property name="top-attach">9</property>
+                            <property name="left-attach">0</property>
+                            <property name="width">1</property>
+                            <property name="height">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="orientation">horizontal</property>
+                            <property name="spacing">8</property>
+                            <property name="tooltip-text" translatable="yes">The message to display on the notification that all items have been completed. Delete it to restore the default setting.</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="label" translatable="yes">Queue complete notification text:</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="CustomNotificationMessage">
+                                <property name="visible">True</property>
+                                <property name="hexpand">True</property>
+                                <property name="placeholder-text" translatable="yes">Put down that cocktail…</property>
+                                <signal name="changed" handler="pref_changed_cb" swapped="no"/>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="top-attach">10</property>
                             <property name="left-attach">0</property>
                             <property name="width">1</property>
                             <property name="height">1</property>

--- a/gtk/src/ui-gtk3/ghb.ui
+++ b/gtk/src/ui-gtk3/ghb.ui
@@ -7826,6 +7826,22 @@ Only one subtitle track can be burned! Since conflicts can occur, the first chos
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkCheckButton" id="NotifyOnQueueDone">
+                        <property name="label" translatable="yes">Show notification when queue is completed</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">False</property>
+                        <property name="halign">start</property>
+                        <property name="draw-indicator">True</property>
+                        <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkCheckButton" id="NotifyOnEncodeDone">
                         <property name="label" translatable="yes">Show notification when each item is completed</property>
                         <property name="visible">True</property>


### PR DESCRIPTION
**Description of Change:**

Adds new option to show notification as each individual job is completed as well as all jobs are done. Also shows the number of completed (and failed) items when the queue is finished, and shows notifications when encoding is paused automatically. Finally there are some minor bug fixes. This also helps address #663.

The notification text is subject to change if you feel it needs to be reworded.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots**
Notifications:
![Screenshot from 2023-11-25 17-45-01](https://github.com/HandBrake/HandBrake/assets/89391914/c1b98327-3e61-4a1a-9bac-0eecae7086b9)
![Screenshot from 2023-11-25 17-45-12](https://github.com/HandBrake/HandBrake/assets/89391914/0e79c67a-196e-4453-80a0-abd378f334fa)
![Screenshot from 2023-11-25 17-45-41](https://github.com/HandBrake/HandBrake/assets/89391914/4f6a0868-4385-4c68-a890-deb314f157a4)
![Screenshot from 2023-11-25 17-45-58](https://github.com/HandBrake/HandBrake/assets/89391914/794ea4d2-3fb5-49bf-9bc1-dbd3e04c4db9)

Notification Settings:
![Screenshot from 2023-11-24 23-51-50](https://github.com/HandBrake/HandBrake/assets/89391914/e706b1f1-1316-466f-a520-cadedde75f8b)

