### PR TITLE
LinGui: GtkHeaderBar UI

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -920,9 +920,6 @@ ghb_application_activate (GApplication *app)
     window = GTK_WINDOW(ghb_builder_widget("title_add_multiple_dialog"));
     gtk_application_add_window(GTK_APPLICATION(app), window);
 
-    GMenuModel *menu = G_MENU_MODEL(ghb_builder_object("handbrake-menu-bar"));
-    gtk_application_set_menubar(GTK_APPLICATION(app), menu);
-
     gtk_window_present(hb_window);
 }
 

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1489,6 +1489,8 @@ start_scan (signal_user_data_t *ud, const char *path, int title_id, int preview_
     ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-stop-small-symbolic");
     ghb_button_set_label(GHB_BUTTON(widget), _("Stop Scan"));
     gtk_widget_set_tooltip_text(widget, _("Stop Scan"));
+    widget = ghb_builder_widget("sourcetoolmenubutton");
+    gtk_widget_set_sensitive(widget, false);
     ghb_backend_scan(path, title_id, preview_count,
             90000L * ghb_dict_get_int(ud->prefs, "MinTitleDuration"));
 }
@@ -1507,6 +1509,8 @@ start_scan_list (signal_user_data_t *ud, GListModel *files, int title_id, int pr
     ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-stop-small-symbolic");
     ghb_button_set_label(GHB_BUTTON(widget), _("Stop Scan"));
     gtk_widget_set_tooltip_text(widget, _("Stop Scan"));
+    widget = ghb_builder_widget("sourcetoolmenubutton");
+    gtk_widget_set_sensitive(widget, false);
     ghb_backend_scan_list(files, title_id, preview_count,
             90000L * ghb_dict_get_int(ud->prefs, "MinTitleDuration"));
 }
@@ -4512,7 +4516,8 @@ ghb_backend_events(signal_user_data_t *ud)
         ghb_button_set_icon_name(GHB_BUTTON(widget), "hb-source");
         ghb_button_set_label(GHB_BUTTON(widget), _("Open Source"));
         gtk_widget_set_tooltip_text(widget, _("Choose Video Source"));
-
+        widget = ghb_builder_widget("sourcetoolmenubutton");
+        gtk_widget_set_sensitive(widget, true);
         hide_scan_progress(ud);
 
         int title_id, titleindex;

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -1335,10 +1335,152 @@ Van Jacobson</property>
     <property name="default-width">500</property>
     <property name="default-height">400</property>
     <property name="icon-name">fr.handbrake.ghb</property>
-    <property name="show-menubar">True</property>
+    <property name="show-menubar">False</property>
     <signal name="close-request" handler="window_close_request_cb" swapped="no"/>
     <signal name="notify::default-height" handler="hb_window_save_size_cb" swapped="no"/>
     <signal name="notify::default-width" handler="hb_window_save_size_cb" swapped="no"/>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <child type="start">
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="css-classes">ghb-linked-button</property>
+            <child>
+              <object class="GhbButton" id="sourcetoolbutton">
+                <property name="tooltip-text" translatable="yes">Choose Video Source</property>
+                <property name="label" translatable="yes">Open Source</property>
+                <property name="icon-name">hb-source</property>
+                <property name="action-name">app.source</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="sourcetoolmenubutton">
+                <property name="css-classes">normal-icons</property>
+                <property name="icon-name">pan-down-symbolic</property>
+                <property name="menu-model">open-source-menu-model</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="start">
+          <object class="GtkSeparator">
+            <property name="orientation">vertical</property>
+            <property name="width-request">10</property>
+            <property name="opacity">0.0</property>
+          </object>
+        </child>
+        <child type="start">
+          <object class="GtkBox" id="queue_add_split_button">
+            <property name="orientation">horizontal</property>
+            <property name="css-classes">ghb-linked-button</property>
+            <child>
+              <object class="GhbButton" id="queue_add">
+                <property name="tooltip-text" translatable="yes">Add to Queue</property>
+                <property name="label" translatable="yes">Add To Queue</property>
+                <property name="icon-name">hb-add-queue</property>
+                <property name="action-name">app.add-current</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton">
+                <property name="css-classes">normal-icons</property>
+                <property name="icon-name">pan-down-symbolic</property>
+                <property name="menu-model">queue-add-menu-model</property>
+                <property name="sensitive" bind-source="queue_add" bind-property="sensitive"/>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="start">
+          <object class="GtkSeparator">
+            <property name="orientation">vertical</property>
+            <property name="width-request">10</property>
+            <property name="opacity">0.0</property>
+          </object>
+        </child>
+        <child type="start">
+          <object class="GhbButton" id="queue_start">
+            <property name="tooltip-text" translatable="yes">Start Encoding</property>
+            <property name="label" translatable="yes">Start</property>
+            <property name="icon-name">hb-start-small-symbolic</property>
+            <property name="action-name">app.queue-start</property>
+          </object>
+        </child>
+        <child type="start">
+          <object class="GhbButton" id="queue_pause">
+            <property name="tooltip-text" translatable="yes">Pause Encoding</property>
+            <property name="label" translatable="yes">Pause</property>
+            <property name="icon-name">hb-pause-small-symbolic</property>
+            <property name="action-name">app.queue-pause</property>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GtkMenuButton">
+            <property name="icon-name">view-more-symbolic</property>
+            <property name="tooltip-text" translatable="yes">Menu</property>
+            <property name="menu-model">hb-main-menu-model</property>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GhbButton" id="show_activity">
+            <property name="tooltip-text" translatable="yes">Show Activity Window</property>
+            <property name="label" translatable="yes">Activity</property>
+            <property name="icon-name">hb-activity</property>
+            <property name="action-name">app.show-activity</property>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="css-classes">ghb-linked-button</property>
+            <child>
+              <object class="GhbButton" id="show_queue">
+                <property name="tooltip-text" translatable="yes">Show Queue</property>
+                <property name="label" translatable="yes">Queue</property>
+                <property name="icon-name">hb-showqueue</property>
+                <property name="action-name">app.show-queue</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton">
+                <property name="css-classes">normal-icons</property>
+                <property name="icon-name">pan-down-symbolic</property>
+                <property name="menu-model">queue-menu-model</property>
+              </object>
+            </child>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GhbButton" id="show_preview">
+            <property name="tooltip-text" translatable="yes">Show Preview Window</property>
+            <property name="label" translatable="yes">Preview</property>
+            <property name="icon-name">hb-picture</property>
+            <property name="action-name">app.show-preview</property>
+          </object>
+        </child>
+        <child type="end">
+          <object class="GtkBox">
+            <property name="orientation">horizontal</property>
+            <property name="css-classes">ghb-linked-button</property>
+            <child>
+              <object class="GhbButton" id="show_presets">
+                <property name="tooltip-text" translatable="yes">Show Presets Window</property>
+                <property name="label" translatable="yes">Presets</property>
+                <property name="icon-name">hb-presets</property>
+                <property name="action-name">app.show-presets</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkMenuButton">
+                <property name="css-classes">normal-icons</property>
+                <property name="icon-name">pan-down-symbolic</property>
+                <property name="menu-model">presets-menu</property>
+              </object>
+            </child>
+          </object>
+        </child>
+      </object>
+    </child>
     <child>
       <object class="GtkBox" id="vbox48">
         <property name="orientation">vertical</property>
@@ -1349,112 +1491,6 @@ Van Jacobson</property>
             <property name="orientation">vertical</property>
             <property name="hexpand">1</property>
             <property name="vexpand">0</property>
-            <child>
-              <object class="GtkBox" id="toolbar1">
-                <property name="css-classes">toolbar
-large-icons</property>
-                <property name="hexpand">1</property>
-                <child>
-                  <object class="GhbButton" id="sourcetoolbutton">
-                    <property name="tooltip-text" translatable="yes">Choose Video Source</property>
-                    <property name="label" translatable="yes">Open Source</property>
-                    <property name="icon-name">hb-source</property>
-                    <property name="action-name">app.source</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator">
-                    <property name="orientation">vertical</property>
-                    <property name="width-request">10</property>
-                    <property name="opacity">0.0</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkBox" id="queue_add_split_button">
-                    <property name="orientation">horizontal</property>
-                    <property name="css-classes">ghb-linked-button</property>
-                    <child>
-                      <object class="GhbButton" id="queue_add">
-                        <property name="tooltip-text" translatable="yes">Add to Queue</property>
-                        <property name="label" translatable="yes">Add To Queue</property>
-                        <property name="icon-name">hb-add-queue</property>
-                        <property name="action-name">app.add-current</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuButton">
-                        <property name="css-classes">normal-icons</property>
-                        <property name="icon-name">pan-down-symbolic</property>
-                        <property name="menu-model">queue-add-menu-model</property>
-                        <property name="sensitive" bind-source="queue_add" bind-property="sensitive"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator">
-                    <property name="orientation">vertical</property>
-                    <property name="width-request">20</property>
-                    <property name="opacity">0.0</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="queue_start">
-                    <property name="tooltip-text" translatable="yes">Start Encoding</property>
-                    <property name="label" translatable="yes">Start</property>
-                    <property name="icon-name">hb-start-small-symbolic</property>
-                    <property name="action-name">app.queue-start</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="queue_pause">
-                    <property name="tooltip-text" translatable="yes">Pause Encoding</property>
-                    <property name="label" translatable="yes">Pause</property>
-                    <property name="icon-name">hb-pause-small-symbolic</property>
-                    <property name="action-name">app.queue-pause</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GtkSeparator" id="main_tool_sep1">
-                    <property name="orientation">vertical</property>
-                    <property name="opacity">0.0</property>
-                    <property name="hexpand">1</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="show_presets">
-                    <property name="tooltip-text" translatable="yes">Show Presets Window</property>
-                    <property name="label" translatable="yes">Presets</property>
-                    <property name="icon-name">hb-presets</property>
-                    <property name="action-name">app.show-presets</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="show_preview">
-                    <property name="tooltip-text" translatable="yes">Show Preview Window</property>
-                    <property name="label" translatable="yes">Preview</property>
-                    <property name="icon-name">hb-picture</property>
-                    <property name="action-name">app.show-preview</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="show_queue">
-                    <property name="tooltip-text" translatable="yes">Show Queue</property>
-                    <property name="label" translatable="yes">Queue</property>
-                    <property name="icon-name">hb-showqueue</property>
-                    <property name="action-name">app.show-queue</property>
-                  </object>
-                </child>
-                <child>
-                  <object class="GhbButton" id="show_activity">
-                    <property name="tooltip-text" translatable="yes">Show Activity Window</property>
-                    <property name="label" translatable="yes">Activity</property>
-                    <property name="icon-name">hb-activity</property>
-                    <property name="action-name">app.show-activity</property>
-                  </object>
-                </child>
-              </object>
-            </child>
             <child>
               <object class="GtkGrid" id="source_title_preset_grid">
                 <property name="row-homogeneous">1</property>

--- a/gtk/src/ui/menu.ui
+++ b/gtk/src/ui/menu.ui
@@ -1,155 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <requires lib="gtk" version="4.0"/>
-  <menu id="handbrake-menu-bar">
-    <submenu>
-      <attribute name="label" translatable="yes">_File</attribute>
-      <section>
-        <item>
-          <attribute name="action">app.source</attribute>
-          <attribute name="label" translatable="yes">_Open Source…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.source-dir</attribute>
-          <attribute name="label" translatable="yes">Open _Directory…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.destination</attribute>
-          <attribute name="label" translatable="yes">_Set Destination…</attribute>
-        </item>
-      </section>
-      <section id="dvd-list">
-      </section>
-      <section>
-        <item>
-          <attribute name="action">app.preferences</attribute>
-          <attribute name="label" translatable="yes">_Preferences</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.quit</attribute>
-          <attribute name="label" translatable="yes">_Quit</attribute>
-        </item>
-      </section>
-    </submenu>
-    <submenu>
-      <attribute name="label" translatable="yes">_Queue</attribute>
-      <section>
-        <item>
-          <attribute name="action">app.add-current</attribute>
-          <attribute name="label" translatable="yes">_Add</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.add-multiple</attribute>
-          <attribute name="label" translatable="yes">Add _Multiple…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.add-all</attribute>
-          <attribute name="label" translatable="yes">Add A_ll</attribute>
-        </item>
-      </section>
-      <section id="queue-encoding-actions">
-        <item>
-          <attribute name="action">app.queue-start</attribute>
-          <attribute name="label" translatable="yes">_Start Encoding</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.queue-pause</attribute>
-          <attribute name="label" translatable="yes">_Pause Encoding</attribute>
-        </item>
-      </section>
-      <section>
-        <item>
-          <attribute name="action">app.queue-import</attribute>
-          <attribute name="label" translatable="yes">_Import Queue…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.queue-export</attribute>
-          <attribute name="label" translatable="yes">_Export Queue…</attribute>
-        </item>
-      </section>
-    </submenu>
-    <submenu>
-      <attribute name="label" translatable="yes">_View</attribute>
-      <section id="view-menu">
-        <item>
-          <attribute name="action">app.show-presets</attribute>
-          <attribute name="label" translatable="yes">Presets _List</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.show-queue</attribute>
-          <attribute name="label" translatable="yes">_Queue</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.show-preview</attribute>
-          <attribute name="label" translatable="yes">_Preview</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.show-activity</attribute>
-          <attribute name="label" translatable="yes">_Activity Window</attribute>
-        </item>
-      </section>
-    </submenu>
-    <submenu id="presets-menu">
-      <attribute name="label" translatable="yes">_Presets</attribute>
-      <section>
-        <item>
-          <attribute name="action">app.preset-default</attribute>
-          <attribute name="label" translatable="yes">Set De_fault</attribute>
-        </item>
-      </section>
-      <section>
-        <item>
-          <attribute name="action">app.preset-save-as</attribute>
-          <attribute name="label" translatable="yes">_New Preset…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.preset-save</attribute>
-          <attribute name="label" translatable="yes">_Save</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.preset-rename</attribute>
-          <attribute name="label" translatable="yes">_Rename…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.preset-remove</attribute>
-          <attribute name="label" translatable="yes">_Delete…</attribute>
-        </item>
-      </section>
-      <section>
-        <item>
-          <attribute name="action">app.preset-import</attribute>
-          <attribute name="label" translatable="yes">_Import Preset…</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.preset-export</attribute>
-          <attribute name="label" translatable="yes">_Export Preset…</attribute>
-        </item>
-      </section>
-      <section>
-        <item>
-          <attribute name="action">app.presets-reload</attribute>
-          <attribute name="label" translatable="yes">Reset _Built-in Presets</attribute>
-        </item>
-      </section>
-      <section id="presets-menu-official">
-      </section>
-      <section id="presets-menu-custom">
-      </section>
-    </submenu>
-    <submenu>
-      <attribute name="label" translatable="yes">_Help</attribute>
-      <section>
-        <item>
-          <attribute name="action">app.guide</attribute>
-          <attribute name="label" translatable="yes">_Online Documentation</attribute>
-        </item>
-        <item>
-          <attribute name="action">app.about</attribute>
-          <attribute name="label" translatable="yes">_About</attribute>
-        </item>
-      </section>
-    </submenu>
-  </menu>
 
   <menu id="hbfd-menu">
     <section id="hbfd-section">
@@ -452,6 +303,113 @@
         <attribute name="action">app.add-all</attribute>
         <attribute name="label" translatable="yes">Add A_ll</attribute>
       </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.queue-import</attribute>
+        <attribute name="label" translatable="yes">_Import Queue…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.queue-export</attribute>
+        <attribute name="label" translatable="yes">_Export Queue…</attribute>
+      </item>
+    </section>
+  </menu>
+
+  <menu id="queue-menu-model">
+    <section id="queue-encoding-actions">
+      <item>
+        <attribute name="action">app.queue-start</attribute>
+        <attribute name="label" translatable="yes">_Start Encoding</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.queue-pause</attribute>
+        <attribute name="label" translatable="yes">_Pause Encoding</attribute>
+      </item>
+    </section>
+  </menu>
+
+  <menu id="open-source-menu-model">
+    <section>
+      <item>
+        <attribute name="action">app.source</attribute>
+        <attribute name="label" translatable="yes">_Open Source…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.source-dir</attribute>
+        <attribute name="label" translatable="yes">Open _Directory…</attribute>
+      </item>
+    </section>
+    <section id="dvd-list">
+    </section>
+  </menu>
+  <menu id="hb-main-menu-model">
+    <section>
+      <item>
+        <attribute name="action">app.destination</attribute>
+        <attribute name="label" translatable="yes">_Set Destination…</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.preferences</attribute>
+        <attribute name="label" translatable="yes">_Preferences</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.guide</attribute>
+        <attribute name="label" translatable="yes">_Online Documentation</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.about</attribute>
+        <attribute name="label" translatable="yes">_About</attribute>
+      </item>
+    </section>
+  </menu>
+
+  <menu id="presets-menu">
+    <section>
+      <item>
+        <attribute name="action">app.preset-default</attribute>
+        <attribute name="label" translatable="yes">Set De_fault</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.preset-save-as</attribute>
+        <attribute name="label" translatable="yes">_New Preset…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.preset-save</attribute>
+        <attribute name="label" translatable="yes">_Save</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.preset-rename</attribute>
+        <attribute name="label" translatable="yes">_Rename…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.preset-remove</attribute>
+        <attribute name="label" translatable="yes">_Delete…</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.preset-import</attribute>
+        <attribute name="label" translatable="yes">_Import Preset…</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.preset-export</attribute>
+        <attribute name="label" translatable="yes">_Export Preset…</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.presets-reload</attribute>
+        <attribute name="label" translatable="yes">Reset _Built-in Presets</attribute>
+      </item>
+    </section>
+    <section id="presets-menu-official">
+    </section>
+    <section id="presets-menu-custom">
     </section>
   </menu>
 </interface>


### PR DESCRIPTION
Most modern Gnome applications use a header bar which integrates the toolbar into the window's titlebar. HandBrake still uses the classic menubar, and I was curious about what a more modern approach might be like.

I thought I'd open a draft PR to see if this is something y'all are interested in, and to get some feedback

Before:
<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/1cd716f8-f3ef-4625-a103-eedb0706a10c">

After:
<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/b9fe2515-f9f8-4c79-9951-56b5c60afade">

I've been careful to maintain all the functionality that's found in the existing menu bar, by adding menu buttons to some of the toolbar buttons

<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/9a647ba1-65c7-441c-94f2-09e388d88150">

<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/e50492c6-20ce-4269-ae49-2911ad8c71b3">

<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/6395fd45-11d1-489a-8c08-564641559948">

<img width="1085" alt="image" src="https://github.com/HandBrake/HandBrake/assets/13986933/0f630875-2ab7-4294-afd4-3f96d3b4ee89">

I appreciate that "more modern" doesn't necessarily mean "better" ;-)
