### PR TITLE
contrib: update fribidi to 1.0.15

### DIFF
--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.defs,FRIBIDI,fribidi))
 $(eval $(call import.CONTRIB.defs,FRIBIDI))
 
-FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/fribidi-1.0.15.tar.gz
+FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs2/releases/download/contribs/fribidi-1.0.15.tar.gz
 FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.15.tar.gz
 FRIBIDI.FETCH.sha256   = 0db5f0621b6fbfae5960c30da4f132009fd72bf4687f1b04a87a4cfc2a08ea38
 FRIBIDI.FETCH.basename = fribidi-1.0.15.tar.gz

--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,FRIBIDI,fribidi))
 $(eval $(call import.CONTRIB.defs,FRIBIDI))
 
-FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/fribidi-1.0.13.tar.gz
-FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.13.tar.gz
-FRIBIDI.FETCH.sha256   = f24e8e381bcf76533ae56bd776196f3a0369ec28e9c0fdb6edd163277e008314
-FRIBIDI.FETCH.basename = fribidi-1.0.13.tar.gz
+FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/fribidi-1.0.15.tar.gz
+FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.15.tar.gz
+FRIBIDI.FETCH.sha256   = 0db5f0621b6fbfae5960c30da4f132009fd72bf4687f1b04a87a4cfc2a08ea38
+FRIBIDI.FETCH.basename = fribidi-1.0.15.tar.gz
 
 FRIBIDI.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
 

--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.defs,FRIBIDI,fribidi))
 $(eval $(call import.CONTRIB.defs,FRIBIDI))
 
-FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs2/releases/download/contribs/fribidi-1.0.15.tar.gz
+FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/fribidi-1.0.15.tar.gz
 FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.15.tar.gz
 FRIBIDI.FETCH.sha256   = 0db5f0621b6fbfae5960c30da4f132009fd72bf4687f1b04a87a4cfc2a08ea38
 FRIBIDI.FETCH.basename = fribidi-1.0.15.tar.gz


### PR DESCRIPTION
**fribidi 1.0.15:**

- Updated Unicode tables to version 15.1

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux