### PR TITLE
libhb: motion-metric neon optimizations

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -17,10 +17,6 @@
 #include <fcntl.h>
 #include <turbojpeg.h>
 
-#if defined(__aarch64__)
-#include <arm_neon.h>
-#endif
-
 #if HB_PROJECT_FEATURE_QSV
 #include "handbrake/qsv_common.h"
 #endif
@@ -1050,103 +1046,6 @@ fail:
  * @param prog_diff   Sensitivity for detecting different colors on progressive frames
  * @param prog_threshold Sensitivity for flagging progressive frames as combed
  */
-
-#if defined(__aarch64__)
-int hb_detect_comb( hb_buffer_t * buf, int color_equal, int color_diff, int threshold, int prog_equal, int prog_diff, int prog_threshold )
-{
-    int j, k, n, off, cc[3] = {0};
-    // int flag[3] ; // debugging flag
-    uint16_t cc_1 = 0;
-    uint16_t cc_2 = 0;
-
-    if ( buf->s.flags & 16 )
-    {
-        /* Frame is progressive, be more discerning. */
-        color_diff = prog_diff;
-        color_equal = prog_equal;
-        threshold = prog_threshold;
-    }
-
-    uint8x16_t color_diff_vec = vdupq_n_u8((uint8_t)color_diff);
-    uint8x16_t color_equal_vec = vdupq_n_u8((uint8_t)color_equal);
-    uint8x16_t one_mask = vdupq_n_u8(1);
-
-    /* One pas for Y, one pass for Cb, one pass for Cr */
-    for( k = 0; k <= buf->f.max_plane; k++ )
-    {
-        uint8_t * data = buf->plane[k].data;
-        int width = buf->plane[k].width;
-        int stride = buf->plane[k].stride;
-        int height = buf->plane[k].height;
-
-        uint8x16_t cc_1_vec = vdupq_n_u8(0);
-        uint8x16_t cc_2_vec = vdupq_n_u8(0);
-
-        for( j = 0; j < width; j += 16 )
-        {
-            off = 0;
-
-            for( n = 0; n < ( height - 4 ); n = n + 2 )
-            {
-                uint8x16_t s1v = vld1q_u8(data + off + j);
-                uint8x16_t s2v = vld1q_u8(data + off + j + stride);
-                uint8x16_t s3v = vld1q_u8(data + off + j + stride * 2);
-                uint8x16_t s4v = vld1q_u8(data + off + j + stride * 3);
-
-                uint8x16_t s1s3 = vabdq_u8(s1v, s3v);
-                uint8x16_t s1s3eq = vcleq_u8(s1s3, color_equal_vec);
-
-                uint8x16_t s1s2 = vabdq_u8(s1v, s2v);
-                uint8x16_t s1s2df = vcgtq_u8(s1s2, color_diff_vec);
-
-                uint8x16_t cc_1_v = vandq_u8(s1s3eq, s1s2df);
-
-                cc_1_vec = vaddq_u8(cc_1_vec, cc_1_v);
-
-                uint8x16_t s2s4 = vabdq_u8(s2v, s4v);
-                uint8x16_t s2s4eq = vcleq_u8(s2s4, color_equal_vec);
-
-                uint8x16_t s2s3 = vabdq_u8(s2v, s3v);
-                uint8x16_t s2s3df = vcgtq_u8(s2s3, color_diff_vec);
-                uint8x16_t cc_2_v = vandq_u8(s2s4eq, s2s3df);
-
-                cc_2_vec = vaddq_u8(cc_2_vec, cc_2_v);
-
-                /* Now move down 2 horizontal lines before starting over.*/
-                off += 2 * stride;
-            }
-        }
-
-        uint8x16_t cc_sum_v = vaddq_u8(cc_1_vec, cc_2_vec);
-        uint8_t cc_sum[16];
-        vst1q_u8(cc_sum, cc_sum_v);
-
-        uint32_t total_cc_sum = 0;
-        for (int i = 0; i < 16; ++i)
-        {
-            total_cc_sum += cc_sum[i];
-        }
-
-        // compare results
-        /*  The final cc score for a plane is the percentage of combed pixels it contains.
-            Because sensitivity goes down to hundredths of a percent, multiply by 1000
-            so it will be easy to compare against the threshold value which is an integer. */
-        cc[k] = (int)( total_cc_sum * 1000.0 / ( width * height ) );
-    }
-
-    /* HandBrake previews are all yuv420, so weight the average percentage of all 3 planes accordingly. */
-    int average_cc = ( 2 * cc[0] + ( cc[1] / 2 ) + ( cc[2] / 2 ) ) / 3;
-
-    /* Now see if that average percentage of combed pixels surpasses the threshold percentage given by the user.*/
-    if( average_cc > threshold )
-    {
-        return 1;
-    }
-
-    /* Reaching this point means no combing detected. */
-    return 0;
-}
-#else
 int hb_detect_comb( hb_buffer_t * buf, int color_equal, int color_diff, int threshold, int prog_equal, int prog_diff, int prog_threshold )
 {
     int j, k, n, off, cc_1, cc_2, cc[3] = {0};
@@ -1227,7 +1126,6 @@ int hb_detect_comb( hb_buffer_t * buf, int color_equal, int color_diff, int thre
     return 0;
 
 }
-#endif
 
 static void hflip_crop_pad(int * dst, int * src, int hflip)
 {

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -8,7 +8,7 @@
  */
 
 #include "handbrake/handbrake.h"
-#if defined (HB_PROJECT_FEATURE_MF)
+#if defined (__aarch64__) && defined(_WIN32)
     #include<arm_neon.h>
 #endif
 
@@ -52,7 +52,7 @@ static void build_gamma_lut(hb_motion_metric_private_t *pv)
 // Compute the sum of squared errors for a 16x16 block
 // Gamma adjusts pixel values so that less visible differences
 // count less.
-#if HB_PROJECT_FEATURE_MF
+#if defined (__aarch64__) && defined(_WIN32)
 static
 float motion_metric_neon_8(hb_motion_metric_private_t *pv,
                                      hb_buffer_t *a, hb_buffer_t *b)
@@ -134,7 +134,7 @@ static inline unsigned sse_block16##_##nbits(unsigned *gamma_lut,               
     return sum;                                                                        \
 }                                                                                      \
 
-#if !HB_PROJECT_FEATURE_MF
+#if !(defined (__aarch64__) && defined(_WIN32))
 DEF_SSE_BLOCK16(8)
 #endif
 
@@ -167,7 +167,7 @@ static float motion_metric##_##nbits(hb_motion_metric_private_t *pv,         \
     return (float)sum / (a->f.width * a->f.height);                          \
 }                                                                            \
 
-#if !HB_PROJECT_FEATURE_MF
+#if !(defined (__aarch64__) && defined(_WIN32))
 DEF_MOTION_METRIC(8)
 #endif
 
@@ -209,7 +209,7 @@ static float hb_motion_metric_work(hb_motion_metric_object_t *metric,
     switch (pv->depth)
     {
         case 8:
-#if HB_PROJECT_FEATURE_MF
+#if defined (__aarch64__) && defined(_WIN32)
             return motion_metric_neon_8(metric->private_data, buf_a, buf_b);
 #else
             return motion_metric_8(metric->private_data, buf_a, buf_b);

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -8,6 +8,9 @@
  */
 
 #include "handbrake/handbrake.h"
+#if defined (__aarch64__)
+    #include<arm_neon.h>
+#endif
 
 struct hb_motion_metric_private_s
 {
@@ -49,6 +52,70 @@ static void build_gamma_lut(hb_motion_metric_private_t *pv)
 // Compute the sum of squared errors for a 16x16 block
 // Gamma adjusts pixel values so that less visible differences
 // count less.
+#if defined (__aarch64__)
+#define DEF_MOTION_METRIC(nbits)                                             \
+static                                                                       \
+float motion_metric##_##nbits(hb_motion_metric_private_t *pv,                \
+                                     hb_buffer_t *a, hb_buffer_t *b)         \
+{                                                                            \
+    int bw = a->f.width / 16;                                                \
+    int bh = a->f.height / 16;                                               \
+    int stride_a = a->plane[0].stride / pv->bps;                             \
+    int stride_b = b->plane[0].stride / pv->bps;                             \
+    const uint##nbits##_t *pa = (const uint##nbits##_t *)a->plane[0].data;   \
+    const uint##nbits##_t *pb = (const uint##nbits##_t *)b->plane[0].data;   \
+    uint64_t sum = 0;                                                        \
+    for (int y = 0; y < bh; y++)                                             \
+    {                                                                        \
+        for (int x = 0; x < bw; x++)                                         \
+        {                                                                    \
+            const uint##nbits##_t *ra = pa + y * 16 * stride_a + x * 16;     \
+            const uint##nbits##_t *rb = pb + y * 16 * stride_b + x * 16;     \
+                                                                             \
+            for (int yy = 0; yy < 16; yy++)                                  \
+            {                                                                \
+                uint32_t arrga[16];                                          \
+                uint32_t arrgb[16];                                          \
+                                                                             \
+                for (int xx = 0; xx < 16; xx++)                              \
+                {                                                            \
+                    arrga[xx] = pv->gamma_lut[ra[xx]];                       \
+                    arrgb[xx] = pv->gamma_lut[rb[xx]];                       \
+                }                                                            \
+                                                                             \
+                uint32x4_t vga0 = vld1q_u32(arrga);                          \
+                uint32x4_t vga1 = vld1q_u32(arrga + 4);                      \
+                uint32x4_t vga2 = vld1q_u32(arrga + 8);                      \
+                uint32x4_t vga3 = vld1q_u32(arrga + 12);                     \
+                                                                             \
+                uint32x4_t vgb0 = vld1q_u32(arrgb);                          \
+                uint32x4_t vgb1 = vld1q_u32(arrgb + 4);                      \
+                uint32x4_t vgb2 = vld1q_u32(arrgb + 8);                      \
+                uint32x4_t vgb3 = vld1q_u32(arrgb + 12);                     \
+                uint32x4_t vdf0 = vsubq_u32(vga0, vgb0);                     \
+                uint32x4_t vdf1 = vsubq_u32(vga1, vgb1);                     \
+                uint32x4_t vdf2 = vsubq_u32(vga2, vgb2);                     \
+                uint32x4_t vdf3 = vsubq_u32(vga3, vgb3);                     \
+                                                                             \
+                uint32x4_t vsq0 = vmulq_u32(vdf0, vdf0);                     \
+                uint32x4_t vsq1 = vmulq_u32(vdf1, vdf1);                     \
+                uint32x4_t vsq2 = vmulq_u32(vdf2, vdf2);                     \
+                uint32x4_t vsq3 = vmulq_u32(vdf3, vdf3);                     \
+                                                                             \
+                sum += vaddvq_u32(vsq0);                                     \
+                sum += vaddvq_u32(vsq1);                                     \
+                sum += vaddvq_u32(vsq2);                                     \
+                sum += vaddvq_u32(vsq3);                                     \
+                                                                             \
+                ra += stride_a;                                              \
+                rb += stride_b;                                              \
+            }                                                                \
+                                                                             \
+        }                                                                    \
+    }                                                                        \
+}                                                                            \
+
+#else
 #define DEF_SSE_BLOCK16(nbits)                                                         \
 static inline unsigned sse_block16##_##nbits(unsigned *gamma_lut,                      \
                                    const uint##nbits##_t *a, const uint##nbits##_t *b, \
@@ -98,6 +165,7 @@ static float motion_metric##_##nbits(hb_motion_metric_private_t *pv,         \
     return (float)sum / (a->f.width * a->f.height);                          \
 }                                                                            \
 
+#endif
 DEF_MOTION_METRIC(8)
 DEF_MOTION_METRIC(16)
 

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -8,7 +8,7 @@
  */
 
 #include "handbrake/handbrake.h"
-#if defined (__aarch64__)
+#if defined (HB_PROJECT_FEATURE_MF)
     #include<arm_neon.h>
 #endif
 
@@ -52,70 +52,69 @@ static void build_gamma_lut(hb_motion_metric_private_t *pv)
 // Compute the sum of squared errors for a 16x16 block
 // Gamma adjusts pixel values so that less visible differences
 // count less.
-#if defined (__aarch64__)
-#define DEF_MOTION_METRIC(nbits)                                             \
-static                                                                       \
-float motion_metric##_##nbits(hb_motion_metric_private_t *pv,                \
-                                     hb_buffer_t *a, hb_buffer_t *b)         \
-{                                                                            \
-    int bw = a->f.width / 16;                                                \
-    int bh = a->f.height / 16;                                               \
-    int stride_a = a->plane[0].stride / pv->bps;                             \
-    int stride_b = b->plane[0].stride / pv->bps;                             \
-    const uint##nbits##_t *pa = (const uint##nbits##_t *)a->plane[0].data;   \
-    const uint##nbits##_t *pb = (const uint##nbits##_t *)b->plane[0].data;   \
-    uint64_t sum = 0;                                                        \
-    for (int y = 0; y < bh; y++)                                             \
-    {                                                                        \
-        for (int x = 0; x < bw; x++)                                         \
-        {                                                                    \
-            const uint##nbits##_t *ra = pa + y * 16 * stride_a + x * 16;     \
-            const uint##nbits##_t *rb = pb + y * 16 * stride_b + x * 16;     \
-                                                                             \
-            for (int yy = 0; yy < 16; yy++)                                  \
-            {                                                                \
-                uint32_t arrga[16];                                          \
-                uint32_t arrgb[16];                                          \
-                                                                             \
-                for (int xx = 0; xx < 16; xx++)                              \
-                {                                                            \
-                    arrga[xx] = pv->gamma_lut[ra[xx]];                       \
-                    arrgb[xx] = pv->gamma_lut[rb[xx]];                       \
-                }                                                            \
-                                                                             \
-                uint32x4_t vga0 = vld1q_u32(arrga);                          \
-                uint32x4_t vga1 = vld1q_u32(arrga + 4);                      \
-                uint32x4_t vga2 = vld1q_u32(arrga + 8);                      \
-                uint32x4_t vga3 = vld1q_u32(arrga + 12);                     \
-                                                                             \
-                uint32x4_t vgb0 = vld1q_u32(arrgb);                          \
-                uint32x4_t vgb1 = vld1q_u32(arrgb + 4);                      \
-                uint32x4_t vgb2 = vld1q_u32(arrgb + 8);                      \
-                uint32x4_t vgb3 = vld1q_u32(arrgb + 12);                     \
-                uint32x4_t vdf0 = vsubq_u32(vga0, vgb0);                     \
-                uint32x4_t vdf1 = vsubq_u32(vga1, vgb1);                     \
-                uint32x4_t vdf2 = vsubq_u32(vga2, vgb2);                     \
-                uint32x4_t vdf3 = vsubq_u32(vga3, vgb3);                     \
-                                                                             \
-                uint32x4_t vsq0 = vmulq_u32(vdf0, vdf0);                     \
-                uint32x4_t vsq1 = vmulq_u32(vdf1, vdf1);                     \
-                uint32x4_t vsq2 = vmulq_u32(vdf2, vdf2);                     \
-                uint32x4_t vsq3 = vmulq_u32(vdf3, vdf3);                     \
-                                                                             \
-                sum += vaddvq_u32(vsq0);                                     \
-                sum += vaddvq_u32(vsq1);                                     \
-                sum += vaddvq_u32(vsq2);                                     \
-                sum += vaddvq_u32(vsq3);                                     \
-                                                                             \
-                ra += stride_a;                                              \
-                rb += stride_b;                                              \
-            }                                                                \
-                                                                             \
-        }                                                                    \
-    }                                                                        \
-}                                                                            \
+#if HB_PROJECT_FEATURE_MF
+static
+float motion_metric_neon_8(hb_motion_metric_private_t *pv,
+                                     hb_buffer_t *a, hb_buffer_t *b)
+{
+    int bw = a->f.width / 16;
+    int bh = a->f.height / 16;
+    int stride_a = a->plane[0].stride / pv->bps;
+    int stride_b = b->plane[0].stride / pv->bps;
+    const uint8_t *pa = (const uint8_t *)a->plane[0].data;
+    const uint8_t *pb = (const uint8_t *)b->plane[0].data;
+    uint64_t sum = 0;
+    for (int y = 0; y < bh; y++)
+    {
+        for (int x = 0; x < bw; x++)
+        {
+            const uint8_t *ra = pa + y * 16 * stride_a + x * 16;
+            const uint8_t *rb = pb + y * 16 * stride_b + x * 16;
 
-#else
+            for (int yy = 0; yy < 16; yy++)
+            {
+                uint32_t arrga[16];
+                uint32_t arrgb[16];
+
+                for (int xx = 0; xx < 16; xx++)
+                {
+                    arrga[xx] = pv->gamma_lut[ra[xx]];
+                    arrgb[xx] = pv->gamma_lut[rb[xx]];
+                }
+
+                uint32x4_t vga0 = vld1q_u32(arrga);
+                uint32x4_t vga1 = vld1q_u32(arrga + 4);
+                uint32x4_t vga2 = vld1q_u32(arrga + 8);
+                uint32x4_t vga3 = vld1q_u32(arrga + 12);
+
+                uint32x4_t vgb0 = vld1q_u32(arrgb);
+                uint32x4_t vgb1 = vld1q_u32(arrgb + 4);
+                uint32x4_t vgb2 = vld1q_u32(arrgb + 8);
+                uint32x4_t vgb3 = vld1q_u32(arrgb + 12);
+                uint32x4_t vdf0 = vsubq_u32(vga0, vgb0);
+                uint32x4_t vdf1 = vsubq_u32(vga1, vgb1);
+                uint32x4_t vdf2 = vsubq_u32(vga2, vgb2);
+                uint32x4_t vdf3 = vsubq_u32(vga3, vgb3);
+
+                uint32x4_t vsq0 = vmulq_u32(vdf0, vdf0);
+                uint32x4_t vsq1 = vmulq_u32(vdf1, vdf1);
+                uint32x4_t vsq2 = vmulq_u32(vdf2, vdf2);
+                uint32x4_t vsq3 = vmulq_u32(vdf3, vdf3);
+
+                sum += vaddvq_u32(vsq0);
+                sum += vaddvq_u32(vsq1);
+                sum += vaddvq_u32(vsq2);
+                sum += vaddvq_u32(vsq3);
+
+                ra += stride_a;
+                rb += stride_b;
+            }
+        }
+    }
+    return (float)sum / (a->f.width * a->f.height);
+}
+#endif
+
 #define DEF_SSE_BLOCK16(nbits)                                                         \
 static inline unsigned sse_block16##_##nbits(unsigned *gamma_lut,                      \
                                    const uint##nbits##_t *a, const uint##nbits##_t *b, \
@@ -135,7 +134,10 @@ static inline unsigned sse_block16##_##nbits(unsigned *gamma_lut,               
     return sum;                                                                        \
 }                                                                                      \
 
+#if !HB_PROJECT_FEATURE_MF
 DEF_SSE_BLOCK16(8)
+#endif
+
 DEF_SSE_BLOCK16(16)
 
 // Sum of squared errors.  Computes and sums the SSEs for all
@@ -165,8 +167,10 @@ static float motion_metric##_##nbits(hb_motion_metric_private_t *pv,         \
     return (float)sum / (a->f.width * a->f.height);                          \
 }                                                                            \
 
-#endif
+#if !HB_PROJECT_FEATURE_MF
 DEF_MOTION_METRIC(8)
+#endif
+
 DEF_MOTION_METRIC(16)
 
 static int hb_motion_metric_init(hb_motion_metric_object_t *metric,
@@ -205,7 +209,11 @@ static float hb_motion_metric_work(hb_motion_metric_object_t *metric,
     switch (pv->depth)
     {
         case 8:
+#if HB_PROJECT_FEATURE_MF
+            return motion_metric_neon_8(metric->private_data, buf_a, buf_b);
+#else
             return motion_metric_8(metric->private_data, buf_a, buf_b);
+#endif
         default:
             return motion_metric_16(metric->private_data, buf_a, buf_b);
     }


### PR DESCRIPTION
**Description of Change:**

Optimized the following functions using neon intrinsics and observed upto ~30% increase in application speed.
~1. hb_detect_comb()~
2. DEF_MOTION_METRIC()



**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
