### PR TITLE
Contrib: update amf to 1.4.33

### DIFF
--- a/contrib/amf/module.defs
+++ b/contrib/amf/module.defs
@@ -2,12 +2,12 @@ $(eval $(call import.MODULE.defs,AMF,amf))
 $(eval $(call import.CONTRIB.defs,AMF))
 
 # Repacked slim tarball removes large third party binaries included upstream
-AMF.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/AMF-1.4.30-slim.tar.gz
-AMF.FETCH.sha256   = 665bd83dc7facb407e9e32168e38f9a1e0f37cd3802f4409d3889a3bcaec908f
-#AMF.FETCH.url      = https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/refs/tags/v1.4.30.tar.gz
-#AMF.FETCH.sha256   = 4a9d43c730a76df6636932cee007917409d5b3607b61cecdf6dfab410f7b5f1d
-#AMF.FETCH.basename = AMF-1.4.30.tar.gz
-AMF.EXTRACT.tarbase = AMF-1.4.30
+#AMF.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/AMF-1.4.33-slim.tar.gz
+#AMF.FETCH.sha256   = 665bd83dc7facb407e9e32168e38f9a1e0f37cd3802f4409d3889a3bcaec908f
+AMF.FETCH.url      = https://github.com/GPUOpen-LibrariesAndSDKs/AMF/archive/refs/tags/v1.4.33.tar.gz
+AMF.FETCH.sha256   = 86b39d5bd4652338bf7b4e48efec58472bb57a985250bc149e7908534a915c8e
+AMF.FETCH.basename = AMF-1.4.33.tar.gz
+AMF.EXTRACT.tarbase = AMF-1.4.33
 
 AMF.CONFIGURE = $(TOUCH.exe) $@
 AMF.BUILD     = $(TOUCH.exe) $@


### PR DESCRIPTION
**AMF 1.4.33:**

   - Added native DX12 support for encoding and PreAnalysis
   - Vulkan encoder became independent from Vulkan driver
   - Switched to public Vulkan Khronos extensions for decoder
   - AMF on Linux can now be used with AMD Pro Vulkan, and experimentally with RADV drivers
   - Improvements to sample presenters
   - Added new FRC component and API doc
   - Added new VQEnhancer API doc
   - Improvements and cleanup to sample presenters
   - Updated FFmpeg to 6.0

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux