### PR TITLE
contrib: update libxml2 to 2.12.6

### DIFF
--- a/contrib/libxml2/module.defs
+++ b/contrib/libxml2/module.defs
@@ -2,9 +2,9 @@ __deps__ := LIBICONV
 $(eval $(call import.MODULE.defs,LIBXML2,libxml2,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBXML2))
 
-LIBXML2.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libxml2-2.12.5.tar.xz
-LIBXML2.FETCH.url    += https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.5.tar.xz
-LIBXML2.FETCH.sha256  = a972796696afd38073e0f59c283c3a2f5a560b5268b4babc391b286166526b21
+LIBXML2.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libxml2-2.12.6.tar.xz
+LIBXML2.FETCH.url    += https://download.gnome.org/sources/libxml2/2.12/libxml2-2.12.6.tar.xz
+LIBXML2.FETCH.sha256  = 889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb
 
 # We don't need LZMA / Zlib support
 LIBXML2.CONFIGURE.extra = --without-lzma --without-zlib


### PR DESCRIPTION
**libxml2 2.12.6:**

_**Regressions:**_

parser: Fix detection of duplicate attributes in XML namespace
xmlreader: Fix xmlTextReaderConstEncoding
html: Fix htmlCreatePushParserCtxt with encoding
xmllint: Return error code if XPath returns empty nodeset

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux