### PR TITLE
LinuxGUI: Fixed the "All Files" open file dialog filter to really show all files

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -5400,7 +5400,7 @@ GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
 static void
 add_video_file_filters (GtkFileChooser *chooser, signal_user_data_t *ud)
 {
-    ghb_add_file_filter(chooser, ud, _("All Files"), "SourceFilterAll");
+    ghb_add_file_filter(chooser, ud, _("All Files"), "FilterAll");
     ghb_add_file_filter(chooser, ud, _("Video"), "SourceFilterVideo");
     ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/mp4"), "SourceFilterMP4");
     ghb_add_file_filter(chooser, ud, g_content_type_get_description("video/mp2t"), "SourceFilterTS");


### PR DESCRIPTION
**Description of Change:**

Fixed the `All Files` open file dialog filter to really show all files.

This restores the behaviour of HandBrake 1.6.x.  See:
https://github.com/HandBrake/HandBrake/blob/b94291a97d0587ba1ce23a87f6987ec78248ec8c/gtk/src/main.c#L1147

This fixes the scenario where user opens a DVD disc via a Linux device (e.g. `/dev/sr0`).

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
