### PR TITLE
cli: use pkg-config to compose library deps

### DIFF
--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -87,6 +87,7 @@ GCC.args.F                 = -F$(1)
 GCC.args.f                 = -framework $(1)
 GCC.args.L                 = -L$(1)
 GCC.args.l                 = -l$(1)
+GCC.args.pkgconfig         = $(1)
 GCC.args.end               = -Wl,--end-group
 
 GCC.args.extra         =
@@ -188,6 +189,7 @@ define import.GCC
     $(1).GCC.args.f         = $$(GCC.args.f)
     $(1).GCC.args.L         = $$(GCC.args.L)
     $(1).GCC.args.l         = $$(GCC.args.l)
+    $(1).GCC.args.pkgconfig = $$(GCC.args.pkgconfig)
     $(1).GCC.args.end       = $$(GCC.args.end)
 
     $(1).GCC.args.extra         = $$(GCC.args.extra)
@@ -226,18 +228,18 @@ define import.GCC
     $(1).GCC.i = $$(4)
 
     # FUNCTION: C link dynamic-lib
-    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
     $(1).GCC.DYLIB = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB.args),$$(1),$$(2))
 
     # FUNCTION: C link executable
-    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
     $(1).GCC.EXE = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE.args),$$(1),$$(2))
 
     # FUNCTION: C++ link dynamic-lib
-    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
     $(1).GCC.DYLIB++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB++.args),$$(1),$$(2))
 
     # FUNCTION: C++ link executable
-    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *i !a ?end
+    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
     $(1).GCC.EXE++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE++.args),$$(1),$$(2))
 endef

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -228,18 +228,18 @@ define import.GCC
     $(1).GCC.i = $$(4)
 
     # FUNCTION: C link dynamic-lib
-    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
+    $(1).GCC.DYLIB.args = !gcc ?c_std ?pipe ?strip ?dylib ?extra.dylib ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l !pkgconfig *i !a ?end
     $(1).GCC.DYLIB = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB.args),$$(1),$$(2))
 
     # FUNCTION: C link executable
-    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
+    $(1).GCC.EXE.args = !gcc ?c_std ?pipe ?strip ?extra.exe ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l !pkgconfig *i !a ?end
     $(1).GCC.EXE = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE.args),$$(1),$$(2))
 
     # FUNCTION: C++ link dynamic-lib
-    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
+    $(1).GCC.DYLIB++.args = !gxx ?cxx_std ?pipe ?strip ?dylib ?extra.dylib++ ?ML *W *archs *sysroot *minvers ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l !pkgconfig *i !a ?end
     $(1).GCC.DYLIB++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.DYLIB++.args),$$(1),$$(2))
 
     # FUNCTION: C++ link executable
-    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l *pkgconfig *i !a ?end
+    $(1).GCC.EXE++.args = !gxx ?cxx_std ?pipe ?strip ?extra.exe++ ?ML *W *archs *sysroot *minver ?vis ?pic .g .O ?extra .lto *D *I !o ?muldefs ?start !i *F *f *L *l !pkgconfig *i !a ?end
     $(1).GCC.EXE++ = $$(call fn.ARGS,$(1).GCC,$$($(1).GCC.EXE++.args),$$(1),$$(2))
 endef

--- a/test/module.defs
+++ b/test/module.defs
@@ -1,6 +1,9 @@
 $(eval $(call import.MODULE.defs,TEST,test,LIBHB))
 $(eval $(call import.GCC,TEST))
 
+TEST.PKGCONFIG.env = PKG_CONFIG_PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/))lib/pkgconfig:$(PKG_CONFIG_PATH)"
+TEST.PKGCONFIG.exe = $(TEST.PKGCONFIG.env) $(PKGCONFIG.exe)
+
 TEST.src/   = $(SRC/)test/
 TEST.build/ = $(BUILD/)test/
 
@@ -13,26 +16,21 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 
 TEST.libs = $(LIBHB.a)
 
-TEST.GCC.l = \
-        ass avformat avfilter avcodec avutil swresample mp3lame dvdnav \
-        dvdread fribidi swscale vpx theoraenc theoradec vorbis vorbisenc ogg \
-        x264 bluray freetype bz2 z jansson harfbuzz opus speex lzma dav1d \
-        turbojpeg zimg SvtAv1Enc
+TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec  libavutil libswresample dvdnav \
+	dvdread fribidi libswscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 libbluray freetype2 \
+	bzip2 zlib jansson harfbuzz opus speex liblzma dav1d libturbojpeg SvtAv1Enc
 
 ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
-    TEST.GCC.l += fontconfig
-endif
-
-ifeq (1,$(FEATURE.qsv))
-    TEST.GCC.l += vpl
-ifneq (,$(filter $(HOST.system),linux freebsd))
-    TEST.GCC.l += va va-drm drm
-endif
+    TEST.pkgconfig_libs += fontconfig
 endif
 
 ifeq (1,$(FEATURE.flatpak))
-    TEST.GCC.l += glib-2.0
+    TEST.pkgconfig_libs += glib-2.0
 endif
+
+TEST.GCC.pkgconfig = $(shell $(TEST.PKGCONFIG.exe) --libs $(TEST.pkgconfig_libs))
+
+TEST.GCC.l = mp3lame zimg
 
 TEST.GCC.l += $(foreach m,$(MODULES.NAMES),$($m.OSL.libs))
 

--- a/test/module.defs
+++ b/test/module.defs
@@ -16,23 +16,17 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 
 TEST.libs = $(LIBHB.a)
 
-TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec  libavutil libswresample dvdnav \
-	dvdread fribidi libswscale vpx theoraenc theoradec vorbis vorbisenc ogg x264 libbluray freetype2 \
-	bzip2 zlib jansson harfbuzz opus speex liblzma dav1d libturbojpeg SvtAv1Enc
+TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswresample dvdnav \
+	dvdread libswscale theoraenc theoradec vorbis vorbisenc ogg x264 libbluray \
+	jansson libturbojpeg SvtAv1Enc
 
-ifeq (,$(filter $(HOST.system),darwin cygwin mingw))
-    TEST.pkgconfig_libs += fontconfig
-endif
+TEST.pkgconfig_libs += $(foreach m,$(MODULES.NAMES),$($m.OSL.libs))
 
 ifeq (1,$(FEATURE.flatpak))
     TEST.pkgconfig_libs += glib-2.0
 endif
 
 TEST.GCC.pkgconfig = $(shell $(TEST.PKGCONFIG.exe) --libs $(TEST.pkgconfig_libs))
-
-TEST.GCC.l = mp3lame zimg
-
-TEST.GCC.l += $(foreach m,$(MODULES.NAMES),$($m.OSL.libs))
 
 TEST.install.exe = $(DESTDIR)$(PREFIX/)bin/$(notdir $(TEST.exe))
 ifeq (1,$(FEATURE.flatpak))


### PR DESCRIPTION
Fixes https://github.com/HandBrake/HandBrake/issues/5954

**Description of Change:**
Uses pkg-config to find dependencies for libraries used directly by HandBrakeCLI

I'm no GNUMake expert, so if something can be done cleaner/better, please chime in...

This *will* require testing on other platforms to be sure all the pkg-config files exist and are named the same on all platforms.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Fedora Linux
