### PR TITLE
contrib: update harfbuzz to 8.4.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.3.1.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.3.1/harfbuzz-8.3.1.tar.xz
-HARFBUZZ.FETCH.sha256  = f73e1eacd7e2ffae687bc3f056bb0c705b7a05aee86337686e09da8fc1c2030c
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/harfbuzz-8.4.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/8.4.0/harfbuzz-8.4.0.tar.xz
+HARFBUZZ.FETCH.sha256  = af4ea73e25ab748c8c063b78c2f88e48833db9b2ac369e29bd115702e789755e
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 8.4.0:**

What's Changed:
- Add /bigobj to MSVC compiler flags in meson build, to fix building hb-subset.cc
- Specify minimum versions of various dependencies in meson and autotools build.
- When subsetting, place variation store at the end of “GDEF” table  to fix shaping issues with some versions of Adobe InDesign.
- Various build fixes.

- New API:
+ hb_buffer_set_random_state()
+ hb_buffer_get_random_state()

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux