### PR TITLE
contrib: update ffmpeg to 6.1.1

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -12,9 +12,9 @@ endif
 $(eval $(call import.MODULE.defs,FFMPEG,ffmpeg,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FFMPEG))
 
-FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-6.1.tar.bz2
-FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-6.1.tar.bz2
-FFMPEG.FETCH.sha256 = eb7da3de7dd3ce48a9946ab447a7346bd11a3a85e6efb8f2c2ce637e7f547611
+FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/ffmpeg-6.1.1.tar.bz2
+FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-6.1.1.tar.bz2
+FFMPEG.FETCH.sha256 = 5e3133939a61ef64ac9b47ffd29a5ea6e337a4023ef0ad972094b4da844e3a20
 
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =


### PR DESCRIPTION
**FFMPEG 6.1.1:**
- avcodec/mpegvideo_enc: Dont copy beyond the image
- avfilter/vf_minterpolate: Check pts before division
- avfilter/avf_showwaves: Check history_nb_samples
- avformat/flacdec: Avoid double AVERRORS
- avfilter/vf_vidstabdetect: Avoid double AVERRORS
- avcodec/vaapi_encode: Avoid double AVERRORS
- avfilter/vf_swaprect: round coordinates down
- avfilter/vf_swaprect: Use height for vertical variables
- avfilter/vf_swaprect: assert that rectangles are within memory
- avfilter/af_alimiter: Check nextpos before use
- avfilter/f_reverse: Apply PTS compensation only when pts is available
- avfilter/af_stereowiden: Check length
- avformat/mov: Fix MSAN issue with stsd_id
- avcodec/jpegxl_parser: Check get_vlc2()
- avfilter/vf_weave: Fix odd height handling
- avfilter/edge_template: Fix small inputs with gaussian_blur()
- avfilter/vf_gradfun: Do not overread last line
- avfilter/avf_showspectrum: fix off by 1 error
- avcodec/jpegxl_parser: Add padding to cs_buffer
- avformat/mov: do not set sign bit for chunk_offsets
- avcodec/jpeglsdec: Check Jpeg-LS LSE
- avcodec/osq: Implement flush()
- configure: Enable section_data_rel_ro for FreeBSD and NetBSD aarch64 / arm
- avcodec/cbs_h266: more restrictive check on pps_tile_idx_delta_val
- avcodec/jpeg2000htdec: check if block decoding will exceed internal precision
- tools/target_dec_fuzzer: Adjust threshold for VMIX
- avcodec/av1dec: Fix resolving zero divisor
- avformat/mov: Ignore duplicate ftyp
- avformat/mov: Fix integer overflow in mov_read_packet().
- lavc/qsvdec: return 0 if more data is required
- avcodec/jpegxl_parser: check ANS cluster alphabet size vs bundle size
- libavformat/vvc: Make probe more conservative
- hwcontext_vulkan: guard unistd.h include
- lavc/Makefile: build vulkan decode code if vulkan_av1 has been enabled
- lavc/dvdsubenc: only check canvas size when it is actually set
- avcodec/decode: validate hw_frames_ctx when AVHWAccel.free_frame_priv is used
- avcoded/fft: Fix memory leak if ctx2 is used
- avcodec/fft: Use av_mallocz to avoid invalid free/uninit

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux