### PR TITLE
contrib: update libdav1d to 1.4.0

### DIFF
--- a/contrib/libdav1d/A99-pkgconfig-location.patch
+++ b/contrib/libdav1d/A99-pkgconfig-location.patch
@@ -1,6 +1,6 @@
---- dav1d-0.5.1/src/meson.build.orig    2019-10-26 04:38:21.000000000 +0900
-+++ dav1d-0.5.1/src/meson.build 2020-02-27 16:48:19.664008000 +0900
-@@ -288,6 +288,7 @@
+--- dav1d-1.4.0/src/meson.build	2024-02-14 19:06:02.000000000 +0100
++++ dav1d-1.4.0-patched/src/meson.build	2024-02-15 17:27:23.400210200 +0100
+@@ -370,6 +370,7 @@
  #
  pkg_mod = import('pkgconfig')
  pkg_mod.generate(libraries: libdav1d,

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-1.3.0.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.3.0/dav1d-1.3.0.tar.bz2
-LIBDAV1D.FETCH.sha256  = bde8db3d0583a4f3733bb5a4ac525556ffd03ab7dcd8a6e7c091bee28d9466b1
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-1.4.0.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.4.0/dav1d-1.4.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = 7661648c95755db3d61857b3fdc427fa6d3271a573e84fd11c235441965e9397
 
 LIBDAV1D.build_dir     = build/
 


### PR DESCRIPTION
**libdav1d 1.4.0:**

_**This version focusing on new architecture support and new optimizations:**_

AVX-512 optimizations for z1, z2, z3 in 8bit and high-bitdepth
New architecture supported: loongarch
Loongarch optimizations for 8bit
New architecture supported: RISC-V
RISC-V optimizations for itx
Misc improvements in threading and in reducing binary size
Fix potential integer overflow with extremely large frame sizes

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux