### PR TITLE
contrib: update libdav1d to 1.4.1

### DIFF
--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-1.4.0.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.4.0/dav1d-1.4.0.tar.bz2
-LIBDAV1D.FETCH.sha256  = 7661648c95755db3d61857b3fdc427fa6d3271a573e84fd11c235441965e9397
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-1.4.1.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.4.1/dav1d-1.4.1.tar.bz2
+LIBDAV1D.FETCH.sha256  = ab02c6c72c69b2b24726251f028b7cb57d5b3659eeec9f67f6cecb2322b127d8
 
 LIBDAV1D.build_dir     = build/
 


### PR DESCRIPTION
**libdav1d 1.4.1:**

_**This is a small release of dav1d, improving notably ARM and RISC-V speed:**_

Optimizations for 6tap filters for NEON (ARM), that can be significative depending on the samples
More RISC-V optimizations for itx (4x8, 8x4, 4x16, 16x4, 8x16, 16x8)
Reduction of binary size on ARM64, ARM32 and RISC-V
Fix out-of-bounds read in 8bpc SSE2/SSSE3 wiener_filter
Msac optimizations

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux