### PR TITLE
LinGUI: Fix final queue item destination

### DIFF
--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -757,7 +757,6 @@ title_add_multiple_action_cb (GSimpleAction *action, GVariant *param,
         {
             ghb_preset_to_settings(settings, preset);
             ghb_set_title_settings(ud, settings);
-            ghb_value_free(&preset);
         }
         title_id = ghb_dict_get_int(settings, "title");
         title = ghb_lookup_title(title_id, &titleindex);
@@ -782,6 +781,12 @@ title_add_multiple_action_cb (GSimpleAction *action, GVariant *param,
 
         gtk_list_box_insert(list, row, -1);
     }
+
+    if (preset != NULL)
+    {
+        ghb_value_free(&preset);
+    }
+
     // Now we need to set the width of the title label since it
     // can vary on each row
     if (max_title_len > 60)
@@ -843,9 +848,13 @@ title_add_all_action_cb (GSimpleAction *action, GVariant *param,
         {
             ghb_preset_to_settings(settings, preset);
             ghb_set_title_settings(ud, settings);
-            ghb_value_free(&preset);
         }
         ghb_dict_set_bool(settings, "title_selected", TRUE);
+    }
+
+    if (preset != NULL)
+    {
+        ghb_value_free(&preset);
     }
 
     for (ii = 0; ii < count; ii++)


### PR DESCRIPTION
**Description of Change:**
In 35e7af2, the preset dict was incorrectly being freed on the first iteration of the loop, resulting in the final item having the same destination as the first one. Fixes #5571.

As the original change was backported to the 1.7.x branch this fix needs to be applied there too, but I want to make sure the fix works first before opening another pull request.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux