### PR TITLE
WinUI: Add Invert Selection option to Queue Selection View

### DIFF
--- a/win/CS/HandBrakeWPF/ViewModels/QueueSelectionViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/QueueSelectionViewModel.cs
@@ -152,13 +152,24 @@ namespace HandBrakeWPF.ViewModels
         }
 
         /// <summary>
-        /// The select all.
+        /// The unselect all.
         /// </summary>
         public void UnSelectAll()
         {
             foreach (var item in TitleList)
             {
                 item.IsSelected = false;
+            }
+        }
+
+        /// <summary>
+        /// Invert selection
+        /// </summary>
+        public void InvertSelection()
+        {
+            foreach (var item in TitleList)
+            {
+                item.IsSelected = !item.IsSelected;
             }
         }
 

--- a/win/CS/HandBrakeWPF/Views/QueueSelectionView.xaml
+++ b/win/CS/HandBrakeWPF/Views/QueueSelectionView.xaml
@@ -58,6 +58,7 @@
                     </MenuItem.Header>
                     <MenuItem Header="Select All" Command="{Binding RelayCommand}" CommandParameter="SelectAll" />
                     <MenuItem Header="Deselect All" Command="{Binding RelayCommand}" CommandParameter="UnSelectAll" />
+                    <MenuItem Header="Invert Selection" Command="{Binding RelayCommand}" CommandParameter="InvertSelection" />
                     <Separator />
                     <MenuItem Header="Order by Title"  Command="{Binding RelayCommand}" CommandParameter="OrderByTitle" />
                     <MenuItem Header="Order by Duration" IsChecked="{Binding OrderedByDuration}" Command="{Binding RelayCommand}" CommandParameter="OrderByDuration" />
@@ -89,6 +90,7 @@
                 <ContextMenu>
                     <MenuItem Header="Select All" Command="{Binding RelayCommand}" CommandParameter="SelectAll" />
                     <MenuItem Header="Deselect All" Command="{Binding RelayCommand}" CommandParameter="UnSelectAll" />
+                    <MenuItem Header="Invert Selection" Command="{Binding RelayCommand}" CommandParameter="InvertSelection" />
                     <Separator />
                     <MenuItem Header="Order by Title" Command="{Binding RelayCommand}" CommandParameter="OrderByTitle" />
                     <MenuItem Header="Order by Duration" Command="{Binding RelayCommand}" CommandParameter="OrderByDuration" />


### PR DESCRIPTION
**Description of Change:**
Fixes issue #5446
Adds Invert Selection option to the Queue Selection View in Windows


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
![image](https://github.com/HandBrake/HandBrake/assets/158429614/f72cc621-0158-4364-acd6-3bc17ce33bdf)