### PR TITLE
contrib: update NVENC to 12.2.72.0

### DIFF
--- a/contrib/nvenc/module.defs
+++ b/contrib/nvenc/module.defs
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.defs,NVENC,nvenc))
 $(eval $(call import.CONTRIB.defs,NVENC))
 
-NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/nv-codec-headers-12.2.72.0.tar.gz
+NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/nv-codec-headers-12.2.72.0.tar.gz
 NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n12.2.72.0/nv-codec-headers-12.2.72.0.tar.gz
 
 NVENC.FETCH.sha256   = c295a2ba8a06434d4bdc5c2208f8a825285210d71d91d572329b2c51fd0d4d03

--- a/contrib/nvenc/module.defs
+++ b/contrib/nvenc/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,NVENC,nvenc))
 $(eval $(call import.CONTRIB.defs,NVENC))
 
-NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/nv-codec-headers-12.1.14.0.tar.gz
-NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n12.1.14.0/nv-codec-headers-12.1.14.0.tar.gz
+NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/nv-codec-headers-12.2.72.0.tar.gz
+NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n12.2.72.0/nv-codec-headers-12.2.72.0.tar.gz
 
-NVENC.FETCH.sha256   = 62b30ab37e4e9be0d0c5b37b8fee4b094e38e570984d56e1135a6b6c2c164c9f
+NVENC.FETCH.sha256   = c295a2ba8a06434d4bdc5c2208f8a825285210d71d91d572329b2c51fd0d4d03
 
 NVENC.CONFIGURE = $(TOUCH.exe) $@
 NVENC.BUILD.extra = PREFIX="$(NVENC.CONFIGURE.prefix)"


### PR DESCRIPTION
**NVENC 12.2.72.0:**

Corresponds to Video Codec SDK version 12.0.16.

Minimum required driver versions:
Linux: 550.54.14 or newer
Windows: 551.76 or newer

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux