### PR TITLE
contrib: update libjpeg-turbo to 3.0.3

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-3.0.2.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.2.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 29f2197345aafe1dcaadc8b055e4cbec9f35aad2a318d61ea081f835af2eebe9
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-3.0.3.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.3.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = a649205a90e39a548863a3614a9576a3fb4465f8e8e66d54999f127957c25b21
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.0.3:**

Significant changes relative to 3.0.2:

- Fixed an issue in the build system, introduced in 3.0.2, that caused all libjpeg-turbo components to depend on the Visual C++ run-time DLL when built with Visual C++ and CMake 3.15 or later, regardless of value of the WITH_CRT_DLL CMake variable.
- The x86-64 SIMD extensions now include support for Intel Control-flow Enforcement Technology (CET), which is enabled automatically if CET is enabled in the C compiler.
- Fixed a regression introduced by 3.0 beta2[6] that made it impossible for calling applications to supply custom Huffman tables when generating 12-bit-per-component lossy JPEG images using the libjpeg API.
- Fixed a segfault that occurred when attempting to use the jpegtran -drop option with a specially-crafted malformed input image or drop image (specifically an image in which all of the scans contain fewer components than the number of components specified in the Start Of Frame segment.)

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux