### PR TITLE
libhb: refactor extradata handling.

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -50,6 +50,7 @@
 #include "handbrake/hwaccel.h"
 #include "handbrake/lang.h"
 #include "handbrake/audio_resample.h"
+#include "handbrake/extradata.h"
 
 #if HB_PROJECT_FEATURE_QSV
 #include "libavutil/hwcontext_qsv.h"
@@ -822,7 +823,8 @@ static int parse_adts_extradata( hb_audio_t * audio, AVCodecContext * context,
         return ret;
     }
 
-    if (audio->priv.config.extradata.length == 0)
+    if (audio->priv.extradata == NULL ||
+        (audio->priv.extradata && audio->priv.extradata->size == 0))
     {
         const uint8_t * extradata;
         size_t          size;
@@ -831,10 +833,7 @@ static int parse_adts_extradata( hb_audio_t * audio, AVCodecContext * context,
                                             &size);
         if (extradata != NULL && size > 0)
         {
-            int len;
-            len = MIN(size, HB_CONFIG_MAX_SIZE);
-            memcpy(audio->priv.config.extradata.bytes, extradata, len);
-            audio->priv.config.extradata.length = len;
+            hb_set_extradata(&audio->priv.extradata, extradata, size);
         }
     }
 

--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -10,6 +10,7 @@
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
 #include "handbrake/decavsub.h"
+#include "handbrake/extradata.h"
 
 struct hb_avsub_context_s
 {
@@ -129,14 +130,14 @@ hb_avsub_context_t * decavsubInit( hb_work_object_t * w, hb_job_t * job )
             case AV_CODEC_ID_EIA_608:
             {
                 // Mono font for CC
-                hb_subtitle_add_ssa_header(ctx->subtitle, HB_FONT_MONO,
-                    20, 384, 288);
+                hb_set_ssa_extradata(&ctx->subtitle->extradata,
+                                     HB_FONT_MONO, 20, 384, 288);
             } break;
 
             default:
             {
-                hb_subtitle_add_ssa_header(ctx->subtitle, HB_FONT_SANS,
-                    .066 * job->title->geometry.height, width, height);
+                hb_set_ssa_extradata(&ctx->subtitle->extradata, HB_FONT_SANS,
+                                     .066 * job->title->geometry.height, width, height);
             } break;
         }
     }

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -16,6 +16,7 @@
 #include "handbrake/handbrake.h"
 #include "handbrake/colormap.h"
 #include "handbrake/decavsub.h"
+#include "handbrake/extradata.h"
 
 struct start_and_end {
     unsigned long start, end;
@@ -566,9 +567,9 @@ static int decsrtInit( hb_work_object_t * w, hb_job_t * job )
     // Generate generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_SANS,
-                               .066 * job->title->geometry.height,
-                               width, height);
+    hb_set_ssa_extradata(&w->subtitle->extradata, HB_FONT_SANS,
+                         .066 * job->title->geometry.height,
+                         width, height);
     return 0;
 
 fail:

--- a/libhb/decssasub.c
+++ b/libhb/decssasub.c
@@ -26,6 +26,7 @@
 
 #include "handbrake/handbrake.h"
 #include "handbrake/decavsub.h"
+#include "handbrake/extradata.h"
 #include "libavformat/avformat.h"
 
 struct hb_work_private_s
@@ -57,11 +58,7 @@ static int extradataInit( hb_work_private_t * pv )
     }
     if (st->codecpar->extradata != NULL)
     {
-        pv->subtitle->extradata = malloc(st->codecpar->extradata_size + 1);
-        memcpy(pv->subtitle->extradata,
-               st->codecpar->extradata, st->codecpar->extradata_size);
-        pv->subtitle->extradata[st->codecpar->extradata_size] = 0;
-        pv->subtitle->extradata_size = st->codecpar->extradata_size + 1;
+        hb_set_text_extradata(&pv->subtitle->extradata, st->codecpar->extradata, st->codecpar->extradata_size);
     }
     return 0;
 }

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 #include "handbrake/handbrake.h"
 #include "handbrake/colormap.h"
+#include "handbrake/extradata.h"
 
 struct hb_work_private_s
 {
@@ -260,9 +261,9 @@ static int dectx3gInit( hb_work_object_t * w, hb_job_t * job )
     // For now we just create a generic SSA Script Info.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(w->subtitle, HB_FONT_SANS,
-                               .066 * job->title->geometry.height,
-                               width, height);
+    hb_set_ssa_extradata(&w->subtitle->extradata, HB_FONT_SANS,
+                         .066 * job->title->geometry.height,
+                         width, height);
 
     return 0;
 }

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -17,6 +17,7 @@
 #include "handbrake/av1_common.h"
 #include "handbrake/nal_units.h"
 #include "handbrake/nvenc_common.h"
+#include "handbrake/extradata.h"
 
 /*
  * The frame info struct remembers information about each frame across calls
@@ -852,9 +853,7 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
 
     if (context->extradata != NULL)
     {
-        memcpy(w->config->extradata.bytes, context->extradata,
-                                           context->extradata_size);
-        w->config->extradata.length = context->extradata_size;
+        hb_set_extradata(w->extradata, context->extradata, context->extradata_size);
     }
 
 done:
@@ -923,7 +922,7 @@ static void compute_dts_offset( hb_work_private_t * pv, hb_buffer_t * buf )
         if ( ( pv->frameno_in ) == pv->job->areBframes )
         {
             pv->dts_delay = buf->s.start;
-            pv->job->config.init_delay = pv->dts_delay;
+            pv->job->init_delay = pv->dts_delay;
         }
     }
 }

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -9,6 +9,7 @@
 
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
+#include "handbrake/extradata.h"
 
 struct hb_work_private_s
 {
@@ -224,8 +225,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         hb_error("encavcodecaInit: hb_avcodec_open() failed");
         return 1;
     }
-    w->config->init_delay = av_rescale(context->initial_padding,
-                                       90000, context->sample_rate);
+    *w->init_delay = av_rescale(context->initial_padding, 90000, context->sample_rate);
 
     // avcodec_open populates the opts dictionary with the
     // things it didn't recognize.
@@ -291,9 +291,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     if (context->extradata != NULL)
     {
-        memcpy(w->config->extradata.bytes, context->extradata,
-               context->extradata_size);
-        w->config->extradata.length = context->extradata_size;
+        hb_set_extradata(w->extradata, context->extradata, context->extradata_size);
     }
 
     return 0;
@@ -313,9 +311,8 @@ static void Finalize(hb_work_object_t *w)
     // Then we need to recopy the header since it was modified
     if (pv->context->extradata != NULL)
     {
-        memcpy(w->config->extradata.bytes, pv->context->extradata,
-               pv->context->extradata_size);
-        w->config->extradata.length = pv->context->extradata_size;
+        hb_set_extradata(w->extradata, pv->context->extradata,
+                         pv->context->extradata_size);
     }
 }
 

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -12,6 +12,7 @@
 #include "handbrake/hb_dict.h"
 #include "handbrake/av1_common.h"
 #include "handbrake/hdr10plus.h"
+#include "handbrake/extradata.h"
 #include "libavutil/avutil.h"
 #include "svt-av1/EbSvtAv1ErrorCodes.h"
 #include "svt-av1/EbSvtAv1Enc.h"
@@ -319,8 +320,11 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
         return 1;
     }
 
-    w->config->extradata.length = headerPtr->n_filled_len;
-    memcpy(w->config->extradata.bytes, headerPtr->p_buffer, headerPtr->n_filled_len);
+    if (hb_set_extradata(w->extradata, headerPtr->p_buffer, headerPtr->n_filled_len))
+    {
+        hb_error("encsvtav1: error setting extradata");
+        return 1;
+    }
 
     svt_ret = svt_av1_enc_stream_header_release(headerPtr);
     if (svt_ret != EB_ErrorNone)

--- a/libhb/enctheora.c
+++ b/libhb/enctheora.c
@@ -8,6 +8,7 @@
  */
 
 #include "handbrake/handbrake.h"
+#include "handbrake/extradata.h"
 #include "theora/codec.h"
 #include "theora/theoraenc.h"
 
@@ -169,17 +170,18 @@ int enctheoraInit( hb_work_object_t * w, hb_job_t * job )
 
     th_comment_init( &tc );
 
-    ogg_packet *header;
+    uint8_t headers[3][HB_CONFIG_MAX_SIZE];
 
-    int ii;
-    for (ii = 0; ii < 3; ii++)
+    for (int ii = 0; ii < 3; ii++)
     {
-        th_encode_flushheader( pv->ctx, &tc, &op );
-        header = (ogg_packet*)w->config->theora.headers[ii];
+        th_encode_flushheader(pv->ctx, &tc, &op);
+        ogg_packet *header = (ogg_packet *)headers[ii];
         memcpy(header, &op, sizeof(op));
-        header->packet = w->config->theora.headers[ii] + sizeof(ogg_packet);
-        memcpy(header->packet, op.packet, op.bytes );
+        header->packet = headers[ii] + sizeof(ogg_packet);
+        memcpy(header->packet, op.packet, op.bytes);
     }
+
+    hb_set_xiph_extradata(w->extradata, headers);
 
     th_comment_clear( &tc );
 

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -17,6 +17,8 @@
 #include "handbrake/h265_common.h"
 #include "handbrake/dovi_common.h"
 #include "handbrake/hdr10plus.h"
+#include "handbrake/extradata.h"
+
 #include "x265.h"
 
 int  encx265Init (hb_work_object_t*, hb_job_t*);
@@ -537,13 +539,11 @@ int encx265Init(hb_work_object_t *w, hb_job_t *job)
         hb_error("encx265: x265_encoder_headers failed (%d)", ret);
         goto fail;
     }
-    if (ret > sizeof(w->config->h265.headers))
+    if (hb_set_extradata(w->extradata, nal->payload, ret))
     {
         hb_error("encx265: bitstream headers too large (%d)", ret);
         goto fail;
     }
-    memcpy(w->config->h265.headers, nal->payload, ret);
-    w->config->h265.headers_length = ret;
 
     return 0;
 
@@ -635,9 +635,9 @@ static hb_buffer_t* nal_encode(hb_work_object_t *w,
     buf->s.stop         = pic_out->pts + buf->s.duration;
     buf->s.start        = pic_out->pts;
     buf->s.renderOffset = pic_out->dts;
-    if (w->config->init_delay == 0 && pic_out->dts < 0)
+    if (*w->init_delay == 0 && pic_out->dts < 0)
     {
-        w->config->init_delay -= pic_out->dts;
+        *w->init_delay -= pic_out->dts;
     }
 
     switch (pic_out->sliceType)

--- a/libhb/extradata.c
+++ b/libhb/extradata.c
@@ -1,0 +1,182 @@
+/* extradata.c
+
+   Copyright (c) 2003-2024 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/extradata.h"
+#include "libavutil/intreadwrite.h"
+#include <ogg/ogg.h>
+
+int hb_set_extradata(hb_data_t **extradata, const uint8_t *bytes, size_t length)
+{
+    hb_data_close(extradata);
+
+    if (length > 0)
+    {
+        *extradata = hb_data_init(length);
+        if (*extradata == NULL)
+        {
+            hb_error("extradata: malloc failure");
+            return 1;
+        }
+        memcpy((*extradata)->bytes, bytes, length);
+    }
+    return 0;
+}
+
+int hb_set_text_extradata(hb_data_t **extradata, const uint8_t *bytes, size_t length)
+{
+    hb_data_close(extradata);
+
+    if (length > 0)
+    {
+        *extradata = hb_data_init(length + 1);
+        if (*extradata == NULL)
+        {
+            hb_error("extradata: malloc failure");
+            return 1;
+        }
+        memcpy((*extradata)->bytes, bytes, length);
+        (*extradata)->bytes[length] = 0;
+    }
+    return 0;
+}
+
+int hb_set_ssa_extradata(hb_data_t **extradata, const char *font, int fs, int w, int h)
+{
+    hb_data_close(extradata);
+
+    char *header = NULL;
+    float shadow_size = fs / 36.0;
+    float outline_size = fs / 30.0;
+
+    char *shadow_size_string = hb_strdup_printf("%.2f", shadow_size);
+    hb_str_from_locale(shadow_size_string);
+
+    char *outline_size_string = hb_strdup_printf("%.2f", outline_size);
+    hb_str_from_locale(outline_size_string);
+
+    if (shadow_size_string == NULL || outline_size_string == NULL)
+    {
+        goto fail;
+    }
+
+    // SRT subtitles are represented internally as SSA
+    // Create an SSA header
+    const char * ssa_header =
+        "[Script Info]\r\n"
+        "ScriptType: v4.00+\r\n"
+        "Collisions: Normal\r\n"
+        "PlayResX: %d\r\n"
+        "PlayResY: %d\r\n"
+        "Timer: 100.0\r\n"
+        "WrapStyle: 0\r\n"
+        "ScaledBorderAndShadow: yes\r\n"
+        "\r\n"
+        "[V4+ Styles]\r\n"
+        "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\r\n"
+        "Style: Default,%s,%d,&H00FFFFFF,&H00FFFFFF,&H000F0F0F,&H000F0F0F,0,0,0,0,100,100,0,0.00,1,%s,%s,2,20,20,20,0\r\n";
+
+    header = hb_strdup_printf(ssa_header, w, h, font, fs, outline_size_string, shadow_size_string);
+    if (header == NULL)
+    {
+        goto fail;
+    }
+
+    size_t size = strlen(header) + 1;
+    *extradata = hb_data_init(size);
+    if (*extradata == NULL)
+    {
+        goto fail;
+    }
+
+    memcpy((*extradata)->bytes, header, size);
+    free(header);
+    free(shadow_size_string);
+    free(outline_size_string);
+
+    return 0;
+
+fail:
+    hb_error("ssa extradata: malloc failure");
+    free(header);
+    free(shadow_size_string);
+    free(outline_size_string);
+
+    return 1;
+}
+
+int hb_set_h264_extradata(hb_data_t **extradata, uint8_t *sps, size_t sps_length, uint8_t *pps, size_t pps_length)
+{
+    hb_data_close(extradata);
+
+    /* Taken from x264 muxers.c */
+    size_t length = 5 + 1 + 2 + sps_length + 1 + 2 + pps_length;
+    *extradata = hb_data_init(length);
+    if (*extradata == NULL)
+    {
+        hb_error("H.264 extradata: malloc failure");
+        return 1;
+    }
+
+    uint8_t *data = (*extradata)->bytes;
+
+    data[0] = 1;
+    data[1] = sps[1]; /* AVCProfileIndication */
+    data[2] = sps[2]; /* profile_compat */
+    data[3] = sps[3]; /* AVCLevelIndication */
+    data[4] = 0xff; // nalu size length is four bytes
+    data[5] = 0xe1; // one sps
+
+    data[6] = sps_length >> 8;
+    data[7] = sps_length;
+
+    memcpy(data + 8, sps, sps_length);
+
+    data[8  + sps_length] = 1; // one pps
+    data[9  + sps_length] = pps_length >> 8;
+    data[10 + sps_length] = pps_length;
+
+    memcpy(data + 11 + sps_length, pps, pps_length);
+
+    return 0;
+}
+
+int hb_set_xiph_extradata(hb_data_t **extradata, uint8_t headers[3][HB_CONFIG_MAX_SIZE])
+{
+    hb_data_close(extradata);
+
+    int size = 0;
+    ogg_packet *ogg_headers[3];
+
+    for (int ii = 0; ii < 3; ii++)
+    {
+        ogg_headers[ii] = (ogg_packet *)headers[ii];
+        size += ogg_headers[ii]->bytes + 2;
+    }
+
+    *extradata = hb_data_init(size);
+    if (*extradata == NULL)
+    {
+        hb_error("xiph extradata: malloc failure");
+        return 1;
+    }
+
+    uint8_t *data = (*extradata)->bytes;
+    size = 0;
+
+    for (int ii = 0; ii < 3; ii++)
+    {
+        AV_WB16(data + size, ogg_headers[ii]->bytes);
+        size += 2;
+        memcpy(data + size, ogg_headers[ii]->packet,
+                               ogg_headers[ii]->bytes);
+        size += ogg_headers[ii]->bytes;
+    }
+
+    return 0;
+}

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -159,8 +159,6 @@ void hb_audio_config_init(hb_audio_config_t * audiocfg);
 int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg);
 hb_audio_config_t * hb_list_audio_config_item(hb_list_t * list, int i);
 
-int hb_subtitle_add_ssa_header(hb_subtitle_t *subtitle, const char *font,
-                               int fs, int width, int height);
 hb_subtitle_t *hb_subtitle_copy(const hb_subtitle_t *src);
 hb_list_t *hb_subtitle_list_copy(const hb_list_t *src);
 void hb_subtitle_close( hb_subtitle_t **sub );
@@ -840,6 +838,9 @@ struct hb_job_s
 
     uint64_t        st_paused;
 
+    int             init_delay;
+    hb_data_t     * extradata;
+
     hb_fifo_t     * fifo_mpeg2;   /* MPEG-2 video ES */
     hb_fifo_t     * fifo_raw;     /* Raw pictures */
     hb_fifo_t     * fifo_sync;    /* Raw pictures, framerate corrected */
@@ -847,8 +848,6 @@ struct hb_job_s
     hb_fifo_t     * fifo_mpeg4;   /* MPEG-4 video ES */
 
     hb_list_t     * list_work;
-
-    hb_esconfig_t config;
 
     hb_mux_data_t * mux_data;
 
@@ -999,13 +998,16 @@ struct hb_audio_s
 
     hb_audio_config_t config;
 
-    struct {
+    struct
+    {
+        int           init_delay;
+        hb_data_t   * extradata;
+
         hb_fifo_t * fifo_in;   /* AC3/MPEG/LPCM ES */
         hb_fifo_t * fifo_raw;  /* Raw audio */
         hb_fifo_t * fifo_sync; /* Resampled, synced raw audio */
         hb_fifo_t * fifo_out;  /* MP3/AAC/Vorbis ES */
 
-        hb_esconfig_t config;
         hb_mux_data_t * mux_data;
         hb_fifo_t     * scan_cache;
     } priv;
@@ -1110,10 +1112,6 @@ struct hb_subtitle_s
     int         width;
     int         height;
 
-    // Codec private data for subtitles originating from FFMPEG sources
-    uint8_t *   extradata;
-    int         extradata_size;
-
     int hits;     /* How many hits/occurrences of this subtitle */
     int forced_hits; /* How many forced hits in this subtitle */
 
@@ -1125,6 +1123,9 @@ struct hb_subtitle_s
     uint32_t        stream_type;    /* stream type from source stream */
     uint32_t        substream_type; /* substream for multiplexed streams */
     hb_rational_t   timebase;
+
+    // Codec private data for subtitles originating from FFMPEG sources
+    hb_data_t   * extradata;
 
     hb_fifo_t     * fifo_in;        /* SPU ES */
     hb_fifo_t     * fifo_raw;       /* Decoded SPU */
@@ -1360,7 +1361,9 @@ struct hb_work_object_s
 
     hb_fifo_t         * fifo_in;
     hb_fifo_t         * fifo_out;
-    hb_esconfig_t     * config;
+
+    int               * init_delay;
+    hb_data_t        ** extradata;
 
     /* Pointer hb_audio_t so we have access to the info in the audio worker threads. */
     hb_audio_t        * audio;

--- a/libhb/handbrake/extradata.h
+++ b/libhb/handbrake/extradata.h
@@ -1,0 +1,27 @@
+/* extradata.h
+
+   Copyright (c) 2003-2024 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#ifndef HANDBRAKE_EXTRADATA_H
+#define HANDBRAKE_EXTRADATA_H
+
+#ifdef __LIBHB__
+
+#include "handbrake/handbrake.h"
+
+int hb_set_extradata(hb_data_t **extradata, const uint8_t *bytes, size_t length);
+
+int hb_set_h264_extradata(hb_data_t **extradata, uint8_t *sps, size_t sps_length, uint8_t *pps, size_t pps_length);
+int hb_set_xiph_extradata(hb_data_t **extradata, uint8_t headers[3][HB_CONFIG_MAX_SIZE]);
+
+int hb_set_text_extradata(hb_data_t **extradata, const uint8_t *bytes, size_t length);
+int hb_set_ssa_extradata(hb_data_t **extradata, const char *font, int fs, int w, int h);
+
+#endif
+
+#endif /* HANDBRAKE_TASKSET_H */

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -35,7 +35,7 @@ typedef struct hb_attachment_s hb_attachment_t;
 typedef struct hb_metadata_s hb_metadata_t;
 typedef struct hb_coverart_s hb_coverart_t;
 typedef struct hb_state_s hb_state_t;
-typedef struct hb_esconfig_s     hb_esconfig_t;
+typedef struct hb_data_s hb_data_t;
 typedef struct hb_work_private_s hb_work_private_t;
 typedef struct hb_work_object_s  hb_work_object_t;
 typedef struct hb_filter_private_s hb_filter_private_t;

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -378,52 +378,18 @@ void hb_stream_set_need_keyframe( hb_stream_t *stream, int need_keyframe );
 /***********************************************************************
  * Work objects
  **********************************************************************/
+
 #define HB_CONFIG_MAX_SIZE (2*8192)
-struct hb_esconfig_s
+
+struct hb_data_s
 {
-    int init_delay;
-
-    union
-    {
-
-    struct
-    {
-        uint8_t bytes[HB_CONFIG_MAX_SIZE];
-        int     length;
-    } mpeg4;
-
-	struct
-	{
-	    uint8_t  sps[HB_CONFIG_MAX_SIZE];
-	    int       sps_length;
-	    uint8_t  pps[HB_CONFIG_MAX_SIZE];
-	    int       pps_length;
-	} h264;
-
-    struct
-    {
-        uint8_t headers[HB_CONFIG_MAX_SIZE];
-        int     headers_length;
-    } h265;
-
-    struct
-    {
-        uint8_t headers[3][HB_CONFIG_MAX_SIZE];
-    } theora;
-
-    struct
-    {
-        uint8_t bytes[HB_CONFIG_MAX_SIZE];
-        int     length;
-    } extradata;
-
-    struct
-    {
-        uint8_t headers[3][HB_CONFIG_MAX_SIZE];
-        char *language;
-    } vorbis;
-    };
+    uint8_t *bytes;
+    size_t   size;
 };
+
+hb_data_t * hb_data_init(size_t size);
+void        hb_data_close(hb_data_t **);
+hb_data_t * hb_data_dup(const hb_data_t *src);
 
 enum
 {

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -9,6 +9,7 @@
 
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
+#include "handbrake/extradata.h"
 #include "libavutil/bswap.h"
 #include <ass/ass.h>
 
@@ -921,8 +922,8 @@ static int ssa_work( hb_filter_object_t * filter,
         // decoder initialization happens after filter initialization,
         // we need to postpone this.
         ass_process_codec_private(pv->ssaTrack,
-                                  (char*)filter->subtitle->extradata,
-                                  filter->subtitle->extradata_size);
+                                  (char *)filter->subtitle->extradata->bytes,
+                                  filter->subtitle->extradata->size);
         pv->script_initialized = 1;
     }
     if (in->s.flags & HB_BUF_FLAG_EOF)
@@ -965,8 +966,8 @@ static int cc608sub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
     int safe_height = 0.8 * job->title->geometry.height;
     // Use fixed width font for CC
-    hb_subtitle_add_ssa_header(filter->subtitle, HB_FONT_MONO,
-                               .08 * safe_height, width, height);
+    hb_set_ssa_extradata(&filter->subtitle->extradata, HB_FONT_MONO,
+                         .08 * safe_height, width, height);
     return ssa_post_init(filter, job);
 }
 
@@ -976,9 +977,9 @@ static int textsub_post_init( hb_filter_object_t * filter, hb_job_t * job )
     // to have the header rewritten with the correct dimensions.
     int height = job->title->geometry.height - job->crop[0] - job->crop[1];
     int width = job->title->geometry.width - job->crop[2] - job->crop[3];
-    hb_subtitle_add_ssa_header(filter->subtitle, HB_FONT_SANS,
-                               .066 * job->title->geometry.height,
-                               width, height);
+    hb_set_ssa_extradata(&filter->subtitle->extradata, HB_FONT_SANS,
+                         .066 * job->title->geometry.height,
+                         width, height);
     return ssa_post_init(filter, job);
 }
 
@@ -1004,8 +1005,8 @@ static int textsub_work(hb_filter_object_t * filter,
     if (!pv->script_initialized)
     {
         ass_process_codec_private(pv->ssaTrack,
-                                  (char*)filter->subtitle->extradata,
-                                  filter->subtitle->extradata_size);
+                                  (char*)filter->subtitle->extradata->bytes,
+                                  filter->subtitle->extradata->size);
         pv->script_initialized = 1;
     }
 

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -14,6 +14,7 @@
 #include "handbrake/handbrake.h"
 #include "handbrake/hbffmpeg.h"
 #include "handbrake/lang.h"
+#include "handbrake/extradata.h"
 #include "libbluray/bluray.h"
 
 #define min(a, b) a < b ? a : b
@@ -2001,10 +2002,9 @@ static void pes_add_subtitle_to_title(
                     subtitle->config.dest = RENDERSUB;
                     if (pes->extradata != NULL)
                     {
-                        subtitle->extradata = malloc(pes->extradata_size);
-                        subtitle->extradata_size = pes->extradata_size;
-                        memcpy(subtitle->extradata, pes->extradata,
-                                                    pes->extradata_size);
+                        hb_set_extradata(&subtitle->extradata,
+                                         pes->extradata,
+                                         pes->extradata_size);
                     }
                     break;
                 case AV_CODEC_ID_HDMV_PGS_SUBTITLE:
@@ -5390,14 +5390,12 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
     {
         case AV_CODEC_ID_AAC:
         {
-            int len = MIN(codecpar->extradata_size, HB_CONFIG_MAX_SIZE);
-            memcpy(audio->priv.config.extradata.bytes, codecpar->extradata, len);
-            audio->priv.config.extradata.length = len;
-            audio->config.in.codec              = HB_ACODEC_FFAAC;
+            hb_set_extradata(&audio->priv.extradata, codecpar->extradata, codecpar->extradata_size);
+            audio->config.in.codec = HB_ACODEC_FFAAC;
         } break;
 
         case AV_CODEC_ID_AC3:
-            audio->config.in.codec       = HB_ACODEC_AC3;
+            audio->config.in.codec = HB_ACODEC_AC3;
             break;
 
         case AV_CODEC_ID_EAC3:
@@ -5433,10 +5431,8 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
 
         case AV_CODEC_ID_FLAC:
         {
-            int len = MIN(codecpar->extradata_size, HB_CONFIG_MAX_SIZE);
-            memcpy(audio->priv.config.extradata.bytes, codecpar->extradata, len);
-            audio->priv.config.extradata.length = len;
-            audio->config.in.codec              = HB_ACODEC_FFFLAC;
+            hb_set_extradata(&audio->priv.extradata, codecpar->extradata, codecpar->extradata_size);
+            audio->config.in.codec = HB_ACODEC_FFFLAC;
         } break;
 
         case AV_CODEC_ID_MP2:
@@ -5449,10 +5445,8 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
 
         case AV_CODEC_ID_OPUS:
         {
-            int len = MIN(codecpar->extradata_size, HB_CONFIG_MAX_SIZE);
-            memcpy(audio->priv.config.extradata.bytes, codecpar->extradata, len);
-            audio->priv.config.extradata.length = len;
-            audio->config.in.codec              = HB_ACODEC_OPUS;
+            hb_set_extradata(&audio->priv.extradata, codecpar->extradata, codecpar->extradata_size);
+            audio->config.in.codec = HB_ACODEC_OPUS;
         } break;
 
         default:
@@ -5694,11 +5688,7 @@ static void add_ffmpeg_subtitle( hb_title_t *title, hb_stream_t *stream, int id 
     // Copy the extradata for the subtitle track
     if (codecpar->extradata != NULL)
     {
-        subtitle->extradata = malloc(codecpar->extradata_size + 1);
-        memcpy(subtitle->extradata,
-               codecpar->extradata, codecpar->extradata_size);
-        subtitle->extradata[codecpar->extradata_size] = 0;
-        subtitle->extradata_size = codecpar->extradata_size + 1;
+        hb_set_text_extradata(&subtitle->extradata, codecpar->extradata, codecpar->extradata_size);
     }
 
     if (st->disposition & AV_DISPOSITION_DEFAULT)

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1206,10 +1206,6 @@ static int sanitize_audio(hb_job_t *job)
             continue;
         }
 
-        /* Vorbis language information */
-        if (audio->config.out.codec == HB_ACODEC_VORBIS)
-            audio->priv.config.vorbis.language = audio->config.lang.simple;
-
         /* sense-check the requested samplerate */
         if (audio->config.out.samplerate <= 0)
         {
@@ -1840,9 +1836,10 @@ static void do_job(hb_job_t *job)
                 *job->die = 1;
                 goto cleanup;
             }
+            w->init_delay = &audio->priv.init_delay;
+            w->extradata  = &audio->priv.extradata;
             w->fifo_in  = audio->priv.fifo_in;
             w->fifo_out = audio->priv.fifo_raw;
-            w->config   = &audio->priv.config;
             w->audio    = audio;
             w->codec_param = audio->config.in.codec_param;
 
@@ -1927,9 +1924,10 @@ static void do_job(hb_job_t *job)
                     *job->die = 1;
                     goto cleanup;
                 }
+                w->init_delay = &audio->priv.init_delay;
+                w->extradata  = &audio->priv.extradata;
                 w->fifo_in  = audio->priv.fifo_sync;
                 w->fifo_out = audio->priv.fifo_out;
-                w->config   = &audio->priv.config;
                 w->audio    = audio;
 
                 hb_list_add( job->list_work, w );
@@ -1974,8 +1972,10 @@ static void do_job(hb_job_t *job)
         else
             w->fifo_in  = job->fifo_sync;
 
-        w->fifo_out = job->fifo_mpeg4;
-        w->config   = &job->config;
+        w->fifo_out  =  job->fifo_mpeg4;
+
+        w->init_delay = &job->init_delay;
+        w->extradata  = &job->extradata;
 
         hb_list_add( job->list_work, w );
 


### PR DESCRIPTION
We were storing the extra data in a fixed size buffer. However, FFV1 extra data can be up to 536596 bytes when encoding with 2 passes, so making a static half MB didn't seem the best idea.

This PR makes the extra data a heap allocated buffer, and refactors a bunch of things to avoid code duplication.
It needs some testing to see if I didn't forgot anything.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux