### PR TITLE
contrib: x264: use default CFLAGS and LDFLAGS when cross-compiling

### DIFF
--- a/contrib/x264/module.defs
+++ b/contrib/x264/module.defs
@@ -20,8 +20,6 @@ ifeq (1,$(HOST.cross))
     ifneq ($(HOST.system),darwin)
         X264.CONFIGURE.extra += --cross-prefix=$(HOST.spec)-
     endif
-    X264.CONFIGURE.env.CFLAGS = CFLAGS="-I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) $(call fn.ARGS,X264.GCC,*archs *sysroot *minver ?extra)"
-    X264.CONFIGURE.env.LDFLAGS = LDFLAGS="-L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib) $(call fn.ARGS,X264.GCC,*archs *sysroot *minver)"
     ifeq (arm64-darwin,$(HOST.machine)-$(HOST.system))
         X264.CONFIGURE.extra += --extra-asflags="-arch $(HOST.arch)"
     endif


### PR DESCRIPTION
Same options.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux