### PR TITLE
SVT-AV1: Increase memory buffers slightly

### DIFF
--- a/contrib/svt-av1/A02-SVT18-EbEncHandle.patch
+++ b/contrib/svt-av1/A02-SVT18-EbEncHandle.patch
@@ -1,0 +1,7 @@
+--- a/Source/Lib/Encoder/Globals/EbEncHandle.c	Sat Dec  9 09:30:29 2023
++++ b/Source/Lib/Encoder/Globals/EbEncHandle.c	Sat Dec  9 09:31:35 2023
+@@ -657,3 +657,3 @@
+ 
+-        max_input  = min_input + (1 + mg_size) * n_extra_mg;
++        max_input  = min_input + (1 + mg_size) * (n_extra_mg + 1);
+         max_parent = max_input;


### PR DESCRIPTION
**Description of Change:**
This change increases the memory buffers slightly for SVT-AV1. This improves the encoding speed on HandBrake when QSV decoding is used. It allows SVT-AV1 to "go ahead" further and process more picture control sets ahead of time. The results are a higher amount of CPU parallelization on an i9-12900k. SVT-AV1 doesn't take into account software accelerated decoding. It is also designed for a server environment. HandBrake is mostly a desktop environment, which benefits from higher memory buffers.

**Testing Conditions**
SVT-AV1 Mode 3 CRF with 1080p AVC source and QSV decoding.
SVT-AV1 Mode 3 CRF with 2160p HEVC source and QSV decoding.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux