### PR TITLE
Update copyright dates to 2024.

### DIFF
--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -1,5 +1,5 @@
 # SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR HandBrake Team
+# Copyright (C) 2024 HandBrake Team
 # This file is distributed under the same license as the ghb package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #

--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * audiohandler.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * audiohandler.c is free software.
  *

--- a/gtk/src/audiohandler.h
+++ b/gtk/src/audiohandler.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * audiohandler.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * audiohandler.h is free software.
  *

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * callbacks.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * callbacks.c is free software.
  *

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * callbacks.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * callbacks.h is free software.
  *

--- a/gtk/src/chapters.c
+++ b/gtk/src/chapters.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * chapters.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * chapters.c is free software.
  *

--- a/gtk/src/chapters.h
+++ b/gtk/src/chapters.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * callbacks.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * callbacks.h is free software.
  *

--- a/gtk/src/color-scheme.c
+++ b/gtk/src/color-scheme.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 HandBrake Team
+/* Copyright (C) 2022-2024 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #define G_LOG_DOMAIN "ghb"

--- a/gtk/src/color-scheme.h
+++ b/gtk/src/color-scheme.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2023 HandBrake Team
+/* Copyright (C) 2022-2024 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #ifndef COLOR_SCHEME_H

--- a/gtk/src/ghb-dvd.c
+++ b/gtk/src/ghb-dvd.c
@@ -1,6 +1,6 @@
 /*
  * ghb-dvd.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * ghb-dvd.c is free software.
  *

--- a/gtk/src/ghb-dvd.h
+++ b/gtk/src/ghb-dvd.h
@@ -1,6 +1,6 @@
 /*
  * ghb-dvd.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * ghb-dvd.h is free software.
  *

--- a/gtk/src/ghbcompat.c
+++ b/gtk/src/ghbcompat.c
@@ -1,6 +1,6 @@
 /*
  * ghbcompat.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * ghbcompat.h is free software.
  *

--- a/gtk/src/ghbcompat.h
+++ b/gtk/src/ghbcompat.h
@@ -1,6 +1,6 @@
 /*
  * ghbcompat.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * ghbcompat.h is free software.
  *

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1,6 +1,6 @@
 /*
  * hb-backend.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * hb-backend.c is free software.
  *

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -1,6 +1,6 @@
 /*
  * hb-backend.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * hb-backend.h is free software.
  *

--- a/gtk/src/icons.c
+++ b/gtk/src/icons.c
@@ -1,6 +1,6 @@
 /*
  * icons.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * icons.c is free software.
  *

--- a/gtk/src/icons.h
+++ b/gtk/src/icons.h
@@ -1,6 +1,6 @@
 /*
  * icons.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * icons.h is free software.
  *

--- a/gtk/src/jobdict.c
+++ b/gtk/src/jobdict.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * jobdict.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.c is free software.
  *

--- a/gtk/src/jobdict.h
+++ b/gtk/src/jobdict.h
@@ -1,6 +1,6 @@
 /*
  * settings.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.h is free software.
  *

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * main.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * main.c is free software.
  *

--- a/gtk/src/notifications.c
+++ b/gtk/src/notifications.c
@@ -1,6 +1,6 @@
 /* notifications.c
  *
- * Copyright (C) HandBrake Team 2023
+ * Copyright (C) HandBrake Team 2024
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/notifications.h
+++ b/gtk/src/notifications.h
@@ -1,5 +1,5 @@
 /* notifications.h
- * Copyright (C) HandBrake Team 2023
+ * Copyright (C) HandBrake Team 2024
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #ifndef _NOTIFICATIONS_H_

--- a/gtk/src/plist.c
+++ b/gtk/src/plist.c
@@ -1,6 +1,6 @@
 /*
  * plist.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * plist.c is free software.
  *

--- a/gtk/src/plist.h
+++ b/gtk/src/plist.h
@@ -1,6 +1,6 @@
 /*
  * plist.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * plist.h is free software.
  *

--- a/gtk/src/power-manager.c
+++ b/gtk/src/power-manager.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023 HandBrake Team
+/* Copyright (C) 2024 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #include "power-manager.h"

--- a/gtk/src/power-manager.h
+++ b/gtk/src/power-manager.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023 HandBrake Team
+/* Copyright (C) 2024 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #ifndef POWER_MANAGEMENT_H

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * presets.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * presets.c is free software.
  *

--- a/gtk/src/presets.h
+++ b/gtk/src/presets.h
@@ -1,6 +1,6 @@
 /*
  * presets.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * presets.h is free software.
  *

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * preview.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * preview.c is free software.
  *

--- a/gtk/src/preview.h
+++ b/gtk/src/preview.h
@@ -1,6 +1,6 @@
 /*
  * preview.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * preview.h is free software.
  *

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * queuehandler.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * queuehandler.c is free software.
  *

--- a/gtk/src/queuehandler.h
+++ b/gtk/src/queuehandler.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * queuehandler.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * queuehandler.h is free software.
  *

--- a/gtk/src/renderer_button.c
+++ b/gtk/src/renderer_button.c
@@ -1,6 +1,6 @@
 /*
  * render_button.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * render_button.c is free software.
  *

--- a/gtk/src/renderer_button.h
+++ b/gtk/src/renderer_button.h
@@ -1,6 +1,6 @@
 /*
  * render_button.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * render_button.h is free software.
  *

--- a/gtk/src/resources.c
+++ b/gtk/src/resources.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * resources.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * resources.c is free software.
  *

--- a/gtk/src/resources.h
+++ b/gtk/src/resources.h
@@ -1,6 +1,6 @@
 /*
  * resources.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * resources.h is free software.
  *

--- a/gtk/src/settings.c
+++ b/gtk/src/settings.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * settings.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.c is free software.
  *

--- a/gtk/src/settings.h
+++ b/gtk/src/settings.h
@@ -1,6 +1,6 @@
 /*
  * settings.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.h is free software.
  *

--- a/gtk/src/subtitlehandler.c
+++ b/gtk/src/subtitlehandler.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * subtitlehandler.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * subtitlehandler.c is free software.
  *

--- a/gtk/src/subtitlehandler.h
+++ b/gtk/src/subtitlehandler.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * subtitlehandler.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * subtitlehandler.h is free software.
  *

--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * title-add.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * title-add.c is free software.
  *

--- a/gtk/src/title-add.h
+++ b/gtk/src/title-add.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * title-add.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * title-add.h is free software.
  *

--- a/gtk/src/titledict.c
+++ b/gtk/src/titledict.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * titledict.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.c is free software.
  *

--- a/gtk/src/titledict.h
+++ b/gtk/src/titledict.h
@@ -1,6 +1,6 @@
 /*
  * titledict.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * settings.h is free software.
  *

--- a/gtk/src/values.c
+++ b/gtk/src/values.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * values.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * values.c is free software.
  *

--- a/gtk/src/values.h
+++ b/gtk/src/values.h
@@ -1,6 +1,6 @@
 /*
  * values.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * values.h is free software.
  *

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * videohandler.c
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * videohandler.c is free software.
  *

--- a/gtk/src/videohandler.h
+++ b/gtk/src/videohandler.h
@@ -1,7 +1,7 @@
 /* -*- Mode: C; indent-tabs-mode: nil; c-basic-offset: 4; tab-width: 4 -*- */
 /*
  * videohandler.h
- * Copyright (C) John Stebbins 2008-2023 <stebbins@stebbins>
+ * Copyright (C) John Stebbins 2008-2024 <stebbins@stebbins>
  *
  * videohandler.h is free software.
  *

--- a/libhb/audio_remap.c
+++ b/libhb/audio_remap.c
@@ -1,6 +1,6 @@
 /* audio_remap.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/audio_resample.c
+++ b/libhb/audio_resample.c
@@ -1,6 +1,6 @@
 /* audio_resample.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -1,6 +1,6 @@
 /* avfilter.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -1,6 +1,6 @@
 /* batch.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -1,6 +1,6 @@
 /* bd.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/bitstream.c
+++ b/libhb/bitstream.c
@@ -1,6 +1,6 @@
 /* bitstream.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -1,7 +1,7 @@
 /* chroma_smooth.c
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/colormap.c
+++ b/libhb/colormap.c
@@ -1,6 +1,6 @@
 /* colormap.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/colorspace.c
+++ b/libhb/colorspace.c
@@ -1,6 +1,6 @@
 /* colorspace.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/comb_detect.c
+++ b/libhb/comb_detect.c
@@ -1,6 +1,6 @@
 /* comb_detect.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1,6 +1,6 @@
 /* common.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/compat.c
+++ b/libhb/compat.c
@@ -1,6 +1,6 @@
 /* compat.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -1,6 +1,6 @@
 /* cropscale.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/deblock.c
+++ b/libhb/deblock.c
@@ -1,6 +1,6 @@
 /* deblock.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1,6 +1,6 @@
 /* decavcodec.c
 
-   Copyright (c) 2003-2020 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -1,6 +1,6 @@
 /* decavsub.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -1,6 +1,6 @@
 /* declpcm.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -1,6 +1,6 @@
 /* decomb.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -1,6 +1,6 @@
 /* decsrtsub.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decssasub.c
+++ b/libhb/decssasub.c
@@ -1,6 +1,6 @@
 /* decssasub.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -1,6 +1,6 @@
 /* dectx3gsub.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/deinterlace.c
+++ b/libhb/deinterlace.c
@@ -1,6 +1,6 @@
 /* deinterlace.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/demuxmpeg.c
+++ b/libhb/demuxmpeg.c
@@ -1,6 +1,6 @@
 /* demuxmpeg.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1,6 +1,6 @@
 /* detelecine.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -1,6 +1,6 @@
 /* dvd.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -1,6 +1,6 @@
 /* dvdnav.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/eedi2.c
+++ b/libhb/eedi2.c
@@ -1,6 +1,6 @@
 /* eedi2.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -1,6 +1,6 @@
 /* encavcodec.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -1,6 +1,6 @@
 /* encavcodecaudio.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -1,6 +1,6 @@
 /* encsvtav1.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    partially based on FFmpeg libsvtav1.c
    Homepage: <http://handbrake.fr/>.

--- a/libhb/enctheora.c
+++ b/libhb/enctheora.c
@@ -1,6 +1,6 @@
 /* enctheora.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -1,6 +1,6 @@
 /* encvorbis.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -1,6 +1,6 @@
 /* encx264.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -1,6 +1,6 @@
 /* encx265.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -1,6 +1,6 @@
 /* fifo.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/format.c
+++ b/libhb/format.c
@@ -1,6 +1,6 @@
 /* format.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/grayscale.c
+++ b/libhb/grayscale.c
@@ -1,6 +1,6 @@
 /* grayscale.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/audio_remap.h
+++ b/libhb/handbrake/audio_remap.h
@@ -1,6 +1,6 @@
 /* audio_remap.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/audio_resample.h
+++ b/libhb/handbrake/audio_resample.h
@@ -1,6 +1,6 @@
 /* audio_resample.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -1,6 +1,6 @@
 /* av1_common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/avfilter_priv.h
+++ b/libhb/handbrake/avfilter_priv.h
@@ -1,6 +1,6 @@
 /* avfilter_priv.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/bitstream.h
+++ b/libhb/handbrake/bitstream.h
@@ -1,6 +1,6 @@
 /* bitstream.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/colormap.h
+++ b/libhb/handbrake/colormap.h
@@ -1,6 +1,6 @@
 /* colormap.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1,6 +1,6 @@
 /* common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/compat.h
+++ b/libhb/handbrake/compat.h
@@ -1,6 +1,6 @@
 /* compat.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/decavsub.h
+++ b/libhb/handbrake/decavsub.h
@@ -1,6 +1,6 @@
 /* decavsub.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/decomb.h
+++ b/libhb/handbrake/decomb.h
@@ -1,6 +1,6 @@
 /* decomb.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/dovi_common.h
+++ b/libhb/handbrake/dovi_common.h
@@ -1,6 +1,6 @@
 /* h265_common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/dvd.h
+++ b/libhb/handbrake/dvd.h
@@ -1,6 +1,6 @@
 /* dvd.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/eedi2.h
+++ b/libhb/handbrake/eedi2.h
@@ -1,6 +1,6 @@
 /* eedi2.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/encx264.h
+++ b/libhb/handbrake/encx264.h
@@ -1,6 +1,6 @@
 /* encx264.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/h264_common.h
+++ b/libhb/handbrake/h264_common.h
@@ -1,6 +1,6 @@
 /* h264_common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/h265_common.h
+++ b/libhb/handbrake/h265_common.h
@@ -1,6 +1,6 @@
 /* h265_common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -1,6 +1,6 @@
 /* handbrake.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hb_dict.h
+++ b/libhb/handbrake/hb_dict.h
@@ -1,6 +1,6 @@
 /* hb_dict.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hb_json.h
+++ b/libhb/handbrake/hb_json.h
@@ -1,6 +1,6 @@
 /* hb_json.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbavfilter.h
+++ b/libhb/handbrake/hbavfilter.h
@@ -1,6 +1,6 @@
 /* hbavfilter.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -1,6 +1,6 @@
 /* hbffmpeg.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -1,6 +1,6 @@
 /* hbtypes.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hdr10plus.h
+++ b/libhb/handbrake/hdr10plus.h
@@ -1,6 +1,6 @@
 /* hdr10plus.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hwaccel.h
+++ b/libhb/handbrake/hwaccel.h
@@ -1,6 +1,6 @@
 /* hwaccel.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -1,6 +1,6 @@
 /* internal.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/lang.h
+++ b/libhb/handbrake/lang.h
@@ -1,6 +1,6 @@
 /* lang.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nal_units.h
+++ b/libhb/handbrake/nal_units.h
@@ -1,6 +1,6 @@
 /* nal_units.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nlmeans.h
+++ b/libhb/handbrake/nlmeans.h
@@ -1,7 +1,7 @@
 /* nlmeans.h
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nvenc_common.h
+++ b/libhb/handbrake/nvenc_common.h
@@ -1,6 +1,6 @@
 /* nvenc_common.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/param.h
+++ b/libhb/handbrake/param.h
@@ -1,6 +1,6 @@
 /* param.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/plist.h
+++ b/libhb/handbrake/plist.h
@@ -1,6 +1,6 @@
 /* plist.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -1,6 +1,6 @@
 /* ports.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/preset.h
+++ b/libhb/handbrake/preset.h
@@ -1,6 +1,6 @@
 /* preset.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -1,6 +1,6 @@
 /* qsv_common.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/ssautil.h
+++ b/libhb/handbrake/ssautil.h
@@ -1,6 +1,6 @@
 /* ssautil.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/taskset.h
+++ b/libhb/handbrake/taskset.h
@@ -1,6 +1,6 @@
 /* taskset.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -1,6 +1,6 @@
 /* vce_common.h
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1,6 +1,6 @@
 /* hb.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb_dict.c
+++ b/libhb/hb_dict.c
@@ -1,6 +1,6 @@
 /* hb_dict.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1,6 +1,6 @@
 /* json.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -1,6 +1,6 @@
 /* hbavfilter.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -1,6 +1,6 @@
 /* hbffmpeg.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hdr10plus.c
+++ b/libhb/hdr10plus.c
@@ -1,6 +1,6 @@
 /* hdr10plus.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -1,6 +1,6 @@
 /* hwaccel.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/lang.c
+++ b/libhb/lang.c
@@ -1,6 +1,6 @@
 /* lang.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -1,6 +1,6 @@
 /* lapsharp.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -1,6 +1,6 @@
 /* motionmetric.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/mt_frame_filter.c
+++ b/libhb/mt_frame_filter.c
@@ -1,6 +1,6 @@
 /* mt_frame_filter.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -1,6 +1,6 @@
 /* muxavformat.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -1,6 +1,6 @@
 /* muxcommon.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nal_units.c
+++ b/libhb/nal_units.c
@@ -1,6 +1,6 @@
 /* nal_units.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -1,7 +1,7 @@
 /* nlmeans.c
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nlmeans_x86.c
+++ b/libhb/nlmeans_x86.c
@@ -1,7 +1,7 @@
 /* nlmeans_x86.c
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -1,6 +1,6 @@
 /* nvenc_common.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/pad.c
+++ b/libhb/pad.c
@@ -1,6 +1,6 @@
 /* pad.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -1,6 +1,6 @@
 /* param.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/chroma_smooth_vt.m
+++ b/libhb/platform/macosx/chroma_smooth_vt.m
@@ -1,7 +1,7 @@
 /* unsharp_vt.m
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/comb_detect_vt.m
+++ b/libhb/platform/macosx/comb_detect_vt.m
@@ -1,6 +1,6 @@
 /* comb_detect.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/config.m
+++ b/libhb/platform/macosx/config.m
@@ -1,3 +1,12 @@
+/* config.m
+
+   Copyright (c) 2003-2024 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
 #import <Foundation/Foundation.h>
 
 static NSURL * macOS_last_modified_url(NSURL *url1, NSURL* url2)

--- a/libhb/platform/macosx/cropscale_vt.c
+++ b/libhb/platform/macosx/cropscale_vt.c
@@ -1,6 +1,6 @@
 /* cropscale_vt.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/cv_utils.c
+++ b/libhb/platform/macosx/cv_utils.c
@@ -1,6 +1,6 @@
 /* cv_utils.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/cv_utils.h
+++ b/libhb/platform/macosx/cv_utils.h
@@ -1,6 +1,6 @@
 /* cv_utils.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/deinterlace_vt.m
+++ b/libhb/platform/macosx/deinterlace_vt.m
@@ -1,6 +1,6 @@
 /* deinterlace_vt.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/encca_aac.c
+++ b/libhb/platform/macosx/encca_aac.c
@@ -1,6 +1,6 @@
 /* encca_aac.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/encvt.c
+++ b/libhb/platform/macosx/encvt.c
@@ -1,6 +1,6 @@
 /* encvt.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/grayscale_vt.m
+++ b/libhb/platform/macosx/grayscale_vt.m
@@ -1,6 +1,6 @@
 /* grayscale_vt.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/lapsharp_vt.m
+++ b/libhb/platform/macosx/lapsharp_vt.m
@@ -1,6 +1,6 @@
 /* lapsharp_vt.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/metal_utils.h
+++ b/libhb/platform/macosx/metal_utils.h
@@ -1,6 +1,6 @@
 /* utils.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/metal_utils.m
+++ b/libhb/platform/macosx/metal_utils.m
@@ -1,6 +1,6 @@
 /* utils.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/motion_metric_vt.m
+++ b/libhb/platform/macosx/motion_metric_vt.m
@@ -1,6 +1,6 @@
 /* motion_metric_vt.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/pad_vt.m
+++ b/libhb/platform/macosx/pad_vt.m
@@ -1,6 +1,6 @@
 /* pad_vt.m
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/prefilter_vt.c
+++ b/libhb/platform/macosx/prefilter_vt.c
@@ -1,6 +1,6 @@
 /* prefilter_vt.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/rotate_vt.c
+++ b/libhb/platform/macosx/rotate_vt.c
@@ -1,6 +1,6 @@
 /* rotate_vt.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/shaders/bwdif_vt.metal
+++ b/libhb/platform/macosx/shaders/bwdif_vt.metal
@@ -1,6 +1,6 @@
 /* bwdif.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    Copyright (c) 2019 Philip Langdale <philipl@overt.org>
 
    port of FFmpeg vf_bwdif_cuda.

--- a/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
+++ b/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
@@ -1,6 +1,6 @@
 /* chroma_smooth.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    port of FFmpeg unsharp.cl.
 

--- a/libhb/platform/macosx/shaders/comb_detect_vt.metal
+++ b/libhb/platform/macosx/shaders/comb_detect_vt.metal
@@ -1,6 +1,6 @@
 /* comb_detect.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/grayscale_vt.metal
+++ b/libhb/platform/macosx/shaders/grayscale_vt.metal
@@ -1,6 +1,6 @@
 /* grayscale.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    Copyright (c) 2021 Paul B Mahol
 
    port of vf_monochrome FFmpeg.

--- a/libhb/platform/macosx/shaders/lapsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/lapsharp_vt.metal
@@ -1,6 +1,6 @@
 /* lapsharp.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/motion_metric_vt.metal
+++ b/libhb/platform/macosx/shaders/motion_metric_vt.metal
@@ -1,6 +1,6 @@
 /* motion_metric_vt.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/pad_vt.metal
+++ b/libhb/platform/macosx/shaders/pad_vt.metal
@@ -1,6 +1,6 @@
 /* pad.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    port of FFmpeg pad.cl.
 

--- a/libhb/platform/macosx/shaders/unsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/unsharp_vt.metal
@@ -1,6 +1,6 @@
 /* unsharp.metal
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
 
    port of FFmpeg unsharp.cl.
 

--- a/libhb/platform/macosx/unsharp_vt.m
+++ b/libhb/platform/macosx/unsharp_vt.m
@@ -1,7 +1,7 @@
 /* unsharp_vt.m
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -1,6 +1,6 @@
 /* vt_common.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/vt_common.h
+++ b/libhb/platform/macosx/vt_common.h
@@ -1,6 +1,6 @@
 /* vt_common.h
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/plist.c
+++ b/libhb/plist.c
@@ -1,6 +1,6 @@
 /* plist.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1,6 +1,6 @@
 /* ports.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1,6 +1,6 @@
 /* preset.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1,6 +1,6 @@
 /* qsv_common.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/reader.c
+++ b/libhb/reader.c
@@ -1,6 +1,6 @@
 /* reader.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -1,6 +1,6 @@
 /* rendersub.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rotate.c
+++ b/libhb/rotate.c
@@ -1,6 +1,6 @@
 /* rotate.c
 
-   Copyright (c) 2003-2015 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rpu.c
+++ b/libhb/rpu.c
@@ -1,6 +1,6 @@
 /* rpu.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1,6 +1,6 @@
 /* scan.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/ssautil.c
+++ b/libhb/ssautil.c
@@ -1,6 +1,6 @@
 /* ssautil.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -1,6 +1,6 @@
 /* stream.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -1,6 +1,6 @@
 /* sync.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/taskset.c
+++ b/libhb/taskset.c
@@ -1,6 +1,6 @@
 /* taskset.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/comb_detect_template.c
+++ b/libhb/templates/comb_detect_template.c
@@ -1,6 +1,6 @@
 /* comb_detect_template.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/decomb_template.c
+++ b/libhb/templates/decomb_template.c
@@ -1,6 +1,6 @@
 /* decomb_template.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/eedi2_template.c
+++ b/libhb/templates/eedi2_template.c
@@ -1,6 +1,6 @@
 /* eedi2_template.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/nlmeans_template.c
+++ b/libhb/templates/nlmeans_template.c
@@ -1,6 +1,6 @@
 /* common.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -1,7 +1,7 @@
 /* unsharp.c
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -1,6 +1,6 @@
 /* vce_common.c
  *
- * Copyright (c) 2003-2023 HandBrake Team
+ * Copyright (c) 2003-2024 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -1,6 +1,6 @@
 /* vfr.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1,6 +1,6 @@
 /* work.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/macosx/Info.plist.m4
+++ b/macosx/Info.plist.m4
@@ -60,7 +60,7 @@ dnl
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2003-2023 __HB_name Team.
+	<string>Copyright © 2003-2024 __HB_name Team.
 GPLv2 license.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>

--- a/macosx/hbsign
+++ b/macosx/hbsign
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Copyright (C) 2012-2017 VLC authors and VideoLAN
 # Copyright (C) 2012-2014 Felix Paul Kühne <fkuehne at videolan dot org>
-# Copyright (C) 2018-2023 Damiano Galassi <damiog@gmail.com>
-# Copyright (C) 2018-2023 Bradley Sepos <bradley@bradleysepos.com>
+# Copyright (C) 2018-2024 Damiano Galassi <damiog@gmail.com>
+# Copyright (C) 2018-2024 Bradley Sepos <bradley@bradleysepos.com>
 #
 # Based on VLC's codesign.sh
 #

--- a/test/fr.handbrake.HandBrakeCLI.metainfo.xml.in.in
+++ b/test/fr.handbrake.HandBrakeCLI.metainfo.xml.in.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018-2023 John Stebbins <your@email.com> -->
+<!-- Copyright 2018-2024 John Stebbins <your@email.com> -->
 <component type="console-application">
   <id>fr.handbrake.HandBrakeCLI</id>
   <update_contact>jstebbins.hb_AT_gmail.com</update_contact>

--- a/test/parsecsv.c
+++ b/test/parsecsv.c
@@ -1,6 +1,6 @@
 /* parsecsv.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/test/parsecsv.h
+++ b/test/parsecsv.h
@@ -1,6 +1,6 @@
 /* parsecsv.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/test/test.c
+++ b/test/test.c
@@ -1,6 +1,6 @@
 /* test.c
 
-   Copyright (c) 2003-2023 HandBrake Team
+   Copyright (c) 2003-2024 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/win/CS/HandBrake.App.Core/HandBrake.App.Core.csproj
+++ b/win/CS/HandBrake.App.Core/HandBrake.App.Core.csproj
@@ -6,7 +6,7 @@
 		<Version>1.7.2</Version>
 		<Authors>HandBrake Team</Authors>
 		<Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
-		<Copyright>Copyright © 2003-2023 HandBrake Team</Copyright>
+		<Copyright>Copyright © 2003-2024 HandBrake Team</Copyright>
 		<PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/win/CS/HandBrake.Interop/HandBrake.Interop.csproj
+++ b/win/CS/HandBrake.Interop/HandBrake.Interop.csproj
@@ -6,7 +6,7 @@
     <Version>1.7.2</Version>
     <Authors>HandBrake Team</Authors>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
-    <Copyright>Copyright © 2003-2023 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2024 HandBrake Team</Copyright>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/win/CS/HandBrake.Worker/HandBrake.Worker.csproj
+++ b/win/CS/HandBrake.Worker/HandBrake.Worker.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
     <Authors>HandBrake Team</Authors>
     <Company>HandBrake Team</Company>
     <Product>HandBrake.Worker</Product>
-    <Copyright>Copyright © 2003-2023 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2024 HandBrake Team</Copyright>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>

--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -9,7 +9,7 @@
     <Authors>HandBrake Team</Authors>
     <Company>HandBrake Team</Company>
     <Product>HandBrake</Product>
-    <Copyright>Copyright © 2003-2023 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2024 HandBrake Team</Copyright>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>


### PR DESCRIPTION
This change is based on https://github.com/HandBrake/HandBrake/commit/86acd31333f836d9d32b713f04be96ecacb4c5ae
And then updated all new/missed files by hand. 


I found this file without a header, is this expected?
https://github.com/HandBrake/HandBrake/blob/master/libhb/platform/macosx/config.m