### PR TITLE
libhb: refactor vfr motion metric, add a metal implementation.

### DIFF
--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -710,12 +710,21 @@ hb_buffer_t * hb_buffer_dup(const hb_buffer_t *src)
         // into another hardware AVFrame.
         if (frame->hw_frames_ctx)
         {
-            buf = hb_buffer_wrapper_init();
-            if (buf)
+#ifdef __APPLE__
+            if (frame->format == AV_PIX_FMT_VIDEOTOOLBOX)
             {
-                buf->f = src->f;
-                hb_buffer_copy_props(buf, src);
-                copy_hwframe_to_video_buffer(frame, buf);
+                buf = hb_vt_buffer_dup(src);
+            }
+            else
+#endif
+            {
+                buf = hb_buffer_wrapper_init();
+                if (buf)
+                {
+                    buf->f = src->f;
+                    hb_buffer_copy_props(buf, src);
+                    copy_hwframe_to_video_buffer(frame, buf);
+                }
             }
         }
         // If not, copy the content to a standard hb_buffer

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1479,6 +1479,20 @@ struct hb_filter_object_s
 #endif
 };
 
+struct hb_motion_metric_object_s
+{
+    char                * name;
+
+#ifdef __LIBHB__
+    int                (* init)       ( hb_motion_metric_object_t *, hb_filter_init_t * );
+    float              (* work)       ( hb_motion_metric_object_t *,
+                                        hb_buffer_t *, hb_buffer_t * );
+    void               (* close)      ( hb_motion_metric_object_t * );
+
+    hb_motion_metric_private_t * private_data;
+#endif
+};
+
 // Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/hb_filter_ids.cs when changing this enum
 enum
 {

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -40,6 +40,8 @@ typedef struct hb_work_private_s hb_work_private_t;
 typedef struct hb_work_object_s  hb_work_object_t;
 typedef struct hb_filter_private_s hb_filter_private_t;
 typedef struct hb_filter_object_s  hb_filter_object_t;
+typedef struct hb_motion_metric_private_s  hb_motion_metric_private_t;
+typedef struct hb_motion_metric_object_s  hb_motion_metric_object_t;
 typedef struct hb_buffer_settings_s hb_buffer_settings_t;
 typedef struct hb_image_format_s hb_image_format_t;
 typedef struct hb_fifo_s hb_fifo_t;

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -508,6 +508,8 @@ extern hb_filter_object_t hb_filter_lapsharp_vt;
 extern hb_filter_object_t hb_filter_unsharp_vt;
 #endif
 
+extern hb_motion_metric_object_t hb_motion_metric;
+
 extern hb_work_object_t * hb_objects;
 
 #define HB_WORK_IDLE     0

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -510,6 +510,10 @@ extern hb_filter_object_t hb_filter_unsharp_vt;
 
 extern hb_motion_metric_object_t hb_motion_metric;
 
+#if defined(__APPLE__)
+extern hb_motion_metric_object_t hb_motion_metric_vt;
+#endif
+
 extern hb_work_object_t * hb_objects;
 
 #define HB_WORK_IDLE     0

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -1,0 +1,157 @@
+/* motionmetric.c
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+
+struct hb_motion_metric_private_s
+{
+    unsigned *gamma_lut;
+    int       depth;
+    int       bps;
+    int       max_value;
+};
+
+static int hb_motion_metric_init(hb_motion_metric_object_t *metric,
+                                 hb_filter_init_t *init);
+
+static float hb_motion_metric_work(hb_motion_metric_object_t *metric,
+                                   hb_buffer_t *buf_a,
+                                   hb_buffer_t *buf_b);
+
+static void hb_motion_metric_close(hb_motion_metric_object_t *metric);
+
+hb_motion_metric_object_t hb_motion_metric =
+{
+    .name  = "Motion metric",
+    .init  = hb_motion_metric_init,
+    .work  = hb_motion_metric_work,
+    .close = hb_motion_metric_close,
+};
+
+// Create gamma lookup table.
+// Note that we are creating a scaled integer lookup table that will
+// not cause overflows in sse_block16() below. This results in
+// small values being truncated to 0 which is ok for this usage.
+static void build_gamma_lut(hb_motion_metric_private_t *pv)
+{
+    for (int i = 0; i < pv->max_value; i++)
+    {
+        pv->gamma_lut[i] = 4095 * pow(((float)i / (float)(pv->max_value -1)), 2.2f);;
+    }
+}
+
+// Compute the sum of squared errors for a 16x16 block
+// Gamma adjusts pixel values so that less visible differences
+// count less.
+#define DEF_SSE_BLOCK16(nbits)                                                         \
+static inline unsigned sse_block16##_##nbits(unsigned *gamma_lut,                      \
+                                   const uint##nbits##_t *a, const uint##nbits##_t *b, \
+                                   int stride_a, int stride_b)                         \
+{                                                                                      \
+    unsigned sum = 0;                                                                  \
+    for (int y = 0; y < 16; y++)                                                       \
+    {                                                                                  \
+        for (int x = 0; x < 16; x++)                                                   \
+        {                                                                              \
+            int diff = gamma_lut[a[x]] - gamma_lut[b[x]];                              \
+            sum += diff * diff;                                                        \
+        }                                                                              \
+        a += stride_a;                                                                 \
+        b += stride_b;                                                                 \
+    }                                                                                  \
+    return sum;                                                                        \
+}                                                                                      \
+
+DEF_SSE_BLOCK16(8)
+DEF_SSE_BLOCK16(16)
+
+// Sum of squared errors.  Computes and sums the SSEs for all
+// 16x16 blocks in the images.  Only checks the Y component.
+#define DEF_MOTION_METRIC(nbits)                                             \
+static float motion_metric##_##nbits(hb_motion_metric_private_t *pv,         \
+                                     hb_buffer_t *a, hb_buffer_t *b)         \
+{                                                                            \
+    int bw = a->f.width / 16;                                                \
+    int bh = a->f.height / 16;                                               \
+    int stride_a = a->plane[0].stride / pv->bps;                             \
+    int stride_b = b->plane[0].stride / pv->bps;                             \
+    const uint##nbits##_t *pa = (const uint##nbits##_t *)a->plane[0].data;   \
+    const uint##nbits##_t *pb = (const uint##nbits##_t *)b->plane[0].data;   \
+    uint64_t sum = 0;                                                        \
+                                                                             \
+    for (int y = 0; y < bh; y++)                                             \
+    {                                                                        \
+        for (int x = 0; x < bw; x++)                                         \
+        {                                                                    \
+            sum += sse_block16##_##nbits(pv->gamma_lut,                      \
+                                         pa + y * 16 * stride_a + x * 16,    \
+                                         pb + y * 16 * stride_b + x * 16,    \
+                                         stride_a, stride_b);                \
+        }                                                                    \
+    }                                                                        \
+    return (float)sum / (a->f.width * a->f.height);                          \
+}                                                                            \
+
+DEF_MOTION_METRIC(8)
+DEF_MOTION_METRIC(16)
+
+static int hb_motion_metric_init(hb_motion_metric_object_t *metric,
+                                 hb_filter_init_t *init)
+{
+    metric->private_data = calloc(sizeof(struct hb_motion_metric_private_s), 1);
+    if (metric->private_data == NULL)
+    {
+        hb_error("motion_metric: calloc failed");
+        return -1;
+    }
+    hb_motion_metric_private_t *pv = metric->private_data;
+
+    const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(init->pix_fmt);
+    pv->depth     = desc->comp[0].depth;
+    pv->bps       = pv->depth > 8 ? 2 : 1;
+    pv->max_value = (1 << pv->depth) - 1;
+
+    pv->gamma_lut = malloc(sizeof(unsigned) * (pv->max_value + 1));
+    if (pv->gamma_lut == NULL)
+    {
+        hb_error("motion_metric: malloc failed");
+        return -1;
+    }
+    build_gamma_lut(pv);
+
+    return 0;
+}
+
+static float hb_motion_metric_work(hb_motion_metric_object_t *metric,
+                                   hb_buffer_t *buf_a,
+                                   hb_buffer_t *buf_b)
+{
+    hb_motion_metric_private_t *pv = metric->private_data;
+
+    switch (pv->depth)
+    {
+        case 8:
+            return motion_metric_8(metric->private_data, buf_a, buf_b);
+        default:
+            return motion_metric_16(metric->private_data, buf_a, buf_b);
+    }
+}
+
+static void hb_motion_metric_close(hb_motion_metric_object_t *metric)
+{
+    hb_motion_metric_private_t *pv = metric->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    free(pv->gamma_lut);
+    free(pv);
+}

--- a/libhb/platform/macosx/comb_detect_vt.m
+++ b/libhb/platform/macosx/comb_detect_vt.m
@@ -248,7 +248,7 @@ static int comb_detect_vt_init(hb_filter_object_t *filter,
             ((pv->block_width == 16 && pv->block_height == 16) || (pv->block_width == 32 && pv->block_height == 32)))
         {
             // Use simd_sum() to speed up the final reduction pass
-            check_combing_name = pv->mode & MODE_FILTER ? "check_filtered_combing_mask_quad" : "check_combing_mask_quad";
+            check_combing_name = pv->mode & MODE_FILTER ? "check_filtered_combing_mask_simd" : "check_combing_mask_simd";
         }
         else if ([pv->mtl->device supportsFamily:MTLGPUFamilyCommon3] &&
                  (pv->block_width * pv->block_height) % 4)

--- a/libhb/platform/macosx/metal_utils.m
+++ b/libhb/platform/macosx/metal_utils.m
@@ -28,6 +28,14 @@ hb_metal_context_t * hb_metal_context_init(const char *metallib_data,
 
     NSArray<id<MTLDevice>> *devices = MTLCopyAllDevices();
     ctx->device = [devices.lastObject retain];
+    for (id<MTLDevice> device in devices)
+    {
+        if (device.isLowPower)
+        {
+            [ctx->device release];
+            ctx->device = [device retain];
+        }
+    }
     [devices release];
     if (!ctx->device)
     {
@@ -141,6 +149,9 @@ void hb_metal_context_close(hb_metal_context_t **_ctx)
             [ctx->functions[i] release];
             [ctx->pipelines[i] release];
         }
+        av_free(ctx->functions);
+        av_free(ctx->pipelines);
+
         [ctx->params_buffer release];
         [ctx->queue release];
         [ctx->library release];

--- a/libhb/platform/macosx/metal_utils.m
+++ b/libhb/platform/macosx/metal_utils.m
@@ -57,12 +57,15 @@ hb_metal_context_t * hb_metal_context_init(const char *metallib_data,
         goto fail;
     }
 
-    ctx->params_buffer = [ctx->device newBufferWithLength:params_buffer_len
-                                                  options:MTLResourceStorageModeShared];
-    if (!ctx->params_buffer)
+    if (params_buffer_len)
     {
-        hb_error("metal: failed to create Metal buffer for parameters");
-        goto fail;
+        ctx->params_buffer = [ctx->device newBufferWithLength:params_buffer_len
+                                                      options:MTLResourceStorageModeShared];
+        if (!ctx->params_buffer)
+        {
+            hb_error("metal: failed to create Metal buffer for parameters");
+            goto fail;
+        }
     }
 
     ctx->queue = ctx->device.newCommandQueue;
@@ -72,10 +75,13 @@ hb_metal_context_t * hb_metal_context_init(const char *metallib_data,
         goto fail;
     }
 
-    if (hb_metal_add_pipeline(ctx, function_name, 0))
+    if (function_name != NULL)
     {
-        hb_error("metal: failed to add Metal function");
-        goto fail;
+        if (hb_metal_add_pipeline(ctx, function_name, 0))
+        {
+            hb_error("metal: failed to add Metal function");
+            goto fail;
+        }
     }
 
     CVReturn ret = CVMetalTextureCacheCreate(NULL, NULL, ctx->device, NULL, &ctx->cache);

--- a/libhb/platform/macosx/motion_metric_vt.m
+++ b/libhb/platform/macosx/motion_metric_vt.m
@@ -1,0 +1,182 @@
+/* motion_metric_vt.m
+
+   Copyright (c) 2003-2023 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "cv_utils.h"
+#include "metal_utils.h"
+
+extern char hb_motion_metric_vt_metallib_data[];
+extern unsigned int hb_motion_metric_vt_metallib_len;
+
+struct hb_motion_metric_private_s
+{
+    hb_metal_context_t *mtl;
+    id<MTLBuffer>       result;
+
+    const AVPixFmtDescriptor *desc;
+};
+
+static int hb_motion_metric_vt_init(hb_motion_metric_object_t *metric,
+                                    hb_filter_init_t *init);
+
+static float hb_motion_metric_vt_work(hb_motion_metric_object_t *metric,
+                                      hb_buffer_t *buf_a,
+                                      hb_buffer_t *buf_b);
+
+static void hb_motion_metric_vt_close(hb_motion_metric_object_t *metric);
+
+hb_motion_metric_object_t hb_motion_metric_vt =
+{
+    .name  = "Motion metric (VideoToolbox)",
+    .init  = hb_motion_metric_vt_init,
+    .work  = hb_motion_metric_vt_work,
+    .close = hb_motion_metric_vt_close,
+};
+
+static int hb_motion_metric_vt_init(hb_motion_metric_object_t *metric,
+                                    hb_filter_init_t *init)
+{
+    metric->private_data = calloc(sizeof(struct hb_motion_metric_private_s), 1);
+    if (metric->private_data == NULL)
+    {
+        hb_error("motion_metric_vt: calloc failed");
+        return -1;
+    }
+    hb_motion_metric_private_t *pv = metric->private_data;
+
+    pv->desc = av_pix_fmt_desc_get(init->pix_fmt);
+
+    pv->mtl = hb_metal_context_init(hb_motion_metric_vt_metallib_data,
+                                    hb_motion_metric_vt_metallib_len,
+                                    NULL, 0,
+                                    init->geometry.width, init->geometry.height,
+                                    init->pix_fmt, init->color_range);
+    if (pv->mtl == NULL)
+    {
+        hb_error("motion_metric_vt: failed to create Metal device");
+        return -1;
+    }
+
+    char *function_name = "motion_metric";
+    if (@available(macOS 13, *))
+    {
+        if ([pv->mtl->device supportsFamily:MTLGPUFamilyMetal3])
+        {
+            // Use simd_sum() to speed up the final reduction pass
+            function_name = "motion_metric_simd";
+        }
+    }
+    hb_metal_add_pipeline(pv->mtl, function_name, 0);
+
+    int w = 16, h = 16;
+    NSUInteger length = sizeof(uint32_t) * ((init->geometry.width + w - 1) / w) * ((init->geometry.height + h - 1) / h);
+
+    pv->result = [pv->mtl->device newBufferWithLength:length options:MTLResourceStorageModeShared];
+    if (pv->result == nil)
+    {
+        hb_error("motion_metric_vt: failed to create buffer");
+        return -1;
+    }
+
+    return 0;
+}
+
+static void call_kernel(hb_motion_metric_private_t *pv,
+                        id<MTLTexture> a,
+                        id<MTLTexture> b)
+{
+    id<MTLCommandBuffer> buffer = pv->mtl->queue.commandBuffer;
+    id<MTLComputeCommandEncoder> encoder = buffer.computeCommandEncoder;
+
+    [encoder setTexture:a atIndex:0];
+    [encoder setTexture:b atIndex:1];
+    [encoder setBuffer:pv->result offset:0 atIndex:0];
+
+    hb_metal_compute_encoder_dispatch_fixed_threadgroup_size(pv->mtl->device,
+                                                             pv->mtl->pipelines[0], encoder,
+                                                             a.width, a.height, 16, 16);
+
+    [encoder endEncoding];
+
+    [buffer commit];
+    [buffer waitUntilCompleted];
+}
+
+static float motion_metric(hb_motion_metric_private_t *pv, hb_buffer_t *a, hb_buffer_t *b)
+{
+    CVPixelBufferRef cv_a = hb_cv_get_pixel_buffer(a);
+    CVPixelBufferRef cv_b = hb_cv_get_pixel_buffer(b);
+
+    if (cv_a == NULL || cv_b == NULL)
+    {
+        hb_log("motion_metric_vt: extract_buf failed");
+        goto fail;
+    }
+
+    const AVComponentDescriptor *comp = &pv->desc->comp[0];
+
+    int channels;
+    const MTLPixelFormat format = hb_metal_pix_fmt_from_component(comp, &channels);
+    if (format == MTLPixelFormatInvalid)
+    {
+        goto fail;
+    }
+
+    CVMetalTextureRef ref_a = hb_metal_create_texture_from_pixbuf(pv->mtl->cache, cv_a, 0, format);
+    CVMetalTextureRef ref_b = hb_metal_create_texture_from_pixbuf(pv->mtl->cache, cv_b, 0, format);
+
+    id<MTLTexture> tex_a = CVMetalTextureGetTexture(ref_a);
+    id<MTLTexture> tex_b = CVMetalTextureGetTexture(ref_b);
+
+    call_kernel(pv, tex_a, tex_b);
+
+    CFRelease(ref_a);
+    CFRelease(ref_b);
+
+    uint32_t *result = pv->result.contents;
+    size_t length = pv->result.length / sizeof(uint32_t);
+
+    // Do the final reduction on CPU
+    // long and float atomics are still
+    // slow or unsupported on too many GPUs
+    uint64_t sum = 0;
+    for (size_t i = 0; i < length; i++)
+    {
+        sum += result[i];
+    }
+
+    return (float)sum / (a->f.width * a->f.height);
+fail:
+    return 0;
+}
+
+static float hb_motion_metric_vt_work(hb_motion_metric_object_t *metric,
+                                      hb_buffer_t *buf_a,
+                                      hb_buffer_t *buf_b)
+{
+    @autoreleasepool
+    {
+        return motion_metric(metric->private_data, buf_a, buf_b);
+    }
+}
+
+static void hb_motion_metric_vt_close(hb_motion_metric_object_t *metric)
+{
+    hb_motion_metric_private_t *pv = metric->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    [pv->result release];
+    hb_metal_context_close(&pv->mtl);
+
+    free(pv);
+}

--- a/libhb/platform/macosx/shaders/comb_detect_vt.metal
+++ b/libhb/platform/macosx/shaders/comb_detect_vt.metal
@@ -307,8 +307,9 @@ kernel void check_filtered_combing_mask_simd(
     device  atomic_int *combed [[buffer(0)]],
     constant params& p         [[buffer(1)]],
     ushort2 pos [[thread_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]],
     ushort  sid [[simdgroup_index_in_threadgroup]],
-    ushort  w   [[simdgroups_per_threadgroup]])
+    ushort  w   [[dispatch_simdgroups_per_threadgroup]])
 {
     threadgroup ushort partial_score[32];
 
@@ -317,7 +318,7 @@ kernel void check_filtered_combing_mask_simd(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (sid == 0) {
+    if (lid.x == 0 && lid.y == 0) {
         ushort block_score = 0;
         for (uchar i = 0; i < w; i++) {
             block_score += partial_score[i];
@@ -331,8 +332,9 @@ kernel void check_filtered_combing_mask_quad(
     device  atomic_int *combed [[buffer(0)]],
     constant params& p         [[buffer(1)]],
     ushort2 pos [[thread_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]],
     ushort  qid [[quadgroup_index_in_threadgroup]],
-    ushort  w   [[quadgroups_per_threadgroup]])
+    ushort  w   [[dispatch_quadgroups_per_threadgroup]])
 {
     threadgroup ushort partial_score[256];
 
@@ -341,7 +343,7 @@ kernel void check_filtered_combing_mask_quad(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (qid == 0) {
+    if (lid.x == 0 && lid.y == 0) {
         ushort block_score = 0;
         for (uchar i = 0; i < w; i++) {
             block_score += partial_score[i];
@@ -377,8 +379,9 @@ kernel void check_combing_mask_simd(
     device  atomic_int *combed [[buffer(0)]],
     constant params& p         [[buffer(1)]],
     ushort2 pos [[thread_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]],
     ushort  sid [[simdgroup_index_in_threadgroup]],
-    ushort  w   [[simdgroups_per_threadgroup]])
+    ushort  w   [[dispatch_simdgroups_per_threadgroup]])
 {
     threadgroup ushort partial_score[32];
     const short2 left  = short2(pos.x -1, pos.y);
@@ -389,7 +392,7 @@ kernel void check_combing_mask_simd(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (sid == 0) {
+    if (lid.x == 0 && lid.y == 0) {
         ushort block_score = 0;
         for (uchar i = 0; i < w; i++) {
             block_score += partial_score[i];
@@ -403,8 +406,9 @@ kernel void check_combing_mask_quad(
     device  atomic_int *combed [[buffer(0)]],
     constant params& p         [[buffer(1)]],
     ushort2 pos [[thread_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]],
     ushort  qid [[quadgroup_index_in_threadgroup]],
-    ushort  w   [[quadgroups_per_threadgroup]])
+    ushort  w   [[dispatch_quadgroups_per_threadgroup]])
 {
     threadgroup ushort partial_score[256];
     const short2 left  = short2(pos.x -1, pos.y);
@@ -415,7 +419,7 @@ kernel void check_combing_mask_quad(
 
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
-    if (qid == 0) {
+    if (lid.x == 0 && lid.y == 0) {
         ushort block_score = 0;
         for (uchar i = 0; i < w; i++) {
             block_score += partial_score[i];

--- a/libhb/platform/macosx/shaders/motion_metric_vt.metal
+++ b/libhb/platform/macosx/shaders/motion_metric_vt.metal
@@ -1,0 +1,95 @@
+/* motion_metric_vt.metal
+
+   Copyright (c) 2003-2023 HandBrake Team
+
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include <metal_stdlib>
+#include <metal_integer>
+#include <metal_texture>
+
+using namespace metal;
+
+/*
+ * Texture access helpers
+ */
+
+constexpr sampler s(coord::pixel,address::clamp_to_zero);
+
+template <typename T>
+T tex2D(texture2d<float, access::sample> tex, ushort2 pos)
+{
+    return tex.sample(s, float2(pos)).x;
+}
+
+template <typename T>
+T tex2D(texture2d<half, access::sample> tex, ushort2 pos)
+{
+    return tex.sample(s, float2(pos)).x;
+}
+
+/*
+ * Motion Metric helpers
+ */
+
+template <typename T>
+T gamma(T value) {
+    return 4095 * pow(value, 2.2f);
+}
+
+/*
+ * Kernel dispatch
+ */
+
+kernel void motion_metric_simd(
+    texture2d<float, access::sample> a [[texture(0)]],
+    texture2d<float, access::sample> b [[texture(1)]],
+    device  uint *result [[buffer(0)]],
+    ushort2 pos [[thread_position_in_grid]],
+    ushort2 lid [[thread_position_in_threadgroup]],
+    ushort  sid [[simdgroup_index_in_threadgroup]],
+    ushort  w   [[dispatch_simdgroups_per_threadgroup]])
+{
+    threadgroup float partial_sums[32];
+
+    int diff = gamma(tex2D<float>(a, pos)) - gamma(tex2D<float>(b, pos));
+    uint squared = diff * diff;
+    partial_sums[sid] = simd_sum(squared);
+
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (lid.x == 0 && lid.y == 0) {
+        uint sum = 0;
+        for (ushort i = 0; i < w; i++) {
+            sum += partial_sums[i];
+        }
+        result[pos.x / 16 + pos.y * (a.get_width() / 16) / 16] = sum;
+    }
+}
+
+kernel void motion_metric(
+    texture2d<float, access::sample> a [[texture(0)]],
+    texture2d<float, access::sample> b [[texture(1)]],
+    device  uint *result [[buffer(0)]],
+    ushort2 pos [[thread_position_in_grid]])
+{
+    if (pos.x % 16 || pos.y % 16) {
+        return;
+    }
+
+    uint sum = 0;
+    for (uchar x = 0; x < 16; x++) {
+        for (uchar y = 0; y < 16; y++) {
+            int diff = gamma(tex2D<float>(a, ushort2(pos.x + x, pos.y + y))) -
+                       gamma(tex2D<float>(b, ushort2(pos.x + x, pos.y + y)));
+            uint squared = diff * diff;
+            sum += squared;
+        }
+    }
+
+    result[pos.x / 16 + pos.y * (a.get_width() / 16) / 16] = sum;
+}

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -402,49 +402,22 @@ int hb_vt_are_filters_supported(hb_list_t *filters)
 
         switch (filter->id)
         {
-            case HB_FILTER_PRE_VT:
-            case HB_FILTER_COMB_DETECT:
-            case HB_FILTER_COMB_DETECT_VT:
-            case HB_FILTER_YADIF:
-            case HB_FILTER_YADIF_VT:
-            case HB_FILTER_BWDIF:
-            case HB_FILTER_BWDIF_VT:
-            case HB_FILTER_CHROMA_SMOOTH:
-            case HB_FILTER_CHROMA_SMOOTH_VT:
-            case HB_FILTER_CROP_SCALE:
-            case HB_FILTER_CROP_SCALE_VT:
-            case HB_FILTER_GRAYSCALE:
-            case HB_FILTER_GRAYSCALE_VT:
-            case HB_FILTER_LAPSHARP:
-            case HB_FILTER_LAPSHARP_VT:
-            case HB_FILTER_UNSHARP:
-            case HB_FILTER_UNSHARP_VT:
-            case HB_FILTER_PAD:
-            case HB_FILTER_PAD_VT:
-                break;
-            case HB_FILTER_ROTATE:
-            case HB_FILTER_ROTATE_VT:
-            {
-#ifdef MAC_OS_VERSION_13_0
-                if (__builtin_available(macOS 13, *)) {}
-                else { supported = 0; }
-                break;
-#else
+            case HB_FILTER_DECOMB:
+            case HB_FILTER_DEBLOCK:
+            case HB_FILTER_DENOISE:
+            case HB_FILTER_NLMEANS:
+            case HB_FILTER_RENDER_SUB:
+            case HB_FILTER_COLORSPACE:
+            case HB_FILTER_FORMAT:
                 supported = 0;
-                break;
-#endif
-            }
-            case HB_FILTER_VFR:
-                // Mode 0 doesn't require access to the frame data
-                supported = hb_dict_get_int(filter->settings, "mode") == 0;
                 break;
             default:
-                supported = 0;
+                break;
         }
 
         if (supported == 0)
         {
-            hb_deep_log(2, "hwaccel: %s isn't yet supported for hw video frames", filter->name);
+            hb_deep_log(2, "videotoolbox: %s isn't yet supported for hw video frames", filter->name);
             ret = 0;
         }
     }

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -39,7 +39,8 @@ struct hb_filter_private_s
     hb_list_t     * frame_rate_list;
     double        * frame_metric;
 
-    unsigned        gamma_lut[256];
+    hb_motion_metric_object_t *metric;
+
 #if defined(HB_DEBUG_CFR_DROPS)
     int64_t         sequence;
 #endif
@@ -71,67 +72,8 @@ hb_filter_object_t hb_filter_vfr =
     .settings_template = hb_vfr_template,
 };
 
-// Create gamma lookup table.
-// Note that we are creating a scaled integer lookup table that will
-// not cause overflows in sse_block16() below.  This results in
-// small values being truncated to 0 which is ok for this usage.
-static void build_gamma_lut( hb_filter_private_t * pv )
-{
-    int i;
-    for( i = 0; i < 256; i++ )
-    {
-        pv->gamma_lut[i] = 4095 * pow( ( (float)i / (float)255 ), 2.2f );
-    }
-}
 
 #define DUP_THRESH_SSE 5.0
-
-// Compute the sum of squared errors for a 16x16 block
-// Gamma adjusts pixel values so that less visible differences
-// count less.
-static inline unsigned sse_block16( unsigned *gamma_lut, uint8_t *a, uint8_t *b, int stride_a, int stride_b )
-{
-    int x, y;
-    unsigned sum = 0;
-    int diff;
-
-    for( y = 0; y < 16; y++ )
-    {
-        for( x = 0; x < 16; x++ )
-        {
-            diff =  gamma_lut[a[x]] - gamma_lut[b[x]];
-            sum += diff * diff;
-        }
-        a += stride_a;
-        b += stride_b;
-    }
-    return sum;
-}
-
-// Sum of squared errors.  Computes and sums the SSEs for all
-// 16x16 blocks in the images.  Only checks the Y component.
-static float motion_metric( unsigned * gamma_lut, hb_buffer_t * a, hb_buffer_t * b )
-{
-    int bw = a->f.width / 16;
-    int bh = a->f.height / 16;
-    int stride_a = a->plane[0].stride;
-    int stride_b = b->plane[0].stride;
-    uint8_t * pa = a->plane[0].data;
-    uint8_t * pb = b->plane[0].data;
-    int x, y;
-    uint64_t sum = 0;
-
-    for( y = 0; y < bh; y++ )
-    {
-        for( x = 0; x < bw; x++ )
-        {
-            sum +=  sse_block16( gamma_lut, pa + y * 16 * stride_a + x * 16,
-                                            pb + y * 16 * stride_b + x * 16,
-                                            stride_a, stride_b );
-        }
-    }
-    return (float)sum / ( a->f.width * a->f.height );;
-}
 
 static void delete_metric(double * metrics, int pos, int size)
 {
@@ -248,8 +190,7 @@ static hb_buffer_t * adjust_frame_rate( hb_filter_private_t * pv,
         penultimate = hb_list_item(pv->frame_rate_list, count - 2);
         ultimate    = hb_list_item(pv->frame_rate_list, count - 1);
 
-        pv->frame_metric[count - 1] = motion_metric(pv->gamma_lut,
-                                                    penultimate, ultimate);
+        pv->frame_metric[count - 1] = pv->metric->work(pv->metric, penultimate, ultimate);
 
         if (count < pv->frame_analysis_depth)
         {
@@ -381,7 +322,10 @@ static int hb_vfr_init(hb_filter_object_t *filter, hb_filter_init_t *init)
 {
     filter->private_data    = calloc(1, sizeof(struct hb_filter_private_s));
     hb_filter_private_t *pv = filter->private_data;
-    build_gamma_lut(pv);
+
+    pv->metric = calloc(1, sizeof(struct hb_motion_metric_object_s));
+    memcpy(pv->metric, &hb_motion_metric, sizeof(hb_motion_metric_object_t));
+    pv->metric->init(pv->metric, init);
 
     pv->cfr              = init->cfr;
     pv->input_vrate = pv->vrate = init->vrate;
@@ -574,6 +518,12 @@ static void hb_vfr_close( hb_filter_object_t * filter )
     }
     free(pv->frame_metric);
     hb_list_close(&pv->frame_rate_list);
+
+    if (pv->metric)
+    {
+        pv->metric->close(pv->metric);
+        free(pv->metric);
+    }
 
     /* Cleanup render work structure */
     free( pv );

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -568,6 +568,13 @@ static void hb_vfr_close( hb_filter_object_t * filter )
         hb_fifo_close( &pv->delay_queue );
     }
     free(pv->frame_metric);
+
+    hb_buffer_t *b;
+    while ((b = hb_list_item(pv->frame_rate_list, 0)))
+    {
+        hb_list_rem(pv->frame_rate_list, b);
+        hb_buffer_close(&b);
+    }
     hb_list_close(&pv->frame_rate_list);
 
     hb_motion_metric_close(&pv->metric);


### PR DESCRIPTION
Refactored the motion metric algorithm to a separate object (objects in C are fun), so it's easy to plug in a new implementation running on a different compute api, and fixed the metric calculation on high depth video. Plus some assorted bug fixes.
Added a metal motion metric implementation for VideoToolbox.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
