### PR TITLE
libhb: Harden DLL loading. This will no longer look on the standard s…

### DIFF
--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1262,7 +1262,7 @@ void hb_system_sleep_private_disable(void *opaque)
 void * hb_dlopen(const char *name)
 {
 #ifdef SYS_MINGW
-    HMODULE h = LoadLibraryExA(name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    HMODULE h = LoadLibraryExA(name, NULL, LOAD_LIBRARY_SEARCH_SYSTEM32);
 #else
     void *h = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
 #endif

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1262,7 +1262,7 @@ void hb_system_sleep_private_disable(void *opaque)
 void * hb_dlopen(const char *name)
 {
 #ifdef SYS_MINGW
-    HMODULE h = LoadLibraryA(name);
+    HMODULE h = LoadLibraryExA(name, NULL, LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
 #else
     void *h = dlopen(name, RTLD_LAZY | RTLD_LOCAL);
 #endif


### PR DESCRIPTION
 This will no longer look on the standard search path and prioritise app and system32 directories.

https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa



**Tested on:**

- [x] Windows 10+  (via MinGW)


I've validated VCN and NVEnc still work. I need to check QSV
