### PR TITLE
contrib: update libass to 0.17.3

### DIFF
--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -7,9 +7,9 @@ endif
 $(eval $(call import.MODULE.defs,LIBASS,libass,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBASS))
 
-LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libass-0.17.2.tar.gz
-LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.17.2/libass-0.17.2.tar.gz
-LIBASS.FETCH.sha256  = a9afb52bf76a2569263fe2038896774c991b35c0968342a03be708e56ea60c3b
+LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libass-0.17.3.tar.gz
+LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.17.3/libass-0.17.3.tar.gz
+LIBASS.FETCH.sha256  = da7c348deb6fa6c24507afab2dee7545ba5dd5bbf90a137bfe9e738f7df68537
 
 LIBASS.GCC.args.c_std =
 


### PR DESCRIPTION
**libass 0.17.3:**

This release fixes a 0.17.2 regression in the fontconfig font provider as well as some build issues. Furthermore it brings API enhancements and a performance improvement for a specific case.

The newly added ass_malloc and ass_free API should always be used when directly interacting with libass-owned or provided data to be safe on setups with multiple allocators as it’s not too uncommon on Microsoft Windows. However libass continues to always use the standard allocators provided at build time; no currently working setups break.

Detailed Changes:

- Fix 0.17.2 regression in the fontconfig fontprovider leading to undesirable widths being chosen from large typographic families
- Fix configure generated with slibtool-provided autoconf macros
- Fix make check for shared-only builds
- Constify some API parameters in a backwards-compatible manner
- Add new ass_malloc and ass_free API functions
- Tweak default optimization flags
- Speed up parsing of events with very long override blocks
- Improve handling of HarfBuzz-related failures
	
**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux