### PR TITLE
Remove leftovers from mpeg2dec contrib

### DIFF
--- a/THANKS.markdown
+++ b/THANKS.markdown
@@ -22,7 +22,6 @@ HandBrake uses many cool libraries from the GNU/Linux world. We thank them and t
 - [liblame](http://lame.sourceforge.net/)
 - [liblzma (xz)](https://tukaani.org/xz/)
 - [libmfx](https://github.com/Rodeo314/libmfx)
-- [libmpeg2dec](http://libmpeg2.sourceforge.net/)
 - [libogg](https://xiph.org/ogg/)
 - [libopus](https://www.opus-codec.org/)
 - [libspeex](https://www.speex.org/)

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1240,7 +1240,7 @@ struct hb_title_s
 
     // additional supported video decoders (e.g. HW-accelerated implementations)
     int           video_decode_support;
-#define HB_DECODE_SUPPORT_SW             0x01 // software (libavcodec or mpeg2dec)
+#define HB_DECODE_SUPPORT_SW             0x01 // software (libavcodec)
 #define HB_DECODE_SUPPORT_QSV            0x02 // Intel Quick Sync Video
 #define HB_DECODE_SUPPORT_NVDEC          0x04
 #define HB_DECODE_SUPPORT_VIDEOTOOLBOX   0x08


### PR DESCRIPTION
Not used since

https://github.com/HandBrake/HandBrake/commit/1d137b47c62a47a4a08f13fc2bd8207633464fd5 https://github.com/HandBrake/HandBrake/commit/3321941ac8398348abfd42c5ca0370b910d540f2