### PR TITLE
Use a libdovi tar package that includes the 3rd party dependencies.

### DIFF
--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,14 +1,16 @@
 $(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
 $(eval $(call import.CONTRIB.defs,LIBDOVI))
 
-ifneq (1,$(FEATURE.flatpak))
+ifeq (1,$(FEATURE.flatpak))
     LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dovi_tool-libdovi-3.3.0_vendor.tar.gz
+    LIBDOVI.FETCH.sha256   = a0b10fcdd51c1268d1ffb210fd5cfe1079db8f349a330be5605e386067d46ed6
+    LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0_vendor.tar.gz
 else
     LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdovi-3.3.0.tar.gz
+    LIBDOVI.FETCH.sha256   = 4b7e28322a5b15ea0eff5ed19e626468b17d5fc17aab9befaa9f725e466a7b40
+    LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0.tar.gz
 endif
 
-LIBDOVI.FETCH.sha256   = a0b10fcdd51c1268d1ffb210fd5cfe1079db8f349a330be5605e386067d46ed6
-LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0_vendor.tar.gz
 LIBDOVI.EXTRACT.tarbase = dovi_tool-libdovi-3.3.0
 
 define LIBDOVI.CONFIGURE

--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,7 +1,12 @@
 $(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
 $(eval $(call import.CONTRIB.defs,LIBDOVI))
 
-LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dovi_tool-libdovi-3.3.0_vendor.tar.gz
+ifneq (1,$(FEATURE.flatpak))
+    LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dovi_tool-libdovi-3.3.0_vendor.tar.gz
+else
+    LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdovi-3.3.0.tar.gz
+endif
+
 LIBDOVI.FETCH.sha256   = a0b10fcdd51c1268d1ffb210fd5cfe1079db8f349a330be5605e386067d46ed6
 LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0_vendor.tar.gz
 LIBDOVI.EXTRACT.tarbase = dovi_tool-libdovi-3.3.0

--- a/contrib/libdovi/module.defs
+++ b/contrib/libdovi/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,LIBDOVI,libdovi))
 $(eval $(call import.CONTRIB.defs,LIBDOVI))
 
-LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libdovi-3.3.0.tar.gz
-LIBDOVI.FETCH.url     += https://github.com/quietvoid/dovi_tool/archive/refs/tags/libdovi-3.3.0.tar.gz
-LIBDOVI.FETCH.sha256   = 4b7e28322a5b15ea0eff5ed19e626468b17d5fc17aab9befaa9f725e466a7b40
-LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0.tar.gz
+LIBDOVI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dovi_tool-libdovi-3.3.0_vendor.tar.gz
+LIBDOVI.FETCH.sha256   = a0b10fcdd51c1268d1ffb210fd5cfe1079db8f349a330be5605e386067d46ed6
+LIBDOVI.FETCH.basename = dovi_tool-libdovi-3.3.0_vendor.tar.gz
+LIBDOVI.EXTRACT.tarbase = dovi_tool-libdovi-3.3.0
 
 define LIBDOVI.CONFIGURE
      cd $(LIBDOVI_DV.dir); $(CARGO.exe) fetch


### PR DESCRIPTION
Following on from: #5819

Relevant: #5813

Change the libdovi contrib package to use a version that includes all 3rd party libraries. 

**To Create the package:**

1.  Download the libdovi source package and extract
2. in the "dolby_vision" folder, add  ./cargo/config.toml with the following contents:
```
[source.crates-io]
replace-with = "vendored-sources"

[source.vendored-sources]
directory = "vendor"

```
3. Run the command, "cargo vendor" in the dolby vision folder.
4. tar the package back up


**Build Log:**

_scott@Discovery:~/sr55/build$ make libdovi
/usr/bin/mkdir -p contrib/libdovi/
sha256 (../download/dovi_tool-libdovi-3.3.0_vendor.tar.gz) = a0b10fcdd51c1268d1ffb210fd5cfe1079db8f349a330be5605e386067d46ed6 (pass)
/usr/bin/rm -fr ./contrib/libdovi/dovi_tool-libdovi-3.3.0/
/usr/bin/tar xfC ../download/dovi_tool-libdovi-3.3.0_vendor.tar.gz ./contrib/libdovi/
touch contrib/libdovi/.stamp.libdovi.extract
touch contrib/libdovi/.stamp.libdovi.patch
cd "./contrib/libdovi/dovi_tool-libdovi-3.3.0/dolby_vision"; /home/scott/.cargo/bin/cargo fetch
touch contrib/libdovi/.stamp.libdovi.configure
/home/scott/.cargo/bin/cargo clean --manifest-path="./contrib/libdovi/dovi_tool-libdovi-3.3.0/dolby_vision/Cargo.toml"
/usr/bin/rm -f ./contrib/libdovi/.stamp.libdovi.build
cd "./contrib/libdovi/dovi_tool-libdovi-3.3.0/dolby_vision"; /home/scott/.cargo/bin/cargo cbuild --release --library-type staticlib --prefix "/home/scott/sr55/build/contrib/" --pkgconfigdir "/home/scott/sr55/build/contrib//lib/pkgconfig"
   Compiling radium v0.7.0
   Compiling anyhow v1.0.81
   Compiling libc v0.2.153
   Compiling tap v1.0.1
   Compiling funty v2.0.0
   Compiling bitstream-io v2.2.0
   Compiling crc-catalog v2.4.0
   Compiling crc v3.0.1
   Compiling wyz v0.5.1
   Compiling bitvec_helpers v3.1.4
   Compiling bitvec v1.0.1
   Compiling dolby_vision v3.3.0 (/home/scott/sr55/build/contrib/libdovi/dovi_tool-libdovi-3.3.0/dolby_vision)
    Finished release [optimized] target(s) in 2.65s
    Building pkg-config files
    Building header file using cbindgen
  Populating uninstalled header directory
touch contrib/libdovi/.stamp.libdovi.build_