### PR TITLE
libhb: add support for lossless VP9

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -455,14 +455,21 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         if ( w->codec_param == AV_CODEC_ID_VP8 ||
              w->codec_param == AV_CODEC_ID_VP9 )
         {
-            // These settings produce better image quality than
-            // what was previously used
-            context->flags |= AV_CODEC_FLAG_QSCALE;
-            context->global_quality = FF_QP2LAMBDA * job->vquality + 0.5;
+            if (w->codec_param == AV_CODEC_ID_VP9 && job->vquality == 0)
+            {
+                av_dict_set( &av_opts, "lossless", "1", 0 );
+            }
+            else
+            {
+                // These settings produce better image quality than
+                // what was previously used
+                context->flags |= AV_CODEC_FLAG_QSCALE;
+                context->global_quality = FF_QP2LAMBDA * job->vquality + 0.5;
 
-            char quality[7];
-            snprintf(quality, 7, "%.2f", job->vquality);
-            av_dict_set( &av_opts, "crf", quality, 0 );
+                char quality[7];
+                snprintf(quality, 7, "%.2f", job->vquality);
+                av_dict_set( &av_opts, "crf", quality, 0 );
+            }
 
             if (w->codec_param == AV_CODEC_ID_VP8)
             {


### PR DESCRIPTION
Activated by setting CQ to 0. Inspired by Blender:

https://github.com/blender/blender/blob/v4.1.1/source/blender/blenkernel/intern/writeffmpeg.cc#L801-L803

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
