### PR TITLE
Flatpak: Update to GNOME SDK 46

### DIFF
--- a/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
+++ b/pkg/linux/flatpak/fr.handbrake.HandBrakeCLI.json
@@ -13,10 +13,24 @@
             "name": "numactl-cli",
             "sources": [
                 {
-                    "type": "archive",
-                    "url": "https://github.com/numactl/numactl/releases/download/v2.0.13/numactl-2.0.13.tar.gz",
-                    "sha256": "991e254b867eb5951a44d2ae0bf1996a8ef0209e026911ef6c3ef4caf6f58c9a"
+                    "type": "git",
+                    "url": "https://github.com/numactl/numactl.git",
+                    "tag": "v2.0.18",
+                    "commit": "3871b1c42fc71bceadafd745d2eff5dddfc2d67e",
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
                 }
+            ],
+            "rm-configure": true,
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/lib/*.a",
+                "/lib/*.la",
+                "/lib/*.so",
+                "/share/man"
             ]
         },
         {
@@ -40,6 +54,15 @@
                 }
             ],
             "modules": [
+            ],
+            "cleanup": [
+                "/etc",
+                "/include",
+                "/lib/cmake",
+                "/lib/pkgconfig",
+                "/lib/*.a",
+                "/lib/*.la",
+                "/lib/*.so"
             ]
         }
     ]

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -13,8 +13,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.3.12.tar.gz",
-                    "sha256": "14ec859936aea696a65e6b9488e95a0ac26b15126ef65b20956ef219004dd9a6"
+                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.3.19.tar.gz",
+                    "sha256": "ea9c418b0fd84a982850f230cb2d783dfe2e1f9923065f54b2fcaad1e9b33417"
                 }
             ],
             "buildsystem": "cmake-ninja",
@@ -38,8 +38,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva/archive/refs/tags/2.19.0.tar.gz",
-                    "sha256": "8cb5e2a9287a76b12c0b6cb96f4f27a0321bbe693df43cd950e5d4542db7f227"
+                    "url": "https://github.com/intel/libva/archive/refs/tags/2.21.0.tar.gz",
+                    "sha256": "f7c3fffef3f04eb146e036dad2587d852bfb70e4926d014bf437244915ef7425"
                 }
             ],
             "no-autogen": false,
@@ -54,8 +54,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/libva-utils/archive/refs/tags/2.19.0.tar.gz",
-                    "sha256": "4135992ab534d0cfd71a93c28e1a22f79c0003cf8d157ffd4621e5e482191b4f"
+                    "url": "https://github.com/intel/libva-utils/archive/refs/tags/2.21.0.tar.gz",
+                    "sha256": "15ca12bd11c7001c04af5079512754fea6ba8d79151b9f07908c99b27622714e"
                 }
             ],
             "no-autogen": false,
@@ -70,8 +70,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-23.2.4.tar.gz",
-                    "sha256": "dfcf2facc4f8bf3df6b147222786032be195874adacc2f4071fc6c91a0abdf0a"
+                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-23.4.3.tar.gz",
+                    "sha256": "83b95eefe86c9d58d92c2a77793541ea3cb643dff419599ffa87899fd58738cd"
                 }
             ],
             "buildsystem": "cmake-ninja",

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -3,7 +3,7 @@
     "branch": "1",
     "runtime": "fr.handbrake.ghb",
     "runtime-version": "development",
-    "sdk": "org.gnome.Sdk//45",
+    "sdk": "org.gnome.Sdk//46",
     "build-extension": true,
     "separate-locales": false,
     "appstream-compose": false,
@@ -139,8 +139,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/oneapi-src/oneVPL-intel-gpu/archive/refs/tags/intel-onevpl-23.2.4.tar.gz",
-                    "sha256": "77a768645c323dfd3e395e6e7e1aff886a7d3af75fb9f38ee9e7014d11e6356f"
+                    "url": "https://github.com/intel/vpl-gpu-rt/archive/refs/tags/intel-onevpl-23.4.3.tar.gz",
+                    "sha256": "d4d54637bae1e00b977bb9a865c1787b2c88c4102099d73daa18f82598d94b77"
                 },
                 {
                     "type": "file",

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "45",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -39,14 +39,15 @@
                 {
                     "type": "git",
                     "url": "https://github.com/numactl/numactl.git",
-                    "tag": "v2.0.16",
-                    "commit": "10285f1a1bad49306839b2c463936460b604e3ea",
+                    "tag": "v2.0.18",
+                    "commit": "3871b1c42fc71bceadafd745d2eff5dddfc2d67e",
                     "x-checker-data": {
                         "type": "git",
                         "tag-pattern": "^v([\\d.]+)$"
                     }
                 }
             ],
+            "rm-configure": true,
             "cleanup": [
                 "/include",
                 "/lib/pkgconfig",


### PR DESCRIPTION
This updates the Flatpak to use the latest SDK version, and also updates the libraries for numactl and the Intel Media SDK plugin.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux