### PR TITLE
Changes to enable multi-instance for Linux

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -696,7 +696,8 @@ ghb_application_constructed (GObject *object)
     g_application_set_application_id(G_APPLICATION(self), "fr.handbrake.ghb");
     g_set_prgname("fr.handbrake.ghb");
     g_set_application_name("HandBrake");
-    g_application_set_flags(G_APPLICATION(self), G_APPLICATION_HANDLES_OPEN);
+    g_application_set_flags(G_APPLICATION(self), G_APPLICATION_HANDLES_OPEN |
+                                                 G_APPLICATION_NON_UNIQUE);
 }
 
 static void

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1226,7 +1226,7 @@ hb_handle_t* ghb_live_handle(void)
     return h_live;
 }
 
-gchar*
+const char*
 ghb_get_tmp_dir (void)
 {
     return hb_get_temporary_directory();
@@ -1235,11 +1235,7 @@ ghb_get_tmp_dir (void)
 void
 ghb_hb_cleanup(gboolean partial)
 {
-    char * dir;
-
-    dir = hb_get_temporary_directory();
-    del_tree(dir, !partial);
-    free(dir);
+    del_tree(hb_get_temporary_directory(), !partial);
 }
 
 gint

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -170,7 +170,7 @@ gint ghb_lookup_combo_int(const gchar *name, const GhbValue *gval);
 gdouble ghb_lookup_combo_double(const gchar *name, const GhbValue *gval);
 gchar* ghb_lookup_combo_option(const gchar *name, const GhbValue *gval);
 const char* ghb_lookup_filter_name(int filter_id, const char *short_name, int preset);
-gchar* ghb_get_tmp_dir(void);
+const char* ghb_get_tmp_dir(void);
 gint ghb_find_closest_audio_samplerate(gint rate);
 
 void ghb_init_lang_list_model(GtkTreeView *tv);

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -405,7 +405,7 @@ live_preview_play_clicked_cb (GtkWidget *widget, gpointer data)
 {
     signal_user_data_t *ud = ghb_ud();
     gint frame = ud->preview->frame;
-    g_autofree char *tmp_dir = ghb_get_tmp_dir();
+    const char *tmp_dir = ghb_get_tmp_dir();
     char *name = g_strdup_printf("%s/live%02d", tmp_dir, ud->preview->frame);
     if (ud->preview->current)
         g_free(ud->preview->current);

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -129,7 +129,7 @@ char * hb_strndup(const char * src, size_t len);
 /************************************************************************
  * File utils
  ***********************************************************************/
-char * hb_get_temporary_directory(void);
+const char * hb_get_temporary_directory(void);
 char * hb_get_temporary_filename( char *fmt, ... );
 size_t hb_getline(char **lineptr, size_t *n, FILE *fp);
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -311,7 +311,7 @@ int hb_get_build( hb_handle_t * h )
 void hb_remove_previews( hb_handle_t * h )
 {
     char          * filename;
-    char          * dirname;
+    const char    * dirname;
     hb_title_t    * title;
     int             i, count, len;
     DIR           * dir;
@@ -321,7 +321,6 @@ void hb_remove_previews( hb_handle_t * h )
     dir = opendir( dirname );
     if (dir == NULL)
     {
-        free(dirname);
         return;
     }
 
@@ -351,7 +350,6 @@ void hb_remove_previews( hb_handle_t * h )
             free(filename);
         }
     }
-    free(dirname);
     closedir( dir );
 }
 
@@ -2176,7 +2174,7 @@ int hb_global_init()
  */
 void hb_global_close()
 {
-    char          * dirname;
+    const char    * dirname;
     DIR           * dir;
     struct dirent * entry;
 
@@ -2202,7 +2200,6 @@ void hb_global_close()
         closedir( dir );
         rmdir( dirname );
     }
-    free(dirname);
 }
 
 /**
@@ -2214,7 +2211,7 @@ void hb_global_close()
 static void thread_func( void * _h )
 {
     hb_handle_t * h = (hb_handle_t *) _h;
-    char * dirname;
+    const char * dirname;
 
     h->pid = getpid();
 
@@ -2222,7 +2219,6 @@ static void thread_func( void * _h )
     dirname = hb_get_temporary_directory();
 
     hb_mkdir( dirname );
-    free(dirname);
 
     while( !h->die )
     {

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -600,40 +600,66 @@ void hb_get_user_config_filename( char name[1024], char *fmt, ... )
 }
 
 /************************************************************************
- * Get a temporary directory for HB
+ * Creates a uniquely-named temporary directory for this process. On
+ * POSIX systems, mkdtemp(3) is used to ensure the directory name is
+ * unique even if multiple HandBrake instances have the same PID.
  ***********************************************************************/
-char * hb_get_temporary_directory()
-{
-    char * path, * base, * p;
+static pthread_once_t tmp_control = PTHREAD_ONCE_INIT;
+static char *tmp_dirname = NULL;
 
-    /* Create the base */
+static void
+hb_init_temporary_directory (void)
+{
+    char *path, *base, *p;
+
 #if defined( SYS_CYGWIN ) || defined( SYS_MINGW )
     base = malloc(MAX_PATH);
-    int i_size = GetTempPath( MAX_PATH, base );
-    if( i_size <= 0 || i_size >= MAX_PATH )
+    int i_size = GetTempPath(MAX_PATH, base);
+    if (i_size <= 0 || i_size >= MAX_PATH)
     {
-        if( getcwd( base, MAX_PATH ) == NULL )
-            strcpy( base, "c:" ); /* Bad fallback but ... */
+        if (getcwd(base, MAX_PATH) == NULL)
+            strcpy(base, "c:"); /* Bad fallback but ... */
     }
 
     /* c:/path/ works like a charm under cygwin(win32?) so use it */
-    while( ( p = strchr( base, '\\' ) ) )
+    while ((p = strchr(base, '\\')))
         *p = '/';
+
+    /* I prefer to remove eventual last '/' (for cygwin) */
+    if (base[strlen(base)-1] == '/')
+        base[strlen(base)-1] = '\0';
+
+    path = hb_strdup_printf("%s/HandBrake-%d", base, (int)getpid());
+    hb_mkdir(path);
+    free(base);
 #else
-    if( (p = getenv( "TMPDIR" ) ) != NULL ||
-        (p = getenv( "TEMP" ) )   != NULL )
+    if ((p = getenv("TMPDIR")) != NULL ||
+        (p = getenv("TEMP"))   != NULL)
         base = strdup(p);
     else
         base = strdup("/tmp");
-#endif
-    /* I prefer to remove eventual last '/' (for cygwin) */
-    if( base[strlen(base)-1] == '/' )
+
+    if (base[strlen(base)-1] == '/')
         base[strlen(base)-1] = '\0';
 
-    path = hb_strdup_printf("%s/hb.%d", base, (int)getpid());
+    /* Create a new randomly-named directory from the template */
+    path = hb_strdup_printf("%s/handbrake-XXXXXX", base);
+    if (!mkdtemp(path))
+    {
+        /* We still use the path even if directory creation fails */
+        hb_error("Failed to create a temporary directory at %s\n", path);
+    }
     free(base);
+#endif
+    tmp_dirname = path;
+}
 
-    return path;
+const char *
+hb_get_temporary_directory (void)
+{
+    /* Ensure the directory name is only created once */
+    pthread_once(&tmp_control, hb_init_temporary_directory);
+    return tmp_dirname;
 }
 
 /************************************************************************
@@ -643,14 +669,12 @@ char * hb_get_temporary_filename( char *fmt, ... )
 {
     va_list   args;
     char    * name, * path;
-    char    * dir = hb_get_temporary_directory();
 
     va_start( args, fmt );
     name = hb_strdup_vaprintf(fmt, args);
     va_end( args );
 
-    path = hb_strdup_printf("%s/%s", dir, name);
-    free(dir);
+    path = hb_strdup_printf("%s/%s", hb_get_temporary_directory(), name);
     free(name);
 
     return path;


### PR DESCRIPTION
**Description of Change:**

This will allow multiple Flatpak HandBrake instances to run simultaneously without overwriting each other's temporary files, in order to fix #5676. The most important change is to use a randomly generated name for the temporary directory instead of the PID, except on Windows where the `mkdtemp` function isn't available.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

