### PR TITLE
libhb: sanitize the color matrix when decoding previews

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -6464,6 +6464,141 @@ int hb_get_bit_depth(int format)
     return max;
 }
 
+int hb_get_color_prim(int color_primaries, hb_geometry_t geometry, hb_rational_t rate)
+{
+    switch (color_primaries)
+    {
+        case AVCOL_PRI_BT709:
+            return HB_COLR_PRI_BT709;
+        case AVCOL_PRI_BT470M:
+            return HB_COLR_PRI_BT470M;
+        case AVCOL_PRI_BT470BG:
+            return HB_COLR_PRI_EBUTECH;
+        case AVCOL_PRI_SMPTE170M:
+        case AVCOL_PRI_SMPTE240M:
+            return HB_COLR_PRI_SMPTEC;
+        case AVCOL_PRI_FILM:
+            return HB_COLR_PRI_FILM;
+        case AVCOL_PRI_SMPTE428:
+            return HB_COLR_PRI_SMPTE428;
+        case AVCOL_PRI_SMPTE431:
+            return HB_COLR_PRI_SMPTE431;
+        case AVCOL_PRI_SMPTE432:
+            return HB_COLR_PRI_SMPTE432;
+        case AVCOL_PRI_JEDEC_P22:
+            return HB_COLR_PRI_JEDEC_P22;
+        case AVCOL_PRI_BT2020:
+            return HB_COLR_PRI_BT2020;
+        default:
+        {
+            if ((geometry.width >= 1280 || geometry.height >= 720)||
+                (geometry.width >   720 && geometry.height >  576 ))
+                // ITU BT.709 HD content
+                return HB_COLR_PRI_BT709;
+            else if (rate.den == 1080000)
+                // ITU BT.601 DVD or SD TV content (PAL)
+                return HB_COLR_PRI_EBUTECH;
+            else
+                // ITU BT.601 DVD or SD TV content (NTSC)
+                return HB_COLR_PRI_SMPTEC;
+        }
+    }
+}
+
+int hb_get_color_transfer(int color_trc)
+{
+    switch (color_trc)
+    {
+        case AVCOL_TRC_GAMMA22:
+            return HB_COLR_TRA_GAMMA22;
+        case AVCOL_TRC_GAMMA28:
+            return HB_COLR_TRA_GAMMA28;
+        case AVCOL_TRC_SMPTE170M:
+            return HB_COLR_TRA_SMPTE170M;
+        case AVCOL_TRC_LINEAR:
+            return HB_COLR_TRA_LINEAR;
+        case AVCOL_TRC_LOG:
+            return HB_COLR_TRA_LOG;
+        case AVCOL_TRC_LOG_SQRT:
+            return HB_COLR_TRA_LOG_SQRT;
+        case AVCOL_TRC_IEC61966_2_4:
+            return HB_COLR_TRA_IEC61966_2_4;
+        case AVCOL_TRC_BT1361_ECG:
+            return HB_COLR_TRA_BT1361_ECG;
+        case AVCOL_TRC_IEC61966_2_1:
+            return HB_COLR_TRA_IEC61966_2_1;
+        case AVCOL_TRC_SMPTE240M:
+            return HB_COLR_TRA_SMPTE240M;
+        case AVCOL_TRC_SMPTEST2084:
+            return HB_COLR_TRA_SMPTEST2084;
+        case AVCOL_TRC_ARIB_STD_B67:
+            return HB_COLR_TRA_ARIB_STD_B67;
+        case AVCOL_TRC_BT2020_10:
+            return HB_COLR_TRA_BT2020_10;
+        case AVCOL_TRC_BT2020_12:
+            return HB_COLR_TRA_BT2020_12;
+        default:
+            // ITU BT.601, BT.709, anything else
+            return HB_COLR_TRA_BT709;
+    }
+}
+
+int hb_get_color_matrix(int colorspace, hb_geometry_t geometry)
+{
+    switch (colorspace)
+    {
+        case AVCOL_SPC_RGB:
+            return HB_COLR_MAT_RGB;
+        case AVCOL_SPC_BT709:
+            return HB_COLR_MAT_BT709;
+        case AVCOL_SPC_FCC:
+            return HB_COLR_MAT_FCC;
+        case AVCOL_SPC_BT470BG:
+            return HB_COLR_MAT_BT470BG;
+        case AVCOL_SPC_SMPTE170M:
+            return HB_COLR_MAT_SMPTE170M;
+        case AVCOL_SPC_SMPTE240M:
+            return HB_COLR_MAT_SMPTE240M;
+        case AVCOL_SPC_YCGCO:
+            return HB_COLR_MAT_YCGCO;
+        case AVCOL_SPC_BT2020_NCL:
+            return HB_COLR_MAT_BT2020_NCL;
+        case AVCOL_SPC_BT2020_CL:
+            return HB_COLR_MAT_BT2020_CL;
+        case AVCOL_SPC_CHROMA_DERIVED_NCL:
+            return HB_COLR_MAT_CD_NCL;
+        case AVCOL_SPC_CHROMA_DERIVED_CL:
+            return HB_COLR_MAT_CD_CL;
+        case AVCOL_SPC_ICTCP:
+            return HB_COLR_MAT_ICTCP;
+        default:
+        {
+            if ((geometry.width >= 1280 || geometry.height >= 720)||
+                (geometry.width >   720 && geometry.height >  576 ))
+                // ITU BT.709 HD content
+                return HB_COLR_MAT_BT709;
+            else
+                // ITU BT.601 DVD or SD TV content (PAL)
+                // ITU BT.601 DVD or SD TV content (NTSC)
+                return HB_COLR_MAT_SMPTE170M;
+        }
+    }
+}
+
+int hb_get_color_range(int color_range)
+{
+    switch (color_range)
+    {
+        case AVCOL_RANGE_MPEG:
+            return AVCOL_RANGE_MPEG;
+        case AVCOL_RANGE_JPEG:
+            return AVCOL_RANGE_JPEG;
+        default:
+            return AVCOL_RANGE_MPEG;
+    }
+}
+
+
 int hb_get_chroma_sub_sample(int format, int *h_shift, int *v_shift)
 {
     return av_pix_fmt_get_chroma_sub_sample(format, h_shift, v_shift);

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1543,6 +1543,15 @@ int reinit_video_filters(hb_work_private_t * pv)
 
     enum AVPixelFormat sw_pix_fmt = pv->frame->format;
     enum AVPixelFormat hw_pix_fmt = AV_PIX_FMT_NONE;
+    enum AVColorSpace color_matrix = pv->frame->colorspace;
+
+    if (!pv->job)
+    {
+        // Sanitize the color_matrix when decoding preview images
+        hb_rational_t par = {pv->frame->sample_aspect_ratio.num, pv->frame->sample_aspect_ratio.den};
+        hb_geometry_t geo = {pv->frame->width, pv->frame->height, par};
+        color_matrix = hb_get_color_matrix(pv->frame->colorspace, geo);
+    }
 
     AVHWFramesContext *frames_ctx = NULL;
     if (pv->frame->hw_frames_ctx)
@@ -1561,7 +1570,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     filter_init.geometry.height   = pv->frame->height;
     filter_init.geometry.par.num  = pv->frame->sample_aspect_ratio.num;
     filter_init.geometry.par.den  = pv->frame->sample_aspect_ratio.den;
-    filter_init.color_matrix      = pv->frame->colorspace;
+    filter_init.color_matrix      = color_matrix;
     filter_init.color_range       = pv->frame->color_range;
     filter_init.time_base.num     = 1;
     filter_init.time_base.den     = 1;

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1629,6 +1629,10 @@ int hb_output_color_transfer(hb_job_t * job);
 int hb_output_color_matrix(hb_job_t * job);
 
 int hb_get_bit_depth(int format);
+int hb_get_color_prim(int color_primaries, hb_geometry_t geometry, hb_rational_t rate);
+int hb_get_color_transfer(int color_trc);
+int hb_get_color_matrix(int colorspace, hb_geometry_t geometry);
+int hb_get_color_range(int color_range);
 int hb_get_chroma_sub_sample(int format, int *h_shift, int *v_shift);
 int hb_get_best_pix_fmt(hb_job_t * job);
 int hb_get_best_hw_pix_fmt(hb_job_t * job);

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -52,11 +52,6 @@ static void UpdateState1(hb_scan_t *scan, int title);
 static void UpdateState2(hb_scan_t *scan, int title);
 static void UpdateState3(hb_scan_t *scan, int preview);
 
-static int get_color_prim(int color_primaries, hb_geometry_t geometry, hb_rational_t rate);
-static int get_color_transfer(int color_trc);
-static int get_color_matrix(int colorspace, hb_geometry_t geometry);
-static int get_color_range(int color_range);
-
 static const char *aspect_to_string(hb_rational_t *dar)
 {
     double aspect = (double)dar->num / dar->den;
@@ -71,140 +66,6 @@ static const char *aspect_to_string(hb_rational_t *dar)
     else
         snprintf(arstr, sizeof(arstr), "1:%.2f", 1. / aspect );
     return arstr;
-}
-
-static int get_color_prim(int color_primaries, hb_geometry_t geometry, hb_rational_t rate)
-{
-    switch (color_primaries)
-    {
-        case AVCOL_PRI_BT709:
-            return HB_COLR_PRI_BT709;
-        case AVCOL_PRI_BT470M:
-            return HB_COLR_PRI_BT470M;
-        case AVCOL_PRI_BT470BG:
-            return HB_COLR_PRI_EBUTECH;
-        case AVCOL_PRI_SMPTE170M:
-        case AVCOL_PRI_SMPTE240M:
-            return HB_COLR_PRI_SMPTEC;
-        case AVCOL_PRI_FILM:
-            return HB_COLR_PRI_FILM;
-        case AVCOL_PRI_SMPTE428:
-            return HB_COLR_PRI_SMPTE428;
-        case AVCOL_PRI_SMPTE431:
-            return HB_COLR_PRI_SMPTE431;
-        case AVCOL_PRI_SMPTE432:
-            return HB_COLR_PRI_SMPTE432;
-        case AVCOL_PRI_JEDEC_P22:
-            return HB_COLR_PRI_JEDEC_P22;
-        case AVCOL_PRI_BT2020:
-            return HB_COLR_PRI_BT2020;
-        default:
-        {
-            if ((geometry.width >= 1280 || geometry.height >= 720)||
-                (geometry.width >   720 && geometry.height >  576 ))
-                // ITU BT.709 HD content
-                return HB_COLR_PRI_BT709;
-            else if (rate.den == 1080000)
-                // ITU BT.601 DVD or SD TV content (PAL)
-                return HB_COLR_PRI_EBUTECH;
-            else
-                // ITU BT.601 DVD or SD TV content (NTSC)
-                return HB_COLR_PRI_SMPTEC;
-        }
-    }
-}
-
-static int get_color_transfer(int color_trc)
-{
-    switch (color_trc)
-    {
-        case AVCOL_TRC_GAMMA22:
-            return HB_COLR_TRA_GAMMA22;
-        case AVCOL_TRC_GAMMA28:
-            return HB_COLR_TRA_GAMMA28;
-        case AVCOL_TRC_SMPTE170M:
-            return HB_COLR_TRA_SMPTE170M;
-        case AVCOL_TRC_LINEAR:
-            return HB_COLR_TRA_LINEAR;
-        case AVCOL_TRC_LOG:
-            return HB_COLR_TRA_LOG;
-        case AVCOL_TRC_LOG_SQRT:
-            return HB_COLR_TRA_LOG_SQRT;
-        case AVCOL_TRC_IEC61966_2_4:
-            return HB_COLR_TRA_IEC61966_2_4;
-        case AVCOL_TRC_BT1361_ECG:
-            return HB_COLR_TRA_BT1361_ECG;
-        case AVCOL_TRC_IEC61966_2_1:
-            return HB_COLR_TRA_IEC61966_2_1;
-        case AVCOL_TRC_SMPTE240M:
-            return HB_COLR_TRA_SMPTE240M;
-        case AVCOL_TRC_SMPTEST2084:
-            return HB_COLR_TRA_SMPTEST2084;
-        case AVCOL_TRC_ARIB_STD_B67:
-            return HB_COLR_TRA_ARIB_STD_B67;
-        case AVCOL_TRC_BT2020_10:
-            return HB_COLR_TRA_BT2020_10;
-        case AVCOL_TRC_BT2020_12:
-            return HB_COLR_TRA_BT2020_12;
-        default:
-            // ITU BT.601, BT.709, anything else
-            return HB_COLR_TRA_BT709;
-    }
-}
-
-static int get_color_matrix(int colorspace, hb_geometry_t geometry)
-{
-    switch (colorspace)
-    {
-        case AVCOL_SPC_RGB:
-            return HB_COLR_MAT_RGB;
-        case AVCOL_SPC_BT709:
-            return HB_COLR_MAT_BT709;
-        case AVCOL_SPC_FCC:
-            return HB_COLR_MAT_FCC;
-        case AVCOL_SPC_BT470BG:
-            return HB_COLR_MAT_BT470BG;
-        case AVCOL_SPC_SMPTE170M:
-            return HB_COLR_MAT_SMPTE170M;
-        case AVCOL_SPC_SMPTE240M:
-            return HB_COLR_MAT_SMPTE240M;
-        case AVCOL_SPC_YCGCO:
-            return HB_COLR_MAT_YCGCO;
-        case AVCOL_SPC_BT2020_NCL:
-            return HB_COLR_MAT_BT2020_NCL;
-        case AVCOL_SPC_BT2020_CL:
-            return HB_COLR_MAT_BT2020_CL;
-        case AVCOL_SPC_CHROMA_DERIVED_NCL:
-            return HB_COLR_MAT_CD_NCL;
-        case AVCOL_SPC_CHROMA_DERIVED_CL:
-            return HB_COLR_MAT_CD_CL;
-        case AVCOL_SPC_ICTCP:
-            return HB_COLR_MAT_ICTCP;
-        default:
-        {
-            if ((geometry.width >= 1280 || geometry.height >= 720)||
-                (geometry.width >   720 && geometry.height >  576 ))
-                // ITU BT.709 HD content
-                return HB_COLR_MAT_BT709;
-            else
-                // ITU BT.601 DVD or SD TV content (PAL)
-                // ITU BT.601 DVD or SD TV content (NTSC)
-                return HB_COLR_MAT_SMPTE170M;
-        }
-    }
-}
-
-static int get_color_range(int color_range)
-{
-    switch (color_range)
-    {
-        case AVCOL_RANGE_MPEG:
-            return AVCOL_RANGE_MPEG;
-        case AVCOL_RANGE_JPEG:
-            return AVCOL_RANGE_JPEG;
-        default:
-            return AVCOL_RANGE_MPEG;
-    }
 }
 
 static const char * const known_file_types[] =
@@ -1327,7 +1188,7 @@ skip_preview:
         // values could be read from the mpeg-2 bitstream. Override those here.
         if (data->dvd)
         {
-            title->color_prim     = get_color_prim(HB_COLR_PRI_UNSET, vid_info.geometry, vid_info.rate);
+            title->color_prim     = hb_get_color_prim(HB_COLR_PRI_UNSET, vid_info.geometry, vid_info.rate);
             title->color_transfer = HB_COLR_TRA_BT709;
             title->color_matrix   = HB_COLR_MAT_SMPTE170M;
         }
@@ -1338,9 +1199,9 @@ skip_preview:
                  (title->color_matrix   != HB_COLR_MAT_UNDEF &&
                   title->color_matrix != HB_COLR_MAT_UNSET))
         {
-            title->color_prim     = get_color_prim(title->color_prim, vid_info.geometry, vid_info.rate);
-            title->color_transfer = get_color_transfer(title->color_transfer);
-            title->color_matrix   = get_color_matrix(title->color_matrix, vid_info.geometry);
+            title->color_prim     = hb_get_color_prim(title->color_prim, vid_info.geometry, vid_info.rate);
+            title->color_transfer = hb_get_color_transfer(title->color_transfer);
+            title->color_matrix   = hb_get_color_matrix(title->color_matrix, vid_info.geometry);
         }
         else if (title->dovi.dv_profile == 5 ||
                  (title->dovi.dv_profile == 10 && title->dovi.dv_bl_signal_compatibility_id == 0))
@@ -1351,12 +1212,12 @@ skip_preview:
         }
         else
         {
-            title->color_prim     = get_color_prim(vid_info.color_prim, vid_info.geometry, vid_info.rate);
-            title->color_transfer = get_color_transfer(vid_info.color_transfer);
-            title->color_matrix   = get_color_matrix(vid_info.color_matrix, vid_info.geometry);
+            title->color_prim     = hb_get_color_prim(vid_info.color_prim, vid_info.geometry, vid_info.rate);
+            title->color_transfer = hb_get_color_transfer(vid_info.color_transfer);
+            title->color_matrix   = hb_get_color_matrix(vid_info.color_matrix, vid_info.geometry);
         }
 
-        title->color_range = get_color_range(vid_info.color_range);
+        title->color_range = hb_get_color_range(vid_info.color_range);
         title->chroma_location = vid_info.chroma_location;
 
         title->video_decode_support = vid_info.video_decode_support;


### PR DESCRIPTION
avfilter requires the color matrix now, and while we were already used sanitized values when encoding a job, previews were still using the unsanitized value, which could break the filters creation if the source file has got an out of spec value.

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux