### PR TITLE
libhb: remove hb_scan, as directed by TODO

### DIFF
--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -3549,7 +3549,7 @@ ghb_backend_scan_list (GListModel *files, int titleindex, int preview_count, uin
 {
     hb_list_t *path_list = get_path_list(files);
     hb_list_t *extensions = ghb_get_excluded_extensions_list();
-    hb_scan_list(h_scan, path_list, titleindex, preview_count, 1, min_duration,
+    hb_scan(h_scan, path_list, titleindex, preview_count, 1, min_duration,
                  0, 0, extensions, 0);
     ghb_free_list(path_list);
     ghb_free_list(extensions);
@@ -3569,7 +3569,7 @@ ghb_backend_scan (const char *path, int titleindex, int preview_count, uint64_t 
     hb_list_t *path_list = hb_list_init();
     hb_list_add(path_list, (void *)path);
     hb_list_t *extensions = ghb_get_excluded_extensions_list();
-    hb_scan_list(h_scan, path_list, titleindex, preview_count, 1, min_duration,
+    hb_scan(h_scan, path_list, titleindex, preview_count, 1, min_duration,
                  0, 0, extensions, 0);
     hb_list_close(&path_list);
     ghb_free_list(extensions);
@@ -3590,7 +3590,7 @@ ghb_backend_queue_scan(const gchar *path, gint titlenum)
     hb_list_t *extensions = ghb_get_excluded_extensions_list();
     hb_list_t *path_list = hb_list_init();
     hb_list_add(path_list, (void *)path);
-    hb_scan_list(h_queue, path_list, titlenum, -1, 0, 0, 0, 0, extensions, 0);
+    hb_scan(h_queue, path_list, titlenum, -1, 0, 0, 0, 0, extensions, 0);
     ghb_free_list(extensions);
     hb_list_close(&path_list);
     hb_status.queue.state |= GHB_STATE_SCANNING;

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -42,10 +42,10 @@ int           hb_get_build( hb_handle_t * );
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
 
-/* hb_scan_list()
+/* hb_scan()
    Scan the specified paths. Can be a DVD device, a VIDEO_TS folder or
    a VOB file. If title_index is 0, scan all titles. */
-void          hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
+void          hb_scan( hb_handle_t * h, hb_list_t * paths, int title_index,
                       int preview_count, int store_previews, uint64_t min_duration,
                       int crop_threshold_frames, int crop_threshold_pixels,
                       hb_list_t * exclude_extensions, int hw_decode);

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -42,15 +42,9 @@ int           hb_get_build( hb_handle_t * );
 char *        hb_dvd_name( char * path );
 void          hb_dvd_set_dvdnav( int enable );
 
-/* hb_scan()
-   Scan the specified path. Can be a DVD device, a VIDEO_TS folder or
+/* hb_scan_list()
+   Scan the specified paths. Can be a DVD device, a VIDEO_TS folder or
    a VOB file. If title_index is 0, scan all titles. */
-void          hb_scan( hb_handle_t *, const char * path,
-                       int title_index, int preview_count,
-                       int store_previews, uint64_t min_duration,
-                       int crop_auto_switch_threshold, int crop_median_threshold,
-                       hb_list_t * exclude_extensions, int hw_decode);
-                       
 void          hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
                       int preview_count, int store_previews, uint64_t min_duration,
                       int crop_threshold_frames, int crop_threshold_pixels,

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -353,20 +353,6 @@ void hb_remove_previews( hb_handle_t * h )
     closedir( dir );
 }
 
-void hb_scan( hb_handle_t * h, const char * path, int title_index,
-              int preview_count, int store_previews, uint64_t min_duration,
-              int crop_threshold_frames, int crop_threshold_pixels,
-              hb_list_t * exclude_extensions, int hw_decode)
-{
-    // TODO: Compatibility later for the other UI's.  Remove when they are updated.
-    hb_list_t *file_paths = hb_list_init();
-    hb_list_add(file_paths, (char *)path);
-
-    hb_scan_list(h, file_paths, title_index, preview_count, store_previews, min_duration, crop_threshold_frames, crop_threshold_pixels, exclude_extensions, hw_decode);
-
-    hb_list_close(&file_paths);
-}
-
 /**
  * Initializes a scan of the by calling hb_scan_init
  * @param h Handle to hb_handle_t

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -366,7 +366,7 @@ void hb_remove_previews( hb_handle_t * h )
  * @param exclude_extensions A list of extensions to exclude for this scan.
  * @param hw_decode  The preferred hardware decoder to use..
  */
-void hb_scan_list( hb_handle_t * h, hb_list_t * paths, int title_index,
+void hb_scan( hb_handle_t * h, hb_list_t * paths, int title_index,
               int preview_count, int store_previews, uint64_t min_duration,
               int crop_threshold_frames, int crop_threshold_pixels,
               hb_list_t * exclude_extensions, int hw_decode)

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1031,8 +1031,11 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
     }
 
     // If the job wants to use Hardware decode, it must also be
-    // enabled during scan.  So enable it here.                      
-    hb_scan(h, path, title_index, -1, 0, 0, 0, 0, NULL, hw_decode);
+    // enabled during scan.  So enable it here.
+    hb_list_t *file_paths = hb_list_init();
+    hb_list_add(file_paths, (char *)path);
+    hb_scan_list(h, file_paths, title_index, -1, 0, 0, 0, 0, NULL, hw_decode);
+    hb_list_close(&file_paths);
 
     // Wait for scan to complete
     hb_state_t state;

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1034,7 +1034,7 @@ void hb_json_job_scan( hb_handle_t * h, const char * json_job )
     // enabled during scan.  So enable it here.
     hb_list_t *file_paths = hb_list_init();
     hb_list_add(file_paths, (char *)path);
-    hb_scan_list(h, file_paths, title_index, -1, 0, 0, 0, 0, NULL, hw_decode);
+    hb_scan(h, file_paths, title_index, -1, 0, 0, 0, 0, NULL, hw_decode);
     hb_list_close(&file_paths);
 
     // Wait for scan to complete

--- a/macosx/HBCore.m
+++ b/macosx/HBCore.m
@@ -306,7 +306,7 @@ HB_OBJC_DIRECT_MEMBERS
         hb_list_add(files_list, (char *)url.fileSystemRepresentation);
     }
 
-    hb_scan_list(_hb_handle, files_list,
+    hb_scan(_hb_handle, files_list,
               (int)index, (int)previewsNum,
               keepPreviews, min_title_duration_ticks,
               0, 0, NULL, hardwareDecoder ? HB_DECODE_SUPPORT_VIDEOTOOLBOX : 0);

--- a/test/test.c
+++ b/test/test.c
@@ -598,10 +598,13 @@ int main( int argc, char ** argv )
 
         hb_system_sleep_prevent(h);
 
-        hb_scan(h, input, titleindex, preview_count, store_previews,
+        hb_list_t *file_paths = hb_list_init();
+        hb_list_add(file_paths, input);
+        hb_scan_list(h, file_paths, titleindex, preview_count, store_previews,
                 min_title_duration * 90000LL,
                 crop_threshold_frames, crop_threshold_pixels,
                 NULL, hw_decode);
+        hb_list_close(&file_paths);
 
         EventLoop(h, preset_dict);
         hb_value_free(&preset_dict);

--- a/test/test.c
+++ b/test/test.c
@@ -600,7 +600,7 @@ int main( int argc, char ** argv )
 
         hb_list_t *file_paths = hb_list_init();
         hb_list_add(file_paths, input);
-        hb_scan_list(h, file_paths, titleindex, preview_count, store_previews,
+        hb_scan(h, file_paths, titleindex, preview_count, store_previews,
                 min_title_duration * 90000LL,
                 crop_threshold_frames, crop_threshold_pixels,
                 NULL, hw_decode);

--- a/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeInstance.cs
@@ -169,7 +169,7 @@ namespace HandBrake.Interop.Interop
 
             // Start the Scan
             IntPtr excludedExtensionsPtr = excludedExtensionsNative?.Ptr ?? IntPtr.Zero;
-            HBFunctions.hb_scan_list(this.Handle, scanPathsList.Ptr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr, hwDecode);
+            HBFunctions.hb_scan(this.Handle, scanPathsList.Ptr, titleIndex, previewCount, 1, (ulong)(minDuration.TotalSeconds * 90000), 0, 0, excludedExtensionsPtr, hwDecode);
 
             this.scanPollTimer = new Timer();
             this.scanPollTimer.Interval = ScanPollIntervalMs;

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -47,8 +47,8 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_dvd_set_dvdnav", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_dvd_set_dvdnav(int enable);
 
-        [DllImport("hb", EntryPoint = "hb_scan_list", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
+        [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
+        public static extern void hb_scan(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
 
         [DllImport("hb", EntryPoint = "hb_scan_stop", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_stop(IntPtr hbHandle);

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -47,9 +47,6 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_dvd_set_dvdnav", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_dvd_set_dvdnav(int enable);
 
-        [DllImport("hb", EntryPoint = "hb_scan", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void hb_scan(IntPtr hbHandle, IntPtr path, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
-
         [DllImport("hb", EntryPoint = "hb_scan_list", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_scan_list(IntPtr hbHandle, IntPtr paths, int title_index, int preview_count, int store_previews, ulong min_duration, int crop_auto_switch_threshold, int crop_median_threshold, IntPtr exclude_extensions, int hw_decode);
 


### PR DESCRIPTION
**Description of Change:**

`hb_scan` is basically a wrapper around `hb_scan_list`, wrapping the path passed to it in a single-item list. There's a TODO left in there about removing it when all the UIs are updated.

The only 2 places it's still used (as far as I can tell) are by the CLI and by `hb_json_job_scan`. I've updated both places to use `hb_scan_list` instead.

I'm not actually sure if this is a good change or not, as it makes the call-sites a little messier. But it does make it easier to change the signature of `hb_scan`.

I think that removing the TODO comment is also a valid course of action, I don't think it's that bad having both `hb_scan` methods personally

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Fedora Linux
