### PR TITLE
LinGui: validate encoder multipass support and only show turbo for encoders that support it

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -423,7 +423,6 @@ static GhbBinding widget_bindings[] =
     {"vquality_type_bitrate", "active", NULL, "VideoAvgBitrate", "sensitive"},
     {"vquality_type_constant", "active", NULL, "VideoQualitySlider", "sensitive"},
     {"vquality_type_constant", "active", NULL, "video_quality_label", "sensitive"},
-    {"vquality_type_constant", "active", NULL, "VideoMultiPassBox", "sensitive", TRUE},
     {"VideoFramerate", "active-id", "auto", "VideoFrameratePFR", "visible", TRUE},
     {"VideoFramerate", "active-id", "auto", "VideoFramerateVFR", "visible"},
     {"VideoMultiPass", "active", NULL, "VideoTurboMultiPass", "sensitive"},
@@ -3277,6 +3276,7 @@ vquality_type_changed_cb (GtkWidget *widget, gpointer data)
     signal_user_data_t *ud = ghb_ud();
 
     ghb_widget_to_setting(ud->settings, widget);
+    ghb_update_multipass(ud);
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
     if (ghb_check_name_template(ud, "{quality}") ||

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -85,5 +85,6 @@ void ghb_break_pts_duration(gint64 ptsDuration,
 void ghb_break_duration(gint64 duration, gint *hh, gint *mm, gint *ss);
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    const char *name, const char *id);
+void ghb_update_multipass(signal_user_data_t *ud);
 
 G_END_DECLS

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -64,6 +64,29 @@ int ghb_set_video_preset(GhbValue *settings, int encoder, const char * preset)
     return result;
 }
 
+void
+ghb_update_multipass(signal_user_data_t *ud)
+{
+    GtkWidget *multi_pass = GTK_WIDGET(ghb_builder_widget("VideoMultiPassBox"));
+    GtkWidget *turbo_multi_pass = GTK_WIDGET(ghb_builder_widget("VideoTurboMultiPass"));
+    int encoder = ghb_get_video_encoder(ud->settings);
+    
+    bool supports_multi_pass = hb_video_multipass_is_supported(encoder);
+    bool turbo_supported = (encoder & HB_VCODEC_X264_MASK) || (encoder & HB_VCODEC_X265_MASK);
+    
+    gtk_widget_set_visible(turbo_multi_pass, supports_multi_pass && turbo_supported);
+    
+    bool constant_quality = ghb_dict_get_bool(ud->settings, "vquality_type_constant");
+    if (constant_quality)
+    {
+        gtk_widget_set_sensitive(multi_pass, false);
+    }
+    else
+    {
+        gtk_widget_set_sensitive(multi_pass, supports_multi_pass);
+    }
+}
+
 G_MODULE_EXPORT void
 vcodec_changed_cb (GtkWidget *widget, gpointer data)
 {
@@ -76,6 +99,7 @@ vcodec_changed_cb (GtkWidget *widget, gpointer data)
     ghb_update_summary_info(ud);
     ghb_clear_presets_selection(ud);
     ghb_live_reset(ud);
+    ghb_update_multipass(ud);
 
     // Set the range of the video quality slider
     val = ghb_vquality_default(ud);


### PR DESCRIPTION
**Description of Change:**

I noticed that the Mac GUI (and I _presume_ the Windows GUI, but I don't have a Windows box to test with) validate support for multi-pass and turbo first pass depending on the selected encoder, but the Linux GUI doesn't.

This change does 2 things:

1. The Linux GUI will now make the same call to `hb_video_multipass_is_supported` for the selected encoder, and disable the multi-pass checkbox for encoders that don't support it
2. The Linux GUI will now hide or show the "Turbo Analysis Pass" based on the selected encoder

I hope I've added the code in the right place, please let me know if it would fit better elsewhere

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

x264 (Turbo is visible)
<img width="957" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/0290d7ce-3168-45c8-8065-0f67c85712f2">

SVT_AV1 (Turbo is not visible)
<img width="957" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/64784ebd-cf68-49c0-947c-18c1190a4acc">

I don't have access to any encoder options that don't support multiple passes to test with
