### PR TITLE
LinGUI: Allow use of non-native file chooser

### DIFF
--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -101,6 +101,7 @@
         "use_dvdnav": true,
         "reduce_hd_preview": true,
         "MinTitleDuration": 10,
+        "NativeFileChooser": true,
         "preview_count": 10,
         "preview_show_crop": false,
         "preview_x": -1,

--- a/gtk/src/chapters.c
+++ b/gtk/src/chapters.c
@@ -229,7 +229,7 @@ chapter_list_export_xml (const gchar *filename, GhbValue *chapter_dict)
 }
 
 static void
-chapter_list_export (GtkFileChooserNative *dialog,
+chapter_list_export (GtkFileChooser *chooser,
                      GtkResponseType response, signal_user_data_t *ud)
 {
     gchar             *filename, *dir;
@@ -243,11 +243,11 @@ chapter_list_export (GtkFileChooserNative *dialog,
 
         if (chapter_list == NULL)
         {
-            gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+            ghb_file_chooser_destroy(chooser);
             return;
         }
 
-        filename = ghb_file_chooser_get_filename(GTK_FILE_CHOOSER(dialog));
+        filename = ghb_file_chooser_get_filename(chooser);
 
         chapter_list_export_xml(filename, chapter_list);
         exportDir = ghb_dict_get_string(ud->prefs, "ExportDirectory");
@@ -260,7 +260,7 @@ chapter_list_export (GtkFileChooserNative *dialog,
         g_free(dir);
         g_free(filename);
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+    ghb_file_chooser_destroy(chooser);
 }
 
 static xmlNodePtr
@@ -437,7 +437,7 @@ chapters_import_response_cb (GtkFileChooser *dialog,
         chapter_list_import_xml(filename, ud);
         g_free(filename);
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(dialog));
+    ghb_file_chooser_destroy(dialog);
 }
 
 G_MODULE_EXPORT void
@@ -445,29 +445,28 @@ chapters_export_action_cb (GSimpleAction *action, GVariant *param,
                            signal_user_data_t *ud)
 {
     GtkWindow       *hb_window;
-    GtkFileChooserNative *dialog;
+    GtkFileChooser  *dialog;
     const gchar     *exportDir;
     GtkFileFilter   *filter;
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    dialog = gtk_file_chooser_native_new("Export Chapters", hb_window,
-                GTK_FILE_CHOOSER_ACTION_SAVE,
-                _("_Save"),
-                _("_Cancel"));
+    dialog = ghb_file_chooser_new("Export Chapters", hb_window,
+                                  GTK_FILE_CHOOSER_ACTION_SAVE,
+                                  _("_Save"),
+                                  _("_Cancel"));
 
-    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), _("All Files"), "FilterAll");
-    filter = ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), _("Chapters (*.xml)"), "FilterXML");
-    gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(dialog), filter);
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(dialog), "chapters.xml");
+    ghb_add_file_filter(dialog, _("All Files"), "FilterAll");
+    filter = ghb_add_file_filter(dialog, _("Chapters (*.xml)"), "FilterXML");
+    gtk_file_chooser_set_filter(dialog, filter);
+    gtk_file_chooser_set_current_name(dialog, "chapters.xml");
 
     exportDir = ghb_dict_get_string(ud->prefs, "ExportDirectory");
     if (exportDir && exportDir[0] != '\0')
-        ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(dialog), exportDir);
+        ghb_file_chooser_set_initial_file(dialog, exportDir);
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
-    gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(dialog), GTK_WINDOW(hb_window));
+    ghb_file_chooser_set_modal(dialog, TRUE);
     g_signal_connect(dialog, "response", G_CALLBACK(chapter_list_export), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
+    ghb_file_chooser_show(dialog);
 }
 
 G_MODULE_EXPORT void
@@ -475,24 +474,22 @@ chapters_import_action_cb (GSimpleAction *action, GVariant *param,
                            signal_user_data_t *ud)
 {
     GtkWindow       *hb_window;
-    GtkFileChooserNative *dialog;
+    GtkFileChooser  *dialog;
     GtkFileFilter   *filter;
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    dialog = gtk_file_chooser_native_new("Import Chapters", hb_window,
-                GTK_FILE_CHOOSER_ACTION_OPEN,
-                _("_Open"),
-                _("_Cancel"));
+    dialog = ghb_file_chooser_new("Import Chapters", hb_window,
+                                  GTK_FILE_CHOOSER_ACTION_OPEN,
+                                  _("_Open"),
+                                  _("_Cancel"));
 
-    ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), _("All Files"), "FilterAll");
-    filter = ghb_add_file_filter(GTK_FILE_CHOOSER(dialog), _("Chapters (*.xml)"), "FilterXML");
-    gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(dialog), filter);
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(dialog),
+    ghb_add_file_filter(dialog, _("All Files"), "FilterAll");
+    filter = ghb_add_file_filter(dialog, _("Chapters (*.xml)"), "FilterXML");
+    gtk_file_chooser_set_filter(dialog, filter);
+    ghb_file_chooser_set_initial_file(dialog,
                                       ghb_dict_get_string(ud->prefs, "ExportDirectory"));
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(dialog), TRUE);
-    gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(dialog), GTK_WINDOW(hb_window));
+    ghb_file_chooser_set_modal(dialog, TRUE);
     g_signal_connect(dialog, "response", G_CALLBACK(chapters_import_response_cb), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(dialog));
-
+    ghb_file_chooser_show(dialog);
 }

--- a/gtk/src/ghb-file-button.c
+++ b/gtk/src/ghb-file-button.c
@@ -336,27 +336,28 @@ chooser_response_cb (GtkFileChooser *chooser, GtkResponseType response,
         ghb_file_button_set_file(self, file);
         g_object_unref(file);
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_destroy(chooser);
 }
 
 static void
 ghb_file_button_clicked (GtkButton *button)
 {
     GtkWindow *window;
-    GtkFileChooserNative *chooser;
+    GtkFileChooser *chooser;
     GhbFileButton *self = GHB_FILE_BUTTON(button);
 
     g_return_if_fail(GHB_IS_FILE_BUTTON(self));
 
     window = GTK_WINDOW(gtk_widget_get_root(GTK_WIDGET(self)));
-    chooser = gtk_file_chooser_native_new(ghb_file_button_get_title(self), window,
-                                          ghb_file_button_get_action(self),
-                                          ghb_file_button_get_accept_label(self), NULL);
+    chooser = ghb_file_chooser_new(ghb_file_button_get_title(self), window,
+                                   ghb_file_button_get_action(self),
+                                   ghb_file_button_get_accept_label(self),
+                                   _("_Cancel"));
     g_autofree char *selected_name = ghb_file_button_get_filename(self);
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(chooser), selected_name);
+    ghb_file_chooser_set_initial_file(chooser, selected_name);
 
     g_signal_connect(chooser, "response", G_CALLBACK(chooser_response_cb), self);
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), GTK_IS_WINDOW(window));
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_set_modal(chooser, GTK_IS_WINDOW(window));
+    ghb_file_chooser_show(chooser);
 }

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -2095,7 +2095,7 @@ preset_import_response_cb (GtkFileChooser *chooser, GtkResponseType response,
             select_preset2(ud, &path);
         }
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_destroy(chooser);
 }
 
 G_MODULE_EXPORT void
@@ -2103,31 +2103,30 @@ preset_import_action_cb(GSimpleAction *action, GVariant *param,
                         signal_user_data_t *ud)
 {
     GtkWindow       *hb_window;
-    GtkFileChooserNative *chooser;
+    GtkFileChooser  *chooser;
     const gchar     *exportDir;
     GtkFileFilter   *filter;
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    chooser = gtk_file_chooser_native_new("Import Preset", hb_window,
-                GTK_FILE_CHOOSER_ACTION_OPEN,
-                _("_Open"),
-                _("_Cancel"));
+    chooser = ghb_file_chooser_new(_("Import Preset"), hb_window,
+                                   GTK_FILE_CHOOSER_ACTION_OPEN,
+                                   _("_Open"),
+                                   _("_Cancel"));
 
-    ghb_add_file_filter(GTK_FILE_CHOOSER(chooser), _("All Files"), "FilterAll");
-    filter = ghb_add_file_filter(GTK_FILE_CHOOSER(chooser), _("Presets (*.json)"), "FilterJSON");
-    gtk_file_chooser_set_filter(GTK_FILE_CHOOSER(chooser), filter);
+    ghb_add_file_filter(chooser, _("All Files"), "FilterAll");
+    filter = ghb_add_file_filter(chooser, _("Presets (*.json)"), "FilterJSON");
+    gtk_file_chooser_set_filter(chooser, filter);
 
     exportDir = ghb_dict_get_string(ud->prefs, "ExportDirectory");
     if (exportDir == NULL || exportDir[0] == '\0')
     {
         exportDir = ".";
     }
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(chooser), exportDir);
+    ghb_file_chooser_set_initial_file(chooser, exportDir);
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), TRUE);
-    gtk_native_dialog_set_transient_for(GTK_NATIVE_DIALOG(chooser), GTK_WINDOW(hb_window));
+    ghb_file_chooser_set_modal(chooser, TRUE);
     g_signal_connect(chooser, "response", G_CALLBACK(preset_import_response_cb), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_show(chooser);
 }
 
 static void
@@ -2162,7 +2161,7 @@ preset_export_response_cb(GtkFileChooser *chooser,
 
         if (dict == NULL)
         {
-            gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+            ghb_file_chooser_destroy(chooser);
             return;
         }
 
@@ -2183,7 +2182,7 @@ preset_export_response_cb(GtkFileChooser *chooser,
         g_free(filename);
         hb_value_free(&dict);
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_destroy(chooser);
 }
 
 G_MODULE_EXPORT void
@@ -2192,7 +2191,7 @@ preset_export_action_cb(GSimpleAction *action, GVariant *param,
 {
     hb_preset_index_t    *path;
     GtkWindow            *hb_window;
-    GtkFileChooserNative *chooser;
+    GtkFileChooser       *chooser;
     const gchar          *exportDir;
     gchar                *filename;
     GhbValue             *dict;
@@ -2224,10 +2223,10 @@ preset_export_action_cb(GSimpleAction *action, GVariant *param,
     preset_name = g_strdup(ghb_dict_get_string(dict, "PresetName"));
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    chooser = gtk_file_chooser_native_new(_("Export Preset"), hb_window,
-                GTK_FILE_CHOOSER_ACTION_SAVE,
-                _("_Save"),
-                _("_Cancel"));
+    chooser = ghb_file_chooser_new(_("Export Preset"), hb_window,
+                                   GTK_FILE_CHOOSER_ACTION_SAVE,
+                                   _("_Save"),
+                                   _("_Cancel"));
 
     exportDir = ghb_dict_get_string(ud->prefs, "ExportDirectory");
     if (exportDir == NULL || exportDir[0] == '\0')
@@ -2240,15 +2239,15 @@ preset_export_action_cb(GSimpleAction *action, GVariant *param,
     g_strstrip(preset_name);
     g_strdelimit(preset_name, GHB_UNSAFE_FILENAME_CHARS, '_');
     filename = g_strdup_printf("%s.json", preset_name);
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(chooser), exportDir);
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), filename);
+    ghb_file_chooser_set_initial_file(chooser, exportDir);
+    gtk_file_chooser_set_current_name(chooser, filename);
     g_free(filename);
     g_free(preset_name);
     hb_value_free(&dict);
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), TRUE);
+    ghb_file_chooser_set_modal(chooser, TRUE);
     g_signal_connect(chooser, "response", G_CALLBACK(preset_export_response_cb), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_show(chooser);
 }
 
 static void

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1376,27 +1376,27 @@ save_queue_file_cb (GtkFileChooser *chooser, gint response,
         g_free (filename); 
         ghb_value_free(&queue);
     }
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_destroy(chooser);
 }
 
 static void save_queue_file (signal_user_data_t *ud)
 {
-    GtkFileChooserNative *chooser;
+    GtkFileChooser *chooser;
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    chooser = gtk_file_chooser_native_new(_("Export Queue"),
-                      hb_window,
-                      GTK_FILE_CHOOSER_ACTION_SAVE,
-                      _("_Save"),
-                      _("_Cancel"));
-    gtk_file_chooser_set_current_name(GTK_FILE_CHOOSER(chooser), "queue.json");
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(chooser),
+    chooser = ghb_file_chooser_new(_("Export Queue"),
+                                   hb_window,
+                                   GTK_FILE_CHOOSER_ACTION_SAVE,
+                                   _("_Save"),
+                                   _("_Cancel"));
+    gtk_file_chooser_set_current_name(chooser, "queue.json");
+    ghb_file_chooser_set_initial_file(chooser,
                                       ghb_dict_get_string(ud->prefs, "ExportDirectory"));
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), TRUE);
+    ghb_file_chooser_set_modal(chooser, TRUE);
     g_signal_connect(G_OBJECT(chooser), "response", G_CALLBACK(save_queue_file_cb), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_show(chooser);
 }
 
 void ghb_add_to_queue_list (signal_user_data_t *ud, GhbValue *queueDict)
@@ -1432,13 +1432,13 @@ open_queue_file_cb (GtkFileChooser *chooser, gint response,
 
     if (response != GTK_RESPONSE_ACCEPT || file == NULL)
     {
-        gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+        ghb_file_chooser_destroy(chooser);
         return;
     }
 
     filename = g_file_get_path(file);
     g_object_unref(file);
-    gtk_native_dialog_destroy(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_destroy(chooser);
 
     queue = ghb_read_settings_file(filename);
     if (queue != NULL)
@@ -1469,25 +1469,25 @@ open_queue_file_cb (GtkFileChooser *chooser, gint response,
 
 static void open_queue_file (signal_user_data_t *ud)
 {
-    GtkFileChooserNative *chooser;
+    GtkFileChooser *chooser;
     GtkWindow *hb_window;
 
     hb_window = GTK_WINDOW(ghb_builder_widget("hb_window"));
-    chooser = gtk_file_chooser_native_new(_("Import Queue"),
-                      hb_window,
-                      GTK_FILE_CHOOSER_ACTION_OPEN,
-                      _("_Open"),
-                      _("_Cancel"));
+    chooser = ghb_file_chooser_new(_("Import Queue"),
+                                   hb_window,
+                                   GTK_FILE_CHOOSER_ACTION_OPEN,
+                                   _("_Open"),
+                                   _("_Cancel"));
 
     // Add filters
-    ghb_add_file_filter(GTK_FILE_CHOOSER(chooser), _("All Files"), "FilterAll");
-    ghb_add_file_filter(GTK_FILE_CHOOSER(chooser), g_content_type_get_description("application/json"), "FilterJSON");
-    ghb_file_chooser_set_initial_file(GTK_FILE_CHOOSER(chooser),
+    ghb_add_file_filter(chooser, _("All Files"), "FilterAll");
+    ghb_add_file_filter(chooser, g_content_type_get_description("application/json"), "FilterJSON");
+    ghb_file_chooser_set_initial_file(chooser,
                                       ghb_dict_get_string(ud->prefs, "ExportDirectory"));
 
-    gtk_native_dialog_set_modal(GTK_NATIVE_DIALOG(chooser), TRUE);
-    g_signal_connect(G_OBJECT(chooser), "response", G_CALLBACK(open_queue_file_cb), ud);
-    gtk_native_dialog_show(GTK_NATIVE_DIALOG(chooser));
+    ghb_file_chooser_set_modal(chooser, TRUE);
+    g_signal_connect(chooser, "response", G_CALLBACK(open_queue_file_cb), ud);
+    ghb_file_chooser_show(chooser);
 }
 
 static gint64 dest_free_space (GhbValue *settings)

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -2556,12 +2556,11 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                     <property name="spacing">2</property>
                                     <child>
                                       <object class="GtkGrid" id="pad_options_grid">
-                                        <property name="row-spacing">2</property>
-                                        <property name="column-spacing">2</property>
+                                        <property name="row-spacing">4</property>
+                                        <property name="column-spacing">4</property>
+                                        <property name="column-homogeneous">True</property>
                                         <property name="halign">start</property>
                                         <property name="valign">start</property>
-                                        <property name="column-spacing">8</property>
-                                        <property name="row-spacing">4</property>
                                         <child>
                                           <object class="GtkLabel" id="pad_mode_label">
                                             <property name="halign">start</property>
@@ -2590,7 +2589,6 @@ The actual display dimensions will differ if the pixel aspect ratio is not 1:1.<
                                           <object class="GtkSpinButton" id="PicturePadLeft">
                                             <property name="width-chars">4</property>
                                             <property name="focusable">1</property>
-                                            <property name="halign">end</property>
                                             <property name="tooltip-text" translatable="yes">Left Pad</property>
                                             <property name="adjustment">LeftPadAdjustment</property>
                                             <signal name="value-changed" handler="pad_changed_cb" swapped="no"/>

--- a/gtk/src/util.h
+++ b/gtk/src/util.h
@@ -24,6 +24,11 @@
 G_BEGIN_DECLS
 
 int ghb_dialog_run(GtkDialog *dialog);
+GtkFileChooser *ghb_file_chooser_new(const char *title, GtkWindow *parent,
+    GtkFileChooserAction action, const char *accept_label, const char *cancel_label);
+void ghb_file_chooser_set_modal(GtkFileChooser *chooser, gboolean modal);
+void ghb_file_chooser_show(GtkFileChooser *chooser);
+void ghb_file_chooser_destroy(GtkFileChooser *chooser);
 void ghb_file_chooser_set_initial_file(GtkFileChooser *chooser, const char *file);
 char *ghb_file_chooser_get_filename(GtkFileChooser *chooser);
 char *ghb_file_chooser_get_current_folder(GtkFileChooser *chooser);


### PR DESCRIPTION
This change allows the use of the built-in GTK file chooser, in situations where the native portal implementation is outdated or broken. I left it as a hidden option for now since it will only be useful to a limited number of people and I didn't think it was worth adding another checkbox to the settings. To test it on the Flatpak version, add `"NativeFileChooser": false` to preferences.json.

Fixes #5545

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
