### PR TITLE
cli: fix processing audio overrides to preset

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -165,7 +165,7 @@ static int      crop_threshold_frames    = 0;
 static char *   vrate                    = NULL;
 static float    vquality                 = HB_INVALID_VIDEO_QUALITY;
 static int      vbitrate                 = 0;
-static int      mux                      = 0;
+static int      mux                      = HB_MUX_AV_MP4;
 static int      anamorphic_mode     = -1;
 static int      modulus             = 0;
 static int      par_height          = -1;
@@ -3916,6 +3916,7 @@ static hb_dict_t * PreparePreset(const char *preset_name)
             list = hb_value_array_init();
             hb_dict_set(preset, "AudioList", list);
         }
+        int list_len = hb_value_array_len(list);
         int count = MAX(hb_str_vlen(mixdowns),
                     MAX(hb_str_vlen(dynamic_range_compression),
                     MAX(hb_str_vlen(audio_gain),
@@ -3928,301 +3929,278 @@ static hb_dict_t * PreparePreset(const char *preset_name)
                     MAX(hb_str_vlen(acodecs),
                         hb_str_vlen(anames)))))))))));
 
-        hb_dict_t *audio_dict, *last_audio_dict = NULL;
-        // Add audio dict entries to list if needed
-        for (ii = 0; ii < count; ii++)
+        if (list_len < count)
         {
-            audio_dict = hb_value_array_get(list, ii);
-            if (audio_dict == NULL)
+            // More command line settings specified than preset currently supports.
+            // Duplicate the last audio encoder settings in the preset or create a
+            // new one if the preset audio list is empty.
+            hb_dict_t *audio_dict_stub;
+            int new_dict = 0;
+            if (list_len == 0)
             {
-                break;
+                audio_dict_stub = hb_dict_init();
+                new_dict = 1;
             }
-            last_audio_dict = audio_dict;
-        }
-        // More settings specified than preset currently supports.
-        // Duplicate the last audio encoder settings in the preset.
-        for (; ii < count && last_audio_dict != NULL; ii++)
-        {
-            audio_dict = hb_value_dup(last_audio_dict);
-            hb_value_array_append(list, audio_dict);
+            else
+            {
+                audio_dict_stub = hb_value_dup(hb_value_array_get(list, list_len - 1));
+            }
+
+            // The command line allows a shortcut where the final audio
+            // setting listed in the comma separated list gets
+            // replicated and applied to any remaining entries.
+            // If the setting is not specified at all or the comma separated
+            // list end in a `,`, defaults are used.
+            // some_setting[last][0] == 0 indicates the list ended in `,`
+            int last = hb_str_vlen(acodecs) - 1;
+            if (last >= 0 && acodecs[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioEncoder",
+                             hb_value_string(acodecs[last]));
+            }
+            else if (new_dict)
+            {
+                // If we created a new dict, populate AudioEncoder as
+                // it is a required entry
+                const char *enc;
+                enc = hb_audio_encoder_get_short_name(
+                        hb_audio_encoder_get_default(mux));
+                hb_dict_set(audio_dict_stub, "AudioEncoder",
+                        hb_value_string(enc));
+            }
+            last = hb_str_vlen(abitrates) - 1;
+            int last_q = hb_str_vlen(aqualities) - 1;
+            if (last_q > last && aqualities[last_q][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioTrackQualityEnable",
+                            hb_value_bool(1));
+                hb_dict_set(audio_dict_stub, "AudioTrackQuality",
+                    hb_value_double(strtod(aqualities[last_q], NULL)));
+            }
+            else if (last >= 0 && abitrates[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioBitrate",
+                    hb_value_int(atoi(abitrates[last])));
+            }
+            else if (new_dict)
+            {
+                // If we created a new dict, populate AudioBitrate as
+                // it is a required entry
+                //
+                // hb_sanitize_audio_settings will select a default bitrate
+                // based on samplerate and mixdown
+                hb_dict_set(audio_dict_stub, "AudioBitrate", hb_value_int(-1));
+            }
+            last = hb_str_vlen(mixdowns) - 1;
+            if (last >= 0 && mixdowns[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioMixdown",
+                            hb_value_string(mixdowns[last]));
+            }
+            last = hb_str_vlen(dynamic_range_compression) - 1;
+            if (last >= 0 && dynamic_range_compression[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioTrackDRCSlider",
+                    hb_value_double(strtod(dynamic_range_compression[last],
+                                    NULL)));
+            }
+            last = hb_str_vlen(audio_gain) - 1;
+            if (last >= 0 && audio_gain[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioTrackGainSlider",
+                  hb_value_double(strtod(audio_gain[last], NULL)));
+            }
+            last = hb_str_vlen(audio_dither) - 1;
+            if (last >= 0 && audio_dither[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioDitherMethod",
+                        hb_value_string(audio_dither[last]));
+            }
+            last = hb_str_vlen(normalize_mix_level) - 1;
+            if (last >= 0 && normalize_mix_level[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioNormalizeMixLevel",
+                    hb_value_bool(atoi(normalize_mix_level[last])));
+            }
+            last = hb_str_vlen(arates) - 1;
+            if (last >= 0 && arates[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioSamplerate",
+                            hb_value_string(arates[last]));
+            }
+            last = hb_str_vlen(acompressions) - 1;
+            if (last >= 0 && acompressions[last][0] != 0)
+            {
+                hb_dict_set(audio_dict_stub, "AudioCompressionLevel",
+                  hb_value_double(strtod(acompressions[last], NULL)));
+            }
+            // Add entries to preset audio list for extra command line options
+            for (ii = list_len; ii < count; ii++)
+            {
+                hb_value_array_append(list, hb_value_dup(audio_dict_stub));
+            }
+            hb_dict_free(&audio_dict_stub);
         }
 
-        // Update codecs
+        hb_dict_t *audio_dict;
+
+        // Override command line specified codecs
         if (hb_str_vlen(acodecs) > 0)
         {
-            int last = -1;
-            for (ii = 0; acodecs[ii] != NULL &&
-                         acodecs[ii][0] != 0; ii++)
+            for (ii = 0; acodecs[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioEncoder",
-                                    hb_value_string(acodecs[ii]));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last codec in list to all other entries
-                for (; ii < count; ii++)
+                if (acodecs[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioEncoder",
-                                        hb_value_string(acodecs[last]));
+                                hb_value_string(acodecs[ii]));
                 }
             }
         }
 
-        // Update bitrates
-        int last_bitrate = -1;
+        // Override command line specified bitrates
         if (hb_str_vlen(abitrates) > 0)
         {
-            for (ii = 0; abitrates[ii]    != NULL &&
-                         abitrates[ii][0] != 0; ii++)
+            for (ii = 0; abitrates[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioBitrate",
-                    hb_value_int(atoi(abitrates[ii])));
-                last_bitrate = ii;
+                if (abitrates[ii][0] != 0)
+                {
+                    audio_dict = hb_value_array_get(list, ii);
+                    hb_dict_set(audio_dict, "AudioBitrate",
+                        hb_value_int(atoi(abitrates[ii])));
+                }
             }
         }
 
-        // Update qualities
-        int last_quality = -1;
+        // Override command line specified qualities
         if (hb_str_vlen(aqualities) > 0)
         {
-            for (ii = 0; aqualities[ii] != NULL &&
-                         aqualities[ii][0] != 0; ii++)
+            for (ii = 0; aqualities[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioTrackQualityEnable",
-                            hb_value_bool(1));
-                hb_dict_set(audio_dict, "AudioTrackQuality",
-                    hb_value_double(strtod(aqualities[ii], NULL)));
-                last_quality = ii;
-            }
-            if (last_audio_dict == NULL)
-            {
-                // No defaults exist in original preset.
-                // Apply last bitrate/quality in list to all other entries
-                if (last_bitrate > last_quality)
+                if (aqualities[ii][0] != 0)
                 {
-                    ii = last_bitrate + 1;
-                    for (; ii < count; ii++)
-                    {
-                        audio_dict = hb_value_array_get(list, ii);
-                        hb_dict_set(audio_dict, "AudioBitrate",
-                            hb_value_int(atoi(abitrates[last_bitrate])));
-                    }
-                }
-                else if (last_quality >= 0)
-                {
-                    ii = last_quality + 1;
-                    for (; ii < count; ii++)
-                    {
-                        audio_dict = hb_value_array_get(list, ii);
-                        hb_dict_set(audio_dict, "AudioTrackQualityEnable",
-                                    hb_value_bool(1));
-                        hb_dict_set(audio_dict, "AudioTrackQuality",
-                            hb_value_double(strtod(aqualities[last_quality], NULL)));
-                    }
+                    audio_dict = hb_value_array_get(list, ii);
+                    hb_dict_set(audio_dict, "AudioTrackQualityEnable",
+                                hb_value_bool(1));
+                    hb_dict_set(audio_dict, "AudioTrackQuality",
+                        hb_value_double(strtod(aqualities[ii], NULL)));
                 }
             }
         }
 
 
-        // Update samplerates
+        // Override command line specified samplerates
         if (hb_str_vlen(arates) > 0)
         {
-            int last = -1;
-            for (ii = 0; arates[ii]    != NULL &&
-                         arates[ii][0] != 0; ii++)
+            for (ii = 0; arates[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioSamplerate",
-                            hb_value_string(arates[ii]));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last samplerate in list to all other entries
-                for (; ii < count; ii++)
+                if (arates[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioSamplerate",
-                                hb_value_string(arates[last]));
+                                hb_value_string(arates[ii]));
                 }
             }
         }
 
-        // Update mixdowns
+        // Override command line specified mixdowns
         if (hb_str_vlen(mixdowns) > 0)
         {
-            int last = -1;
-            for (ii = 0; mixdowns[ii]    != NULL &&
-                         mixdowns[ii][0] != 0; ii++)
+            for (ii = 0; mixdowns[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioMixdown",
-                            hb_value_string(mixdowns[ii]));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last codec in list to all other entries
-                for (; ii < count; ii++)
+                if (mixdowns[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioMixdown",
-                                hb_value_string(mixdowns[last]));
+                                hb_value_string(mixdowns[ii]));
                 }
             }
         }
 
-        // Update mixdowns normalization
+        // Override command line specified mixdowns normalization
         if (hb_str_vlen(normalize_mix_level) > 0)
         {
-            int last = -1;
-            for (ii = 0; normalize_mix_level[ii]    != NULL &&
-                         normalize_mix_level[ii][0] != 0; ii++)
+            for (ii = 0; normalize_mix_level[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioNormalizeMixLevel",
-                    hb_value_bool(atoi(normalize_mix_level[ii])));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last mix norm in list to all other entries
-                for (; ii < count; ii++)
+                if (normalize_mix_level[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
-                    hb_dict_set(audio_dict,
-                                "AudioNormalizeMixLevel",
-                        hb_value_bool(
-                            atoi(normalize_mix_level[last])));
+                    hb_dict_set(audio_dict, "AudioNormalizeMixLevel",
+                        hb_value_bool(atoi(normalize_mix_level[ii])));
                 }
             }
         }
 
-        // Update DRC
+        // Override command line specified DRC
         if (hb_str_vlen(dynamic_range_compression) > 0)
         {
-            int last = -1;
-            for (ii = 0;dynamic_range_compression[ii]    != NULL &&
-                        dynamic_range_compression[ii][0] != 0; ii++)
+            for (ii = 0; dynamic_range_compression[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioTrackDRCSlider",
-                  hb_value_double(
-                    strtod(dynamic_range_compression[ii], NULL)));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last DRC in list to all other entries
-                for (; ii < count; ii++)
+                if (dynamic_range_compression[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioTrackDRCSlider",
-                        hb_value_double(
-                            strtod(dynamic_range_compression[last],
-                                   NULL)));
+                      hb_value_double(
+                        strtod(dynamic_range_compression[ii], NULL)));
                 }
             }
         }
 
-        // Update Gain
+        // Override command line specified Gain
         if (hb_str_vlen(audio_gain) > 0)
         {
-            int last = -1;
-            for (ii = 0; audio_gain[ii]    != NULL &&
-                         audio_gain[ii][0] != 0; ii++)
+            for (ii = 0; audio_gain[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioTrackGainSlider",
-                  hb_value_double(
-                    strtod(audio_gain[ii], NULL)));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last gain in list to all other entries
-                for (; ii < count; ii++)
+                if (audio_gain[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioTrackGainSlider",
                       hb_value_double(
-                        strtod(audio_gain[last], NULL)));
+                        strtod(audio_gain[ii], NULL)));
                 }
             }
         }
 
-        // Update dither method
+        // Override command line specified dither method
         if (hb_str_vlen(audio_dither) > 0)
         {
-            int last = -1;
-            for (ii = 0; audio_dither[ii]    != NULL &&
-                         audio_dither[ii][0] != 0; ii++)
+            for (ii = 0; audio_dither[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioDitherMethod",
-                            hb_value_string(audio_dither[ii]));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last dither in list to all other entries
-                for (; ii < count; ii++)
+                if (audio_dither[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioDitherMethod",
-                            hb_value_string(audio_dither[last]));
+                                hb_value_string(audio_dither[ii]));
                 }
             }
         }
 
-        // Update compression
+        // Override command line specified compression
         if (hb_str_vlen(acompressions) > 0)
         {
-            int last = -1;
-            for (ii = 0; acompressions[ii]    != NULL &&
-                         acompressions[ii][0] != 0; ii++)
+            for (ii = 0; acompressions[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioCompressionLevel",
-                  hb_value_double(
-                    strtod(acompressions[ii], NULL)));
-                last = ii;
-            }
-            if (last_audio_dict == NULL && last >= 0)
-            {
-                // No defaults exist in original preset.
-                // Apply last compression in list to all other entries
-                for (; ii < count; ii++)
+                if (acompressions[ii][0] != 0)
                 {
                     audio_dict = hb_value_array_get(list, ii);
                     hb_dict_set(audio_dict, "AudioCompressionLevel",
                       hb_value_double(
-                        strtod(acompressions[last], NULL)));
+                        strtod(acompressions[ii], NULL)));
                 }
             }
         }
 
-        // Update track names
+        // Override command line specified track names
         if (hb_str_vlen(anames) > 0)
         {
-            for (ii = 0; anames[ii]    != NULL &&
-                         anames[ii][0] != 0; ii++)
+            for (ii = 0; anames[ii] != NULL; ii++)
             {
-                audio_dict = hb_value_array_get(list, ii);
-                hb_dict_set(audio_dict, "AudioTrackName",
-                                    hb_value_string(anames[ii]));
+                if (anames[ii][0] != 0)
+                {
+                    audio_dict = hb_value_array_get(list, ii);
+                    hb_dict_set(audio_dict, "AudioTrackName",
+                                        hb_value_string(anames[ii]));
+                }
             }
         }
     }


### PR DESCRIPTION
Overrides to preset audio settings were pretty broken. If there is no audio list in the preset, the overrides were pretty much ignored. And there were other corner cases where they were getting ignored.

Hopefully addresses the problems brought up in PR
https://github.com/HandBrake/HandBrake/pull/5944#issuecomment-2063097075

**Tested on:**

I've only done very basic *does it crash?* testing so far.
@samhutchins please try out your test cases with this pr.

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

