### PR TITLE
contrib: update harfbuzz to 8.3.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.2.2.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.2.2/harfbuzz-8.2.2.tar.xz
-HARFBUZZ.FETCH.sha256  = e433ad85fbdf57f680be29479b3f964577379aaf319f557eb76569f0ecbc90f3
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.3.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/harfbuzz-8.3.0.tar.xz
+HARFBUZZ.FETCH.sha256  = 109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 8.3.0:**
What's Changed
- Improve memory barrier to fix potential segfaults.

- Various build fixes.

- Various subsetting and instancing fixes.

- Rename “hb-subset” option “--instance” to “--variations” to match the other
  tools. Old option is kept as an alias.

- New API:
  HB_AAT_LAYOUT_FEATURE_TYPE_CURSIVE_CONNECTION

- Deprecated API:
  HB_AAT_LAYOUT_FEATURE_TYPE_CURISVE_CONNECTION
  
**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux