### PR TITLE
Lowpowerfix

### DIFF
--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3505,12 +3505,6 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         {
             param->videoParam->ExtParam[param->videoParam->NumExtParam++] = (mfxExtBuffer*)&param->av1BitstreamParam;
         }
-#if defined(_WIN32) || defined(__MINGW32__)
-        if (info->capabilities & HB_QSV_CAP_LOWPOWER_ENCODE)
-        {
-            param->videoParam->mfx.LowPower = MFX_CODINGOPTION_ON;
-        }
-#endif
     }
     else
     {

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1068,6 +1068,13 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
     }
 
     {
+    	// Will fail MFXVideoENCODE_Init if not available
+    	if (inputParam.mfx.LowPower &&
+    	    inputParam.mfx.LowPower == MFX_CODINGOPTION_ON)
+    	{
+    		info->capabilities |= HB_QSV_CAP_LOWPOWER_ENCODE;
+    	}
+
         /* Implementation-specific features that can't be queried */
         if (info->codec_id == MFX_CODEC_AVC || info->codec_id == MFX_CODEC_HEVC || info->codec_id == MFX_CODEC_AV1)
         {
@@ -1076,21 +1083,6 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 if (hb_qsv_hardware_generation(hb_qsv_get_platform(index)) >= QSV_G3)
                 {
                     info->capabilities |= HB_QSV_CAP_B_REF_PYRAMID;
-                }
-                if (info->codec_id == MFX_CODEC_AVC &&
-                    (hb_qsv_hardware_generation(hb_qsv_get_platform(index)) >= QSV_G7))
-                {
-                    info->capabilities |= HB_QSV_CAP_LOWPOWER_ENCODE;
-                }
-                if (info->codec_id == MFX_CODEC_HEVC &&
-                    (hb_qsv_hardware_generation(hb_qsv_get_platform(index)) >= QSV_G7))
-                {
-                    info->capabilities |= HB_QSV_CAP_LOWPOWER_ENCODE;
-                }
-                if (info->codec_id == MFX_CODEC_AV1 &&
-                    (hb_qsv_hardware_generation(hb_qsv_get_platform(index)) > QSV_G8))
-                {
-                    info->capabilities |= HB_QSV_CAP_LOWPOWER_ENCODE;
                 }
             }
             else
@@ -1122,7 +1114,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&inputParam);
             inputParam.mfx.CodecId           = info->codec_id;
-            inputParam.mfx.LowPower          = lowpower;
+            inputParam.mfx.LowPower          = MFX_CODINGOPTION_OFF;
             inputParam.mfx.RateControlMethod = MFX_RATECONTROL_LA;
             inputParam.mfx.TargetKbps        = 5000;
 
@@ -1137,7 +1129,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 // also check for LA + interlaced support
                 init_video_param(&inputParam);
                 inputParam.mfx.CodecId             = info->codec_id;
-                inputParam.mfx.LowPower            = lowpower;
+                inputParam.mfx.LowPower            = MFX_CODINGOPTION_OFF;
                 inputParam.mfx.RateControlMethod   = MFX_RATECONTROL_LA;
                 inputParam.mfx.FrameInfo.PicStruct = MFX_PICSTRUCT_FIELD_TFF;
                 inputParam.mfx.TargetKbps          = 5000;
@@ -1157,7 +1149,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&inputParam);
             inputParam.mfx.CodecId           = info->codec_id;
-            inputParam.mfx.LowPower          = lowpower;
+            inputParam.mfx.LowPower          = MFX_CODINGOPTION_OFF;
             inputParam.mfx.RateControlMethod = MFX_RATECONTROL_ICQ;
             inputParam.mfx.ICQQuality        = 20;
 
@@ -1178,7 +1170,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_video_signal_info(&extVideoSignalInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extVideoSignalInfo;
@@ -1210,7 +1202,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_coding_option(&extCodingOption);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extCodingOption;
@@ -1246,7 +1238,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_coding_option2(&extCodingOption2);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extCodingOption2;
@@ -1360,7 +1352,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_chroma_loc_info(&extChromaLocInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extChromaLocInfo;
@@ -1385,7 +1377,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_mastering_display_colour_volume(&extMasteringDisplayColourVolume);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extMasteringDisplayColourVolume;
@@ -1400,7 +1392,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
 
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
             init_ext_content_light_level_info(&extContentLightLevelInfo);
             videoParam.ExtParam    = videoExtParam;
             videoParam.ExtParam[0] = (mfxExtBuffer*)&extContentLightLevelInfo;
@@ -1420,12 +1412,12 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 info->capabilities |= HB_QSV_CAP_VPP_INTERPOLATION;
             }
         }
-        if (lowpower == MFX_CODINGOPTION_ON)
+
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
             init_video_hyperencode_param(&videoParam, info->codec_id);
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
 
             init_ext_hyperencode_option(&extHyperEncodeParam);
             videoParam.ExtParam    = videoExtParam;
@@ -1438,11 +1430,11 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 info->capabilities |= HB_QSV_CAP_HYPERENCODE;
             }
         }
-        if ((lowpower == MFX_CODINGOPTION_ON) && (info->codec_id == MFX_CODEC_AV1))
+        if (info->codec_id == MFX_CODEC_AV1)
         {
             init_video_param(&videoParam);
             videoParam.mfx.CodecId = info->codec_id;
-            videoParam.mfx.LowPower = lowpower;
+            videoParam.mfx.LowPower = MFX_CODINGOPTION_OFF;
 
             init_ext_av1bitstream_option(&extAV1BitstreamParam);
             videoParam.ExtParam    = videoExtParam;


### PR DESCRIPTION
Fixes problems in handbrake qsv encoding when running with a CPU that supports low power encoding for the in use codec. Low power support is much more limited than non low power support and passing low power to encoder init functions of the intel library will trigger an error if the hardware doesn't support it for that rate control method / codec pairing. This is a particular problem under windows where low power is always defaulted to on so the default is changed to off. Patch also fixes problems under linux where capability checking failure caused encodes to fallback to CQP encoding even though ICQ works fine. I'm pretty certain this will close at least #5932.

The following example shows what happens pre/post patch when encoding using a 13th Gen intel CPU with kernel master firmware and driver at time of posting.

Pre-patch under linux:

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=0"`
Runs a high power CQP encode with video size = 158833956 at roughly 60fps

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=1"`
Runs a high power CQP encode with video size = 158833956 at roughly 60fps

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=1:force-cqp=1"`
Runs a high power CQP encode with video size = 158833956 at roughly 60fps

Post-patch:

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=0"`
Runs a high power ICQ encode with video size = 198500428 at roughly 35fps.

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=1"`
Fails to run a low power ICQ encode as not hardware supported.

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=1:force-cqp=1"`
Runs a low power CQP encode with video size = 159432944 at roughly 300fps

`HandBrakeCLI -i in.mkv -o out.mkv -e qsv_h265 -q 20 -x "lowpower=0:force-cqp=1"`
Runs a high power CQP encode with video size = 158833956 at roughly 60fps

Any desktop CPU newer than 8th gen will show these problems provided the correct Huc and Guc firmwares are loaded and working, but exactly what will happen is hard to predict. For example with the 9th gen CPU that doesn't support any low power hevc methods so the above example won't fail but but problems will be visible when the codec is changed to qsv_h264. This is why it's hard to be certain if it will fix existing bugs without testing on the users hardware.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
