### PR TITLE
Linux: Update metainfo for 1.7.3

### DIFF
--- a/gtk/data/fr.handbrake.ghb.metainfo.xml.in
+++ b/gtk/data/fr.handbrake.ghb.metainfo.xml.in
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018-2023 John Stebbins <your@email.com> -->
+<!-- Copyright 2018-2024 John Stebbins <your@email.com> -->
 <component type="desktop-application">
   <id>fr.handbrake.ghb</id>
-  <translation>ghb</translation>
+  <translation type="gettext">ghb</translation>
+  <developer_name>HandBrake Team</developer_name>
   <update_contact>jstebbins.hb_AT_gmail.com</update_contact>
   <launchable type="desktop-id">fr.handbrake.ghb.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
@@ -24,40 +25,6 @@
   <url type="help">https://handbrake.fr/docs/</url>
   <url type="bugtracker">https://github.com/HandBrake/HandBrake/issues</url>
   <url type="translate">https://www.transifex.com/HandBrakeProject/</url>
-  <mimetypes>
-    <mimetype>application/ogg</mimetype>
-    <mimetype>application/x-extension-mp4</mimetype>
-    <mimetype>application/x-flac</mimetype>
-    <mimetype>application/x-matroska</mimetype>
-    <mimetype>application/x-ogg</mimetype>
-    <mimetype>audio/ac3</mimetype>
-    <mimetype>audio/mp4</mimetype>
-    <mimetype>audio/mpeg</mimetype>
-    <mimetype>audio/ogg</mimetype>
-    <mimetype>audio/x-flac</mimetype>
-    <mimetype>audio/x-matroska</mimetype>
-    <mimetype>audio/x-mp2</mimetype>
-    <mimetype>audio/x-mp3</mimetype>
-    <mimetype>audio/x-mpeg</mimetype>
-    <mimetype>audio/x-vorbis</mimetype>
-    <mimetype>video/mp4</mimetype>
-    <mimetype>video/mp4v-es</mimetype>
-    <mimetype>video/mpeg</mimetype>
-    <mimetype>video/msvideo</mimetype>
-    <mimetype>video/quicktime</mimetype>
-    <mimetype>video/vnd.divx</mimetype>
-    <mimetype>video/x-avi</mimetype>
-    <mimetype>video/x-m4v</mimetype>
-    <mimetype>video/x-matroska</mimetype>
-    <mimetype>video/x-mpeg</mimetype>
-    <mimetype>video/x-ms-wmv</mimetype>
-    <mimetype>video/ogg</mimetype>
-    <mimetype>video/x-ogm+ogg</mimetype>
-    <mimetype>video/x-theora+ogg</mimetype>
-    <mimetype>x-content/video-dvd</mimetype>
-    <mimetype>x-content/video-vcd</mimetype>
-    <mimetype>x-content/video-svcd</mimetype>
-  </mimetypes>
 
   <screenshots>
     <screenshot type="default">
@@ -84,6 +51,38 @@
 
   <provides>
     <binary>ghb</binary>
+    <mediatype>application/ogg</mediatype>
+    <mediatype>application/x-extension-mp4</mediatype>
+    <mediatype>application/x-flac</mediatype>
+    <mediatype>application/x-matroska</mediatype>
+    <mediatype>application/x-ogg</mediatype>
+    <mediatype>audio/ac3</mediatype>
+    <mediatype>audio/mp4</mediatype>
+    <mediatype>audio/mpeg</mediatype>
+    <mediatype>audio/ogg</mediatype>
+    <mediatype>audio/x-flac</mediatype>
+    <mediatype>audio/x-matroska</mediatype>
+    <mediatype>audio/x-mp2</mediatype>
+    <mediatype>audio/x-mp3</mediatype>
+    <mediatype>audio/x-mpeg</mediatype>
+    <mediatype>audio/x-vorbis</mediatype>
+    <mediatype>video/mp4</mediatype>
+    <mediatype>video/mp4v-es</mediatype>
+    <mediatype>video/mpeg</mediatype>
+    <mediatype>video/msvideo</mediatype>
+    <mediatype>video/quicktime</mediatype>
+    <mediatype>video/vnd.divx</mediatype>
+    <mediatype>video/x-avi</mediatype>
+    <mediatype>video/x-m4v</mediatype>
+    <mediatype>video/x-matroska</mediatype>
+    <mediatype>video/x-mpeg</mediatype>
+    <mediatype>video/x-ms-wmv</mediatype>
+    <mediatype>video/ogg</mediatype>
+    <mediatype>video/x-ogm+ogg</mediatype>
+    <mediatype>video/x-theora+ogg</mediatype>
+    <mediatype>x-content/video-dvd</mediatype>
+    <mediatype>x-content/video-vcd</mediatype>
+    <mediatype>x-content/video-svcd</mediatype>
   </provides>
 
   <recommends>
@@ -100,6 +99,11 @@
   </requires>
 
   <releases>
+    <release version="1.7.3" date="2024-02-09">
+      <description>
+        <p>Fixes an issue where adding a new default audio track automatically set the gain to -20dB.</p>
+      </description>
+    </release>
     <release version="1.7.2" date="2023-12-17">
       <description>
         <p>Addresses an issue where the file chooser opens in the home directory instead of the folder that was previously selected.</p>


### PR DESCRIPTION
**Description of Change:**

Updates the metainfo file in order to fix the version number as needed for the Flatpak build.


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux