### PR TITLE
contrib: libdav1d: set compiler and linker options

### DIFF
--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,4 +1,4 @@
-$(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d,PTHREADW32))
+$(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
 LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/dav1d-1.4.1.tar.bz2
@@ -14,7 +14,9 @@ LIBDAV1D.CONFIGURE.host   =
 LIBDAV1D.CONFIGURE.build  =
 LIBDAV1D.CONFIGURE.static = -Ddefault_library=static
 LIBDAV1D.CONFIGURE.extra  = --libdir=$(call fn.ABSOLUTE,$(CONTRIB.build/))lib/ \
-                            -Denable_tools=false -Denable_tests=false
+                            -Denable_tools=false -Denable_tests=false \
+                            -Dc_args="-I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) $(call fn.ARGS,LIBDAV1D.GCC,*archs *sysroot *minver ?extra)" \
+                            -Dc_link_args="-L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib) $(call fn.ARGS,LIBDAV1D.GCC,*archs *sysroot *minver ?extra.exe)"
 LIBDAV1D.CONFIGURE.env    =
 
 ifneq (none,$(LIBDAV1D.GCC.g))
@@ -30,7 +32,7 @@ else
 endif
 
 ifeq (darwin,$(HOST.system))
-        LIBDAV1D.CONFIGURE.extra += --cross-file=$(call fn.ABSOLUTE,$(SRC/))make/cross/$(HOST.machine)-darwin-gcc.meson -Dc_args="-arch $(HOST.machine)"
+        LIBDAV1D.CONFIGURE.extra += --cross-file=$(call fn.ABSOLUTE,$(SRC/))make/cross/$(HOST.machine)-darwin-gcc.meson
 endif
 
 ifeq (1-mingw,$(HOST.cross)-$(HOST.system))


### PR DESCRIPTION
Otherwise its C code is not compiled with HB options (hardening, etc).

Also drop leftover reference to pthreads-w32, removed in

https://github.com/HandBrake/HandBrake/commit/4daf62b54a11d4f960c231000297733bc738645c

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

--

Before:

> x86_64-w64-mingw32-gcc -Isrc/libdav1d.a.p -Isrc -I../src -I. -I.. -Iinclude/dav1d -I../include/dav1d -Iinclude -I../include -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -O3 -fvisibility=hidden -Wundef -Werror=vla -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -Wstrict-prototypes -Werror=missing-prototypes -fomit-frame-pointer -ffast-math -mcmodel=small -MD -MQ src/libdav1d.a.p/dequant_tables.c.obj -MF src/libdav1d.a.p/dequant_tables.c.obj.d -o src/libdav1d.a.p/dequant_tables.c.obj -c ../src/dequant_tables.c

After:

> x86_64-w64-mingw32-gcc -Isrc/libdav1d.a.p -Isrc -I../src -I. -I.. -Iinclude/dav1d -I../include/dav1d -Iinclude -I../include -I/home/marcos/Downloads/HandBrake/build/contrib/include -fdiagnostics-color=always -DNDEBUG -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=c99 -O3 -fvisibility=hidden -Wundef -Werror=vla -Wno-maybe-uninitialized -Wno-missing-field-initializers -Wno-unused-parameter -Wstrict-prototypes -Werror=missing-prototypes -fomit-frame-pointer -ffast-math -mfpmath=sse -msse2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mno-ms-bitfields -mcmodel=small -MD -MQ src/libdav1d.a.p/dequant_tables.c.obj -MF src/libdav1d.a.p/dequant_tables.c.obj.d -o src/libdav1d.a.p/dequant_tables.c.obj -c ../src/dequant_tables.c