### PR TITLE
Automatically regenerate file names after selecting presets

### DIFF
--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1868,15 +1868,11 @@ namespace HandBrakeWPF.ViewModels
 
                     this.isSettingPreset = false;
 
-                    if (this.userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming) && this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null)
+                    if (this.userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming))
                     {
-                        if (this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat).Contains(Constants.Preset))
-                        {
-                            this.Destination = AutoNameHelper.AutoName(this.CurrentTask, this.SelectedTitle?.DisplaySourceName, this.SelectedTitle?.DisplaySourceName, this.selectedPreset);
-                        }
+                        if(this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null)
+                            this.ReGenerateAutoName();
                     }
-
-                    this.ReGenerateAutoName();
 
                     return true;
                 }

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1876,6 +1876,8 @@ namespace HandBrakeWPF.ViewModels
                         }
                     }
 
+                    this.ReGenerateAutoName();
+
                     return true;
                 }
             }


### PR DESCRIPTION
**Description of Change:**
#5670




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
