### PR TITLE
contrib: update libjpeg-turbo to 3.0.2

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-3.0.1.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.1.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 5b9bbca2b2a87c6632c821799438d358e27004ab528abf798533c15d50b39f82
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-3.0.2.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.2.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 29f2197345aafe1dcaadc8b055e4cbec9f35aad2a318d61ea081f835af2eebe9
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.0.2:**

_**Significant changes relative to 3.0.1:**_

- Fixed a signed integer overflow in the tj3CompressFromYUV8(), tj3DecodeYUV8(), tj3DecompressToYUV8(), and tj3EncodeYUV8() functions, detected by the Clang and GCC undefined behavior sanitizers, that could be triggered by setting the align parameter to an unreasonably large value. This issue did not pose a security threat, but removing the warning made it easier to detect actual security issues, should they arise in the future.
- Introduced a new parameter (TJPARAM_MAXMEMORY in the TurboJPEG C API and TJ.PARAM_MAXMEMORY in the TurboJPEG Java API) and a corresponding TJBench option (-maxmemory) for specifying the maximum amount of memory (in megabytes) that will be allocated for intermediate buffers, which are used with progressive JPEG compression and decompression, optimized baseline entropy coding, lossless JPEG compression, and lossless transformation. The new parameter and option serve the same purpose as the max_memory_to_use field in the jpeg_memory_mgr struct in the libjpeg API, the JPEGMEM environment variable, and the cjpeg/djpeg/jpegtran -maxmemory option.
- Introduced a new parameter (TJPARAM_MAXPIXELS in the TurboJPEG C API and TJ.PARAM_MAXPIXELS in the TurboJPEG Java API) and a corresponding TJBench option (-maxpixels) for specifying the maximum number of pixels that the decompression, lossless transformation, and packed-pixel image loading functions/methods will process.
- Fixed an error ("Unsupported color conversion request") that occurred when attempting to decompress a 3-component lossless JPEG image without an Adobe APP14 marker. The decompressor now assumes that a 3-component lossless JPEG image without an Adobe APP14 marker uses the RGB colorspace if its component IDs are 1, 2, and 3.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux