### PR TITLE
libhb/gtk: do not modify stderr struct directly on mingw

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -995,8 +995,8 @@ ghb_application_handle_local_options (GApplication *app, GVariantDict *options)
     {
         // Non-console windows apps do not have a stderr->_file
         // assigned properly
-        stderr->_file = STDERR_FILENO;
-        stdout->_file = STDOUT_FILENO;
+        (void) freopen("NUL", "w", stderr);
+        (void) freopen("NUL", "w", stdout);
     }
 #else
     redirect_io = FALSE;

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -2297,11 +2297,15 @@ static void redirect_thread_func(void * _data)
     if (pipe(pfd))
        return;
 #if defined( SYS_MINGW )
-    // dup2 doesn't work on windows for some stupid reason
-    stderr->_file = pfd[1];
+    // Non-console windows apps do not have a stderr->_file
+    // assigned properly
+    (void) freopen("NUL", "w", stderr);
+    _dup2(pfd[1], _fileno(stderr));
 #else
-    dup2(pfd[1], /*stderr*/ 2);
+    dup2(pfd[1], STDERR_FILENO);
 #endif
+    setvbuf(stderr, NULL, _IONBF, 0);
+
     FILE * log_f = fdopen(pfd[0], "rb");
 
     char line_buffer[500];


### PR DESCRIPTION
Breaks mingw build when using UCRT:

```
../libhb/hb.c: In function 'redirect_thread_func': ../libhb/hb.c:2314:11: error: 'FILE' {aka 'struct _iobuf'} has no member named '_file'
 2314 |     stderr->_file = pfd[1];
      |           ^~
```

See:

https://github.com/mingw-w64/mingw-w64/commit/fe226dd9028f3f64bef4b4384edb1ef2c95c15f4

Implement the same approach used by the GTK UI code:

https://github.com/HandBrake/HandBrake/blob/3a9e37d9b211579540d63ac54c31784756986b53/gtk/src/application.c#L307-L311

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] Fedora 39 mingw cross-compile (with both ucrt and msvcrt)