### PR TITLE
contrib: fix copy-and-paste error in lame's module.defs

### DIFF
--- a/contrib/lame/module.defs
+++ b/contrib/lame/module.defs
@@ -6,9 +6,11 @@ LAME.FETCH.url    += https://sourceforge.net/projects/lame/files/lame/3.100/lame
 LAME.FETCH.sha256  = ddfe36cab873794038ae2c1210557ad34857a4b6bdc515785d1da9e175b1da1e
 
 LAME.CONFIGURE.extra += --disable-frontend
-ifneq (none,$(FFMPEG.GCC.g))
+ifneq (none,$(LAME.GCC.g))
 	LAME.CONFIGURE.extra += --enable-debug
 endif
+
+LAME.GCC.args.extra += $(LAME.GCC.args.O.$(LAME.GCC.O))
 
 ifeq (1-msys,$(HOST.cross)-$(BUILD.system))
     LAME.CONFIGURE.args.build = --build=$(BUILD.machine)-unknown-linux-gnu


### PR DESCRIPTION
It was always being configured with --enable-debug. Without it, no optimization is set. Add it manually.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux