### PR TITLE
contrib: fix reading dvdsub in mp4.

### DIFF
--- a/contrib/ffmpeg/A05-dvdsubdec-fix-processing-of-partial-packets.patch
+++ b/contrib/ffmpeg/A05-dvdsubdec-fix-processing-of-partial-packets.patch
@@ -1,42 +1,55 @@
-From b5846bbdf2bea0ec40ab68fbb5440e17a9390f65 Mon Sep 17 00:00:00 2001
-From: John Stebbins <jstebbins@jetheaddev.com>
-Date: Wed, 11 Dec 2019 14:10:09 -0800
+From 263190a74a245423833bd6e1bc10726577e5502d Mon Sep 17 00:00:00 2001
+From: Damiano Galassi <damiog@gmail.com>
+Date: Sun, 25 Feb 2024 16:52:20 +0100
 Subject: [PATCH] dvdsubdec: fix processing of partial packets
 
 Wait for a complete dvd subtitle before processing.
 
-If the input packet is large enough to start processing, but does not
-contain complete data, unfinished results are emitted and the following
-input packet causes an error because the stream is no longer in sync
-with the decoder.
+If the input packet is large enough to start processing, but does not contain complete data, unfinished results are emitted and the following input packet causes an error because the stream is no longer in sync with the decoder.
+
+Original patch by John Stebbins.
 ---
- libavcodec/dvdsubdec.c | 12 ++++++------
- 1 file changed, 6 insertions(+), 6 deletions(-)
+ libavcodec/dvdsubdec.c | 24 +++++++++++++++++-------
+ 1 file changed, 17 insertions(+), 7 deletions(-)
 
 diff --git a/libavcodec/dvdsubdec.c b/libavcodec/dvdsubdec.c
-index 741ea9fd1e..c0c9962bad 100644
+index a5da0d7b08..bee42e3c61 100644
 --- a/libavcodec/dvdsubdec.c
 +++ b/libavcodec/dvdsubdec.c
-@@ -232,7 +232,7 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
+@@ -229,7 +229,10 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
+     uint32_t size;
      int64_t offset1, offset2;
  
-     if (buf_size < 10)
--        return -1;
+-    if (buf_size < 10)
++    if (buf_size < 2)
 +        return AVERROR(EAGAIN);
++
++    if (buf_size == 2 && AV_RB16(buf) == 0)
+         return -1;
  
      if (AV_RB16(buf) == 0) {   /* HD subpicture with 4-byte offsets */
-         big_offsets = 1;
-@@ -247,12 +247,12 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
+@@ -242,15 +245,22 @@ static int decode_dvd_subtitles(DVDSubContext *ctx, AVSubtitle *sub_header,
+         cmd_pos = 2;
+     }
+ 
++    if (big_offsets && buf_size < 6)
++        return AVERROR(EAGAIN);
++
      size = READ_OFFSET(buf + (big_offsets ? 2 : 0));
-     cmd_pos = READ_OFFSET(buf + cmd_pos);
+-    cmd_pos = READ_OFFSET(buf + cmd_pos);
  
 -    if (cmd_pos < 0 || cmd_pos > buf_size - 2 - offset_size) {
 -        if (cmd_pos > size) {
 -            av_log(ctx, AV_LOG_ERROR, "Discarding invalid packet\n");
 -            return 0;
 -        }
++    if (size == 0)
++        return -1;
++
 +    if (buf_size < size)
          return AVERROR(EAGAIN);
++
++    cmd_pos = READ_OFFSET(buf + cmd_pos);
 +
 +    if (cmd_pos < 0 || cmd_pos > size) {
 +        av_log(ctx, AV_LOG_ERROR, "Discarding invalid packet\n");
@@ -45,5 +58,5 @@ index 741ea9fd1e..c0c9962bad 100644
  
      while (cmd_pos > 0 && cmd_pos < buf_size - 2 - offset_size) {
 -- 
-2.23.0
+2.39.3 (Apple Git-146)
 


### PR DESCRIPTION
The patch modified dvdsubdec.c to wait for more data even if the packet was smaller than 10 bytes, however dvdsub in mp4 uses zero filled two bytes buffers for empty segments, and the patch caused these empty packets to be merged with the others valid packets, creating invalid data and so nothing was ever decoded.

Partial packets are still processed properly in the few DVD I tried.

Fix  #5747