### PR TITLE
Add ThinLTO option for FFmpeg

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -86,6 +86,8 @@ endif
 
 ifeq (on,$(GCC.lto))
     FFMPEG.CONFIGURE.extra += --enable-lto
+else ifeq (thin,$(GCC.lto))
+    FFMPEG.CONFIGURE.extra += --enable-lto=thin
 endif
 
 ifneq (,$(filter $(FEATURE.qsv)-$(HOST.system),1-linux 1-freebsd))


### PR DESCRIPTION
Since https://github.com/FFmpeg/FFmpeg/commit/4f555682172d838ba994df0482485973d45c6fdf it is possible to use `--enable-lto=thin`. So let's use it if HandBrake is built with ThinLTO.
