### PR TITLE
LinGui: add support for running a command after an encode completes

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -4491,7 +4491,16 @@ send_to_external_app(gint index, signal_user_data_t * ud)
         destDict = ghb_dict_get(jobDict, "Destination");
 
         gchar * file = g_shell_quote(ghb_dict_get_string(destDict, "File"));
-        gchar * command_str = g_strjoin(" ", send_file_to_target, file, NULL);
+        gchar * command_str;
+        if (g_access("/.flatpak-info", F_OK) == 0)
+        {
+            command_str = g_strjoin(" ", "flatpak-spawn", "--host", "--", send_file_to_target, file, NULL);
+        }
+        else
+        {
+            command_str = g_strjoin(" ", send_file_to_target, file, NULL);
+        }
+
         gchar ** command_array = NULL;
         GError * error = NULL;
         ghb_log("Running command `%s`", command_str);

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -456,7 +456,8 @@ static GhbBinding widget_bindings[] =
     {"PresetCategory", "active-id", "new", "PresetCategoryName", "visible"},
     {"PresetCategory", "active-id", "new", "PresetCategoryEntryLabel", "visible"},
     {"DiskFreeCheck", "active", NULL, "DiskFreeLimitGB", "sensitive"},
-    {"LimitMaxDuration", "active", NULL, "MaxTitleDuration", "sensitive"}
+    {"LimitMaxDuration", "active", NULL, "MaxTitleDuration", "sensitive"},
+    {"SendFileTo", "active", NULL, "SendFileToTarget", "sensitive"}
 };
 
 void
@@ -4478,6 +4479,48 @@ searching_status_string(signal_user_data_t *ud, ghb_instance_status_t *status)
 }
 
 static void
+send_to_external_app(gint index, signal_user_data_t * ud)
+{
+    gboolean send_file_to = ghb_dict_get_bool(ud->prefs, "SendFileTo");
+    const gchar * send_file_to_target = ghb_dict_get_string(ud->prefs, "SendFileToTarget");
+    if (send_file_to && send_file_to_target != NULL && send_file_to_target[0] != '\0')
+    {
+        GhbValue *queueDict, *jobDict, *destDict;
+        queueDict = ghb_array_get(ud->queue, index);
+        jobDict = ghb_dict_get(queueDict, "Job");
+        destDict = ghb_dict_get(jobDict, "Destination");
+
+        gchar * file = g_shell_quote(ghb_dict_get_string(destDict, "File"));
+        gchar * command_str = g_strjoin(" ", send_file_to_target, file, NULL);
+        gchar ** command_array = NULL;
+        GError * error = NULL;
+        ghb_log("Running command `%s`", command_str);
+        if (g_shell_parse_argv(command_str, NULL, &command_array, &error))
+        {
+            g_spawn_async(
+                NULL,
+                command_array,
+                NULL,
+                G_SPAWN_SEARCH_PATH | G_SPAWN_STDERR_TO_DEV_NULL | G_SPAWN_STDOUT_TO_DEV_NULL,
+                NULL,
+                NULL,
+                NULL, 
+                &error);
+            g_strfreev(command_array);
+        }
+
+        if (error != NULL)
+        {
+            ghb_log("Failed to run command `%s`: %s", command_str, error->message);
+            g_error_free(error);
+        }
+        
+        g_free(command_str);
+        g_free(file);
+    }
+}
+
+static void
 ghb_backend_events(signal_user_data_t *ud)
 {
     ghb_status_t     status;
@@ -4650,6 +4693,7 @@ ghb_backend_events(signal_user_data_t *ud)
             case GHB_ERROR_NONE:
                 gtk_label_set_text(work_status, _("Encode Done!"));
                 qstatus = GHB_QUEUE_DONE;
+                send_to_external_app(index, ud);
                 ghb_send_notification (GHB_NOTIFY_ITEM_DONE, index, ud);
                 break;
             case GHB_ERROR_CANCELED:

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -5771,6 +5771,28 @@ battery is charged.</property>
                             <signal name="toggled" handler="pref_changed_cb" swapped="no"/>
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="spacing">4</property>
+                            <child>
+                              <object class="GtkCheckButton" id="SendFileTo">
+                                <property name="label" translatable="yes">Send file to:</property>
+                                <property name="halign">start</property>
+                                <signal name="toggled" handler="pref_changed_cb" />
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="SendFileToTarget">
+                                <property name="width-chars">30</property>
+                                <property name="truncate-multiline">1</property>
+                                <signal name="changed" handler="pref_changed_cb" swapped="no"/>
+                                <accessibility>
+                                  <relation name="labelled-by">SendFileTo</relation>
+                                </accessibility>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
                       </object>
                     </property>
                   </object>

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -13,6 +13,7 @@
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
+        "--talk-name=org.freedesktop.Flatpak",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.UPower",
         "--env=PATH=/app/bin:/app/extensions/bin:/usr/bin",


### PR DESCRIPTION
**Description of Change:**

My lack of C and glib/gtk experience may very well be showing in full force here...

macOS and Windows can send the encoded file to an external application after the encode completes, this change adds that functionality for the Linux GUI as well. I'm not sure if this is the best way to invoke an external command

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Fedora Linux