### PR TITLE
libhb: add cuda format filter.

### DIFF
--- a/libhb/format.c
+++ b/libhb/format.c
@@ -73,8 +73,18 @@ static int format_init(hb_filter_object_t *filter, hb_filter_init_t *init)
     else
 #endif
     {
-        hb_dict_set_string(avsettings, "pix_fmts", format);
-        hb_dict_set(avfilter, "format", avsettings);
+        if (init->hw_pix_fmt == AV_PIX_FMT_CUDA)
+        {
+            hb_dict_set_int(avsettings, "w", init->geometry.width);
+            hb_dict_set_int(avsettings, "h", init->geometry.height);
+            hb_dict_set_string(avsettings, "format", format);
+            hb_dict_set(avfilter, "scale_cuda", avsettings);
+        }
+        else
+        {
+            hb_dict_set_string(avsettings, "pix_fmts", format);
+            hb_dict_set(avfilter, "format", avsettings);
+        }
     }
 
     hb_value_array_append(avfilters, avfilter);

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -261,6 +261,8 @@ int hb_nvenc_are_filters_supported(hb_list_t *filters)
                 // Mode 0 doesn't require access to the frame data
                 supported = hb_dict_get_int(filter->settings, "mode") == 0;
                 break;
+            case HB_FILTER_FORMAT:
+                break;
             default:
                 supported = 0;
         }

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -262,6 +262,7 @@ int hb_nvenc_are_filters_supported(hb_list_t *filters)
                 supported = hb_dict_get_int(filter->settings, "mode") == 0;
                 break;
             case HB_FILTER_FORMAT:
+            case HB_FILTER_AVFILTER:
                 break;
             default:
                 supported = 0;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1526,11 +1526,11 @@ static void sanitize_filter_list_post(hb_job_t *job)
     if (job->hw_pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
     {
         hb_vt_setup_hw_filters(job);
+        return;
     }
 #endif
 
-    if ((job->hw_pix_fmt == AV_PIX_FMT_NONE || job->hw_pix_fmt == AV_PIX_FMT_QSV) &&
-        hb_video_encoder_pix_fmt_is_supported(job->vcodec, job->input_pix_fmt, job->encoder_profile) == 0)
+    if (hb_video_encoder_pix_fmt_is_supported(job->vcodec, job->input_pix_fmt, job->encoder_profile) == 0)
     {
         // Some encoders require a specific input pixel format
         // that could be different from the current pipeline format.


### PR DESCRIPTION
Converts the frames to the pixel format required by the encoder. Should fix #5606
If someone with an NVIDIA GPU could test it.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux