### PR TITLE
contrib: update xz to 5.4.6

### DIFF
--- a/contrib/xz/module.defs
+++ b/contrib/xz/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,XZ,xz))
 $(eval $(call import.CONTRIB.defs,XZ))
 
-XZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/xz-5.4.5.tar.bz2
-XZ.FETCH.url    += https://tukaani.org/xz/xz-5.4.5.tar.bz2
-XZ.FETCH.sha256  = 8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79
+XZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/xz-5.4.6.tar.bz2
+XZ.FETCH.url    += https://github.com/tukaani-project/xz/releases/download/v5.4.6/xz-5.4.6.tar.bz2
+XZ.FETCH.sha256  = 913851b274e8e1d31781ec949f1c23e8dbcf0ecf6e73a2436dc21769dd3e6f49
 
 XZ.CONFIGURE.extra = \
     --disable-xz \


### PR DESCRIPTION
**XZ 5.4.6:**
 
   - Fixed a bug involving internal function pointers in liblzma not being initialized to NULL. The bug can only be triggered if lzma_filters_update() is called on a LZMA1 encoder, so it does not affect xz or any application known to us that uses liblzma.
   - Fixed a regression introduced in 5.4.2 that caused encoding in the raw format to unnecessarily fail if --suffix was not used.
     For instance, the following command no longer reports that --suffix must be used:
     _echo foo | xz --format=raw --lzma2 | wc -c_
   - Fixed an issue on MinGW-w64 builds that prevented reading from or writing to non-terminal character devices like NUL.
   - Added a new test.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux