### PR TITLE
contrib: update xz to 5.6.0

### DIFF
--- a/contrib/xz/module.defs
+++ b/contrib/xz/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,XZ,xz))
 $(eval $(call import.CONTRIB.defs,XZ))
 
-XZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/xz-5.4.5.tar.bz2
-XZ.FETCH.url    += https://tukaani.org/xz/xz-5.4.5.tar.bz2
-XZ.FETCH.sha256  = 8ccf5fff868c006f29522e386fb4c6a1b66463fbca65a4cfc3c4bd596e895e79
+XZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/xz-5.6.0.tar.bz2
+XZ.FETCH.url    += https://github.com/tukaani-project/xz/releases/download/v5.6.0/xz-5.6.0.tar.bz2
+XZ.FETCH.sha256  = 88c8631cefba91664fdc47b14bb753e1876f4964a07db650821d203992b1e1ea
 
 XZ.CONFIGURE.extra = \
     --disable-xz \


### PR DESCRIPTION
**XZ 5.6.0:**

This bumps the minor version of liblzma because new features were
added. The API and ABI are still backward compatible with liblzma
5.4.x and 5.2.x and 5.0.x.

NOTE: The core components are now under the BSD Zero Clause License (0BSD).

- liblzma:
  Disabled the branchless C variant in the LZMA decoder based
  on the benchmark results from the community.
  
  Disabled x86-64 inline assembly on x32 to fix the build.

- Sandboxing support in xz:
  Landlock is now used even when xz needs to create files.
  In this case the sandbox is has to be more permissive than
  when no files need to be created. A similar thing was
  already in use with pledge(2) since 5.3.4alpha.

  Landlock and pledge(2) are now stricter when reading from
  more than one input file and only writing to standard output.

  Added support for Landlock ABI version 4.

- CMake:
  Default to -O2 instead of -O3 with CMAKE_BUILD_TYPE=Release.
  -O3 is not useful for speed and makes the code larger.

  Now builds lzmainfo and lzmadec.

  xzdiff, xzgrep, xzless, xzmore, and their symlinks are now
  installed. The scripts are also tested during "make test".

  Added translation support for xz, lzmainfo, and the man pages.

  Applied the symbol versioning workaround for MicroBlaze that
  is used in the Autotools build.

  The general XZ Utils and liblzma API documentation is now installed.

  The CMake component names were changed a little and several
  were added. liblzma_Runtime and liblzma_Development are
  unchanged.

  Minimum required CMake version is now 3.14. However,
  translation support is disabled with CMake versions
  older than 3.20.

  The CMake-based build is now close to feature parity with the
  Autotools-based build. Most importantly a few tests aren't
  run yet. Testing the CMake-based build on different operating
  systems would be welcome now. See the comment at the top of
  CMakeLists.txt.

- Fixed a bug in the Autotools feature test for ARM64 CRC32
  instruction support for old versions of Clang. This did not
  affect the CMake build.

- Windows:
  The build instructions in INSTALL and windows/INSTALL*.txt
  were revised completely.

  windows/build-with-cmake.bat along with the instructions
  in windows/INSTALL-MinGW-w64_with_CMake.txt should make
  it very easy to build liblzma.dll and xz.exe on Windows
  using CMake and MinGW-w64 with either GCC or Clang/LLVM.

  windows/build.bash was updated. It now works on MSYS2 and
  on GNU/Linux (cross-compiling) to create a .zip and .7z
  package for 32-bit and 64-bit x86 using GCC + MinGW-w64.

- The TODO file is no longer installed as part of the
  documentation. The file is out of date and does not reflect
  the actual tasks that will be completed in the future.

- Translations:
  Translated lzmainfo man pages are now installed. These
  had been forgotten in earlier versions.

  Updated Croatian, Esperanto, German, Hungarian, Korean,
  Polish, Romanian, Spanish, Swedish, Vietnamese, and Ukrainian
  translations.

  Updated German, Korean, Romanian, and Ukrainian man page
  translations.

- Added a few tests.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux