### PR TITLE
fix audio resample crash in declpcm.c

### DIFF
--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -341,7 +341,7 @@ static hb_buffer_t *Decode( hb_work_object_t *w )
     }
 
     AVChannelLayout channel_layout;
-    av_channel_layout_default(&channel_layout, hdr2layout[pv->nchannels - 1]);
+    av_channel_layout_from_mask(&channel_layout, hdr2layout[pv->nchannels - 1]);
     hb_audio_resample_set_ch_layout(pv->resample,
                                     &channel_layout);
     av_channel_layout_uninit(&channel_layout);


### PR DESCRIPTION
av_channel_layout_default expects number of channels, not the channel layout.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

