### PR TITLE
rendersub: Set correct ASS storage and frame size.

### DIFF
--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -872,8 +872,16 @@ static int ssa_post_init( hb_filter_object_t * filter, hb_job_t * job )
 
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
+
+    //Set the right storage space, necessary for some ASS transforms.
+    double ass_par = 1.0;
+    if (job->title->geometry.par.den != 0 && job->title->geometry.par.num != 0)
+    {
+        ass_par /= hb_q2d(job->title->geometry.par);
+    }
+
     ass_set_frame_size(pv->renderer, width, height);
-    ass_set_storage_size(pv->renderer, width, height);
+    ass_set_pixel_aspect(pv->renderer, ass_par);
 
     return 0;
 }


### PR DESCRIPTION
**Description of Change:**
Some ASS tags require the correct frame and storage sizes to be configured in the renderer to yield the expected result.  LayoutResX/Y header values were introduced to the ASS specifications to address this issue. However, legacy scripts may lack those fields; the video processing software should tell libass the frame size and storage size (or pixel aspect ratio) to guarantee more consistent rendering with different video formats of the same footage.

Reference: [libass documentation](https://github.com/libass/libass/blob/97435e513f41d5968c1d2a0524e9365b757d9fab/libass/ass.h#L451-L472)
 
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux