### PR TITLE
contrib: update SVT-AV1 to 2.1.2

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -2,7 +2,7 @@ $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
 SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v2.1.2.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.1/SVT-AV1-v2.1.2.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.2/SVT-AV1-v2.1.2.tar.gz
 SVT-AV1.FETCH.sha256  = 65e90af18f31f8c8d2e9febf909a7d61f36172536abb25a7089f152210847cd9
 
 SVT-AV1.GCC.args.c_std =

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v2.1.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.0/SVT-AV1-v2.1.0.tar.gz
-SVT-AV1.FETCH.sha256  = 72a076807544f3b269518ab11656f77358284da7782cece497781ab64ed4cb8a
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs2/releases/download/contribs/SVT-AV1-v2.1.1.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.1/SVT-AV1-v2.1.1.tar.gz
+SVT-AV1.FETCH.sha256  = 03b3cf985b52da294f241cbd2b0a8996a34f817fa75c4e8f9dc1bb6458d24de2
 
 SVT-AV1.GCC.args.c_std =
 

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs2/releases/download/contribs/SVT-AV1-v2.1.1.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.1/SVT-AV1-v2.1.1.tar.gz
-SVT-AV1.FETCH.sha256  = 03b3cf985b52da294f241cbd2b0a8996a34f817fa75c4e8f9dc1bb6458d24de2
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v2.1.2.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.1/SVT-AV1-v2.1.2.tar.gz
+SVT-AV1.FETCH.sha256  = 65e90af18f31f8c8d2e9febf909a7d61f36172536abb25a7089f152210847cd9
 
 SVT-AV1.GCC.args.c_std =
 


### PR DESCRIPTION
**SVT-AV1 2.1.1:**

Changes in 2.1.1 (2024-06-25):
- Cleanup, bug fixes, and documentation improvements:
- Removed the SVT-AV1 Decoder portion of the project. The last version containing the decoder is SVT-AV1 v2.1.0.
- Updated the folder structure and library build order to reflect the removal of the decoder.
- Renamed all files (except for API files) to remove the "Eb" prefix and changed them to camel_case format.
- Updated the gtest version to v1.12.1.
- Added CI support for ARM-based macOS machines.
- Improved documentation for accuracy and completeness.
	
**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux