### PR TITLE
contrib: update zlib to 1.3.1

### DIFF
--- a/contrib/zlib/P00-mingw-configure.patch
+++ b/contrib/zlib/P00-mingw-configure.patch
@@ -1,9 +1,10 @@
---- zlib-1.3/configure	2023-08-18 10:45:36.000000000 +0200
-+++ zlib-1.3-patched/configure	2023-08-19 23:06:46.875730600 +0200
-@@ -31,14 +31,6 @@
+--- zlib-1.3.1/configure	2023-08-18 10:45:36.000000000 +0200
++++ zlib-1.3.1-patched/configure	2023-08-19 23:06:46.875730600 +0200
+@@ -30,15 +30,6 @@
+     SRCDIR="$SRCDIR/"
  fi
  
- # set command prefix for cross-compilation
+-# set command prefix for cross-compilation
 -if [ -n "${CHOST}" ]; then
 -    uname=${CHOST}
 -    mname=${CHOST}
@@ -15,10 +16,11 @@
  # destination name for static library
  STATICLIB=libz.a
  
-@@ -47,27 +39,6 @@
- VER1=`sed -n -e '/VERSION "/s/.*"\([0-9]*\)\\..*/\1/p' < ${SRCDIR}zlib.h`
+@@ -47,28 +38,6 @@
+ VER3=`echo ${VER}|sed -n -e 's/\([0-9]\{1,\}\(\\.[0-9]\{1,\}\)\{1,2\}\).*/\1/p'`
+ VER1=`echo ${VER}|sed -n -e 's/\([0-9]\{1,\}\)\\..*/\1/p'`
  
- # establish commands for library building
+-# establish commands for library building
 -if "${CROSS_PREFIX}ar" --version >/dev/null 2>/dev/null || test $? -lt 126; then
 -    AR=${AR-"${CROSS_PREFIX}ar"}
 -    test -n "${CROSS_PREFIX}" && echo Using ${AR} | tee -a configure.log
@@ -43,7 +45,7 @@
  # set defaults before processing command line options
  LDCONFIG=${LDCONFIG-"ldconfig"}
  LDSHAREDLIBC="${LDSHAREDLIBC--lc}"
-@@ -225,56 +196,7 @@
+@@ -226,56 +195,7 @@
    if test -z "$uname"; then
      uname=`(uname -s || echo unknown) 2>/dev/null`
    fi
@@ -85,7 +87,7 @@
 -        SHAREDLIB=libz$shared_ext
 -        SHAREDLIBV=libz.$VER$shared_ext
 -        SHAREDLIBM=libz.$VER1$shared_ext
--        LDSHARED=${LDSHARED-"$cc -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER"}
+-        LDSHARED=${LDSHARED-"$cc -dynamiclib -install_name $libdir/$SHAREDLIBM -compatibility_version $VER1 -current_version $VER3"}
 -        if "${CROSS_PREFIX}libtool" -V 2>&1 | grep Apple > /dev/null; then
 -            AR="${CROSS_PREFIX}libtool"
 -        elif libtool -V 2>&1 | grep Apple > /dev/null; then

--- a/contrib/zlib/module.defs
+++ b/contrib/zlib/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,ZLIB,zlib))
 $(eval $(call import.CONTRIB.defs,ZLIB))
 
-ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zlib-1.3.tar.gz
-ZLIB.FETCH.url    += https://www.zlib.net/fossils/zlib-1.3.tar.gz
-ZLIB.FETCH.sha256  = ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e
+ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zlib-1.3.1.tar.gz
+ZLIB.FETCH.url    += https://www.zlib.net/fossils/zlib-1.3.1.tar.gz
+ZLIB.FETCH.sha256  = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
 
 ZLIB.CONFIGURE.args = !sete @dir !env !exe @prefix !extra
 


### PR DESCRIPTION
**zlib 1.3.1:**

Changes in 1.3.1 (22 Jan 2024)
- Reject overflows of zip header fields in minizip
- Fix bug in inflateSync() for data held in bit buffer
- Add LIT_MEM define to use more memory for a small deflate speedup
- Fix decision on the emission of Zip64 end records in minizip
- Add bounds checking to ERR_MSG() macro, used by zError()
- Neutralize zip file traversal attacks in miniunz
- Fix a bug in ZLIB_DEBUG compiles in check_match()
- Various portability and appearance improvements
	
**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux