### PR TITLE
contrib: remove more mingw specific linker options

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -141,7 +141,6 @@ else ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
         --pkg-config=$(PKGCONFIG.exe) \
         --pkg-config-flags="--static"
     FFMPEG.GCC.args.extra += -fno-common
-    FFMPEG.GCC.args.extra-ldflags = -static-libgcc -static-libstdc++ -static
 else ifeq (darwin,$(HOST.system))
     FFMPEG.GCC.args.extra-ldflags = -lc++
 else

--- a/make/cross/aarch64-w64-mingw32.meson
+++ b/make/cross/aarch64-w64-mingw32.meson
@@ -9,9 +9,6 @@ strip = 'aarch64-w64-mingw32-strip'
 windres = 'aarch64-w64-mingw32-windres'
 dlltool = 'aarch64-w64-mingw32-dlltool'
 
-[builtin_options]
-c_link_args = ['-static-libgcc']
-
 [properties]
 needs_exe_wrapper = true
 

--- a/make/cross/x86_64-w64-mingw32.meson
+++ b/make/cross/x86_64-w64-mingw32.meson
@@ -9,9 +9,6 @@ strip = 'x86_64-w64-mingw32-strip'
 windres = 'x86_64-w64-mingw32-windres'
 dlltool = 'x86_64-w64-mingw32-dlltool'
 
-[builtin_options]
-c_link_args = ['-static-libgcc']
-
 [properties]
 needs_exe_wrapper = true
 has_function_posix_memalign = false


### PR DESCRIPTION
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux