### PR TITLE
contrib: update libvpl to 2.11.0

### DIFF
--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -2,7 +2,7 @@ $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
 LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.11.0.tar.gz
-LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libvpl-2.11.0.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpl-2.11.0.tar.gz
 LIBVPL.FETCH.sha256    = 3e322ba6b3593da03e1cfdb8062f9f1545f6d9b1de39e36876de5934b26737d2
 LIBVPL.FETCH.basename  = libvpl-2.11.0.tar.gz
 LIBVPL.EXTRACT.tarbase = libvpl-2.11.0

--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
-LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.10.1.tar.gz
-LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libvpl-2.10.1.tar.gz
-LIBVPL.FETCH.sha256    = 524299a7b920ac0de1f6913ca90515858ea3a8ea2daaea60f8e0be62f22c8041
-LIBVPL.FETCH.basename  = libvpl-2.10.1.tar.gz
-LIBVPL.EXTRACT.tarbase = libvpl-2.10.1
+LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.11.0.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libvpl-2.11.0.tar.gz
+LIBVPL.FETCH.sha256    = 3e322ba6b3593da03e1cfdb8062f9f1545f6d9b1de39e36876de5934b26737d2
+LIBVPL.FETCH.basename  = libvpl-2.11.0.tar.gz
+LIBVPL.EXTRACT.tarbase = libvpl-2.11.0
 
 LIBVPL.build_dir             = build
 LIBVPL.CONFIGURE.exe         = cmake
@@ -15,7 +15,7 @@ LIBVPL.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(LIBVPL.CONFIGURE.prefix
 LIBVPL.CONFIGURE.deps        =
 LIBVPL.CONFIGURE.static      =
 LIBVPL.CONFIGURE.shared      = -DBUILD_SHARED_LIBS=OFF
-LIBVPL.CONFIGURE.extra       = -DBUILD_DISPATCHER_ONEVPL_EXPERIMENTAL=ON -DBUILD_PREVIEW=OFF -DBUILD_TOOLS=OFF -DBUILD_EXAMPLES=OFF
+LIBVPL.CONFIGURE.extra       = -DBUILD_EXPERIMENTAL=ON -DBUILD_TOOLS=OFF -DBUILD_EXAMPLES=OFF
 
 ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
     LIBVPL.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel


### PR DESCRIPTION
**libvpl 2.11.0:**

Added:
    Intel® VPL API 2.11 support

Removed:
    Command line tools. They have been moved to a separate repository
    (https://github.com/intel/libvpl-tools)

Known Issues:
    vpl-infer example will fail to load model if built with CMake version higher than 3.25.3 on Windows

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux