### PR TITLE
contrib: ffmpeg: do not duplicate CFLAGS and LDFLAGS

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -16,6 +16,8 @@ FFMPEG.FETCH.url    = https://github.com/HandBrake/HandBrake-contribs/releases/d
 FFMPEG.FETCH.url   += https://ffmpeg.org/releases/ffmpeg-7.0.tar.bz2
 FFMPEG.FETCH.sha256 = a24d9074bf5523a65aaa9e7bd02afe4109ce79d69bd77d104fed3dab4b934d7a
 
+FFMPEG.GCC.args.c_std =
+
 FFMPEG.CONFIGURE.deps  =
 FFMPEG.CONFIGURE.host  =
 FFMPEG.CONFIGURE.build =

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -22,11 +22,6 @@ FFMPEG.CONFIGURE.build =
 FFMPEG.CONFIGURE.env.LOCAL_PATH = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
 FFMPEG.BUILD.env                = PATH="$(call fn.ABSOLUTE,$(CONTRIB.build/)bin):$(PATH)"
 
-ifneq (,$(filter $(HOST.system),freebsd netbsd openbsd))
-	FFMPEG.CONFIGURE.env += CFLAGS=-I$(LOCALBASE)/include
-	FFMPEG.CONFIGURE.env += LDFLAGS=-L$(LOCALBASE)/lib
-endif
-
 FFMPEG.CONFIGURE.extra = \
     --enable-gpl \
     --disable-doc \
@@ -143,6 +138,11 @@ else ifeq (darwin,$(HOST.system))
     FFMPEG.CONFIGURE.extra += --extra-libs="-lc++"
 else
     FFMPEG.CONFIGURE.extra += --extra-libs="-lm -lstdc++"
+endif
+
+ifneq (,$(filter $(HOST.system),freebsd netbsd openbsd))
+    FFMPEG.CONFIGURE.extra += --extra-cflags="-I$(LOCALBASE)/include"
+    FFMPEG.CONFIGURE.extra += --extra-ldflags="-L$(LOCALBASE)/lib"
 endif
 
 ifneq (none,$(FFMPEG.GCC.g))

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -80,8 +80,7 @@ FFMPEG.CONFIGURE.extra = \
     --enable-filter=hwdownload \
     --enable-filter=hwmap \
     --enable-filter=hwupload \
-    --cc="$(FFMPEG.GCC.gcc)" \
-    --extra-ldflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib) $(FFMPEG.GCC.args.extra-ldflags)"
+    --cc="$(FFMPEG.GCC.gcc)"
 
 ifeq (size-aggressive,$(GCC.O))
 FFMPEG.CONFIGURE.extra += \
@@ -141,7 +140,7 @@ else ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
         --pkg-config-flags="--static"
     FFMPEG.GCC.args.extra += -fno-common
 else ifeq (darwin,$(HOST.system))
-    FFMPEG.GCC.args.extra-ldflags = -lc++
+    FFMPEG.CONFIGURE.extra += --extra-libs="-lc++"
 else
     FFMPEG.CONFIGURE.extra += --extra-libs="-lm -lstdc++"
 endif
@@ -149,13 +148,13 @@ endif
 ifneq (none,$(FFMPEG.GCC.g))
     FFMPEG.CONFIGURE.extra += --enable-debug
     ifeq (max,$(FFMPEG.GCC.g))
-        FFMPEG.CONFIGURE.extra += --extra-cflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) -DDEBUG"
+        FFMPEG.GCC.D += DEBUG
     else
-        FFMPEG.CONFIGURE.extra += --extra-cflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) -DNDEBUG"
+        FFMPEG.GCC.D += NDEBUG
     endif
 else
     FFMPEG.CONFIGURE.extra += --disable-debug
-    FFMPEG.CONFIGURE.extra += --extra-cflags="$(call fn.ARGS,FFMPEG.GCC,*archs *sysroot *minver ?extra) -I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) -DNDEBUG"
+    FFMPEG.GCC.D += NDEBUG
 endif
 
 ifeq (none,$(FFMPEG.GCC.O))


### PR DESCRIPTION
ffmpeg configure script makes use of CFLAGS and LDFLAGS environment variables already.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux