### PR TITLE
LinGui: add a dropdown menu to the "Open Source" button

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1489,6 +1489,8 @@ start_scan (signal_user_data_t *ud, const char *path, int title_id, int preview_
     ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-stop-small-symbolic");
     ghb_button_set_label(GHB_BUTTON(widget), _("Stop Scan"));
     gtk_widget_set_tooltip_text(widget, _("Stop Scan"));
+    widget = ghb_builder_widget("sourcetoolmenubutton");
+    gtk_widget_set_sensitive(widget, false);
     ghb_backend_scan(path, title_id, preview_count,
             90000L * ghb_dict_get_int(ud->prefs, "MinTitleDuration"));
 }
@@ -1507,6 +1509,8 @@ start_scan_list (signal_user_data_t *ud, GListModel *files, int title_id, int pr
     ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-stop-small-symbolic");
     ghb_button_set_label(GHB_BUTTON(widget), _("Stop Scan"));
     gtk_widget_set_tooltip_text(widget, _("Stop Scan"));
+    widget = ghb_builder_widget("sourcetoolmenubutton");
+    gtk_widget_set_sensitive(widget, false);
     ghb_backend_scan_list(files, title_id, preview_count,
             90000L * ghb_dict_get_int(ud->prefs, "MinTitleDuration"));
 }
@@ -4512,6 +4516,8 @@ ghb_backend_events(signal_user_data_t *ud)
         ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-source");
         ghb_button_set_label(GHB_BUTTON(widget), _("Open Source"));
         gtk_widget_set_tooltip_text(widget, _("Choose Video Source"));
+        widget = ghb_builder_widget("sourcetoolmenubutton");
+        gtk_widget_set_sensitive(widget, true);
 
         hide_scan_progress(ud);
 

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -1355,11 +1355,24 @@ Van Jacobson</property>
 large-icons</property>
                 <property name="hexpand">1</property>
                 <child>
-                  <object class="GhbButton" id="sourcetoolbutton">
-                    <property name="tooltip-text" translatable="yes">Choose Video Source</property>
-                    <property name="label" translatable="yes">Open Source</property>
-                    <property name="icon-name">hb-source</property>
-                    <property name="action-name">app.source</property>
+                  <object class="GtkBox" id="open_source_split_button">
+                  <property name="orientation">horizontal</property>
+                  <property name="css-classes">ghb-linked-button</property>
+                    <child>
+                      <object class="GhbButton" id="sourcetoolbutton">
+                        <property name="tooltip-text" translatable="yes">Choose Video Source</property>
+                        <property name="label" translatable="yes">Open Source</property>
+                        <property name="icon-name">hb-source</property>
+                        <property name="action-name">app.source</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkMenuButton" id="sourcetoolmenubutton">
+                        <property name="css-classes">normal-icons</property>
+                        <property name="icon-name">pan-down-symbolic</property>
+                        <property name="menu-model">open-source-menu-model</property>
+                      </object>
+                    </child>
                   </object>
                 </child>
                 <child>

--- a/gtk/src/ui/menu.ui
+++ b/gtk/src/ui/menu.ui
@@ -454,5 +454,18 @@
       </item>
     </section>
   </menu>
+
+  <menu id="open-source-menu-model">
+    <section>
+      <item>
+        <attribute name="action">app.source</attribute>
+        <attribute name="label" translatable="yes">_Open Source…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.source-dir</attribute>
+        <attribute name="label" translatable="yes">Open _Directory…</attribute>
+      </item>
+    </section>
+  </menu>
 </interface>
 


### PR DESCRIPTION
**Description of Change:**

I often get caught out by the "Open Source" button only allowing you to open a single file, and I thought a split menu button like this might make the "Open Directory" option more obvious


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**

![image](https://github.com/HandBrake/HandBrake/assets/13986933/416f7977-29c6-4b9a-b54d-8d6f3d3fff9a)

