### PR TITLE
libhb: support multi-pass with VP9 Constant Quality mode

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -423,7 +423,6 @@ static GhbBinding widget_bindings[] =
     {"vquality_type_bitrate", "active", NULL, "VideoAvgBitrate", "sensitive"},
     {"vquality_type_constant", "active", NULL, "VideoQualitySlider", "sensitive"},
     {"vquality_type_constant", "active", NULL, "video_quality_label", "sensitive"},
-    {"vquality_type_constant", "active", NULL, "VideoMultiPassBox", "sensitive", TRUE},
     {"VideoFramerate", "active-id", "auto", "VideoFrameratePFR", "visible", TRUE},
     {"VideoFramerate", "active-id", "auto", "VideoFramerateVFR", "visible"},
     {"VideoMultiPass", "active", NULL, "VideoTurboMultiPass", "sensitive"},
@@ -3277,6 +3276,7 @@ vquality_type_changed_cb (GtkWidget *widget, gpointer data)
     signal_user_data_t *ud = ghb_ud();
 
     ghb_widget_to_setting(ud->settings, widget);
+    ghb_update_multipass(ud);
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
     if (ghb_check_name_template(ud, "{quality}") ||

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -34,6 +34,7 @@
 #include "resources.h"
 #include "subtitlehandler.h"
 #include "util.h"
+#include "videohandler.h"
 
 #include <fcntl.h>
 #include <libavutil/parseutils.h>

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -85,5 +85,6 @@ void ghb_break_pts_duration(gint64 ptsDuration,
 void ghb_break_duration(gint64 duration, gint *hh, gint *mm, gint *ss);
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    const char *name, const char *id);
+void ghb_update_multipass(signal_user_data_t *ud);
 
 G_END_DECLS

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -85,6 +85,5 @@ void ghb_break_pts_duration(gint64 ptsDuration,
 void ghb_break_duration(gint64 duration, gint *hh, gint *mm, gint *ss);
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    const char *name, const char *id);
-void ghb_update_multipass(signal_user_data_t *ud);
 
 G_END_DECLS

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -293,23 +293,32 @@ static void queue_update_summary (GhbValue * queueDict, signal_user_data_t *ud)
     {
         // ABR
         int br = ghb_dict_get_int(uiDict, "VideoAvgBitrate");
-        if (!multi_pass)
+        if (multi_pass && hb_video_multipass_is_supported(video_encoder->codec))
         {
-            g_string_append_printf(str, _("%s, Bitrate %dkbps"),
+            g_string_append_printf(str, _("%s, Bitrate %dkbps (Multi Pass)"),
                                    video_encoder->name, br);
         }
         else
         {
-            g_string_append_printf(str, _("%s, Bitrate %dkbps (Multi Pass)"),
+            g_string_append_printf(str, _("%s, Bitrate %dkbps"),
                                    video_encoder->name, br);
         }
     }
     else
     {
         gdouble quality = ghb_dict_get_double(uiDict, "VideoQualitySlider");
-        g_string_append_printf(str, _("%s, Constant Quality %.4g(%s)"),
+        if (multi_pass && hb_video_cq_multipass_is_supported(video_encoder->codec))
+        {
+            g_string_append_printf(str, _("%s, Constant Quality %.4g(%s) (Multi Pass)"),
                                video_encoder->name, quality,
                                hb_video_quality_get_name(video_encoder->codec));
+        }
+        else
+        {
+            g_string_append_printf(str, _("%s, Constant Quality %.4g(%s)"),
+                               video_encoder->name, quality,
+                               hb_video_quality_get_name(video_encoder->codec));
+        }
     }
     const char * enc_preset  = NULL;
     const char * enc_tune    = NULL;

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -293,33 +293,22 @@ static void queue_update_summary (GhbValue * queueDict, signal_user_data_t *ud)
     {
         // ABR
         int br = ghb_dict_get_int(uiDict, "VideoAvgBitrate");
-        if (multi_pass && hb_video_multipass_is_supported(video_encoder->codec))
-        {
-            g_string_append_printf(str, _("%s, Bitrate %dkbps (Multi Pass)"),
-                                   video_encoder->name, br);
-        }
-        else
-        {
-            g_string_append_printf(str, _("%s, Bitrate %dkbps"),
-                                   video_encoder->name, br);
-        }
+        g_string_append_printf(str, _("%s, Bitrate %dkbps"),
+                                video_encoder->name, br);
     }
     else
     {
         gdouble quality = ghb_dict_get_double(uiDict, "VideoQualitySlider");
-        if (multi_pass && hb_video_cq_multipass_is_supported(video_encoder->codec))
-        {
-            g_string_append_printf(str, _("%s, Constant Quality %.4g(%s) (Multi Pass)"),
-                               video_encoder->name, quality,
-                               hb_video_quality_get_name(video_encoder->codec));
-        }
-        else
-        {
-            g_string_append_printf(str, _("%s, Constant Quality %.4g(%s)"),
-                               video_encoder->name, quality,
-                               hb_video_quality_get_name(video_encoder->codec));
-        }
+        g_string_append_printf(str, _("%s, Constant Quality %.4g(%s)"),
+                            video_encoder->name, quality,
+                            hb_video_quality_get_name(video_encoder->codec));
     }
+
+    if (multi_pass && hb_video_multipass_is_supported(video_encoder->codec, vqtype))
+    {
+        g_string_append_printf(str, _(" (Multi Pass)"));
+    }
+
     const char * enc_preset  = NULL;
     const char * enc_tune    = NULL;
     const char * enc_level   = NULL;

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -3523,7 +3523,6 @@ to limit instantaneous bitrate, look into x264&apos;s vbv-bufsize and vbv-maxrat
                                 <child>
                                   <object class="GtkBox" id="VideoMultiPassBox">
                                     <property name="spacing">20</property>
-                                    <property name="margin-start">10</property>
                                     <child>
                                       <object class="GtkCheckButton" id="VideoMultiPass">
                                         <property name="label" translatable="yes">Multi-Pass Encoding</property>

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -71,21 +71,12 @@ ghb_update_multipass(signal_user_data_t *ud)
     GtkWidget *turbo_multi_pass = GTK_WIDGET(ghb_builder_widget("VideoTurboMultiPass"));
     int encoder = ghb_get_video_encoder(ud->settings);
     
-    bool supports_multi_pass = hb_video_multipass_is_supported(encoder);
+    bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
+    bool supports_multi_pass = hb_video_multipass_is_supported(encoder, constant_quality);
     bool turbo_supported = (encoder & HB_VCODEC_X264_MASK) || (encoder & HB_VCODEC_X265_MASK);
     
-    gtk_widget_set_visible(turbo_multi_pass, supports_multi_pass && turbo_supported);
-    
-    bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
-    if (constant_quality)
-    {
-        bool supports_cq_multi_pass = hb_video_cq_multipass_is_supported(encoder);
-        gtk_widget_set_sensitive(multi_pass, supports_cq_multi_pass);
-    }
-    else
-    {
-        gtk_widget_set_sensitive(multi_pass, supports_multi_pass);
-    }
+    gtk_widget_set_sensitive(multi_pass, supports_multi_pass);
+    gtk_widget_set_visible(turbo_multi_pass, turbo_supported);
 }
 
 G_MODULE_EXPORT void

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -64,6 +64,29 @@ int ghb_set_video_preset(GhbValue *settings, int encoder, const char * preset)
     return result;
 }
 
+void
+ghb_update_multipass(signal_user_data_t *ud)
+{
+    GtkWidget *multi_pass = GTK_WIDGET(ghb_builder_widget("VideoMultiPassBox"));
+    GtkWidget *turbo_multi_pass = GTK_WIDGET(ghb_builder_widget("VideoTurboMultiPass"));
+    int encoder = ghb_get_video_encoder(ud->settings);
+    
+    bool supports_multi_pass = hb_video_multipass_is_supported(encoder);
+    bool turbo_supported = (encoder & HB_VCODEC_X264_MASK) || (encoder & HB_VCODEC_X265_MASK);
+    
+    gtk_widget_set_visible(turbo_multi_pass, supports_multi_pass && turbo_supported);
+    
+    bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
+    if (constant_quality)
+    {
+        gtk_widget_set_sensitive(multi_pass, false);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(multi_pass, supports_multi_pass);
+    }
+}
+
 G_MODULE_EXPORT void
 vcodec_changed_cb (GtkWidget *widget, gpointer data)
 {
@@ -76,6 +99,7 @@ vcodec_changed_cb (GtkWidget *widget, gpointer data)
     ghb_update_summary_info(ud);
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
+    ghb_update_multipass(ud);
 
     // Set the range of the video quality slider
     val = ghb_vquality_default(ud);

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -79,7 +79,8 @@ ghb_update_multipass(signal_user_data_t *ud)
     bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
     if (constant_quality)
     {
-        gtk_widget_set_sensitive(multi_pass, false);
+        bool supports_cq_multi_pass = hb_video_cq_multipass_is_supported(encoder);
+        gtk_widget_set_sensitive(multi_pass, supports_cq_multi_pass);
     }
     else
     {

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -67,13 +67,13 @@ int ghb_set_video_preset(GhbValue *settings, int encoder, const char * preset)
 void
 ghb_update_multipass(signal_user_data_t *ud)
 {
-    GtkWidget *multi_pass = GTK_WIDGET(ghb_builder_widget("VideoMultiPassBox"));
-    GtkWidget *turbo_multi_pass = GTK_WIDGET(ghb_builder_widget("VideoTurboMultiPass"));
+    GtkWidget *multi_pass = ghb_builder_widget("VideoMultiPassBox");
+    GtkWidget *turbo_multi_pass = ghb_builder_widget("VideoTurboMultiPass");
     int encoder = ghb_get_video_encoder(ud->settings);
     
-    bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
-    bool supports_multi_pass = hb_video_multipass_is_supported(encoder, constant_quality);
-    bool turbo_supported = (encoder & HB_VCODEC_X264_MASK) || (encoder & HB_VCODEC_X265_MASK);
+    gboolean constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
+    gboolean supports_multi_pass = hb_video_multipass_is_supported(encoder, constant_quality);
+    gboolean turbo_supported = (encoder & HB_VCODEC_X264_MASK) || (encoder & HB_VCODEC_X265_MASK);
     
     gtk_widget_set_sensitive(multi_pass, supports_multi_pass);
     gtk_widget_set_visible(turbo_multi_pass, turbo_supported);

--- a/gtk/src/videohandler.h
+++ b/gtk/src/videohandler.h
@@ -28,5 +28,6 @@ G_BEGIN_DECLS
 int ghb_get_video_encoder(GhbValue *settings);
 void ghb_video_setting_changed(GtkWidget *widget, signal_user_data_t *ud);
 int ghb_set_video_preset(GhbValue *settings, int encoder, const char * preset);
+void ghb_update_multipass(signal_user_data_t *ud);
 
 G_END_DECLS

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1640,6 +1640,19 @@ int hb_video_multipass_is_supported(uint32_t codec)
     }
 }
 
+int hb_video_cq_multipass_is_supported(uint32_t codec)
+{
+    switch (codec)
+    {
+        case HB_VCODEC_FFMPEG_VP9:
+        case HB_VCODEC_FFMPEG_VP9_10BIT:
+            return 1;
+        
+        default:
+            return 0;
+    }
+}
+
 int hb_video_encoder_is_supported(int encoder)
 {
     const hb_encoder_t *video_encoder = NULL;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1606,7 +1606,7 @@ int hb_video_quality_is_supported(uint32_t codec)
     }
 }
 
-int hb_video_multipass_is_supported(uint32_t codec)
+int hb_video_multipass_is_supported(uint32_t codec, int constant_quality)
 {
     switch (codec)
     {
@@ -1614,7 +1614,7 @@ int hb_video_multipass_is_supported(uint32_t codec)
         case HB_VCODEC_VT_H264:
         case HB_VCODEC_VT_H265:
         case HB_VCODEC_VT_H265_10BIT:
-            return hb_vt_is_multipass_available(codec);
+            return !constant_quality && hb_vt_is_multipass_available(codec);
 #endif
 
         case HB_VCODEC_FFMPEG_MF_H264:
@@ -1635,21 +1635,12 @@ int hb_video_multipass_is_supported(uint32_t codec)
         case HB_VCODEC_QSV_AV1_10BIT:
             return 0;
 
-        default:
-            return 1;
-    }
-}
-
-int hb_video_cq_multipass_is_supported(uint32_t codec)
-{
-    switch (codec)
-    {
         case HB_VCODEC_FFMPEG_VP9:
         case HB_VCODEC_FFMPEG_VP9_10BIT:
             return 1;
-        
+
         default:
-            return 0;
+            return !constant_quality;
     }
 }
 

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -434,6 +434,7 @@ const char* hb_video_quality_get_name(uint32_t codec);
 int         hb_video_quality_is_supported(uint32_t codec);
 
 int         hb_video_multipass_is_supported(uint32_t codec);
+int         hb_video_cq_multipass_is_supported(uint32_t codec);
 
 int                hb_video_encoder_is_supported(int encoder);
 int                hb_video_encoder_get_count_of_analysis_passes(int encoder);

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -433,8 +433,7 @@ void        hb_video_quality_get_limits(uint32_t codec, float *low, float *high,
 const char* hb_video_quality_get_name(uint32_t codec);
 int         hb_video_quality_is_supported(uint32_t codec);
 
-int         hb_video_multipass_is_supported(uint32_t codec);
-int         hb_video_cq_multipass_is_supported(uint32_t codec);
+int         hb_video_multipass_is_supported(uint32_t codec, int constant_quality);
 
 int                hb_video_encoder_is_supported(int encoder);
 int                hb_video_encoder_get_count_of_analysis_passes(int encoder);

--- a/libhb/handbrake/preset_builtin.h
+++ b/libhb/handbrake/preset_builtin.h
@@ -10009,7 +10009,7 @@ const char hb_builtin_presets_json[] =
 "            \"x264Option\": \"\",\n"
 "            \"x264UseAdvancedOptions\": false\n"
 "        },\n"
-"        \"VersionMajor\": 53,\n"
+"        \"VersionMajor\": 54,\n"
 "        \"VersionMicro\": 0,\n"
 "        \"VersionMinor\": 0\n"
 "    }\n"

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1901,7 +1901,7 @@ int hb_add( hb_handle_t * h, hb_job_t * job )
 
 void hb_job_setup_passes(hb_handle_t * h, hb_job_t * job, hb_list_t * list_pass)
 {
-    if (job->vquality > HB_INVALID_VIDEO_QUALITY && ! hb_video_cq_multipass_is_supported(job->vcodec))
+    if (job->vquality > HB_INVALID_VIDEO_QUALITY && ! hb_video_multipass_is_supported(job->vcodec, 1))
     {
         job->multipass = 0;
     }

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1901,7 +1901,7 @@ int hb_add( hb_handle_t * h, hb_job_t * job )
 
 void hb_job_setup_passes(hb_handle_t * h, hb_job_t * job, hb_list_t * list_pass)
 {
-    if (job->vquality > HB_INVALID_VIDEO_QUALITY)
+    if (job->vquality > HB_INVALID_VIDEO_QUALITY && ! hb_video_cq_multipass_is_supported(job->vcodec))
     {
         job->multipass = 0;
     }

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1843,16 +1843,6 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(video_dict, "Quality",
                     hb_value_xform(hb_dict_get(preset, "VideoQualitySlider"),
                                    HB_VALUE_TYPE_DOUBLE));
-        
-        if (hb_video_cq_multipass_is_supported(vcodec))
-        {
-            hb_dict_set(video_dict, "MultiPass",
-                        hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
-                                       HB_VALUE_TYPE_BOOL));
-            hb_dict_set(video_dict, "Turbo",
-                        hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
-                                       HB_VALUE_TYPE_BOOL));
-        }
         hb_dict_remove(video_dict, "Bitrate");
     }
     else if (vqtype == 1)   // ABR
@@ -1860,15 +1850,6 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(video_dict, "Bitrate",
                     hb_value_xform(hb_dict_get(preset, "VideoAvgBitrate"),
                                    HB_VALUE_TYPE_INT));
-        if (hb_video_multipass_is_supported(vcodec))
-        {
-            hb_dict_set(video_dict, "MultiPass",
-                        hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
-                                       HB_VALUE_TYPE_BOOL));
-            hb_dict_set(video_dict, "Turbo",
-                        hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
-                                       HB_VALUE_TYPE_BOOL));
-        }
         hb_dict_remove(video_dict, "Quality");
     }
     else
@@ -1878,15 +1859,6 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         {
             hb_dict_set(video_dict, "Quality",
                         hb_value_xform(value, HB_VALUE_TYPE_DOUBLE));
-            if (hb_video_cq_multipass_is_supported(vcodec))
-            {
-                hb_dict_set(video_dict, "MultiPass",
-                            hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
-                                        HB_VALUE_TYPE_BOOL));
-                hb_dict_set(video_dict, "Turbo",
-                            hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
-                                        HB_VALUE_TYPE_BOOL));
-            }
             hb_dict_remove(video_dict, "Bitrate");
         }
         else
@@ -1894,17 +1866,18 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
             hb_dict_set(video_dict, "Bitrate",
                         hb_value_xform(hb_dict_get(preset, "VideoAvgBitrate"),
                                        HB_VALUE_TYPE_INT));
-            if (hb_video_multipass_is_supported(vcodec))
-            {
-                hb_dict_set(video_dict, "MultiPass",
-                            hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
-                                           HB_VALUE_TYPE_BOOL));
-                hb_dict_set(video_dict, "Turbo",
-                            hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
-                                           HB_VALUE_TYPE_BOOL));
-            }
             hb_dict_remove(video_dict, "Quality");
         }
+    }
+
+    if (hb_video_multipass_is_supported(vcodec, hb_dict_get(video_dict, "Quality") != NULL))
+    {
+        hb_dict_set(video_dict, "MultiPass",
+            hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
+                            HB_VALUE_TYPE_BOOL));
+        hb_dict_set(video_dict, "Turbo",
+                    hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
+                                    HB_VALUE_TYPE_BOOL));
     }
     
     if ((value = hb_dict_get(preset, "VideoHWDecode")) != NULL)

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1843,6 +1843,16 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         hb_dict_set(video_dict, "Quality",
                     hb_value_xform(hb_dict_get(preset, "VideoQualitySlider"),
                                    HB_VALUE_TYPE_DOUBLE));
+        
+        if (hb_video_cq_multipass_is_supported(vcodec))
+        {
+            hb_dict_set(video_dict, "MultiPass",
+                        hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
+                                       HB_VALUE_TYPE_BOOL));
+            hb_dict_set(video_dict, "Turbo",
+                        hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
+                                       HB_VALUE_TYPE_BOOL));
+        }
         hb_dict_remove(video_dict, "Bitrate");
     }
     else if (vqtype == 1)   // ABR
@@ -1868,6 +1878,15 @@ int hb_preset_apply_video(const hb_dict_t *preset, hb_dict_t *job_dict)
         {
             hb_dict_set(video_dict, "Quality",
                         hb_value_xform(value, HB_VALUE_TYPE_DOUBLE));
+            if (hb_video_cq_multipass_is_supported(vcodec))
+            {
+                hb_dict_set(video_dict, "MultiPass",
+                            hb_value_xform(hb_dict_get(preset, "VideoMultiPass"),
+                                        HB_VALUE_TYPE_BOOL));
+                hb_dict_set(video_dict, "Turbo",
+                            hb_value_xform(hb_dict_get(preset, "VideoTurboMultiPass"),
+                                        HB_VALUE_TYPE_BOOL));
+            }
             hb_dict_remove(video_dict, "Bitrate");
         }
         else

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -2812,6 +2812,20 @@ static void und_to_any(hb_value_array_t * list)
     }
 }
 
+static void import_vp9_multipass_settings_53_0_0(hb_value_t *preset)
+{
+    const char *enc = hb_dict_get_string(preset, "VideoEncoder");
+    int codec = hb_video_encoder_get_from_name(enc);
+
+    int vquality_type = hb_dict_get_int(preset, "VideoQualityType");
+
+    if ((codec == HB_VCODEC_FFMPEG_VP9 || codec == HB_VCODEC_FFMPEG_VP9_10BIT)
+        && vquality_type == 2) // constant quality
+    {
+        hb_dict_set_bool(preset, "VideoMultiPass", 0);
+    }
+}
+
 static void import_container_settings_51_0_0(hb_value_t *preset)
 {
     int optimize = hb_dict_get_bool(preset, "Mp4HttpOptimize");
@@ -3522,9 +3536,16 @@ static void import_video_0_0_0(hb_value_t *preset)
     }
 }
 
+static void import_53_0_0(hb_value_t *preset)
+{
+    import_vp9_multipass_settings_53_0_0(preset);
+}
+
 static void import_51_0_0(hb_value_t *preset)
 {
     import_container_settings_51_0_0(preset);
+
+    import_53_0_0(preset);
 }
 
 static void import_50_0_0(hb_value_t *preset)
@@ -3702,6 +3723,11 @@ static int preset_import(hb_value_t *preset, int major, int minor, int micro)
         else if (cmpVersion(major, minor, micro, 51, 0, 0) <= 0)
         {
             import_51_0_0(preset);
+            result = 1;
+        }
+        else if (cmpVersion(major, minor, micro, 53, 0, 0) <= 0)
+        {
+            import_53_0_0(preset);
             result = 1;
         }
 

--- a/macosx/Base.lproj/Video.xib
+++ b/macosx/Base.lproj/Video.xib
@@ -123,7 +123,7 @@
                         <font key="font" metaFont="controlContent" size="11"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="-2" name="enabled2" keyPath="self.video" previousBinding="7aV-7j-MzB" id="c4g-dz-q05">
+                        <binding destination="-2" name="enabled" keyPath="self.video" id="c4g-dz-q05">
                             <dictionary key="options">
                                 <integer key="NSMultipleValuesPlaceholder" value="-1"/>
                                 <integer key="NSNoSelectionPlaceholder" value="-1"/>
@@ -133,17 +133,12 @@
                             </dictionary>
                         </binding>
                         <binding destination="-2" name="value" keyPath="self.video.multiPass" id="oMA-Mr-zX3"/>
-                        <binding destination="-2" name="enabled3" keyPath="self.video.multiPassSupported" previousBinding="c4g-dz-q05" id="e4I-LB-isN">
+                        <binding destination="-2" name="enabled2" keyPath="self.video.multiPassSupported" previousBinding="c4g-dz-q05" id="e4I-LB-isN">
                             <dictionary key="options">
                                 <integer key="NSMultipleValuesPlaceholder" value="-1"/>
                                 <integer key="NSNoSelectionPlaceholder" value="-1"/>
                                 <integer key="NSNotApplicablePlaceholder" value="-1"/>
                                 <integer key="NSNullPlaceholder" value="-1"/>
-                            </dictionary>
-                        </binding>
-                        <binding destination="-2" name="enabled" keyPath="self.video.qualityType" id="7aV-7j-MzB">
-                            <dictionary key="options">
-                                <string key="NSValueTransformerName">NSNegateBoolean</string>
                             </dictionary>
                         </binding>
                     </connections>
@@ -683,7 +678,7 @@ Syntax: option-1=foo:opt2=bar</string>
                 <constraint firstItem="GPu-Ht-bKg" firstAttribute="leading" secondItem="Vae-sv-7Up" secondAttribute="leading" constant="16" id="8oT-Pe-dhL"/>
                 <constraint firstItem="brN-9J-qa1" firstAttribute="firstBaseline" secondItem="A3o-Zx-OfM" secondAttribute="firstBaseline" id="Aaw-iQ-f0a"/>
                 <constraint firstItem="1au-ZO-l1i" firstAttribute="baseline" secondItem="gfa-Hb-cDP" secondAttribute="baseline" id="BfH-Qs-3mV"/>
-                <constraint firstItem="bnV-aE-FVh" firstAttribute="leading" secondItem="brN-9J-qa1" secondAttribute="leading" constant="16" id="D6T-CW-ala"/>
+                <constraint firstItem="bnV-aE-FVh" firstAttribute="leading" secondItem="brN-9J-qa1" secondAttribute="leading" constant="0" id="D6T-CW-ala"/>
                 <constraint firstItem="A3o-Zx-OfM" firstAttribute="leading" secondItem="1au-ZO-l1i" secondAttribute="leading" id="F0a-Kc-s3X"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="olm-zg-k9Y" secondAttribute="trailing" constant="20" id="Fsh-Kh-XyK"/>
                 <constraint firstItem="Pai-3Q-Gs3" firstAttribute="leading" secondItem="1au-ZO-l1i" secondAttribute="trailing" constant="8" symbolic="YES" id="GPO-LT-xtY"/>

--- a/macosx/HBJob+UIAdditions.m
+++ b/macosx/HBJob+UIAdditions.m
@@ -22,7 +22,7 @@
 #import "HBLocalizationUtilities.h"
 
 #import "HBRange.h"
-#import "HBVideo.h"
+#import "HBVideo+UIAdditions.h"
 #import "HBPicture.h"
 #import "HBFilters.h"
 #import "HBAudio.h"
@@ -166,7 +166,7 @@ static HBMixdownTransformer    *mixdownTransformer;
     {
         [passesString appendString:HBKitLocalizedString(@"1 Foreign Language Search Pass - ", @"Title description")];
     }
-    if (self.video.qualityType != 1 && self.video.multiPass == YES)
+    if (self.video.multiPassSupported && self.video.multiPass == YES)
     {
         if (self.video.turboMultiPass == YES)
         {

--- a/macosx/HBVideo+UIAdditions.m
+++ b/macosx/HBVideo+UIAdditions.m
@@ -100,7 +100,7 @@
 
 + (NSSet<NSString *> *)keyPathsForValuesAffectingTurboMultiPassSupported
 {
-    return [NSSet setWithObjects:@"encoder", nil];
+    return [NSSet setWithObjects:@"encoder", @"qualityType", nil];
 }
 
 - (BOOL)turboMultiPassSupported
@@ -111,12 +111,19 @@
 
 + (NSSet<NSString *> *)keyPathsForValuesAffectingMultiPassSupported
 {
-    return [NSSet setWithObjects:@"encoder", nil];
+    return [NSSet setWithObjects:@"encoder", @"qualityType", nil];
 }
 
 - (BOOL)multiPassSupported
 {
-    return hb_video_multipass_is_supported(self.encoder);
+    if (self.qualityType == 0)
+    {
+        return hb_video_multipass_is_supported(self.encoder);
+    }
+    else
+    {
+        return hb_video_cq_multipass_is_supported(self.encoder);
+    }
 }
 
 + (NSSet<NSString *> *)keyPathsForValuesAffectingConstantQualityLabel

--- a/macosx/HBVideo+UIAdditions.m
+++ b/macosx/HBVideo+UIAdditions.m
@@ -116,14 +116,7 @@
 
 - (BOOL)multiPassSupported
 {
-    if (self.qualityType == 0)
-    {
-        return hb_video_multipass_is_supported(self.encoder);
-    }
-    else
-    {
-        return hb_video_cq_multipass_is_supported(self.encoder);
-    }
+    return hb_video_multipass_is_supported(self.encoder, self.qualityType != 0);
 }
 
 + (NSSet<NSString *> *)keyPathsForValuesAffectingConstantQualityLabel

--- a/macosx/HBVideo.m
+++ b/macosx/HBVideo.m
@@ -294,7 +294,8 @@ NSString * const HBVideoChangedNotification = @"HBVideoChangedNotification";
         self.qualityType = 0;
     }
 
-    if (!hb_video_multipass_is_supported(self.encoder))
+    if (! (hb_video_multipass_is_supported(self.encoder, false)
+            || hb_video_multipass_is_supported(self.encoder, true)))
     {
         self.multiPass = NO;
     }

--- a/preset/preset_builtin.list
+++ b/preset/preset_builtin.list
@@ -1,6 +1,6 @@
 <resources>
     <section name="PresetTemplate">
-        <integer name="VersionMajor" value="53" />
+        <integer name="VersionMajor" value="54" />
         <integer name="VersionMinor" value="0" />
         <integer name="VersionMicro" value="0" />
         <json name="Preset" file="preset_template.json" />

--- a/test/test.c
+++ b/test/test.c
@@ -4288,22 +4288,22 @@ static hb_dict_t * PreparePreset(const char *preset_name)
     {
         hb_dict_set(preset, "VideoQualityType", hb_value_int(1));
         hb_dict_set(preset, "VideoAvgBitrate", hb_value_int(vbitrate));
-        if (multiPass == 1)
-        {
-            hb_dict_set(preset, "VideoMultiPass", hb_value_bool(1));
-        }
-        else if (multiPass == 0)
-        {
-            hb_dict_set(preset, "VideoMultiPass", hb_value_bool(0));
-        }
-        if (fastanalysispass == 1)
-        {
-            hb_dict_set(preset, "VideoTurboMultiPass", hb_value_bool(1));
-        }
-        else if (fastanalysispass == 0)
-        {
-            hb_dict_set(preset, "VideoTurboMultiPass", hb_value_bool(0));
-        }
+    }
+    if (multiPass == 1)
+    {
+        hb_dict_set(preset, "VideoMultiPass", hb_value_bool(1));
+    }
+    else if (multiPass == 0)
+    {
+        hb_dict_set(preset, "VideoMultiPass", hb_value_bool(0));
+    }
+    if (fastanalysispass == 1)
+    {
+        hb_dict_set(preset, "VideoTurboMultiPass", hb_value_bool(1));
+    }
+    else if (fastanalysispass == 0)
+    {
+        hb_dict_set(preset, "VideoTurboMultiPass", hb_value_bool(0));
     }
     const char *vrate_preset;
     const char *cfr_preset;

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -289,24 +289,13 @@ namespace HandBrake.Interop.Interop
             return Containers.SingleOrDefault(c => c.ShortName == shortName);
         }
 
-        public static bool VideoEncoderSupportsMultiPass(string encoderShortName)
+        public static bool VideoEncoderSupportsMultiPass(string encoderShortName, bool constantQuality)
         {
             HBVideoEncoder encoder = GetVideoEncoder(encoderShortName);
 
             if (encoder != null)
             {
-                return VideoEncoderSupportsMultiPass(encoder.Id);
-            }
-
-            return false;
-        }
-        public static bool VideoEncoderSupportsCQMultiPass(string encoderShortName)
-        {
-            HBVideoEncoder encoder = GetVideoEncoder(encoderShortName);
-
-            if (encoder != null)
-            {
-                return VideoEncoderSupportsCQMultiPass(encoder.Id);
+                return VideoEncoderSupportsMultiPass(encoder.Id, constantQuality);
             }
 
             return false;
@@ -321,23 +310,9 @@ namespace HandBrake.Interop.Interop
         /// <returns>
         /// True if the given video encoder supports multi-pass mode.
         /// </returns>
-        public static bool VideoEncoderSupportsMultiPass(int encoderId)
+        public static bool VideoEncoderSupportsMultiPass(int encoderId, bool constantQuality)
         {
-            return HBFunctions.hb_video_multipass_is_supported((uint)encoderId) > 0;
-        }
-
-        /// <summary>
-        /// Returns true if the given video encoder supports multi-pass mode.
-        /// </summary>
-        /// <param name="encoderId">
-        /// The encoder ID.
-        /// </param>
-        /// <returns>
-        /// True if the given video encoder supports multi-pass mode.
-        /// </returns>
-        public static bool VideoEncoderSupportsCQMultiPass(int encoderId)
-        {
-            return HBFunctions.hb_video_cq_multipass_is_supported((uint)encoderId) > 0;
+            return HBFunctions.hb_video_multipass_is_supported((uint)encoderId, Convert.ToInt32(constantQuality)) > 0;
         }
 
         /// <summary>

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -300,6 +300,17 @@ namespace HandBrake.Interop.Interop
 
             return false;
         }
+        public static bool VideoEncoderSupportsCQMultiPass(string encoderShortName)
+        {
+            HBVideoEncoder encoder = GetVideoEncoder(encoderShortName);
+
+            if (encoder != null)
+            {
+                return VideoEncoderSupportsCQMultiPass(encoder.Id);
+            }
+
+            return false;
+        }
 
         /// <summary>
         /// Returns true if the given video encoder supports multi-pass mode.
@@ -313,6 +324,20 @@ namespace HandBrake.Interop.Interop
         public static bool VideoEncoderSupportsMultiPass(int encoderId)
         {
             return HBFunctions.hb_video_multipass_is_supported((uint)encoderId) > 0;
+        }
+
+        /// <summary>
+        /// Returns true if the given video encoder supports multi-pass mode.
+        /// </summary>
+        /// <param name="encoderId">
+        /// The encoder ID.
+        /// </param>
+        /// <returns>
+        /// True if the given video encoder supports multi-pass mode.
+        /// </returns>
+        public static bool VideoEncoderSupportsCQMultiPass(int encoderId)
+        {
+            return HBFunctions.hb_video_cq_multipass_is_supported((uint)encoderId) > 0;
         }
 
         /// <summary>

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -155,6 +155,9 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_video_multipass_is_supported", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_video_multipass_is_supported(uint codec);
 
+        [DllImport("hb", EntryPoint = "hb_video_cq_multipass_is_supported", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_video_cq_multipass_is_supported(uint codec);
+
         [DllImport("hb", EntryPoint = "hb_video_encoder_is_supported", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_video_encoder_is_supported(int encoder);
 

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -153,10 +153,7 @@ namespace HandBrake.Interop.Interop.HbLib
         public static extern IntPtr hb_video_quality_get_name(uint codec);
 
         [DllImport("hb", EntryPoint = "hb_video_multipass_is_supported", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_video_multipass_is_supported(uint codec);
-
-        [DllImport("hb", EntryPoint = "hb_video_cq_multipass_is_supported", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_video_cq_multipass_is_supported(uint codec);
+        public static extern int hb_video_multipass_is_supported(uint codec, int constant_quality);
 
         [DllImport("hb", EntryPoint = "hb_video_encoder_is_supported", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_video_encoder_is_supported(int encoder);

--- a/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Encoders/HBVideoEncoder.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Encoders/HBVideoEncoder.cs
@@ -146,9 +146,11 @@ namespace HandBrake.Interop.Interop.Interfaces.Model.Encoders
         public bool SupportsWebM => (this.CompatibleContainers & NativeConstants.HB_MUX_MASK_WEBM) == NativeConstants.HB_MUX_MASK_WEBM
                                     || (this.CompatibleContainers & NativeConstants.HB_MUX_AV_WEBM) == NativeConstants.HB_MUX_AV_WEBM;
 
-        public bool SupportsMultiPass => HandBrakeEncoderHelpers.VideoEncoderSupportsMultiPass(this.ShortName);
+        public bool SupportsMultiPass() => HandBrakeEncoderHelpers.VideoEncoderSupportsMultiPass(this.ShortName, true)
+                                    || HandBrakeEncoderHelpers.VideoEncoderSupportsMultiPass(this.ShortName, false);
 
-        public bool SupportsCQMultiPass => HandBrakeEncoderHelpers.VideoEncoderSupportsCQMultiPass(this.ShortName);
+        public bool SupportsMultiPass(bool constantQuality) => HandBrakeEncoderHelpers.VideoEncoderSupportsMultiPass(this.ShortName, constantQuality);
+        
 
         // TODO check if there is a nicer way of doing this.
         public bool IsSVTAV1 => this.ShortName.Contains("svt_av1");

--- a/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Encoders/HBVideoEncoder.cs
+++ b/win/CS/HandBrake.Interop/Interop/Interfaces/Model/Encoders/HBVideoEncoder.cs
@@ -148,6 +148,8 @@ namespace HandBrake.Interop.Interop.Interfaces.Model.Encoders
 
         public bool SupportsMultiPass => HandBrakeEncoderHelpers.VideoEncoderSupportsMultiPass(this.ShortName);
 
+        public bool SupportsCQMultiPass => HandBrakeEncoderHelpers.VideoEncoderSupportsCQMultiPass(this.ShortName);
+
         // TODO check if there is a nicer way of doing this.
         public bool IsSVTAV1 => this.ShortName.Contains("svt_av1");
         public bool IsX264 => this.ShortName.Contains("x264");

--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -251,10 +251,10 @@ namespace HandBrakeWPF.Services.Encode.Factories
             if (job.VideoEncodeRateType == VideoEncodeRateType.AverageBitrate)
             {
                 video.Bitrate = job.VideoBitrate;
-                video.MultiPass = job.MultiPass;
-                video.Turbo = job.TurboAnalysisPass;
             }
 
+            video.MultiPass = job.MultiPass;
+            video.Turbo = job.TurboAnalysisPass;
 
             bool enableQuickSyncEncoding = userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncEncoding);
             bool enableQuickSyncDecoding = userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncDecoding);

--- a/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
@@ -114,8 +114,6 @@ namespace HandBrakeWPF.ViewModels
                 if (value)
                 {
                     this.Task.VideoEncodeRateType = VideoEncodeRateType.ConstantQuality;
-                    this.MultiPass = false;
-                    this.TurboAnalysisPass = false;
                     this.VideoBitrate = null;
                     this.NotifyOfPropertyChange(() => this.Task);
                 }
@@ -136,15 +134,12 @@ namespace HandBrakeWPF.ViewModels
             {
                 if (this.IsConstantQuantity)
                 {
-                    return false;
+                    return this.SelectedVideoEncoder.SupportsCQMultiPass;
                 }
-
-                if (!this.SelectedVideoEncoder.SupportsMultiPass)
+                else
                 {
-                    return false;
+                    return this.SelectedVideoEncoder.SupportsMultiPass;
                 }
-
-                return true;
             }
         }
 
@@ -1108,7 +1103,7 @@ namespace HandBrakeWPF.ViewModels
             this.NotifyOfPropertyChange(() => this.IsMultiPassEnabled);
             this.NotifyOfPropertyChange(() => this.DisplayMultiPass);
 
-            if (this.SelectedVideoEncoder != null && !this.SelectedVideoEncoder.SupportsMultiPass)
+            if (this.SelectedVideoEncoder != null && !(this.SelectedVideoEncoder.SupportsMultiPass || this.SelectedVideoEncoder.SupportsCQMultiPass))
             {
                 this.MultiPass = false;
                 this.TurboAnalysisPass = false;

--- a/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
@@ -132,14 +132,7 @@ namespace HandBrakeWPF.ViewModels
         {
             get
             {
-                if (this.IsConstantQuantity)
-                {
-                    return this.SelectedVideoEncoder.SupportsCQMultiPass;
-                }
-                else
-                {
-                    return this.SelectedVideoEncoder.SupportsMultiPass;
-                }
+                return this.SelectedVideoEncoder.SupportsMultiPass(this.IsConstantQuantity);
             }
         }
 
@@ -378,7 +371,7 @@ namespace HandBrakeWPF.ViewModels
             }
         }
 
-        public bool DisplayMultiPass => this.SelectedVideoEncoder.SupportsMultiPass;
+        public bool DisplayMultiPass => this.SelectedVideoEncoder.SupportsMultiPass();
 
         public bool DisplayTuneControls
         {
@@ -1103,7 +1096,7 @@ namespace HandBrakeWPF.ViewModels
             this.NotifyOfPropertyChange(() => this.IsMultiPassEnabled);
             this.NotifyOfPropertyChange(() => this.DisplayMultiPass);
 
-            if (this.SelectedVideoEncoder != null && !(this.SelectedVideoEncoder.SupportsMultiPass || this.SelectedVideoEncoder.SupportsCQMultiPass))
+            if (this.SelectedVideoEncoder != null && !this.SelectedVideoEncoder.SupportsMultiPass())
             {
                 this.MultiPass = false;
                 this.TurboAnalysisPass = false;

--- a/win/CS/HandBrakeWPF/Views/VideoView.xaml
+++ b/win/CS/HandBrakeWPF/Views/VideoView.xaml
@@ -105,7 +105,7 @@
                              ToolTip="{x:Static Properties:ResourcesTooltips.Video_AvgBitrate}" AutomationProperties.Name="{x:Static Properties:Resources.VideoView_AverageBitrate}"  />
                 </StackPanel>
 
-                <StackPanel Orientation="Horizontal" Margin="30,0,0,0" Visibility="{Binding DisplayMultiPass, Converter={StaticResource boolToVisConverter}}">
+                <StackPanel Orientation="Horizontal" Margin="0,0,0,0" Visibility="{Binding DisplayMultiPass, Converter={StaticResource boolToVisConverter}}">
                     <CheckBox Content="{x:Static Properties:Resources.VideoView_MultiPass}" IsEnabled="{Binding IsMultiPassEnabled, Converter={StaticResource boolConverter}}"
                               IsChecked="{Binding MultiPass}" Margin="0,0,10,0" ToolTip="{x:Static Properties:ResourcesTooltips.Video_MultiPass}"  />
                     <CheckBox Content="{x:Static Properties:Resources.VideoView_TurboAnalysisPass}" IsEnabled="{Binding IsConstantQuantity, Converter={StaticResource boolConverter}, ConverterParameter=true}"


### PR DESCRIPTION
**Description of Change:**

This change adds support for multi-pass encoding with VP9 in CQ mode. There's an enhancement request open for this here: #1905

~I've only done this for the CLI in this PR as a) I don't immediately know how to do it in the various GUIs and b) I'm not sure if this will be accepted, or if the way I've done it makes sense. I'm happy to have a crack at the GUI changes necessary, but I'd probably need some guidance on where to look.~

Edit: I've made an attempt at the Mac and Linux GUIs, but I'm afraid I don't have access to a Windows box

I do feel like the change makes the code a little repetitive in `preset.c`, would it be better to find a way to do this without setting the multi-pass stuff in every branch of the if statements? I also wasn't sure if I could/should change the signature of `hb_video_multipass_is_supported` so it could handle both cases (ABR and CQ), rather than adding a new method for CQ mode.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux
