### PR TITLE
libhb: add utilities to insert dynamic metadata, and enable Dolby Vision and HDR10 Plus in VideoToolbox.

### DIFF
--- a/contrib/ffmpeg/A20-vf_scale_preserve_range.patch
+++ b/contrib/ffmpeg/A20-vf_scale_preserve_range.patch
@@ -1,0 +1,26 @@
+From cfc595e41ac431677760efba6e9e7d3810a48f36 Mon Sep 17 00:00:00 2001
+From: Damiano Galassi <damiog@gmail.com>
+Date: Sun, 7 Jan 2024 10:33:50 +0100
+Subject: [PATCH] vf_scale: preserve the range of the input if not set.
+
+---
+ libavfilter/vf_scale.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/libavfilter/vf_scale.c b/libavfilter/vf_scale.c
+index 23335cef4b..6ed9a11a5a 100644
+--- a/libavfilter/vf_scale.c
++++ b/libavfilter/vf_scale.c
+@@ -588,6 +588,9 @@ static int config_props(AVFilterLink *outlink)
+             if (scale->out_range != AVCOL_RANGE_UNSPECIFIED)
+                 av_opt_set_int(s, "dst_range",
+                                scale->out_range == AVCOL_RANGE_JPEG, 0);
++            else if (scale->in_frame_range != AVCOL_RANGE_UNSPECIFIED)
++                av_opt_set_int(s, "dst_range",
++                               scale->in_frame_range == AVCOL_RANGE_JPEG, 0);
+ 
+             /* Override chroma location default settings to have the correct
+              * chroma positions. MPEG chroma positions are used by convention.
+-- 
+2.39.3 (Apple Git-145)
+

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -732,6 +732,9 @@ struct hb_job_s
 #define HB_COLR_MAT_CD_CL        13 // chromaticity derived constant lum
 #define HB_COLR_MAT_ICTCP        14 // ITU-R BT.2100-0, ICtCp
 // 0, 3-5, 8, 11-65535: reserved/not implemented
+#define HB_COLR_RANGE_UNSET     -1
+#define HB_COLR_RANGE_LIMITED    1
+#define HB_COLR_RANGE_FULL       2
 
     hb_mastering_display_metadata_t mastering;
     hb_content_light_metadata_t coll;

--- a/libhb/handbrake/nal_units.h
+++ b/libhb/handbrake/nal_units.h
@@ -42,10 +42,109 @@ size_t hb_nal_unit_write_isomp4(uint8_t *buf, const uint8_t *nal_unit, const siz
 uint8_t* hb_annexb_find_next_nalu(const uint8_t *start, size_t *size);
 
 /*
+ * Search the provided data buffer for NAL units.
+ *
+ * Returns a pointer to the start of the first NAL unit found,
+ * or NULL if no NAL units were found in the buffer.
+ *
+ * On input,  size holds the length of the provided data buffer.
+ * On output, size holds the length of the returned NAL unit.
+ */
+uint8_t* hb_isomp4_find_next_nalu(const uint8_t *start, size_t *size, const uint8_t nal_length_size);
+
+/*
  * Returns a newly-allocated buffer holding a copy of the provided
  * NAL unit bitstream data, converted to the requested format.
  */
 hb_buffer_t* hb_nal_bitstream_annexb_to_mp4(const uint8_t *data, const size_t size);
 hb_buffer_t* hb_nal_bitstream_mp4_to_annexb(const uint8_t *data, const size_t size, const uint8_t nal_length_size);
+
+typedef enum
+{
+    HB_HEVC_NAL_UNIT_CODED_SLICE_TRAIL_N = 0,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_TRAIL_R,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_TSA_N,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_TSA_R,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_STSA_N,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_STSA_R,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_RADL_N,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_RADL_R,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_RASL_N,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_RASL_R,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_BLA_W_LP = 16,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_BLA_W_RADL,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_BLA_N_LP,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_IDR_W_RADL,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_IDR_N_LP,
+    HB_HEVC_NAL_UNIT_CODED_SLICE_CRA,
+    HB_HEVC_NAL_UNIT_VPS = 32,
+    HB_HEVC_NAL_UNIT_SPS,
+    HB_HEVC_NAL_UNIT_PPS,
+    HB_HEVC_NAL_UNIT_ACCESS_UNIT_DELIMITER,
+    HB_HEVC_NAL_UNIT_EOS,
+    HB_HEVC_NAL_UNIT_EOB,
+    HB_HEVC_NAL_UNIT_FILLER_DATA,
+    HB_HEVC_NAL_UNIT_PREFIX_SEI,
+    HB_HEVC_NAL_UNIT_SUFFIX_SEI,
+    HB_HEVC_NAL_UNIT_UNSPECIFIED = 62,
+    HB_HEVC_NAL_UNIT_INVALID = 64,
+} hb_nal_type_t;
+
+typedef enum
+{
+    HB_BUFFERING_PERIOD                     = 0,
+    HB_PICTURE_TIMING                       = 1,
+    HB_PAN_SCAN_RECT                        = 2,
+    HB_FILLER_PAYLOAD                       = 3,
+    HB_USER_DATA_REGISTERED_ITU_T_T35       = 4,
+    HB_USER_DATA_UNREGISTERED               = 5,
+    HB_RECOVERY_POINT                       = 6,
+    HB_SCENE_INFO                           = 9,
+    HB_FULL_FRAME_SNAPSHOT                  = 15,
+    HB_PROGRESSIVE_REFINEMENT_SEGMENT_START = 16,
+    HB_PROGRESSIVE_REFINEMENT_SEGMENT_END   = 17,
+    HB_FILM_GRAIN_CHARACTERISTICS           = 19,
+    HB_POST_FILTER_HINT                     = 22,
+    HB_TONE_MAPPING_INFO                    = 23,
+    HB_FRAME_PACKING                        = 45,
+    HB_DISPLAY_ORIENTATION                  = 47,
+    HB_SOP_DESCRIPTION                      = 128,
+    HB_ACTIVE_PARAMETER_SETS                = 129,
+    HB_DECODING_UNIT_INFO                   = 130,
+    HB_TEMPORAL_LEVEL0_INDEX                = 131,
+    HB_DECODED_PICTURE_HASH                 = 132,
+    HB_SCALABLE_NESTING                     = 133,
+    HB_REGION_REFRESH_INFO                  = 134,
+    HB_MASTERING_DISPLAY_INFO               = 137,
+    HB_CONTENT_LIGHT_LEVEL_INFO             = 144,
+    HB_ALTERNATIVE_TRANSFER_CHARACTERISTICS = 147,
+    HB_AMBIENT_VIEWING_ENVIRONMENT          = 148,
+} hb_sei_type_t;
+
+typedef struct hb_nal_s
+{
+    hb_nal_type_t  type;
+    size_t         payload_size;
+    const uint8_t *payload;
+} hb_nal_t;
+
+typedef struct hb_sei_s
+{
+    hb_sei_type_t  type;
+    size_t         payload_size;
+    const uint8_t *payload;
+} hb_sei_t;
+
+/*
+ * Returns a newly-allocated buffer holding a copy of the provided
+ * NAL unit bitstream data plus the sei.
+ */
+hb_buffer_t * hb_isomp4_hevc_nal_bitstream_insert_payloads(const uint8_t *data,
+                                                           const size_t size,
+                                                           const hb_sei_t *sei,
+                                                           const size_t sei_count,
+                                                           const hb_nal_t *nals,
+                                                           const size_t nal_count,
+                                                           const uint8_t nal_length_size);
 
 #endif // HANDBRAKE_NAL_UNITS_H

--- a/libhb/nal_units.c
+++ b/libhb/nal_units.c
@@ -1,6 +1,7 @@
 /* nal_units.c
  *
  * Copyright (c) 2003-2024 HandBrake Team
+ * Copyright (c) FFmpeg
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.
@@ -49,6 +50,38 @@ size_t hb_nal_unit_write_isomp4(uint8_t *buf,
     return sizeof(length) + nal_unit_size;
 }
 
+size_t hb_nal_unit_payload_write_isomp4(uint8_t *buf,
+                                        const uint8_t *payload,
+                                        size_t payload_size,
+                                        const int nal_type,
+                                        const uint8_t nal_length_size)
+{
+    int i;
+    uint8_t length[4]; // 4-byte length replaces Annex B start code prefix
+    uint8_t header[2]; // 2-byte NAL header
+
+    size_t nal_unit_size = payload_size + 2;
+
+    if (buf != NULL)
+    {
+        for (i = 0; i < nal_length_size; i++)
+        {
+            length[i] = (nal_unit_size >> (8 * (nal_length_size - 1 - i))) & 0xff;
+        }
+
+        header[0] = nal_type << 1;
+        header[1] = 1;
+
+        memcpy(buf, &length[0], nal_length_size);
+        buf += nal_length_size;
+        memcpy(buf, &header[0], sizeof(header));
+        buf += sizeof(header);
+        memcpy(buf, payload, payload_size);
+    }
+
+    return nal_length_size + nal_unit_size;
+}
+
 uint8_t* hb_annexb_find_next_nalu(const uint8_t *start, size_t *size)
 {
     uint8_t *nal = NULL;
@@ -93,6 +126,39 @@ uint8_t* hb_annexb_find_next_nalu(const uint8_t *start, size_t *size)
     return  nal;
 }
 
+uint8_t* hb_isomp4_find_next_nalu(const uint8_t *start, size_t *size, const uint8_t nal_length_size)
+{
+    uint8_t *nal = NULL;
+    uint8_t *buf = (uint8_t*)start;
+    uint8_t *end = (uint8_t*)start + *size;
+
+    if (nal_length_size > 4)
+    {
+        return NULL;
+    }
+
+    while (end - buf > nal_length_size)
+    {
+        uint8_t length[4]; // 4-byte length replaces Annex B start code prefix
+        size_t nal_unit_size = 0;
+
+        memcpy(length, buf, nal_length_size);
+
+        for (int i = 0; i < nal_length_size; i++)
+        {
+            nal_unit_size <<= 8;
+            nal_unit_size |= length[i];
+        }
+
+        nal = buf;
+        *size = nal_unit_size + nal_length_size;
+
+        return nal;
+    }
+
+    return NULL;
+}
+
 hb_buffer_t* hb_nal_bitstream_annexb_to_mp4(const uint8_t *data,
                                             const size_t size)
 {
@@ -133,7 +199,7 @@ hb_buffer_t* hb_nal_bitstream_annexb_to_mp4(const uint8_t *data,
 }
 
 static size_t mp4_nal_unit_length(const uint8_t *data,
-                                  const size_t nal_length_size,
+                                  const uint8_t nal_length_size,
                                   size_t *nal_unit_length)
 {
     uint8_t i;
@@ -189,6 +255,306 @@ hb_buffer_t* hb_nal_bitstream_mp4_to_annexb(const uint8_t *data,
         buf      += mp4_nal_unit_length(buf, nal_length_size, &nal_size);
         out_size += hb_nal_unit_write_annexb(out->data + out_size, buf, nal_size);
         buf      += nal_size;
+    }
+
+    return out;
+}
+
+static int is_post_hevc_sei_nal_type(int nal_type)
+{
+    return nal_type != HB_HEVC_NAL_UNIT_PREFIX_SEI &&
+           nal_type != HB_HEVC_NAL_UNIT_SPS &&
+           nal_type != HB_HEVC_NAL_UNIT_PPS &&
+           nal_type != HB_HEVC_NAL_UNIT_ACCESS_UNIT_DELIMITER;
+}
+
+/**
+ * Copies the data inserting emulation prevention bytes as needed.
+ * Existing data in the destination can be taken into account by providing
+ * dst with a dst_offset > 0.
+ *
+ * @return The number of bytes copied on success. On failure, the negative of
+ *         the number of bytes needed to copy src is returned.
+ */
+static int copy_emulation_prev(const uint8_t *src,
+                               size_t         src_size,
+                               uint8_t       *dst,
+                               ssize_t        dst_offset,
+                               size_t         dst_size)
+{
+    int zeros = 0;
+    int wrote_bytes = 0;
+    uint8_t *dst_end = dst ? dst + dst_size : NULL;
+    const uint8_t* src_end = src + src_size;
+    int start_at = dst_offset > 2 ? dst_offset - 2 : 0;
+
+    for (int i = start_at; i < dst_offset && i < dst_size; i++)
+    {
+        if (!dst[i])
+        {
+            zeros++;
+        }
+        else
+        {
+            zeros = 0;
+        }
+    }
+
+    if (dst)
+    {
+        dst += dst_offset;
+    }
+    for (; src < src_end;)
+    {
+        if (zeros == 2)
+        {
+            int insert_ep3_byte = *src <= 3;
+            if (insert_ep3_byte)
+            {
+                if (dst < dst_end)
+                {
+                    *dst = 3;
+                }
+                if (dst)
+                {
+                    dst++;
+                }
+                wrote_bytes++;
+            }
+
+            zeros = 0;
+        }
+
+        if (dst < dst_end)
+        {
+            *dst = *src;
+        }
+
+        if (!*src)
+        {
+            zeros++;
+        }
+        else
+        {
+            zeros = 0;
+        }
+
+        src++;
+        if (dst)
+        {
+            dst++;
+        }
+        wrote_bytes++;
+    }
+
+    if (!dst)
+    {
+        return -wrote_bytes;
+    }
+
+    return wrote_bytes;
+}
+
+/**
+ * Returns a sufficient number of bytes to contain the sei data.
+ * It may be greater than the minimum required.
+ */
+static int get_sei_msg_bytes(const uint8_t *sei_data, const size_t sei_size, int type)
+{
+    int copied_size;
+    if (sei_size == 0)
+    {
+        return 0;
+    }
+
+    copied_size = -copy_emulation_prev(sei_data,
+                                       sei_size,
+                                       NULL,
+                                       0,
+                                       0);
+
+    if ((sei_size % 255) == 0) //may result in an extra byte
+    {
+        copied_size++;
+    }
+
+    return copied_size + sei_size / 255 + 1 + type / 255 + 1;
+}
+
+size_t hb_sei_unit_write_isomp4(const uint8_t *sei,
+                                const size_t   sei_size,
+                                int            sei_type,
+                                uint8_t       *dst,
+                                size_t         dst_size,
+                                const uint8_t  nal_length_size)
+{
+    size_t remaining_sei_size = sei_size;
+    size_t remaining_dst_size = dst_size;
+    int sei_header_bytes;
+    int bytes_written = 0;
+    ssize_t offset;
+
+    if (!remaining_dst_size)
+    {
+        return -1;
+    }
+
+    size_t sei_nalu_size = dst_size - nal_length_size;
+
+    uint8_t length[4]; // up to 4-byte length replaces Annex B start code prefix
+    uint8_t header[2]; // 2-byte NAL header
+
+    for (int i = 0; i < nal_length_size; i++)
+    {
+        length[i] = (sei_nalu_size >> (8 * (nal_length_size - 1 - i))) & 0xff;
+    }
+    memcpy(dst, &length[0], nal_length_size);
+    dst += nal_length_size;
+
+    // NAL Header
+    header[0] = HB_HEVC_NAL_UNIT_PREFIX_SEI << 1;
+    header[1] = 1;
+
+    memcpy(dst, &header[0], sizeof(header));
+    dst += sizeof(header);
+
+    remaining_dst_size -= nal_length_size + sizeof(header);
+
+    uint8_t *sei_start = dst;
+
+    while (sei_type && remaining_dst_size != 0)
+    {
+        int sei_byte = sei_type > 255 ? 255 : sei_type;
+        *dst = sei_byte;
+
+        sei_type -= sei_byte;
+        dst++;
+        remaining_dst_size--;
+    }
+
+    if (!dst_size)
+    {
+        return -1;
+    }
+
+    while (remaining_sei_size && remaining_dst_size != 0)
+    {
+        int size_byte = remaining_sei_size > 255 ? 255 : remaining_sei_size;
+        *dst = size_byte;
+
+        remaining_sei_size -= size_byte;
+        dst++;
+        remaining_dst_size--;
+    }
+
+    if (remaining_dst_size < sei_size)
+    {
+        return -1;
+    }
+
+    sei_header_bytes = dst - sei_start;
+
+    offset = sei_header_bytes;
+    bytes_written = copy_emulation_prev(sei,
+                                        sei_size,
+                                        sei_start,
+                                        offset,
+                                        dst_size - nal_length_size - sizeof(header) - 1);
+    if (bytes_written < 0)
+    {
+        return -1;
+    }
+
+    remaining_dst_size -= bytes_written;
+
+    if (remaining_dst_size < 1)
+    {
+        return -1;
+    }
+
+    // rbsp_stop_one_bit
+    dst+= bytes_written;
+    *dst = 0x80;
+
+    return nal_length_size + sizeof(header) + sei_header_bytes + bytes_written + 1;
+}
+
+hb_buffer_t * hb_isomp4_hevc_nal_bitstream_insert_payloads(const uint8_t *data,
+                                                           const size_t size,
+                                                           const hb_sei_t *seis,
+                                                           const size_t sei_count,
+                                                           const hb_nal_t *nals,
+                                                           const size_t nal_count,
+                                                           const uint8_t nal_length_size)
+{
+    hb_buffer_t *out;
+    const uint8_t *buf, *end;
+    uint8_t *out_data;
+    size_t out_size = 0, buf_size;
+
+    size_t sei_nalu_size[4];
+    uint8_t sei_written[4];
+
+    if ((seis == NULL || sei_count == 0) &&
+        (nals == NULL || nal_count == 0))
+    {
+        return NULL;
+    }
+
+    for (int i = 0; i < sei_count; i++)
+    {
+        size_t msg_size = get_sei_msg_bytes(seis[i].payload, seis[i].payload_size, seis[i].type);
+        sei_nalu_size[i] = nal_length_size + 2 + msg_size + 1;
+        sei_written[i] = 0;
+
+        out_size += sei_nalu_size[i];
+    }
+
+    for (int i = 0; i < nal_count; i++)
+    {
+        size_t nalu_size = nal_length_size + 2 + nals[i].payload_size;
+        out_size += nalu_size;
+    }
+
+    out_size += size;
+
+    out = hb_buffer_init(out_size);
+    if (out == NULL)
+    {
+        hb_error("hb_nal_bitstream_insert_sei: hb_buffer_init failed");
+        return NULL;
+    }
+
+    buf_size = size;
+    buf      = data;
+    end      = data + size;
+    out_data = out->data;
+
+    while ((buf = hb_isomp4_find_next_nalu(buf, &buf_size, nal_length_size)) != NULL)
+    {
+        uint8_t nal_type = buf[nal_length_size] >> 1;
+
+        for (int i = 0; i < sei_count; i++)
+        {
+            if (!sei_written[i] && is_post_hevc_sei_nal_type(nal_type))
+            {
+                out_data += hb_sei_unit_write_isomp4(seis[i].payload, seis[i].payload_size, seis[i].type,
+                                                     out_data, sei_nalu_size[i], nal_length_size);
+                sei_written[i] = 1;
+            }
+        }
+
+        memcpy(out_data, buf, buf_size);
+        out_data += buf_size;
+        buf      += buf_size;
+        buf_size  = end - buf;
+    }
+
+    for (int i = 0; i < nal_count; i++)
+    {
+        // Append the DOVI RPU payload at the end
+        out_data += hb_nal_unit_payload_write_isomp4(out_data, nals[i].payload, nals[i].payload_size,
+                                                     nals[i].type, nal_length_size);
     }
 
     return out;

--- a/libhb/platform/macosx/cv_utils.c
+++ b/libhb/platform/macosx/cv_utils.c
@@ -216,6 +216,19 @@ CFStringRef hb_cv_colr_mat_xlat(int color_matrix)
     }
 }
 
+CFStringRef hb_cv_colr_range_xlat(int color_range)
+{
+    switch (color_range)
+    {
+        case HB_COLR_RANGE_LIMITED:
+            return kCVPixelFormatComponentRange_VideoRange;
+        case HB_COLR_RANGE_FULL:
+            return kCVPixelFormatComponentRange_FullRange;
+        default:
+            return NULL;
+    }
+}
+
 CFStringRef hb_cv_chroma_loc_xlat(int chroma_location)
 {
     switch (chroma_location)

--- a/libhb/platform/macosx/cv_utils.h
+++ b/libhb/platform/macosx/cv_utils.h
@@ -26,6 +26,7 @@ CFStringRef hb_cv_colr_pri_xlat(int color_prim);
 CFStringRef hb_cv_colr_tra_xlat(int color_transfer);
 CFNumberRef hb_cv_colr_gamma_xlat(int color_transfer) CF_RETURNS_RETAINED;
 CFStringRef hb_cv_colr_mat_xlat(int color_matrix);
+CFStringRef hb_cv_colr_range_xlat(int color_range);
 CFStringRef hb_cv_chroma_loc_xlat(int chroma_location);
 
 void hb_cv_add_color_tag(CVPixelBufferRef pix_buf,

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -661,6 +661,8 @@ void hb_display_job_info(hb_job_t *job)
 
         hb_log("     + color profile: %d-%d-%d",
                job->color_prim, job->color_transfer, job->color_matrix);
+        hb_log("     + color range: %s",
+                av_color_range_name(job->color_range));
         hb_log("     + chroma location: %s",
                av_chroma_location_name(job->chroma_location));
 
@@ -1522,7 +1524,8 @@ static void sanitize_dynamic_hdr_metadata_passthru(hb_job_t *job)
         return;
     }
 
-    if (job->vcodec != HB_VCODEC_X265_10BIT &&
+    if (job->vcodec != HB_VCODEC_X265_10BIT    &&
+        job->vcodec != HB_VCODEC_VT_H265_10BIT &&
         job->vcodec != HB_VCODEC_SVT_AV1_10BIT)
     {
         job->passthru_dynamic_hdr_metadata &= ~HDR_10_PLUS;
@@ -1532,7 +1535,8 @@ static void sanitize_dynamic_hdr_metadata_passthru(hb_job_t *job)
     if ((job->dovi.dv_profile != 5 &&
          job->dovi.dv_profile != 7 &&
          job->dovi.dv_profile != 8) ||
-         job->vcodec != HB_VCODEC_X265_10BIT)
+        (job->vcodec != HB_VCODEC_X265_10BIT &&
+         job->vcodec != HB_VCODEC_VT_H265_10BIT))
     {
         job->passthru_dynamic_hdr_metadata &= ~DOVI;
     }


### PR DESCRIPTION
Added some new functions to nal_utils.c to insert nal payloads and sei in the HEVC bitstream and modified encvt.c to insert the Dolby Vision and HDR10 Plus dynamic metadata.

Can be (easily?) expanded to others hardware encoders, the main issue is how to insert the right metadata in the reordered encoded frames.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux