### PR TITLE
LinGUI: Update notes for 1.7.2

### DIFF
--- a/gtk/data/fr.handbrake.ghb.metainfo.xml.in
+++ b/gtk/data/fr.handbrake.ghb.metainfo.xml.in
@@ -100,7 +100,17 @@
   </requires>
 
   <releases>
-    <release version="1.7.0" date="2023-10-10">
+    <release version="1.7.2" date="2023-12-17">
+      <description>
+        <p>Addresses an issue where the file chooser opens in the home directory instead of the folder that was previously selected.</p>
+      </description>
+    </release>
+    <release version="1.7.1" date="2023-11-22">
+      <description>
+        <p>Fixed Intel QSV devices enumeration where devices from other vendors are present.</p>
+      </description>
+    </release>
+    <release version="1.7.0" date="2023-11-12">
       <description>
         <p>Drag and drop support, native file chooser, chapter import and export, Dolby Vision metadata passthrough, and various user interface improvements.</p>
       </description>


### PR DESCRIPTION
**Description of Change:**
Updates the metainfo file to include the next version number. It turns out that Flatpak uses the version number from this file in some places, meaning the current version is still seen as 1.7.0 (example below). For the main branch I'm planning a change that will insert the version and release date automatically, in order to avoid having to change this file with every update.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Log file output (If relevant):**
```
$ flatpak info fr.handbrake.ghb

HandBrake - Video Transcoder

          ID: fr.handbrake.ghb
         Ref: app/fr.handbrake.ghb/x86_64/stable
        Arch: x86_64
      Branch: stable
     Version: 1.7.0
     License: GPL-2.0
      Origin: flathub
  Collection: org.flathub.Stable
Installation: system
   Installed: 114.8 MB
     Runtime: org.gnome.Platform/x86_64/45
         Sdk: org.gnome.Sdk/x86_64/45

      Commit: a2a4c8ddfd2e6336b82a3e9f9cd0904f48ce864b24eb48863b764b744fcb1f14
      Parent: 147516cd3ac20215fc781375d3f1a5c529d8670e515b9a59ea8920928478d580
     Subject: New HandBrake release 1.7.1 (73151d6f)
        Date: 2023-11-27 16:07:24 +0000
```
