### PR TITLE
fixes #6067 Incorrect Destination filename for file 1 when adding multiple files to a queue on linux

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -2829,7 +2829,7 @@ ghb_set_title_settings(signal_user_data_t *ud, GhbValue *settings)
     dest_dir = ghb_dict_get_string(settings, "dest_dir");
     dest = g_strdup_printf("%s" G_DIR_SEPARATOR_S "%s", dest_dir, dest_file);
     ghb_dict_set_string(settings, "destination", dest);
-    GhbValue *dest_dict = ghb_get_job_dest_settings(ud->settings);
+    GhbValue *dest_dict = ghb_get_job_dest_settings(settings);
     ghb_dict_set_string(dest_dict, "File", dest);
     g_free(dest);
 


### PR DESCRIPTION
update ghb_set_title_settings to use the input settings parameter to set Destination File path instead of the first settings value on input parameter ud


**Description of Change:**
This fixes the ghb_set_title_settings function so that it updates the Destination filename on the input settings instead of pulling the first setting off of input ud.  

This is my first time looking at a C codebase in about 15 years, so please review as I'm not sure if this negatively impacts other areas that calls `ghb_set_title_settings`

fixes #6067


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
