### PR TITLE
LinGUI: Fix default audio gain getting set to -20dB

### DIFF
--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -1898,6 +1898,7 @@ create_audio_settings_row (signal_user_data_t *ud)
     gtk_widget_set_tooltip_markup(GTK_WIDGET(scale),
       _("<b>Audio Gain:</b> "
         "Adjust the amplification or attenuation of the output audio track."));
+    gtk_scale_button_set_value(scale, 0.0);
 
     gtk_widget_set_valign(GTK_WIDGET(scale), GTK_ALIGN_CENTER);
     gtk_widget_set_name(GTK_WIDGET(scale), "AudioTrackGainSlider");


### PR DESCRIPTION
**Description of Change:**
Fixes the issue where audio tracks were getting set to -20dB due the default audio selection settings. Unfortunately it can't fix cases where the incorrect setting was saved to a preset.


**Tested on:**
- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
