### PR TITLE
WinGui:Merge AutoNameHelper.AutoName call into TriggerAutonameChange.

### DIFF
--- a/win/CS/HandBrakeWPF/Model/ChangedOption.cs
+++ b/win/CS/HandBrakeWPF/Model/ChangedOption.cs
@@ -12,6 +12,7 @@ namespace HandBrakeWPF.Model
         Quality,
         Bitrate,
         Encoder,
+        Chapters,
         Dimensions
     }
 }


### PR DESCRIPTION
**Description of Change:**

Merge multiple AutoName parameters with the same value to simplify:

 if (this.userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming))
 if (this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) != null)

![20240111034831](https://github.com/HandBrake/HandBrake/assets/37351410/35b2f773-3f48-4e20-a4e4-61d28f6fef00)
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
