### PR TITLE
contrib: Update freetype to 2.13.3

### DIFF
--- a/contrib/freetype/module.defs
+++ b/contrib/freetype/module.defs
@@ -2,9 +2,9 @@ __deps__ := BZIP2 ZLIB
 $(eval $(call import.MODULE.defs,FREETYPE,freetype,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FREETYPE))
 
-FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/freetype-2.13.2.tar.gz
-FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.13.2.tar.gz
-FREETYPE.FETCH.sha256  = 1ac27e16c134a7f2ccea177faba19801131116fd682efc1f5737037c5db224b5
+FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.13.3.tar.gz
+FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz
+FREETYPE.FETCH.sha256  = 5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747
 
 FREETYPE.CONFIGURE.deps  =
 FREETYPE.CONFIGURE.extra = --with-harfbuzz=no --with-png=no --with-brotli=no


### PR DESCRIPTION
**freetype 2.13.3:**

* docs/VERSION.TXT: Add entry for version 2.13.3.
* docs/CHANGES: Updated.
* docs/release, docs/README, builds/macs/README: Updated.

* README, src/base/ftver.rc, builds/windows/vc2010/index.html,
builds/windows/visualc/index.html, builds/windows/visualce/index.html,
builds/wince/vc2005-ce/index.html, builds/wince/vc2008-ce/index.html,
docs/freetype-config.1: s/2.13.2/2.13.3/, s/2132/2133/.

* include/freetype/freetype.h (FREETYPE_PATCH): Set to 3.

* builds/unix/configure.raw (version_info): Set to 26:2:20.
* CMakeLists.txt (VERSION_PATCH): Set to 3.
	
**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux