### PR TITLE
libhb: add support for VP9 tunes

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -555,6 +555,8 @@ void hb_display_job_info(hb_job_t *job)
                 case HB_VCODEC_X265_16BIT:
                 case HB_VCODEC_SVT_AV1:
                 case HB_VCODEC_SVT_AV1_10BIT:
+                case HB_VCODEC_FFMPEG_VP9:
+                case HB_VCODEC_FFMPEG_VP9_10BIT:
                     hb_log("     + tune:    %s", job->encoder_tune);
                 default:
                     break;


### PR DESCRIPTION
**Description of Change:**

#5851/#5852 

I've added the framework methods needed to apply tunes to the various `HB_VCODEC_FFMPEG_*` encoders, and implement encoder tunes for VP9.

I _think_ I've done everything that needs doing, but this is my first contribution to HandBrake's core code so I may have missed something. In particular, I'm assuming the GUI's pick the change up automatically. macOS certainly appears to


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
