### PR TITLE
contrib: do not build libspeex encoder and decoder programs

### DIFF
--- a/contrib/libspeex/module.defs
+++ b/contrib/libspeex/module.defs
@@ -6,4 +6,6 @@ LIBSPEEX.FETCH.url    += https://downloads.us.xiph.org/releases/speex/speex-1.2.
 LIBSPEEX.FETCH.sha256  = 4b44d4f2b38a370a2d98a78329fefc56a0cf93d1c1be70029217baae6628feea
 LIBSPEEX.EXTRACT.tarbase = speex-1.2.1
 
+LIBSPEEX.CONFIGURE.extra = --disable-binaries
+
 LIBSPEEX.GCC.args.extra += $(LIBSPEEX.GCC.args.O.$(LIBSPEEX.GCC.O))


### PR DESCRIPTION
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux