### PR TITLE
Enable libvpx's AVX-512 optimization on mingw

### DIFF
--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -49,7 +49,3 @@ ifeq (darwin,$(HOST.system))
         LIBVPX.CONFIGURE.extra += --target=x86_64-darwin14-gcc
     endif
 endif
-
-ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
-    LIBVPX.CONFIGURE.extra += --disable-avx512
-endif


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65782 is fixed in GCC 8.4+, 9.3+, and 10+.

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

--

Let's see if CI likes it.