### PR TITLE
contrib: update harfbuzz to 8.3.1

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.3.0.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.3.0/harfbuzz-8.3.0.tar.xz
-HARFBUZZ.FETCH.sha256  = 109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.3.1.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.3.1/harfbuzz-8.3.1.tar.xz
+HARFBUZZ.FETCH.sha256  = f73e1eacd7e2ffae687bc3f056bb0c705b7a05aee86337686e09da8fc1c2030c
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 8.3.1:**

What's Changed:

- hb_blob_create_from_file_or_fail() on Windows will now try to interpret the file name as UTF-8 first, and as system code page if it is not valid UTF-8.
- Fix hb_style_get_value() in fonts with “STAT” table.
- Properly handle negative offsets in CFF table.
- Update IANA Language Subtag Registry to 2024-03-07.
- Subsetter now supports subsetting “BASE” table.
- Subsetter will update “hhea” font metrics in sync with “OS/2” ones.
- “--variations” option of “hb-subset” now supports leaving out values that should be unchanged, e.g. “wght=:500:” will change the default and keep max and min unchanged. It also supports “*=drop” to to pin all axes to default location.
- Fix hb_ot_math_get_glyph_kerning() to match updated “MATH” table spec.
- Support legacy MacRoman encoding in “cmap” table.
- Various build fixes.
- Various subsetting and instancing fixes.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux