### PR TITLE
contrib: SVT-AV1 2.2.0

### DIFF
--- a/contrib/svt-av1/A01-Neon-optimizations.patch
+++ b/contrib/svt-av1/A01-Neon-optimizations.patch
@@ -1,0 +1,5386 @@
+From 7b338979580e2f63763ebfdf10588a167b233d3e Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Fri, 5 Jul 2024 01:00:13 +0100
+Subject: [PATCH 1/6] Port the libaom implementation of
+ highbd_jnt_convolve_2d_neon
+
+Replace the current implementation of
+svt_av1_highbd_jnt_convolve_2d_neon with the one present in libaom. This
+version includes specialized paths for each filter size to avoid
+performing unecessary operations, as well as a specialized path for bd =
+12 to simplify the final rounding steps.
+
+Also take the opportunity to move this function to
+highbd_jnt_convolve_neon.c with the rest of the highbd_jnt_convolve
+functions. A helper had to be renamed in order to avoid name
+duplication, but this is not an issue as this helper will be removed in
+the next commit.
+---
+ Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c | 259 ------
+ .../Lib/ASM_NEON/highbd_jnt_convolve_neon.c   | 812 +++++++++++++++++-
+ .../Lib/ASM_NEON/highbd_jnt_convolve_neon.h   | 279 ++++++
+ 3 files changed, 1078 insertions(+), 272 deletions(-)
+ create mode 100644 Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.h
+
+diff --git a/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c b/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
+index 88a8dceb4..5f61ac636 100644
+--- a/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
+@@ -17,265 +17,6 @@
+ #include "common_dsp_rtcd.h"
+ #include "convolve.h"
+ 
+-static INLINE int32x4_t highbd_comp_avg_neon(const int32x4_t *const data_ref_0, const int32x4_t *const res_unsigned,
+-                                             const int32x4_t *const wt0, const int32x4_t *const wt1,
+-                                             const int use_dist_wtd_avg) {
+-    int32x4_t res;
+-    if (use_dist_wtd_avg) {
+-        const int32x4_t wt0_res = vmulq_s32(*data_ref_0, *wt0);
+-        const int32x4_t wt1_res = vmulq_s32(*res_unsigned, *wt1);
+-
+-        const int32x4_t wt_res = vaddq_s32(wt0_res, wt1_res);
+-        res                    = vshrq_n_s32(wt_res, DIST_PRECISION_BITS);
+-    } else {
+-        const int32x4_t wt_res = vaddq_s32(*data_ref_0, *res_unsigned);
+-        res                    = vshrq_n_s32(wt_res, 1);
+-    }
+-    return res;
+-}
+-
+-static INLINE int32x4_t highbd_convolve_rounding_neon(const int32x4_t *const res_unsigned,
+-                                                      const int32x4_t *const offset_const,
+-                                                      const int32x4_t *const round_const, const int round_shift) {
+-    const int32x4_t res_signed = vsubq_s32(*res_unsigned, *offset_const);
+-    const int32x4_t res_round  = vshlq_s32(vaddq_s32(res_signed, *round_const), vdupq_n_s32(-round_shift));
+-
+-    return res_round;
+-}
+-
+-static INLINE int32x4_t multiply_then_pairwise_add(const int16x8_t a, const int16x8_t b) {
+-    int32x4_t a_even = vmovl_s16(vget_low_s16(vuzp1q_s16(a, a)));
+-    int32x4_t a_odd  = vmovl_s16(vget_low_s16(vuzp2q_s16(a, a)));
+-
+-    int32x4_t b_even = vmovl_s16(vget_low_s16(vuzp1q_s16(b, b)));
+-    int32x4_t b_odd  = vmovl_s16(vget_low_s16(vuzp2q_s16(b, b)));
+-
+-    int32x4_t res_even = vmulq_s32(a_even, b_even);
+-    int32x4_t res_odd  = vmulq_s32(a_odd, b_odd);
+-
+-    return vaddq_s32(res_even, res_odd);
+-}
+-
+-void svt_av1_highbd_jnt_convolve_2d_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst16, int32_t dst16_stride,
+-                                         int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                         const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                         const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
+-    if (w < 8) {
+-        svt_av1_highbd_jnt_convolve_2d_c(src,
+-                                         src_stride,
+-                                         dst16,
+-                                         dst16_stride,
+-                                         w,
+-                                         h,
+-                                         filter_params_x,
+-                                         filter_params_y,
+-                                         subpel_x_q4,
+-                                         subpel_y_q4,
+-                                         conv_params,
+-                                         bd);
+-        return;
+-    }
+-
+-    DECLARE_ALIGNED(16, int16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP - 1) * MAX_SB_SIZE]);
+-    ConvBufType          *dst        = conv_params->dst;
+-    int                   dst_stride = conv_params->dst_stride;
+-    int                   im_h       = h + filter_params_y->taps - 1;
+-    int                   im_stride  = MAX_SB_SIZE;
+-    int                   i, j;
+-    const int             do_average       = conv_params->do_average;
+-    const int             use_jnt_comp_avg = conv_params->use_jnt_comp_avg;
+-    const int             fo_vert          = filter_params_y->taps / 2 - 1;
+-    const int             fo_horiz         = filter_params_x->taps / 2 - 1;
+-    const uint16_t *const src_ptr          = src - fo_vert * src_stride - fo_horiz;
+-
+-    const int w0 = conv_params->fwd_offset;
+-    const int w1 = conv_params->bck_offset;
+-
+-    const int offset_0       = bd + 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const int offset         = (1 << offset_0) + (1 << (offset_0 - 1));
+-    const int rounding_shift = 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-
+-    const int32x4_t wt0 = vdupq_n_s32(w0);
+-    const int32x4_t wt1 = vdupq_n_s32(w1);
+-
+-    const int32x4_t offset_const   = vdupq_n_s32(offset);
+-    const int32x4_t rounding_const = vdupq_n_s32((1 << rounding_shift) >> 1);
+-
+-    const uint16x8_t clip_pixel_to_bd_128 = vdupq_n_u16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-
+-    // Check that, even with 12-bit input, the intermediate values will fit
+-    // into an unsigned 16-bit intermediate array.
+-    assert(bd + FILTER_BITS + 2 - conv_params->round_0 <= 16);
+-
+-    /* Horizontal filter */
+-    {
+-        const int16_t  *x_filter = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_q4 & SUBPEL_MASK);
+-        const int16x8_t coeffs_x = vld1q_s16(x_filter);
+-
+-        // coeffs 0 1 0 1 2 3 2 3
+-        const int16x8_t tmp_0 = vreinterpretq_s16_s32(
+-            vzip1q_s32(vreinterpretq_s32_s16(coeffs_x), vreinterpretq_s32_s16(coeffs_x)));
+-        // coeffs 4 5 4 5 6 7 6 7
+-        const int16x8_t tmp_1 = vreinterpretq_s16_s32(
+-            vzip2q_s32(vreinterpretq_s32_s16(coeffs_x), vreinterpretq_s32_s16(coeffs_x)));
+-
+-        // coeffs 0 1 0 1 0 1 0 1
+-        const int16x8_t coeff_01 = vreinterpretq_s16_s64(
+-            vzip1q_s64(vreinterpretq_s64_s16(tmp_0), vreinterpretq_s64_s16(tmp_0)));
+-        // coeffs 2 3 2 3 2 3 2 3
+-        const int16x8_t coeff_23 = vreinterpretq_s16_s64(
+-            vzip2q_s64(vreinterpretq_s64_s16(tmp_0), vreinterpretq_s64_s16(tmp_0)));
+-        // coeffs 4 5 4 5 4 5 4 5
+-        const int16x8_t coeff_45 = vreinterpretq_s16_s64(
+-            vzip1q_s64(vreinterpretq_s64_s16(tmp_1), vreinterpretq_s64_s16(tmp_1)));
+-        // coeffs 6 7 6 7 6 7 6 7
+-        const int16x8_t coeff_67 = vreinterpretq_s16_s64(
+-            vzip2q_s64(vreinterpretq_s64_s16(tmp_1), vreinterpretq_s64_s16(tmp_1)));
+-
+-        const int32x4_t round_const  = vdupq_n_s32(((1 << conv_params->round_0) >> 1) + (1 << (bd + FILTER_BITS - 1)));
+-        const int32_t   round_shift  = conv_params->round_0;
+-        const int32x4_t vround_shift = vdupq_n_s32(round_shift);
+-
+-        for (i = 0; i < im_h; ++i) {
+-            for (j = 0; j < w; j += 8) {
+-                const int16x8_t data  = vld1q_s16((int16_t *)&src_ptr[i * src_stride + j]);
+-                const int16x8_t data2 = vld1q_s16((int16_t *)&src_ptr[i * src_stride + j + 8]);
+-
+-                // Filter even-index pixels
+-                const int32x4_t res_0 = multiply_then_pairwise_add(data, coeff_01);
+-                const int32x4_t res_2 = multiply_then_pairwise_add(vextq_s16(data, data2, 4 / 2), coeff_23);
+-                const int32x4_t res_4 = multiply_then_pairwise_add(vextq_s16(data, data2, 8 / 2), coeff_45);
+-                const int32x4_t res_6 = multiply_then_pairwise_add(vextq_s16(data, data2, 12 / 2), coeff_67);
+-
+-                int32x4_t res_even = vaddq_s32(vaddq_s32(res_0, res_4), vaddq_s32(res_2, res_6));
+-                res_even           = vshlq_s32(vaddq_s32(res_even, round_const), -vround_shift);
+-
+-                // Filter odd-index pixels
+-                const int32x4_t res_1 = multiply_then_pairwise_add(vextq_s16(data, data2, 2 / 2), coeff_01);
+-                const int32x4_t res_3 = multiply_then_pairwise_add(vextq_s16(data, data2, 6 / 2), coeff_23);
+-                const int32x4_t res_5 = multiply_then_pairwise_add(vextq_s16(data, data2, 10 / 2), coeff_45);
+-                const int32x4_t res_7 = multiply_then_pairwise_add(vextq_s16(data, data2, 14 / 2), coeff_67);
+-
+-                int32x4_t res_odd = vaddq_s32(vaddq_s32(res_1, res_5), vaddq_s32(res_3, res_7));
+-                res_odd           = vshlq_s32(vaddq_s32(res_odd, round_const), -vround_shift);
+-
+-                // Pack in the column order 0, 2, 4, 6, 1, 3, 5, 7
+-                int16x8_t res = vcombine_s16(vqmovn_s32(res_even), vqmovn_s32(res_odd));
+-                vst1q_s16(&im_block[i * im_stride + j], res);
+-            }
+-        }
+-    }
+-
+-    /* Vertical filter */
+-    {
+-        const int16_t  *y_filter = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_q4 & SUBPEL_MASK);
+-        const int16x8_t coeffs_y = vld1q_s16(y_filter);
+-
+-        // coeffs 0 1 0 1 2 3 2 3
+-        const int16x8_t tmp_0 = vreinterpretq_s16_s32(
+-            vzip1q_s32(vreinterpretq_s32_s16(coeffs_y), vreinterpretq_s32_s16(coeffs_y)));
+-        // coeffs 4 5 4 5 6 7 6 7
+-        const int16x8_t tmp_1 = vreinterpretq_s16_s32(
+-            vzip2q_s32(vreinterpretq_s32_s16(coeffs_y), vreinterpretq_s32_s16(coeffs_y)));
+-
+-        // coeffs 0 1 0 1 0 1 0 1
+-        const int16x8_t coeff_01 = vreinterpretq_s16_s64(
+-            vzip1q_s64(vreinterpretq_s64_s16(tmp_0), vreinterpretq_s64_s16(tmp_0)));
+-        // coeffs 2 3 2 3 2 3 2 3
+-        const int16x8_t coeff_23 = vreinterpretq_s16_s64(
+-            vzip2q_s64(vreinterpretq_s64_s16(tmp_0), vreinterpretq_s64_s16(tmp_0)));
+-        // coeffs 4 5 4 5 4 5 4 5
+-        const int16x8_t coeff_45 = vreinterpretq_s16_s64(
+-            vzip1q_s64(vreinterpretq_s64_s16(tmp_1), vreinterpretq_s64_s16(tmp_1)));
+-        // coeffs 6 7 6 7 6 7 6 7
+-        const int16x8_t coeff_67 = vreinterpretq_s16_s64(
+-            vzip2q_s64(vreinterpretq_s64_s16(tmp_1), vreinterpretq_s64_s16(tmp_1)));
+-
+-        const int32x4_t round_const  = vdupq_n_s32(((1 << conv_params->round_1) >> 1) -
+-                                                  (1 << (bd + 2 * FILTER_BITS - conv_params->round_0 - 1)));
+-        const int32_t   round_shift  = conv_params->round_1;
+-        const int32x4_t vround_shift = vdupq_n_s32(round_shift);
+-
+-        for (i = 0; i < h; ++i) {
+-            for (j = 0; j < w; j += 8) {
+-                const int16_t *data = &im_block[i * im_stride + j];
+-
+-                // Filter even-index pixels
+-                const int16x8_t data_0 = vld1q_s16(data + 0 * im_stride);
+-                const int16x8_t data_1 = vld1q_s16(data + 1 * im_stride);
+-                const int16x8_t data_2 = vld1q_s16(data + 2 * im_stride);
+-                const int16x8_t data_3 = vld1q_s16(data + 3 * im_stride);
+-                const int16x8_t data_4 = vld1q_s16(data + 4 * im_stride);
+-                const int16x8_t data_5 = vld1q_s16(data + 5 * im_stride);
+-                const int16x8_t data_6 = vld1q_s16(data + 6 * im_stride);
+-                const int16x8_t data_7 = vld1q_s16(data + 7 * im_stride);
+-
+-                const int16x8_t src_0 = vzip1q_s16(data_0, data_1);
+-                const int16x8_t src_2 = vzip1q_s16(data_2, data_3);
+-                const int16x8_t src_4 = vzip1q_s16(data_4, data_5);
+-                const int16x8_t src_6 = vzip1q_s16(data_6, data_7);
+-
+-                const int32x4_t res_0 = multiply_then_pairwise_add(src_0, coeff_01);
+-                const int32x4_t res_2 = multiply_then_pairwise_add(src_2, coeff_23);
+-                const int32x4_t res_4 = multiply_then_pairwise_add(src_4, coeff_45);
+-                const int32x4_t res_6 = multiply_then_pairwise_add(src_6, coeff_67);
+-
+-                const int32x4_t res_even = vaddq_s32(vaddq_s32(res_0, res_2), vaddq_s32(res_4, res_6));
+-
+-                // Filter odd-index pixels
+-                const int16x8_t src_1 = vzip2q_s16(data_0, data_1);
+-                const int16x8_t src_3 = vzip2q_s16(data_2, data_3);
+-                const int16x8_t src_5 = vzip2q_s16(data_4, data_5);
+-                const int16x8_t src_7 = vzip2q_s16(data_6, data_7);
+-
+-                const int32x4_t res_1 = multiply_then_pairwise_add(src_1, coeff_01);
+-                const int32x4_t res_3 = multiply_then_pairwise_add(src_3, coeff_23);
+-                const int32x4_t res_5 = multiply_then_pairwise_add(src_5, coeff_45);
+-                const int32x4_t res_7 = multiply_then_pairwise_add(src_7, coeff_67);
+-
+-                const int32x4_t res_odd = vaddq_s32(vaddq_s32(res_1, res_3), vaddq_s32(res_5, res_7));
+-
+-                // Rearrange pixels back into the order 0 ... 7
+-                const int32x4_t res_lo = vzip1q_s32(res_even, res_odd);
+-                const int32x4_t res_hi = vzip2q_s32(res_even, res_odd);
+-
+-                const int32x4_t res_lo_round    = vshlq_s32(vaddq_s32(res_lo, round_const), -vround_shift);
+-                const int32x4_t res_unsigned_lo = vaddq_s32(res_lo_round, offset_const);
+-
+-                const int32x4_t res_hi_round    = vshlq_s32(vaddq_s32(res_hi, round_const), -vround_shift);
+-                const int32x4_t res_unsigned_hi = vaddq_s32(res_hi_round, offset_const);
+-
+-                if (do_average) {
+-                    const uint16x4_t data_lo = vld1_u16(&dst[i * dst_stride + j + 0]);
+-                    const uint16x4_t data_hi = vld1_u16(&dst[i * dst_stride + j + 4]);
+-
+-                    const int32x4_t data_ref_0_lo = vreinterpretq_s32_u32(vmovl_u16(data_lo));
+-                    const int32x4_t data_ref_0_hi = vreinterpretq_s32_u32(vmovl_u16(data_hi));
+-
+-                    const int32x4_t comp_avg_res_lo = highbd_comp_avg_neon(
+-                        &data_ref_0_lo, &res_unsigned_lo, &wt0, &wt1, use_jnt_comp_avg);
+-                    const int32x4_t comp_avg_res_hi = highbd_comp_avg_neon(
+-                        &data_ref_0_hi, &res_unsigned_hi, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                    const int32x4_t round_result_lo = highbd_convolve_rounding_neon(
+-                        &comp_avg_res_lo, &offset_const, &rounding_const, rounding_shift);
+-                    const int32x4_t round_result_hi = highbd_convolve_rounding_neon(
+-                        &comp_avg_res_hi, &offset_const, &rounding_const, rounding_shift);
+-
+-                    const uint16x8_t res_16b = vcombine_u16(vqmovun_s32(round_result_lo), vqmovun_s32(round_result_hi));
+-                    const uint16x8_t res_clip = vminq_u16(res_16b, clip_pixel_to_bd_128);
+-
+-                    vst1q_u16(&dst16[i * dst16_stride + j], res_clip);
+-                } else {
+-                    const uint16x8_t res_16b = vcombine_u16(vqmovun_s32(res_unsigned_lo), vqmovun_s32(res_unsigned_hi));
+-
+-                    vst1q_u16(&dst[i * dst_stride + j], res_16b);
+-                }
+-            }
+-        }
+-    }
+-}
+-
+ static INLINE void svt_prepare_coeffs_12tap(const int16_t *const filter, int16x8_t *coeffs /* [6] */) {
+     int32x4_t coeffs_y  = vld1q_s32((int32_t const *)filter);
+     int32x4_t coeffs_y2 = vld1q_s32((int32_t const *)(filter + 8));
+diff --git a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+index 29cecf1db..006397ff0 100644
+--- a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+@@ -12,9 +12,11 @@
+ #include <arm_neon.h>
+ #include <assert.h>
+ 
+-#include "definitions.h"
+ #include "common_dsp_rtcd.h"
+ #include "convolve.h"
++#include "definitions.h"
++#include "highbd_jnt_convolve_neon.h"
++#include "mem_neon.h"
+ 
+ static INLINE int32x4_t svt_aom_convolve(const uint16x8_t *const s, const int16x8_t *const coeffs) {
+     const int32x4_t res_0 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0])),
+@@ -44,9 +46,9 @@ static INLINE void prepare_coeffs(const int16_t *const filter, int16x8_t *const
+     coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 3)));
+ }
+ 
+-static INLINE int32x4_t highbd_comp_avg_neon(const uint32x4_t *const data_ref_0, const uint32x4_t *const res_unsigned,
+-                                             const int32x4_t *const wt0, const int32x4_t *const wt1,
+-                                             const int use_dist_wtd_avg) {
++static INLINE int32x4_t highbd_comp_avg_helper_neon(const uint32x4_t *const data_ref_0,
++                                                    const uint32x4_t *const res_unsigned, const int32x4_t *const wt0,
++                                                    const int32x4_t *const wt1, const int use_dist_wtd_avg) {
+     int32x4_t res;
+     if (use_dist_wtd_avg) {
+         const int32x4_t wt0_res = vmulq_s32(vreinterpretq_s32_u32(*data_ref_0), *wt0);
+@@ -148,7 +150,7 @@ void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int32_t src_stride,
+                     const uint16x4_t data_0     = vld1_u16(&dst[i * dst_stride + j]);
+                     const uint32x4_t data_ref_0 = vmovl_u16(data_0);
+ 
+-                    const int32x4_t comp_avg_res = highbd_comp_avg_neon(
++                    const int32x4_t comp_avg_res = highbd_comp_avg_helper_neon(
+                         &data_ref_0, &res_unsigned_lo, &wt0, &wt1, use_jnt_comp_avg);
+                     const int32x4_t round_result = highbd_convolve_rounding_neon(
+                         &comp_avg_res, &offset_const, rounding_shift);
+@@ -169,9 +171,9 @@ void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int32_t src_stride,
+                     const uint32x4_t data_ref_0_lo = vmovl_u16(vget_low_u16(data_0));
+                     const uint32x4_t data_ref_0_hi = vmovl_u16(vget_high_u16(data_0));
+ 
+-                    const int32x4_t comp_avg_res_lo = highbd_comp_avg_neon(
++                    const int32x4_t comp_avg_res_lo = highbd_comp_avg_helper_neon(
+                         &data_ref_0_lo, &res_unsigned_lo, &wt0, &wt1, use_jnt_comp_avg);
+-                    const int32x4_t comp_avg_res_hi = highbd_comp_avg_neon(
++                    const int32x4_t comp_avg_res_hi = highbd_comp_avg_helper_neon(
+                         &data_ref_0_hi, &res_unsigned_hi, &wt0, &wt1, use_jnt_comp_avg);
+ 
+                     const int32x4_t round_result_lo = highbd_convolve_rounding_neon(
+@@ -296,9 +298,9 @@ void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride,
+                         const uint32x4_t data_ref_0 = vmovl_u16(data_0);
+                         const uint32x4_t data_ref_1 = vmovl_u16(data_1);
+ 
+-                        const int32x4_t comp_avg_res_0 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_0 = highbd_comp_avg_helper_neon(
+                             &data_ref_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_1 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_1 = highbd_comp_avg_helper_neon(
+                             &data_ref_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+ 
+                         const int32x4_t round_result_0 = highbd_convolve_rounding_neon(
+@@ -350,13 +352,13 @@ void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride,
+                         const uint32x4_t data_ref_0_hi_0 = vmovl_high_u16(data_0);
+                         const uint32x4_t data_ref_0_hi_1 = vmovl_high_u16(data_1);
+ 
+-                        const int32x4_t comp_avg_res_lo_0 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_lo_0 = highbd_comp_avg_helper_neon(
+                             &data_ref_0_lo_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_lo_1 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_lo_1 = highbd_comp_avg_helper_neon(
+                             &data_ref_0_lo_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_0 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_hi_0 = highbd_comp_avg_helper_neon(
+                             &data_ref_0_hi_0, &res_unsigned_hi_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_1 = highbd_comp_avg_neon(
++                        const int32x4_t comp_avg_res_hi_1 = highbd_comp_avg_helper_neon(
+                             &data_ref_0_hi_1, &res_unsigned_hi_1, &wt0, &wt1, use_jnt_comp_avg);
+ 
+                         const int32x4_t round_result_lo_0 = highbd_convolve_rounding_neon(
+@@ -410,3 +412,787 @@ void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride,
+         }
+     }
+ }
++
++static INLINE uint16x4_t highbd_convolve6_4_2d_v(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x8_t y_filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, y_filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_4_7, 2);
++
++    return vqrshrun_n_s32(sum, COMPOUND_ROUND1_BITS);
++}
++
++static INLINE uint16x8_t highbd_convolve6_8_2d_v(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                                 const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                                 const int16x8_t y_filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), y_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), y_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_4_7, 2);
++
++    return vcombine_u16(vqrshrun_n_s32(sum0, COMPOUND_ROUND1_BITS), vqrshrun_n_s32(sum1, COMPOUND_ROUND1_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_2d_vert_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                         int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                         int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4;
++        load_s16_4x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++        s += 5 * src_stride;
++
++        do {
++            int16x4_t s5, s6, s7, s8;
++            load_s16_4x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++            uint16x4_t d0 = highbd_convolve6_4_2d_v(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve6_4_2d_v(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve6_4_2d_v(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve6_4_2d_v(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4;
++            load_s16_8x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++            s += 5 * src_stride;
++
++            do {
++                int16x8_t s5, s6, s7, s8;
++                load_s16_8x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++                uint16x8_t d0 = highbd_convolve6_8_2d_v(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve6_8_2d_v(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve6_8_2d_v(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve6_8_2d_v(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve8_4_2d_v(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x4_t s6, const int16x4_t s7, const int16x8_t y_filter,
++                                                 const int32x4_t offset) {
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, y_filter_0_3, 0);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s6, y_filter_4_7, 2);
++    sum           = vmlal_lane_s16(sum, s7, y_filter_4_7, 3);
++
++    return vqrshrun_n_s32(sum, COMPOUND_ROUND1_BITS);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8_2d_v(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                                 const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                                 const int16x8_t s6, const int16x8_t s7, const int16x8_t y_filter,
++                                                 const int32x4_t offset) {
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), y_filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), y_filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), y_filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), y_filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), y_filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), y_filter_4_7, 3);
++
++    return vcombine_u16(vqrshrun_n_s32(sum0, COMPOUND_ROUND1_BITS), vqrshrun_n_s32(sum1, COMPOUND_ROUND1_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_2d_vert_8tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                         int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                         int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w <= 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4, s5, s6;
++        load_s16_4x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++        s += 7 * src_stride;
++
++        do {
++            int16x4_t s7, s8, s9, s10;
++            load_s16_4x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++            uint16x4_t d0 = highbd_convolve8_4_2d_v(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve8_4_2d_v(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve8_4_2d_v(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve8_4_2d_v(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s5 = s9;
++            s6 = s10;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4, s5, s6;
++            load_s16_8x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++            s += 7 * src_stride;
++
++            do {
++                int16x8_t s7, s8, s9, s10;
++                load_s16_8x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++                uint16x8_t d0 = highbd_convolve8_8_2d_v(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve8_8_2d_v(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve8_8_2d_v(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve8_8_2d_v(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s5 = s9;
++                s6 = s10;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x8_t highbd_12_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                               const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
++}
++
++static INLINE void highbd_12_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                             int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                             const int offset) {
++    // The smallest block height is 4, and the horizontal convolution needs to
++    // process an extra (filter_taps/2 - 1) lines for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++
++    int height = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_12_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            uint16x8_t d1 = highbd_12_convolve6_8(s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], x_filter, offset_vec);
++            uint16x8_t d2 = highbd_12_convolve6_8(s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], x_filter, offset_vec);
++            uint16x8_t d3 = highbd_12_convolve6_8(s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], x_filter, offset_vec);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height > 4);
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6];
++            load_s16_8x6(s, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++
++            uint16x8_t d0 = highbd_12_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            vst1q_u16(d, d0);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += src_stride;
++        dst_ptr += dst_stride;
++    } while (--height != 0);
++}
++
++static INLINE uint16x8_t highbd_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                            const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, 3), vqshrun_n_s32(sum1, ROUND0_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                          int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                          const int offset) {
++    // The smallest block height is 4, and the horizontal convolution needs to
++    // process an extra (filter_taps/2 - 1) lines for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++
++    int height = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            uint16x8_t d1 = highbd_convolve6_8(s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], x_filter, offset_vec);
++            uint16x8_t d2 = highbd_convolve6_8(s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], x_filter, offset_vec);
++            uint16x8_t d3 = highbd_convolve6_8(s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], x_filter, offset_vec);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height > 4);
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6];
++            load_s16_8x6(s, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            vst1q_u16(d, d0);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += src_stride;
++        dst_ptr += dst_stride;
++    } while (--height != 0);
++}
++
++static INLINE uint16x4_t highbd_12_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter,
++                                                 const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    return vqshrun_n_s32(sum, 5);
++}
++
++static INLINE uint16x8_t highbd_12_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                               const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
++                                               const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
++}
++
++static INLINE void highbd_12_jnt_convolve_2d_horiz_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                        int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                        const int offset) {
++    // The smallest block height is 4, and the horizontal convolution needs to
++    // process an extra (filter_taps/2 - 1) lines for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        // 4-tap filters are used for blocks having width == 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 1);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_12_convolve4_4_x(s0, x_filter, offset_vec);
++            uint16x4_t d1 = highbd_12_convolve4_4_x(s1, x_filter, offset_vec);
++            uint16x4_t d2 = highbd_12_convolve4_4_x(s2, x_filter, offset_vec);
++            uint16x4_t d3 = highbd_12_convolve4_4_x(s3, x_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h > 4);
++
++        do {
++            int16x4_t s0[4];
++            load_s16_4x4(s, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++
++            uint16x4_t d0 = highbd_12_convolve4_4_x(s0, x_filter, offset_vec);
++            vst1_u16(d, d0);
++
++            s += src_stride;
++            d += dst_stride;
++        } while (--h != 0);
++    } else {
++        const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++        int             height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_12_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                uint16x8_t d1 = highbd_12_convolve8_8(
++                    s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], s1[6], s1[7], x_filter, offset_vec);
++                uint16x8_t d2 = highbd_12_convolve8_8(
++                    s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], s2[6], s2[7], x_filter, offset_vec);
++                uint16x8_t d3 = highbd_12_convolve8_8(
++                    s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], s3[6], s3[7], x_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height > 4);
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++
++                uint16x8_t d0 = highbd_12_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                vst1q_u16(d, d0);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++        } while (--height != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter, const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                            const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
++                                            const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS), vqshrun_n_s32(sum1, ROUND0_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_2d_horiz_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                     int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                     const int offset) {
++    // The smallest block height is 4, and the horizontal convolution needs to
++    // process an extra (filter_taps/2 - 1) lines for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        // 4-tap filters are used for blocks having width == 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 1);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_x(s0, x_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve4_4_x(s1, x_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve4_4_x(s2, x_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve4_4_x(s3, x_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h > 4);
++
++        do {
++            int16x4_t s0[4];
++            load_s16_4x4(s, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_x(s0, x_filter, offset_vec);
++            vst1_u16(d, d0);
++
++            s += src_stride;
++            d += dst_stride;
++        } while (--h != 0);
++    } else {
++        const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++        int             height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve8_8(
++                    s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], s1[6], s1[7], x_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve8_8(
++                    s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], s2[6], s2[7], x_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve8_8(
++                    s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], s3[6], s3[7], x_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height > 4);
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                vst1q_u16(d, d0);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++        } while (--height != 0);
++    }
++}
++
++void svt_av1_highbd_jnt_convolve_2d_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
++                                         int h, const InterpFilterParams *filter_params_x,
++                                         const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                         const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
++    if (h == 2 || w == 2) {
++        svt_av1_highbd_jnt_convolve_2d_c(src,
++                                         src_stride,
++                                         dst,
++                                         dst_stride,
++                                         w,
++                                         h,
++                                         filter_params_x,
++                                         filter_params_y,
++                                         subpel_x_qn,
++                                         subpel_y_qn,
++                                         conv_params,
++                                         bd);
++        return;
++    }
++    DECLARE_ALIGNED(16, uint16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP) * MAX_SB_SIZE]);
++    DECLARE_ALIGNED(16, uint16_t, im_block2[(MAX_SB_SIZE + MAX_FILTER_TAP) * MAX_SB_SIZE]);
++
++    CONV_BUF_TYPE *dst16          = conv_params->dst;
++    int            dst16_stride   = conv_params->dst_stride;
++    const int      x_filter_taps  = get_filter_tap(filter_params_x, subpel_x_qn);
++    const int      clamped_x_taps = x_filter_taps < 6 ? 6 : x_filter_taps;
++    const int      y_filter_taps  = get_filter_tap(filter_params_y, subpel_y_qn);
++    const int      clamped_y_taps = y_filter_taps < 6 ? 6 : y_filter_taps;
++
++    const int im_h         = h + clamped_y_taps - 1;
++    const int im_stride    = MAX_SB_SIZE;
++    const int vert_offset  = clamped_y_taps / 2 - 1;
++    const int horiz_offset = clamped_x_taps / 2 - 1;
++    // The extra shim of (1 << (conv_params->round_0 - 1)) allows us to use a
++    // faster non-rounding non-saturating left shift.
++    const int round_offset_conv_x = (1 << (bd + FILTER_BITS - 1)) + (1 << (conv_params->round_0 - 1));
++    const int y_offset_bits       = bd + 2 * FILTER_BITS - conv_params->round_0;
++    const int round_offset_conv_y = (1 << y_offset_bits);
++
++    const uint16_t *src_ptr = src - vert_offset * src_stride - horiz_offset;
++
++    const int16_t *x_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_qn & SUBPEL_MASK);
++    const int16_t *y_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_qn & SUBPEL_MASK);
++
++    // horizontal filter
++    if (bd == 12) {
++        if (x_filter_taps <= 6 && w != 4) {
++            highbd_12_jnt_convolve_2d_horiz_6tap_neon(
++                src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, round_offset_conv_x);
++        } else {
++            highbd_12_jnt_convolve_2d_horiz_neon(
++                src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, round_offset_conv_x);
++        }
++    } else {
++        if (x_filter_taps <= 6 && w != 4) {
++            highbd_jnt_convolve_2d_horiz_6tap_neon(
++                src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, round_offset_conv_x);
++        } else {
++            highbd_jnt_convolve_2d_horiz_neon(
++                src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, round_offset_conv_x);
++        }
++    }
++
++    // vertical filter
++    if (y_filter_taps <= 6) {
++        if (conv_params->do_average) {
++            highbd_jnt_convolve_2d_vert_6tap_neon(
++                im_block, im_stride, im_block2, im_stride, w, h, y_filter_ptr, round_offset_conv_y);
++        } else {
++            highbd_jnt_convolve_2d_vert_6tap_neon(
++                im_block, im_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv_y);
++        }
++    } else {
++        if (conv_params->do_average) {
++            highbd_jnt_convolve_2d_vert_8tap_neon(
++                im_block, im_stride, im_block2, im_stride, w, h, y_filter_ptr, round_offset_conv_y);
++        } else {
++            highbd_jnt_convolve_2d_vert_8tap_neon(
++                im_block, im_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv_y);
++        }
++    }
++
++    // Do the compound averaging outside the loop, avoids branching within the
++    // main loop
++    if (conv_params->do_average) {
++        if (conv_params->use_jnt_comp_avg) {
++            if (bd == 12) {
++                highbd_12_jnt_comp_avg_neon(im_block2, im_stride, dst, dst_stride, w, h, conv_params);
++            } else {
++                highbd_jnt_comp_avg_neon(im_block2, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            }
++        } else {
++            if (bd == 12) {
++                highbd_12_comp_avg_neon(im_block2, im_stride, dst, dst_stride, w, h, conv_params);
++            } else {
++                highbd_comp_avg_neon(im_block2, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            }
++        }
++    }
++}
+diff --git a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.h b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.h
+new file mode 100644
+index 000000000..d6d04c335
+--- /dev/null
++++ b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.h
+@@ -0,0 +1,279 @@
++/*
++ * Copyright (c) 2024, Alliance for Open Media. All rights reserved
++ *
++ * This source code is subject to the terms of the BSD 2 Clause License and
++ * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
++ * was not distributed with this source code in the LICENSE file, you can
++ * obtain it at www.aomedia.org/license/software. If the Alliance for Open
++ * Media Patent License 1.0 was not distributed with this source code in the
++ * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
++ */
++
++#ifndef HIGHBD_JNT_CONVOLVE_NEON_H_
++#define HIGHBD_JNT_CONVOLVE_NEON_H_
++
++#include <assert.h>
++
++#include <arm_neon.h>
++
++#include "common_dsp_rtcd.h"
++#include "convolve.h"
++#include "definitions.h"
++#include "mem_neon.h"
++
++#define ROUND_SHIFT 2 * FILTER_BITS - ROUND0_BITS - COMPOUND_ROUND1_BITS
++
++static INLINE void highbd_12_comp_avg_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr, int dst_stride,
++                                           int w, int h, ConvolveParams *conv_params) {
++    const int offset_bits = 12 + 2 * FILTER_BITS - ROUND0_BITS - 2;
++    const int offset = (1 << (offset_bits - COMPOUND_ROUND1_BITS)) + (1 << (offset_bits - COMPOUND_ROUND1_BITS - 1));
++
++    CONV_BUF_TYPE   *ref_ptr    = conv_params->dst;
++    const int        ref_stride = conv_params->dst_stride;
++    const uint16x4_t offset_vec = vdup_n_u16((uint16_t)offset);
++    const uint16x8_t max        = vdupq_n_u16((1 << 12) - 1);
++
++    if (w == 4) {
++        do {
++            const uint16x4_t src = vld1_u16(src_ptr);
++            const uint16x4_t ref = vld1_u16(ref_ptr);
++
++            uint16x4_t avg = vhadd_u16(src, ref);
++            int32x4_t  d0  = vreinterpretq_s32_u32(vsubl_u16(avg, offset_vec));
++
++            uint16x4_t d0_u16 = vqrshrun_n_s32(d0, ROUND_SHIFT - 2);
++            d0_u16            = vmin_u16(d0_u16, vget_low_u16(max));
++
++            vst1_u16(dst_ptr, d0_u16);
++
++            src_ptr += src_stride;
++            ref_ptr += ref_stride;
++            dst_ptr += dst_stride;
++        } while (--h != 0);
++    } else {
++        do {
++            int             width = w;
++            const uint16_t *src   = src_ptr;
++            const uint16_t *ref   = ref_ptr;
++            uint16_t       *dst   = dst_ptr;
++            do {
++                const uint16x8_t s = vld1q_u16(src);
++                const uint16x8_t r = vld1q_u16(ref);
++
++                uint16x8_t avg   = vhaddq_u16(s, r);
++                int32x4_t  d0_lo = vreinterpretq_s32_u32(vsubl_u16(vget_low_u16(avg), offset_vec));
++                int32x4_t  d0_hi = vreinterpretq_s32_u32(vsubl_u16(vget_high_u16(avg), offset_vec));
++
++                uint16x8_t d0 = vcombine_u16(vqrshrun_n_s32(d0_lo, ROUND_SHIFT - 2),
++                                             vqrshrun_n_s32(d0_hi, ROUND_SHIFT - 2));
++                d0            = vminq_u16(d0, max);
++                vst1q_u16(dst, d0);
++
++                src += 8;
++                ref += 8;
++                dst += 8;
++                width -= 8;
++            } while (width != 0);
++
++            src_ptr += src_stride;
++            ref_ptr += ref_stride;
++            dst_ptr += dst_stride;
++        } while (--h != 0);
++    }
++}
++
++static INLINE void highbd_comp_avg_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr, int dst_stride,
++                                        int w, int h, ConvolveParams *conv_params, const int bd) {
++    const int offset_bits = bd + 2 * FILTER_BITS - ROUND0_BITS;
++    const int offset = (1 << (offset_bits - COMPOUND_ROUND1_BITS)) + (1 << (offset_bits - COMPOUND_ROUND1_BITS - 1));
++
++    CONV_BUF_TYPE   *ref_ptr    = conv_params->dst;
++    const int        ref_stride = conv_params->dst_stride;
++    const uint16x4_t offset_vec = vdup_n_u16((uint16_t)offset);
++    const uint16x8_t max        = vdupq_n_u16((1 << bd) - 1);
++
++    if (w == 4) {
++        do {
++            const uint16x4_t src = vld1_u16(src_ptr);
++            const uint16x4_t ref = vld1_u16(ref_ptr);
++
++            uint16x4_t avg = vhadd_u16(src, ref);
++            int32x4_t  d0  = vreinterpretq_s32_u32(vsubl_u16(avg, offset_vec));
++
++            uint16x4_t d0_u16 = vqrshrun_n_s32(d0, ROUND_SHIFT);
++            d0_u16            = vmin_u16(d0_u16, vget_low_u16(max));
++
++            vst1_u16(dst_ptr, d0_u16);
++
++            src_ptr += src_stride;
++            ref_ptr += ref_stride;
++            dst_ptr += dst_stride;
++        } while (--h != 0);
++    } else {
++        do {
++            int             width = w;
++            const uint16_t *src   = src_ptr;
++            const uint16_t *ref   = ref_ptr;
++            uint16_t       *dst   = dst_ptr;
++            do {
++                const uint16x8_t s = vld1q_u16(src);
++                const uint16x8_t r = vld1q_u16(ref);
++
++                uint16x8_t avg   = vhaddq_u16(s, r);
++                int32x4_t  d0_lo = vreinterpretq_s32_u32(vsubl_u16(vget_low_u16(avg), offset_vec));
++                int32x4_t  d0_hi = vreinterpretq_s32_u32(vsubl_u16(vget_high_u16(avg), offset_vec));
++
++                uint16x8_t d0 = vcombine_u16(vqrshrun_n_s32(d0_lo, ROUND_SHIFT), vqrshrun_n_s32(d0_hi, ROUND_SHIFT));
++                d0            = vminq_u16(d0, max);
++                vst1q_u16(dst, d0);
++
++                src += 8;
++                ref += 8;
++                dst += 8;
++                width -= 8;
++            } while (width != 0);
++
++            src_ptr += src_stride;
++            ref_ptr += ref_stride;
++            dst_ptr += dst_stride;
++        } while (--h != 0);
++    }
++}
++
++static INLINE void highbd_12_jnt_comp_avg_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                               int dst_stride, int w, int h, ConvolveParams *conv_params) {
++    const int offset_bits = 12 + 2 * FILTER_BITS - ROUND0_BITS - 2;
++    const int offset = (1 << (offset_bits - COMPOUND_ROUND1_BITS)) + (1 << (offset_bits - COMPOUND_ROUND1_BITS - 1));
++
++    CONV_BUF_TYPE   *ref_ptr    = conv_params->dst;
++    const int        ref_stride = conv_params->dst_stride;
++    const uint32x4_t offset_vec = vdupq_n_u32(offset);
++    const uint16x8_t max        = vdupq_n_u16((1 << 12) - 1);
++    uint16x4_t       fwd_offset = vdup_n_u16(conv_params->fwd_offset);
++    uint16x4_t       bck_offset = vdup_n_u16(conv_params->bck_offset);
++
++    // Weighted averaging
++    if (w == 4) {
++        do {
++            const uint16x4_t src = vld1_u16(src_ptr);
++            const uint16x4_t ref = vld1_u16(ref_ptr);
++
++            uint32x4_t wtd_avg = vmull_u16(ref, fwd_offset);
++            wtd_avg            = vmlal_u16(wtd_avg, src, bck_offset);
++            wtd_avg            = vshrq_n_u32(wtd_avg, DIST_PRECISION_BITS);
++            int32x4_t d0       = vreinterpretq_s32_u32(vsubq_u32(wtd_avg, offset_vec));
++
++            uint16x4_t d0_u16 = vqrshrun_n_s32(d0, ROUND_SHIFT - 2);
++            d0_u16            = vmin_u16(d0_u16, vget_low_u16(max));
++
++            vst1_u16(dst_ptr, d0_u16);
++
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++            ref_ptr += ref_stride;
++        } while (--h != 0);
++    } else {
++        do {
++            int             width = w;
++            const uint16_t *src   = src_ptr;
++            const uint16_t *ref   = ref_ptr;
++            uint16_t       *dst   = dst_ptr;
++            do {
++                const uint16x8_t s = vld1q_u16(src);
++                const uint16x8_t r = vld1q_u16(ref);
++
++                uint32x4_t wtd_avg0 = vmull_u16(vget_low_u16(r), fwd_offset);
++                wtd_avg0            = vmlal_u16(wtd_avg0, vget_low_u16(s), bck_offset);
++                wtd_avg0            = vshrq_n_u32(wtd_avg0, DIST_PRECISION_BITS);
++                int32x4_t d0        = vreinterpretq_s32_u32(vsubq_u32(wtd_avg0, offset_vec));
++
++                uint32x4_t wtd_avg1 = vmull_u16(vget_high_u16(r), fwd_offset);
++                wtd_avg1            = vmlal_u16(wtd_avg1, vget_high_u16(s), bck_offset);
++                wtd_avg1            = vshrq_n_u32(wtd_avg1, DIST_PRECISION_BITS);
++                int32x4_t d1        = vreinterpretq_s32_u32(vsubq_u32(wtd_avg1, offset_vec));
++
++                uint16x8_t d01 = vcombine_u16(vqrshrun_n_s32(d0, ROUND_SHIFT - 2), vqrshrun_n_s32(d1, ROUND_SHIFT - 2));
++                d01            = vminq_u16(d01, max);
++                vst1q_u16(dst, d01);
++
++                src += 8;
++                ref += 8;
++                dst += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++            ref_ptr += ref_stride;
++        } while (--h != 0);
++    }
++}
++
++static INLINE void highbd_jnt_comp_avg_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr, int dst_stride,
++                                            int w, int h, ConvolveParams *conv_params, const int bd) {
++    const int offset_bits = bd + 2 * FILTER_BITS - ROUND0_BITS;
++    const int offset = (1 << (offset_bits - COMPOUND_ROUND1_BITS)) + (1 << (offset_bits - COMPOUND_ROUND1_BITS - 1));
++
++    CONV_BUF_TYPE   *ref_ptr    = conv_params->dst;
++    const int        ref_stride = conv_params->dst_stride;
++    const uint32x4_t offset_vec = vdupq_n_u32(offset);
++    const uint16x8_t max        = vdupq_n_u16((1 << bd) - 1);
++    uint16x4_t       fwd_offset = vdup_n_u16(conv_params->fwd_offset);
++    uint16x4_t       bck_offset = vdup_n_u16(conv_params->bck_offset);
++
++    // Weighted averaging
++    if (w == 4) {
++        do {
++            const uint16x4_t src = vld1_u16(src_ptr);
++            const uint16x4_t ref = vld1_u16(ref_ptr);
++
++            uint32x4_t wtd_avg = vmull_u16(ref, fwd_offset);
++            wtd_avg            = vmlal_u16(wtd_avg, src, bck_offset);
++            wtd_avg            = vshrq_n_u32(wtd_avg, DIST_PRECISION_BITS);
++            int32x4_t d0       = vreinterpretq_s32_u32(vsubq_u32(wtd_avg, offset_vec));
++
++            uint16x4_t d0_u16 = vqrshrun_n_s32(d0, ROUND_SHIFT);
++            d0_u16            = vmin_u16(d0_u16, vget_low_u16(max));
++
++            vst1_u16(dst_ptr, d0_u16);
++
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++            ref_ptr += ref_stride;
++        } while (--h != 0);
++    } else {
++        do {
++            int             width = w;
++            const uint16_t *src   = src_ptr;
++            const uint16_t *ref   = ref_ptr;
++            uint16_t       *dst   = dst_ptr;
++            do {
++                const uint16x8_t s = vld1q_u16(src);
++                const uint16x8_t r = vld1q_u16(ref);
++
++                uint32x4_t wtd_avg0 = vmull_u16(vget_low_u16(r), fwd_offset);
++                wtd_avg0            = vmlal_u16(wtd_avg0, vget_low_u16(s), bck_offset);
++                wtd_avg0            = vshrq_n_u32(wtd_avg0, DIST_PRECISION_BITS);
++                int32x4_t d0        = vreinterpretq_s32_u32(vsubq_u32(wtd_avg0, offset_vec));
++
++                uint32x4_t wtd_avg1 = vmull_u16(vget_high_u16(r), fwd_offset);
++                wtd_avg1            = vmlal_u16(wtd_avg1, vget_high_u16(s), bck_offset);
++                wtd_avg1            = vshrq_n_u32(wtd_avg1, DIST_PRECISION_BITS);
++                int32x4_t d1        = vreinterpretq_s32_u32(vsubq_u32(wtd_avg1, offset_vec));
++
++                uint16x8_t d01 = vcombine_u16(vqrshrun_n_s32(d0, ROUND_SHIFT), vqrshrun_n_s32(d1, ROUND_SHIFT));
++                d01            = vminq_u16(d01, max);
++                vst1q_u16(dst, d01);
++
++                src += 8;
++                ref += 8;
++                dst += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++            ref_ptr += ref_stride;
++        } while (--h != 0);
++    }
++}
++
++#endif // HIGHBD_JNT_CONVOLVE_NEON_H_
+-- 
+GitLab
+
+
+From eb10c47eacd164f2c015171890faa27134bc7279 Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Fri, 5 Jul 2024 01:00:43 +0100
+Subject: [PATCH 2/6] Port libaom implementation of highbd_jnt_convolve_x_neon
+
+Replace the current implementation of svt_av1_highbd_jnt_convolve_x_neon
+with the one present in libaom. This new version includes specialized
+paths for the various filter sizes.
+---
+ .../Lib/ASM_NEON/highbd_jnt_convolve_neon.c   | 663 +++++++++++-------
+ 1 file changed, 416 insertions(+), 247 deletions(-)
+
+diff --git a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+index 006397ff0..7c9b7ac7c 100644
+--- a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+@@ -18,6 +18,422 @@
+ #include "highbd_jnt_convolve_neon.h"
+ #include "mem_neon.h"
+ 
++static INLINE uint16x8_t highbd_12_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                               const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
++}
++
++static INLINE void highbd_12_jnt_convolve_x_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                      int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                      const int offset) {
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++
++    int height = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_12_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            uint16x8_t d1 = highbd_12_convolve6_8(s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], x_filter, offset_vec);
++            uint16x8_t d2 = highbd_12_convolve6_8(s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], x_filter, offset_vec);
++            uint16x8_t d3 = highbd_12_convolve6_8(s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], x_filter, offset_vec);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height != 0);
++}
++
++static INLINE uint16x8_t highbd_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                            const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, 3), vqshrun_n_s32(sum1, ROUND0_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_x_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                   int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                   const int offset) {
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++
++    int height = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8(s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], x_filter, offset_vec);
++            uint16x8_t d1 = highbd_convolve6_8(s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], x_filter, offset_vec);
++            uint16x8_t d2 = highbd_convolve6_8(s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], x_filter, offset_vec);
++            uint16x8_t d3 = highbd_convolve6_8(s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], x_filter, offset_vec);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height != 0);
++}
++
++static INLINE uint16x4_t highbd_12_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter,
++                                                 const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    return vqshrun_n_s32(sum, 5);
++}
++
++static INLINE uint16x8_t highbd_12_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                               const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
++                                               const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
++}
++
++static INLINE void highbd_12_jnt_convolve_x_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                 int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                 const int offset) {
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        // 4-tap filters are used for blocks having width == 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 2);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_12_convolve4_4_x(s0, x_filter, offset_vec);
++            uint16x4_t d1 = highbd_12_convolve4_4_x(s1, x_filter, offset_vec);
++            uint16x4_t d2 = highbd_12_convolve4_4_x(s2, x_filter, offset_vec);
++            uint16x4_t d3 = highbd_12_convolve4_4_x(s3, x_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++        int             height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_12_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                uint16x8_t d1 = highbd_12_convolve8_8(
++                    s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], s1[6], s1[7], x_filter, offset_vec);
++                uint16x8_t d2 = highbd_12_convolve8_8(
++                    s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], s2[6], s2[7], x_filter, offset_vec);
++                uint16x8_t d3 = highbd_12_convolve8_8(
++                    s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], s3[6], s3[7], x_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter, const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                            const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
++                                            const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS), vqshrun_n_s32(sum1, ROUND0_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_x_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                              int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                              const int offset) {
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        // 4-tap filters are used for blocks having width == 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 2);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_x(s0, x_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve4_4_x(s1, x_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve4_4_x(s2, x_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve4_4_x(s3, x_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++        int             height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8(
++                    s0[0], s0[1], s0[2], s0[3], s0[4], s0[5], s0[6], s0[7], x_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve8_8(
++                    s1[0], s1[1], s1[2], s1[3], s1[4], s1[5], s1[6], s1[7], x_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve8_8(
++                    s2[0], s2[1], s2[2], s2[3], s2[4], s2[5], s2[6], s2[7], x_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve8_8(
++                    s3[0], s3[1], s3[2], s3[3], s3[4], s3[5], s3[6], s3[7], x_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height != 0);
++    }
++}
++
++void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
++                                        int h, const InterpFilterParams *filter_params_x,
++                                        const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                        const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
++    (void)filter_params_y;
++    (void)subpel_y_qn;
++    if (h == 2 || w == 2) {
++        svt_av1_highbd_jnt_convolve_x_c(src,
++                                        src_stride,
++                                        dst,
++                                        dst_stride,
++                                        w,
++                                        h,
++                                        filter_params_x,
++                                        filter_params_y,
++                                        subpel_x_qn,
++                                        subpel_y_qn,
++                                        conv_params,
++                                        bd);
++        return;
++    }
++    DECLARE_ALIGNED(16, uint16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP) * MAX_SB_SIZE]);
++    CONV_BUF_TYPE *dst16         = conv_params->dst;
++    const int      x_filter_taps = get_filter_tap(filter_params_x, subpel_x_qn);
++    int            dst16_stride  = conv_params->dst_stride;
++    const int      im_stride     = MAX_SB_SIZE;
++    const int      horiz_offset  = filter_params_x->taps / 2 - 1;
++    assert(FILTER_BITS == COMPOUND_ROUND1_BITS);
++    const int offset_convolve = (1 << (conv_params->round_0 - 1)) + (1 << (bd + FILTER_BITS)) +
++        (1 << (bd + FILTER_BITS - 1));
++
++    const int16_t *x_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_qn & SUBPEL_MASK);
++
++    src -= horiz_offset;
++
++    // horizontal filter
++    if (bd == 12) {
++        if (conv_params->do_average) {
++            if (x_filter_taps <= 6 && w != 4) {
++                highbd_12_jnt_convolve_x_6tap_neon(
++                    src + 1, src_stride, im_block, im_stride, w, h, x_filter_ptr, offset_convolve);
++            } else {
++                highbd_12_jnt_convolve_x_neon(
++                    src, src_stride, im_block, im_stride, w, h, x_filter_ptr, offset_convolve);
++            }
++            if (conv_params->use_jnt_comp_avg) {
++                highbd_12_jnt_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params);
++            } else {
++                highbd_12_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params);
++            }
++        } else {
++            if (x_filter_taps <= 6 && w != 4) {
++                highbd_12_jnt_convolve_x_6tap_neon(
++                    src + 1, src_stride, dst16, dst16_stride, w, h, x_filter_ptr, offset_convolve);
++            } else {
++                highbd_12_jnt_convolve_x_neon(
++                    src, src_stride, dst16, dst16_stride, w, h, x_filter_ptr, offset_convolve);
++            }
++        }
++    } else {
++        if (conv_params->do_average) {
++            if (x_filter_taps <= 6 && w != 4) {
++                highbd_jnt_convolve_x_6tap_neon(
++                    src + 1, src_stride, im_block, im_stride, w, h, x_filter_ptr, offset_convolve);
++            } else {
++                highbd_jnt_convolve_x_neon(src, src_stride, im_block, im_stride, w, h, x_filter_ptr, offset_convolve);
++            }
++            if (conv_params->use_jnt_comp_avg) {
++                highbd_jnt_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            } else {
++                highbd_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            }
++        } else {
++            if (x_filter_taps <= 6 && w != 4) {
++                highbd_jnt_convolve_x_6tap_neon(
++                    src + 1, src_stride, dst16, dst16_stride, w, h, x_filter_ptr, offset_convolve);
++            } else {
++                highbd_jnt_convolve_x_neon(src, src_stride, dst16, dst16_stride, w, h, x_filter_ptr, offset_convolve);
++            }
++        }
++    }
++}
++
+ static INLINE int32x4_t svt_aom_convolve(const uint16x8_t *const s, const int16x8_t *const coeffs) {
+     const int32x4_t res_0 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0])),
+                                        vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[0])), vget_high_s16(coeffs[0])));
+@@ -70,130 +486,6 @@ static INLINE int32x4_t highbd_convolve_rounding_neon(const int32x4_t *const res
+     return vrshlq_s32(res_signed, vdupq_n_s32(-round_shift));
+ }
+ 
+-void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0,
+-                                        int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                        const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                        const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
+-    if (w <= 4) {
+-        svt_av1_highbd_jnt_convolve_x_c(src,
+-                                        src_stride,
+-                                        dst0,
+-                                        dst_stride0,
+-                                        w,
+-                                        h,
+-                                        filter_params_x,
+-                                        filter_params_y,
+-                                        subpel_x_q4,
+-                                        subpel_y_q4,
+-                                        conv_params,
+-                                        bd);
+-        return;
+-    }
+-    CONV_BUF_TYPE        *dst        = conv_params->dst;
+-    int                   dst_stride = conv_params->dst_stride;
+-    const int             fo_horiz   = filter_params_x->taps / 2 - 1;
+-    const uint16_t *const src_ptr    = src - fo_horiz;
+-
+-    int        i, j;
+-    uint16x8_t s[4];
+-    int16x8_t  coeffs_x[4];
+-
+-    const int        do_average       = conv_params->do_average;
+-    const int        use_jnt_comp_avg = conv_params->use_jnt_comp_avg;
+-    const int        w0               = conv_params->fwd_offset;
+-    const int        w1               = conv_params->bck_offset;
+-    const int32x4_t  wt0              = vdupq_n_s32(w0);
+-    const int32x4_t  wt1              = vdupq_n_s32(w1);
+-    const int32x4_t  round_const_x    = vdupq_n_s32(((1 << conv_params->round_0) >> 1));
+-    const int        offset_0         = bd + 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const int        offset           = (1 << offset_0) + (1 << (offset_0 - 1));
+-    const int32x4_t  offset_const     = vdupq_n_s32(offset);
+-    const int        rounding_shift   = 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const uint16x8_t clip_pixel_to_bd = vdupq_n_u16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-
+-    const int16_t *filter_x = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_q4 & SUBPEL_MASK);
+-    prepare_coeffs(filter_x, coeffs_x);
+-
+-    for (j = 0; j < w; j += 8) {
+-        /* Horizontal filter */
+-        for (i = 0; i < h; i += 1) {
+-            const uint16x8_t row00 = vld1q_u16(&src_ptr[i * src_stride + j]);
+-            const uint16x8_t row01 = vld1q_u16(&src_ptr[i * src_stride + (j + 8)]);
+-
+-            // even pixels
+-            s[0] = vextq_u16(row00, row01, 0);
+-            s[1] = vextq_u16(row00, row01, 2);
+-            s[2] = vextq_u16(row00, row01, 4);
+-            s[3] = vextq_u16(row00, row01, 6);
+-
+-            int32x4_t res_even = svt_aom_convolve(s, coeffs_x);
+-            res_even           = vshlq_s32(vaddq_s32(res_even, round_const_x), vdupq_n_s32(-conv_params->round_0));
+-
+-            // odd pixels
+-            s[0] = vextq_u16(row00, row01, 1);
+-            s[1] = vextq_u16(row00, row01, 3);
+-            s[2] = vextq_u16(row00, row01, 5);
+-            s[3] = vextq_u16(row00, row01, 7);
+-
+-            int32x4_t res_odd = svt_aom_convolve(s, coeffs_x);
+-            res_odd           = vshlq_s32(vaddq_s32(res_odd, round_const_x), vdupq_n_s32(-conv_params->round_0));
+-
+-            res_even = vreinterpretq_s32_u32(
+-                vshlq_u32(vreinterpretq_u32_s32(res_even), vdupq_n_s32(FILTER_BITS - conv_params->round_1)));
+-            res_odd = vreinterpretq_s32_u32(
+-                vshlq_u32(vreinterpretq_u32_s32(res_odd), vdupq_n_s32(FILTER_BITS - conv_params->round_1)));
+-
+-            int32x4_t  res1            = vzip1q_s32(res_even, res_odd);
+-            uint32x4_t res_unsigned_lo = vreinterpretq_u32_s32(vaddq_s32(res1, offset_const));
+-            if (w - j < 8) {
+-                if (do_average) {
+-                    const uint16x4_t data_0     = vld1_u16(&dst[i * dst_stride + j]);
+-                    const uint32x4_t data_ref_0 = vmovl_u16(data_0);
+-
+-                    const int32x4_t comp_avg_res = highbd_comp_avg_helper_neon(
+-                        &data_ref_0, &res_unsigned_lo, &wt0, &wt1, use_jnt_comp_avg);
+-                    const int32x4_t round_result = highbd_convolve_rounding_neon(
+-                        &comp_avg_res, &offset_const, rounding_shift);
+-
+-                    const uint16x8_t res_16b  = vcombine_u16(vqmovun_s32(round_result), vqmovun_s32(round_result));
+-                    const uint16x8_t res_clip = vminq_u16(res_16b, clip_pixel_to_bd);
+-                    vst1_u16(&dst0[i * dst_stride0 + j], vget_low_u16(res_clip));
+-                } else {
+-                    uint16x8_t res_16b = vcombine_u16(vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo)),
+-                                                      vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo)));
+-                    vst1_u16(&dst[i * dst_stride + j], vget_low_u16(res_16b));
+-                }
+-            } else {
+-                int32x4_t  res2            = vzip2q_s32(res_even, res_odd);
+-                uint32x4_t res_unsigned_hi = vreinterpretq_u32_s32(vaddq_s32(res2, offset_const));
+-                if (do_average) {
+-                    const uint16x8_t data_0        = vld1q_u16(&dst[i * dst_stride + j]);
+-                    const uint32x4_t data_ref_0_lo = vmovl_u16(vget_low_u16(data_0));
+-                    const uint32x4_t data_ref_0_hi = vmovl_u16(vget_high_u16(data_0));
+-
+-                    const int32x4_t comp_avg_res_lo = highbd_comp_avg_helper_neon(
+-                        &data_ref_0_lo, &res_unsigned_lo, &wt0, &wt1, use_jnt_comp_avg);
+-                    const int32x4_t comp_avg_res_hi = highbd_comp_avg_helper_neon(
+-                        &data_ref_0_hi, &res_unsigned_hi, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                    const int32x4_t round_result_lo = highbd_convolve_rounding_neon(
+-                        &comp_avg_res_lo, &offset_const, rounding_shift);
+-                    const int32x4_t round_result_hi = highbd_convolve_rounding_neon(
+-                        &comp_avg_res_hi, &offset_const, rounding_shift);
+-
+-                    const uint16x8_t res_16b = vcombine_u16(vqmovun_s32(round_result_lo), vqmovun_s32(round_result_hi));
+-                    const uint16x8_t res_clip = vminq_u16(res_16b, clip_pixel_to_bd);
+-                    vst1q_u16(&dst0[i * dst_stride0 + j], res_clip);
+-                } else {
+-                    uint16x8_t res_16b = vcombine_u16(vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo)),
+-                                                      vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_hi)));
+-                    vst1q_u16(&dst[i * dst_stride + j], res_16b);
+-                }
+-            }
+-        }
+-    }
+-}
+-
+ void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0,
+                                         int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+                                         const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+@@ -647,30 +939,6 @@ static INLINE void highbd_jnt_convolve_2d_vert_8tap_neon(const uint16_t *src_ptr
+     }
+ }
+ 
+-static INLINE uint16x8_t highbd_12_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+-                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
+-                                               const int16x8_t filter, const int32x4_t offset) {
+-    // Values at indices 0 and 7 of y_filter are zero.
+-    const int16x4_t filter_0_3 = vget_low_s16(filter);
+-    const int16x4_t filter_4_7 = vget_high_s16(filter);
+-
+-    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
+-
+-    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
+-
+-    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
+-}
+-
+ static INLINE void highbd_12_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
+                                                              int dst_stride, int w, int h, const int16_t *x_filter_ptr,
+                                                              const int offset) {
+@@ -732,30 +1000,6 @@ static INLINE void highbd_12_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src
+     } while (--height != 0);
+ }
+ 
+-static INLINE uint16x8_t highbd_convolve6_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+-                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
+-                                            const int16x8_t filter, const int32x4_t offset) {
+-    // Values at indices 0 and 7 of y_filter are zero.
+-    const int16x4_t filter_0_3 = vget_low_s16(filter);
+-    const int16x4_t filter_4_7 = vget_high_s16(filter);
+-
+-    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 3);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_4_7, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 2);
+-
+-    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 3);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_4_7, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 2);
+-
+-    return vcombine_u16(vqshrun_n_s32(sum0, 3), vqshrun_n_s32(sum1, ROUND0_BITS));
+-}
+-
+ static INLINE void highbd_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
+                                                           int dst_stride, int w, int h, const int16_t *x_filter_ptr,
+                                                           const int offset) {
+@@ -817,44 +1061,6 @@ static INLINE void highbd_jnt_convolve_2d_horiz_6tap_neon(const uint16_t *src_pt
+     } while (--height != 0);
+ }
+ 
+-static INLINE uint16x4_t highbd_12_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter,
+-                                                 const int32x4_t offset) {
+-    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
+-    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
+-    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
+-    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
+-
+-    return vqshrun_n_s32(sum, 5);
+-}
+-
+-static INLINE uint16x8_t highbd_12_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+-                                               const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
+-                                               const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
+-                                               const int32x4_t offset) {
+-    const int16x4_t filter_0_3 = vget_low_s16(filter);
+-    const int16x4_t filter_4_7 = vget_high_s16(filter);
+-
+-    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
+-
+-    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
+-
+-    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
+-}
+-
+ static INLINE void highbd_12_jnt_convolve_2d_horiz_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
+                                                         int dst_stride, int w, int h, const int16_t *x_filter_ptr,
+                                                         const int offset) {
+@@ -957,43 +1163,6 @@ static INLINE void highbd_12_jnt_convolve_2d_horiz_neon(const uint16_t *src_ptr,
+     }
+ }
+ 
+-static INLINE uint16x4_t highbd_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter, const int32x4_t offset) {
+-    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
+-    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
+-    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
+-    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
+-
+-    return vqshrun_n_s32(sum, ROUND0_BITS);
+-}
+-
+-static INLINE uint16x8_t highbd_convolve8_8(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
+-                                            const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
+-                                            const int16x8_t s6, const int16x8_t s7, const int16x8_t filter,
+-                                            const int32x4_t offset) {
+-    const int16x4_t filter_0_3 = vget_low_s16(filter);
+-    const int16x4_t filter_4_7 = vget_high_s16(filter);
+-
+-    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter_0_3, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter_0_3, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter_0_3, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter_0_3, 3);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), filter_4_7, 0);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), filter_4_7, 1);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), filter_4_7, 2);
+-    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), filter_4_7, 3);
+-
+-    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter_0_3, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter_0_3, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter_0_3, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter_0_3, 3);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), filter_4_7, 0);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), filter_4_7, 1);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), filter_4_7, 2);
+-    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), filter_4_7, 3);
+-
+-    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS), vqshrun_n_s32(sum1, ROUND0_BITS));
+-}
+-
+ static INLINE void highbd_jnt_convolve_2d_horiz_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
+                                                      int dst_stride, int w, int h, const int16_t *x_filter_ptr,
+                                                      const int offset) {
+-- 
+GitLab
+
+
+From e78c4abbfaeb5344d3276590fd4d41f899aa8fa5 Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Thu, 4 Jul 2024 18:02:49 +0100
+Subject: [PATCH 3/6] Port libaom implementation of highbd_jnt_convolve_y_neon
+
+Replace the current implementation of svt_av1_highbd_jnt_convolve_y_neon
+with the one present in libaom. This version includes specialized paths
+for the different filter sizes, as well as a specialized path for bd =
+12 to simplify the final rounding steps.
+---
+ .../Lib/ASM_NEON/highbd_jnt_convolve_neon.c   | 865 +++++++++++++-----
+ .../Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c | 286 ------
+ Source/Lib/ASM_NEON/mem_neon.h                |  18 +
+ 3 files changed, 639 insertions(+), 530 deletions(-)
+ delete mode 100644 Source/Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c
+
+diff --git a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+index 7c9b7ac7c..f374b0a66 100644
+--- a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon.c
+@@ -434,272 +434,649 @@ void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int src_stride, uin
+     }
+ }
+ 
+-static INLINE int32x4_t svt_aom_convolve(const uint16x8_t *const s, const int16x8_t *const coeffs) {
+-    const int32x4_t res_0 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[0])), vget_high_s16(coeffs[0])));
+-    const int32x4_t res_1 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[1])), vget_low_s16(coeffs[1])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[1])), vget_high_s16(coeffs[1])));
+-    const int32x4_t res_2 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[2])), vget_low_s16(coeffs[2])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[2])), vget_high_s16(coeffs[2])));
+-    const int32x4_t res_3 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[3])), vget_low_s16(coeffs[3])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[3])), vget_high_s16(coeffs[3])));
+-
+-    const int32x4_t res = vaddq_s32(vaddq_s32(res_0, res_1), vaddq_s32(res_2, res_3));
+-
+-    return res;
++static INLINE uint16x4_t highbd_12_convolve6_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s1, filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s2, filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s3, filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s4, filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s5, filter_4_7, 2);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS + 2);
++}
++
++static INLINE void highbd_12_jnt_convolve_y_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                      int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                      const int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4;
++        load_s16_4x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++        s += 5 * src_stride;
++
++        do {
++            int16x4_t s5, s6, s7, s8;
++            load_s16_4x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++            uint16x4_t d0 = highbd_12_convolve6_4_y(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_12_convolve6_4_y(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_12_convolve6_4_y(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_12_convolve6_4_y(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4;
++            load_s16_8x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++            s += 5 * src_stride;
++
++            do {
++                int16x8_t s5, s6, s7, s8;
++                load_s16_8x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++                uint16x8_t d0 = highbd_12_convolve6_8(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_12_convolve6_8(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_12_convolve6_8(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_12_convolve6_8(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve6_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                              const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                              const int16x8_t filter, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s1, filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s2, filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s3, filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s4, filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s5, filter_4_7, 2);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS);
++}
++
++static INLINE void highbd_jnt_convolve_y_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                   int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                   const int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4;
++        load_s16_4x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++        s += 5 * src_stride;
++
++        do {
++            int16x4_t s5, s6, s7, s8;
++            load_s16_4x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++            uint16x4_t d0 = highbd_convolve6_4_y(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve6_4_y(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve6_4_y(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve6_4_y(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4;
++            load_s16_8x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++            s += 5 * src_stride;
++
++            do {
++                int16x8_t s5, s6, s7, s8;
++                load_s16_8x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++                uint16x8_t d0 = highbd_convolve6_8(s0, s1, s2, s3, s4, s5, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve6_8(s1, s2, s3, s4, s5, s6, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve6_8(s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve6_8(s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
+ }
+ 
+-static INLINE void prepare_coeffs(const int16_t *const filter, int16x8_t *const coeffs /* [4] */) {
+-    const int16x8_t coeff = vld1q_s16(filter);
+-
+-    // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 0)));
+-    // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 1)));
+-    // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 2)));
+-    // coeffs 6 7 6 7 6 7 6 7
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 3)));
++static INLINE uint16x4_t highbd_12_convolve4_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t filter, const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter, 0);
++    sum           = vmlal_lane_s16(sum, s1, filter, 1);
++    sum           = vmlal_lane_s16(sum, s2, filter, 2);
++    sum           = vmlal_lane_s16(sum, s3, filter, 3);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS + 2);
++}
++
++static INLINE uint16x8_t highbd_12_convolve4_8_y(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                                 const int16x8_t s3, const int16x4_t filter, const int32x4_t offset) {
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS + 2), vqshrun_n_s32(sum1, ROUND0_BITS + 2));
+ }
+ 
+-static INLINE int32x4_t highbd_comp_avg_helper_neon(const uint32x4_t *const data_ref_0,
+-                                                    const uint32x4_t *const res_unsigned, const int32x4_t *const wt0,
+-                                                    const int32x4_t *const wt1, const int use_dist_wtd_avg) {
+-    int32x4_t res;
+-    if (use_dist_wtd_avg) {
+-        const int32x4_t wt0_res = vmulq_s32(vreinterpretq_s32_u32(*data_ref_0), *wt0);
+-        const int32x4_t wt1_res = vmulq_s32(vreinterpretq_s32_u32(*res_unsigned), *wt1);
++static INLINE void highbd_12_jnt_convolve_y_4tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                      int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                      const int offset) {
++    const int16x4_t y_filter   = vld1_s16(y_filter_ptr + 2);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
+ 
+-        const int32x4_t wt_res = vaddq_s32(wt0_res, wt1_res);
+-        res                    = vshrq_n_s32(wt_res, DIST_PRECISION_BITS);
++        int16x4_t s0, s1, s2;
++        load_s16_4x3(s, src_stride, &s0, &s1, &s2);
++        s += 3 * src_stride;
++
++        do {
++            int16x4_t s3, s4, s5, s6;
++            load_s16_4x4(s, src_stride, &s3, &s4, &s5, &s6);
++
++            uint16x4_t d0 = highbd_12_convolve4_4_y(s0, s1, s2, s3, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_12_convolve4_4_y(s1, s2, s3, s4, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_12_convolve4_4_y(s2, s3, s4, s5, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_12_convolve4_4_y(s3, s4, s5, s6, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
+     } else {
+-        const int32x4_t wt_res = vaddq_s32(vreinterpretq_s32_u32(*data_ref_0), vreinterpretq_s32_u32(*res_unsigned));
+-        res                    = vshrq_n_s32(wt_res, 1);
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2;
++            load_s16_8x3(s, src_stride, &s0, &s1, &s2);
++            s += 3 * src_stride;
++
++            do {
++                int16x8_t s3, s4, s5, s6;
++                load_s16_8x4(s, src_stride, &s3, &s4, &s5, &s6);
++
++                uint16x8_t d0 = highbd_12_convolve4_8_y(s0, s1, s2, s3, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_12_convolve4_8_y(s1, s2, s3, s4, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_12_convolve4_8_y(s2, s3, s4, s5, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_12_convolve4_8_y(s3, s4, s5, s6, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
+     }
+-    return res;
+ }
+ 
+-static INLINE int32x4_t highbd_convolve_rounding_neon(const int32x4_t *const res_unsigned,
+-                                                      const int32x4_t *const offset_const, const int round_shift) {
+-    const int32x4_t res_signed = vsubq_s32(*res_unsigned, *offset_const);
++static INLINE uint16x4_t highbd_convolve4_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                              const int16x4_t s3, const int16x4_t filter, const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter, 0);
++    sum           = vmlal_lane_s16(sum, s1, filter, 1);
++    sum           = vmlal_lane_s16(sum, s2, filter, 2);
++    sum           = vmlal_lane_s16(sum, s3, filter, 3);
+ 
+-    return vrshlq_s32(res_signed, vdupq_n_s32(-round_shift));
++    return vqshrun_n_s32(sum, ROUND0_BITS);
+ }
+ 
+-void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0,
+-                                        int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                        const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                        const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
+-    if (w <= 4) {
++static INLINE uint16x8_t highbd_convolve4_8_y(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                              const int16x8_t s3, const int16x4_t filter, const int32x4_t offset) {
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), filter, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), filter, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), filter, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), filter, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), filter, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), filter, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), filter, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), filter, 3);
++
++    return vcombine_u16(vqshrun_n_s32(sum0, ROUND0_BITS), vqshrun_n_s32(sum1, ROUND0_BITS));
++}
++
++static INLINE void highbd_jnt_convolve_y_4tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                   int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                   const int offset) {
++    const int16x4_t y_filter   = vld1_s16(y_filter_ptr + 2);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2;
++        load_s16_4x3(s, src_stride, &s0, &s1, &s2);
++        s += 3 * src_stride;
++
++        do {
++            int16x4_t s3, s4, s5, s6;
++            load_s16_4x4(s, src_stride, &s3, &s4, &s5, &s6);
++
++            uint16x4_t d0 = highbd_convolve4_4_y(s0, s1, s2, s3, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve4_4_y(s1, s2, s3, s4, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve4_4_y(s2, s3, s4, s5, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve4_4_y(s3, s4, s5, s6, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2;
++            load_s16_8x3(s, src_stride, &s0, &s1, &s2);
++            s += 3 * src_stride;
++
++            do {
++                int16x8_t s3, s4, s5, s6;
++                load_s16_8x4(s, src_stride, &s3, &s4, &s5, &s6);
++
++                uint16x8_t d0 = highbd_convolve4_8_y(s0, s1, s2, s3, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve4_8_y(s1, s2, s3, s4, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve4_8_y(s2, s3, s4, s5, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve4_8_y(s3, s4, s5, s6, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_12_convolve8_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x4_t s6, const int16x4_t s7, const int16x8_t filter,
++                                                 const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter_0_3, 0);
++    sum           = vmlal_lane_s16(sum, s1, filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s2, filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s3, filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s4, filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s5, filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s6, filter_4_7, 2);
++    sum           = vmlal_lane_s16(sum, s7, filter_4_7, 3);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS + 2);
++}
++
++static INLINE void highbd_12_jnt_convolve_y_8tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                      int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                      const int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4, s5, s6;
++        load_s16_4x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++        s += 7 * src_stride;
++
++        do {
++            int16x4_t s7, s8, s9, s10;
++            load_s16_4x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++            uint16x4_t d0 = highbd_12_convolve8_4_y(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_12_convolve8_4_y(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_12_convolve8_4_y(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_12_convolve8_4_y(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s5 = s9;
++            s6 = s10;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4, s5, s6;
++            load_s16_8x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++            s += 7 * src_stride;
++
++            do {
++                int16x8_t s7, s8, s9, s10;
++                load_s16_8x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++                uint16x8_t d0 = highbd_12_convolve8_8(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_12_convolve8_8(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_12_convolve8_8(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_12_convolve8_8(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s5 = s9;
++                s6 = s10;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve8_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                              const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                              const int16x4_t s6, const int16x4_t s7, const int16x8_t filter,
++                                              const int32x4_t offset) {
++    const int16x4_t filter_0_3 = vget_low_s16(filter);
++    const int16x4_t filter_4_7 = vget_high_s16(filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, filter_0_3, 0);
++    sum           = vmlal_lane_s16(sum, s1, filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s2, filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s3, filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s4, filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s5, filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s6, filter_4_7, 2);
++    sum           = vmlal_lane_s16(sum, s7, filter_4_7, 3);
++
++    return vqshrun_n_s32(sum, ROUND0_BITS);
++}
++
++static INLINE void highbd_jnt_convolve_y_8tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                   int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                   const int offset) {
++    const int16x8_t y_filter   = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_vec = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        const int16_t *s = (const int16_t *)src_ptr;
++        uint16_t      *d = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4, s5, s6;
++        load_s16_4x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++        s += 7 * src_stride;
++
++        do {
++            int16x4_t s7, s8, s9, s10;
++            load_s16_4x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++            uint16x4_t d0 = highbd_convolve8_4_y(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++            uint16x4_t d1 = highbd_convolve8_4_y(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++            uint16x4_t d2 = highbd_convolve8_4_y(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++            uint16x4_t d3 = highbd_convolve8_4_y(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s5 = s9;
++            s6 = s10;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4, s5, s6;
++            load_s16_8x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++            s += 7 * src_stride;
++
++            do {
++                int16x8_t s7, s8, s9, s10;
++                load_s16_8x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++                uint16x8_t d0 = highbd_convolve8_8(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, offset_vec);
++                uint16x8_t d1 = highbd_convolve8_8(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, offset_vec);
++                uint16x8_t d2 = highbd_convolve8_8(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, offset_vec);
++                uint16x8_t d3 = highbd_convolve8_8(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, offset_vec);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s5 = s9;
++                s6 = s10;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
++                                        int h, const InterpFilterParams *filter_params_x,
++                                        const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                        const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
++    (void)filter_params_x;
++    (void)subpel_x_qn;
++    if (h == 2 || w == 2) {
+         svt_av1_highbd_jnt_convolve_y_c(src,
+                                         src_stride,
+-                                        dst0,
+-                                        dst_stride0,
++                                        dst,
++                                        dst_stride,
+                                         w,
+                                         h,
+                                         filter_params_x,
+                                         filter_params_y,
+-                                        subpel_x_q4,
+-                                        subpel_y_q4,
++                                        subpel_x_qn,
++                                        subpel_y_qn,
+                                         conv_params,
+                                         bd);
+         return;
+     }
+-    CONV_BUF_TYPE        *dst        = conv_params->dst;
+-    const int             dst_stride = conv_params->dst_stride;
+-    const int             fo_vert    = filter_params_y->taps / 2 - 1;
+-    const uint16_t *const src_ptr    = src - fo_vert * src_stride;
+-
+-    int       i, j;
+-    const int do_average       = conv_params->do_average;
+-    const int use_jnt_comp_avg = conv_params->use_jnt_comp_avg;
+-
+-    const int       w0            = conv_params->fwd_offset;
+-    const int       w1            = conv_params->bck_offset;
+-    const int32x4_t wt0           = vdupq_n_s32(w0);
+-    const int32x4_t wt1           = vdupq_n_s32(w1);
+-    const int32x4_t round_const_y = vdupq_n_s32(((1 << conv_params->round_1) >> 1));
+-
+-    const int        offset_0         = bd + 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const int        offset           = (1 << offset_0) + (1 << (offset_0 - 1));
+-    const int32x4_t  offset_const     = vdupq_n_s32(offset);
+-    const int        rounding_shift   = 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const uint16x8_t clip_pixel_to_bd = vdupq_n_u16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-    uint16x8_t       s[16];
+-    int16x8_t        coeffs_y[4];
+-
+-    const int16_t *filter_y = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_q4 & SUBPEL_MASK);
+-    prepare_coeffs(filter_y, coeffs_y);
+-
+-    for (j = 0; j < w; j += 8) {
+-        const uint16_t *data = &src_ptr[j];
+-        /* Vertical filter */
+-        {
+-            uint16x8_t s0 = vld1q_u16(data + 0 * src_stride);
+-            uint16x8_t s1 = vld1q_u16(data + 1 * src_stride);
+-            uint16x8_t s2 = vld1q_u16(data + 2 * src_stride);
+-            uint16x8_t s3 = vld1q_u16(data + 3 * src_stride);
+-            uint16x8_t s4 = vld1q_u16(data + 4 * src_stride);
+-            uint16x8_t s5 = vld1q_u16(data + 5 * src_stride);
+-            uint16x8_t s6 = vld1q_u16(data + 6 * src_stride);
+-
+-            s[0] = vzip1q_u16(s0, s1);
+-            s[1] = vzip1q_u16(s2, s3);
+-            s[2] = vzip1q_u16(s4, s5);
+-
+-            s[4] = vzip2q_u16(s0, s1);
+-            s[5] = vzip2q_u16(s2, s3);
+-            s[6] = vzip2q_u16(s4, s5);
+-
+-            s[0 + 8] = vzip1q_u16(s1, s2);
+-            s[1 + 8] = vzip1q_u16(s3, s4);
+-            s[2 + 8] = vzip1q_u16(s5, s6);
+-
+-            s[4 + 8] = vzip2q_u16(s1, s2);
+-            s[5 + 8] = vzip2q_u16(s3, s4);
+-            s[6 + 8] = vzip2q_u16(s5, s6);
+-
+-            for (i = 0; i < h; i += 2) {
+-                data = &src_ptr[i * src_stride + j];
+-
+-                const uint16x8_t s7 = vld1q_u16(data + 7 * src_stride);
+-                const uint16x8_t s8 = vld1q_u16(data + 8 * src_stride);
+-
+-                s[3] = vzip1q_u16(s6, s7);
+-                s[7] = vzip2q_u16(s6, s7);
+-
+-                s[3 + 8] = vzip1q_u16(s7, s8);
+-                s[7 + 8] = vzip2q_u16(s7, s8);
+-
+-                const int32x4_t res_a0       = svt_aom_convolve(s, coeffs_y);
+-                int32x4_t       res_a_round0 = vshlq_s32(res_a0, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                res_a_round0 = vshlq_s32(vaddq_s32(res_a_round0, round_const_y), vdupq_n_s32(-conv_params->round_1));
+-
+-                const int32x4_t res_a1       = svt_aom_convolve(s + 8, coeffs_y);
+-                int32x4_t       res_a_round1 = vshlq_s32(res_a1, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                res_a_round1 = vshlq_s32(vaddq_s32(res_a_round1, round_const_y), vdupq_n_s32(-conv_params->round_1));
+-
+-                const uint32x4_t res_unsigned_lo_0 = vreinterpretq_u32_s32(vaddq_s32(res_a_round0, offset_const));
+-                const uint32x4_t res_unsigned_lo_1 = vreinterpretq_u32_s32(vaddq_s32(res_a_round1, offset_const));
+-
+-                if (w - j < 8) {
+-                    if (do_average) {
+-                        const uint16x4_t data_0 = vld1_u16(&dst[i * dst_stride + j]);
+-                        const uint16x4_t data_1 = vld1_u16(&dst[i * dst_stride + j + dst_stride]);
+-
+-                        const uint32x4_t data_ref_0 = vmovl_u16(data_0);
+-                        const uint32x4_t data_ref_1 = vmovl_u16(data_1);
+-
+-                        const int32x4_t comp_avg_res_0 = highbd_comp_avg_helper_neon(
+-                            &data_ref_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_1 = highbd_comp_avg_helper_neon(
+-                            &data_ref_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                        const int32x4_t round_result_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_1, &offset_const, rounding_shift);
+-
+-                        const uint16x8_t res_16b_0  = vqmovun_high_s32(vqmovun_s32(round_result_0), round_result_0);
+-                        const uint16x8_t res_clip_0 = vminq_u16(res_16b_0, clip_pixel_to_bd);
+-                        const uint16x8_t res_16b_1  = vqmovun_high_s32(vqmovun_s32(round_result_1), round_result_1);
+-                        const uint16x8_t res_clip_1 = vminq_u16(res_16b_1, clip_pixel_to_bd);
+-
+-                        vst1_u16(&dst0[i * dst_stride0 + j], vget_low_u16(res_clip_0));
+-                        vst1_u16(&dst0[i * dst_stride0 + j + dst_stride0], vget_low_u16(res_clip_1));
+-
+-                    } else {
+-                        const uint16x8_t res_16b_0 = vqmovun_high_s32(
+-                            vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo_0)),
+-                            vreinterpretq_s32_u32(res_unsigned_lo_0));
+-
+-                        const uint16x8_t res_16b_1 = vqmovun_high_s32(
+-                            vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo_1)),
+-                            vreinterpretq_s32_u32(res_unsigned_lo_1));
+-
+-                        vst1_u16(&dst[i * dst_stride + j], vget_low_u16(res_16b_0));
+-                        vst1_u16(&dst[i * dst_stride + j + dst_stride], vget_low_u16(res_16b_1));
+-                    }
+-                } else {
+-                    const int32x4_t res_b0       = svt_aom_convolve(s + 4, coeffs_y);
+-                    int32x4_t       res_b_round0 = vshlq_s32(res_b0, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                    res_b_round0                 = vshlq_s32(vaddq_s32(res_b_round0, round_const_y),
+-                                             vdupq_n_s32(-conv_params->round_1));
+-
+-                    const int32x4_t res_b1       = svt_aom_convolve(s + 4 + 8, coeffs_y);
+-                    int32x4_t       res_b_round1 = vshlq_s32(res_b1, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                    res_b_round1                 = vshlq_s32(vaddq_s32(res_b_round1, round_const_y),
+-                                             vdupq_n_s32(-conv_params->round_1));
+-
+-                    uint32x4_t res_unsigned_hi_0 = vreinterpretq_u32_s32(vaddq_s32(res_b_round0, offset_const));
+-                    uint32x4_t res_unsigned_hi_1 = vreinterpretq_u32_s32(vaddq_s32(res_b_round1, offset_const));
+-
+-                    if (do_average) {
+-                        const uint16x8_t data_0 = vld1q_u16(&dst[i * dst_stride + j]);
+-                        const uint16x8_t data_1 = vld1q_u16(&dst[i * dst_stride + j + dst_stride]);
+-
+-                        const uint32x4_t data_ref_0_lo_0 = vmovl_u16(vget_low_u16(data_0));
+-                        const uint32x4_t data_ref_0_lo_1 = vmovl_u16(vget_low_u16(data_1));
+-
+-                        const uint32x4_t data_ref_0_hi_0 = vmovl_high_u16(data_0);
+-                        const uint32x4_t data_ref_0_hi_1 = vmovl_high_u16(data_1);
+-
+-                        const int32x4_t comp_avg_res_lo_0 = highbd_comp_avg_helper_neon(
+-                            &data_ref_0_lo_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_lo_1 = highbd_comp_avg_helper_neon(
+-                            &data_ref_0_lo_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_0 = highbd_comp_avg_helper_neon(
+-                            &data_ref_0_hi_0, &res_unsigned_hi_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_1 = highbd_comp_avg_helper_neon(
+-                            &data_ref_0_hi_1, &res_unsigned_hi_1, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                        const int32x4_t round_result_lo_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_lo_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_lo_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_lo_1, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_hi_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_hi_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_hi_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_hi_1, &offset_const, rounding_shift);
+-
+-                        const uint16x8_t res_16b_0  = vqmovun_high_s32(vqmovun_s32(round_result_lo_0),
+-                                                                      round_result_hi_0);
+-                        const uint16x8_t res_clip_0 = vminq_u16(res_16b_0, clip_pixel_to_bd);
+-
+-                        const uint16x8_t res_16b_1  = vqmovun_high_s32(vqmovun_s32(round_result_lo_1),
+-                                                                      round_result_hi_1);
+-                        const uint16x8_t res_clip_1 = vminq_u16(res_16b_1, clip_pixel_to_bd);
+-
+-                        vst1q_u16(&dst0[i * dst_stride0 + j], res_clip_0);
+-                        vst1q_u16(&dst0[i * dst_stride0 + j + dst_stride0], res_clip_1);
+-                    } else {
+-                        const uint16x8_t res_16bit0 = vqmovun_high_s32(
+-                            vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo_0)),
+-                            vreinterpretq_s32_u32(res_unsigned_hi_0));
+-                        const uint16x8_t res_16bit1 = vqmovun_high_s32(
+-                            vqmovun_s32(vreinterpretq_s32_u32(res_unsigned_lo_1)),
+-                            vreinterpretq_s32_u32(res_unsigned_hi_1));
+-                        vst1q_u16(&dst[i * dst_stride + j], res_16bit0);
+-                        vst1q_u16(&dst[i * dst_stride + j + dst_stride], res_16bit1);
+-                    }
+-                }
+-                s[0] = s[1];
+-                s[1] = s[2];
+-                s[2] = s[3];
+-
+-                s[4] = s[5];
+-                s[5] = s[6];
+-                s[6] = s[7];
+-
+-                s[0 + 8] = s[1 + 8];
+-                s[1 + 8] = s[2 + 8];
+-                s[2 + 8] = s[3 + 8];
+-
+-                s[4 + 8] = s[5 + 8];
+-                s[5 + 8] = s[6 + 8];
+-                s[6 + 8] = s[7 + 8];
+-
+-                s6 = s8;
++    DECLARE_ALIGNED(16, uint16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP) * MAX_SB_SIZE]);
++    CONV_BUF_TYPE *dst16         = conv_params->dst;
++    const int      y_filter_taps = get_filter_tap(filter_params_y, subpel_y_qn);
++    int            dst16_stride  = conv_params->dst_stride;
++    const int      im_stride     = MAX_SB_SIZE;
++    const int      vert_offset   = filter_params_y->taps / 2 - 1;
++    assert(FILTER_BITS == COMPOUND_ROUND1_BITS);
++    const int round_offset_conv = (1 << (conv_params->round_0 - 1)) + (1 << (bd + FILTER_BITS)) +
++        (1 << (bd + FILTER_BITS - 1));
++
++    const int16_t *y_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_qn & SUBPEL_MASK);
++
++    src -= vert_offset * src_stride;
++
++    if (bd == 12) {
++        if (conv_params->do_average) {
++            if (y_filter_taps <= 4) {
++                highbd_12_jnt_convolve_y_4tap_neon(
++                    src + 2 * src_stride, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else if (y_filter_taps == 6) {
++                highbd_12_jnt_convolve_y_6tap_neon(
++                    src + src_stride, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else {
++                highbd_12_jnt_convolve_y_8tap_neon(
++                    src, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            }
++            if (conv_params->use_jnt_comp_avg) {
++                highbd_12_jnt_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params);
++            } else {
++                highbd_12_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params);
++            }
++        } else {
++            if (y_filter_taps <= 4) {
++                highbd_12_jnt_convolve_y_4tap_neon(
++                    src + 2 * src_stride, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else if (y_filter_taps == 6) {
++                highbd_12_jnt_convolve_y_6tap_neon(
++                    src + src_stride, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else {
++                highbd_12_jnt_convolve_y_8tap_neon(
++                    src, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
++            }
++        }
++    } else {
++        if (conv_params->do_average) {
++            if (y_filter_taps <= 4) {
++                highbd_jnt_convolve_y_4tap_neon(
++                    src + 2 * src_stride, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else if (y_filter_taps == 6) {
++                highbd_jnt_convolve_y_6tap_neon(
++                    src + src_stride, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else {
++                highbd_jnt_convolve_y_8tap_neon(
++                    src, src_stride, im_block, im_stride, w, h, y_filter_ptr, round_offset_conv);
++            }
++            if (conv_params->use_jnt_comp_avg) {
++                highbd_jnt_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            } else {
++                highbd_comp_avg_neon(im_block, im_stride, dst, dst_stride, w, h, conv_params, bd);
++            }
++        } else {
++            if (y_filter_taps <= 4) {
++                highbd_jnt_convolve_y_4tap_neon(
++                    src + 2 * src_stride, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else if (y_filter_taps == 6) {
++                highbd_jnt_convolve_y_6tap_neon(
++                    src + src_stride, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
++            } else {
++                highbd_jnt_convolve_y_8tap_neon(
++                    src, src_stride, dst16, dst16_stride, w, h, y_filter_ptr, round_offset_conv);
+             }
+         }
+     }
+diff --git a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c b/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c
+deleted file mode 100644
+index 8d7a7005d..000000000
+--- a/Source/Lib/ASM_NEON/highbd_jnt_convolve_neon_y.c
++++ /dev/null
+@@ -1,286 +0,0 @@
+-/*
+- * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+- *
+- * This source code is subject to the terms of the BSD 2 Clause License and
+- * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+- * was not distributed with this source code in the LICENSE file, you can
+- * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+- * Media Patent License 1.0 was not distributed with this source code in the
+- * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+- */
+-
+-#include <arm_neon.h>
+-
+-#include <assert.h>
+-
+-#include "EbDefinitions.h"
+-#include "common_dsp_rtcd.h"
+-#include "convolve.h"
+-
+-static INLINE int32x4_t svt_aom_convolve(const uint16x8_t *const s, const int16x8_t *const coeffs) {
+-    const int32x4_t res_0 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0])),
+-                                       vmull_high_s16(vreinterpretq_s16_u16(s[0]), coeffs[0]));
+-    const int32x4_t res_1 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[1])), vget_low_s16(coeffs[1])),
+-                                       vmull_high_s16(vreinterpretq_s16_u16(s[1]), coeffs[1]));
+-    const int32x4_t res_2 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[2])), vget_low_s16(coeffs[2])),
+-                                       vmull_high_s16(vreinterpretq_s16_u16(s[2]), coeffs[2]));
+-    const int32x4_t res_3 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[3])), vget_low_s16(coeffs[3])),
+-                                       vmull_high_s16(vreinterpretq_s16_u16(s[3]), coeffs[3]));
+-
+-    return vaddq_s32(vaddq_s32(res_0, res_1), vaddq_s32(res_2, res_3));
+-}
+-
+-static INLINE int32x4_t highbd_convolve_rounding_neon(const int32x4_t *const res_unsigned,
+-                                                      const int32x4_t *const offset_const, const int round_shift) {
+-    const int32x4_t res_signed = vsubq_s32(*res_unsigned, *offset_const);
+-
+-    return vrshlq_s32(res_signed, vdupq_n_s32(-round_shift));
+-}
+-
+-static INLINE int32x4_t highbd_comp_avg_neon(const uint16x8_t *const data_ref_0, const int32x4_t *const res_unsigned,
+-                                             const int32x4_t *const wt0, const int32x4_t *const wt1,
+-                                             const int use_dist_wtd_avg) {
+-    int32x4_t res;
+-    if (use_dist_wtd_avg) {
+-        const int32x4_t wt0_res = vmulq_s32(vreinterpretq_s32_u16(*data_ref_0), *wt0);
+-        const int32x4_t wt1_res = vmulq_s32(*res_unsigned, *wt1);
+-
+-        const int32x4_t wt_res = vaddq_s32(wt0_res, wt1_res);
+-        res                    = vshrq_n_s32(wt_res, DIST_PRECISION_BITS);
+-    } else {
+-        const int32x4_t wt_res = vaddq_s32(vreinterpretq_s32_u16(*data_ref_0), *res_unsigned);
+-        res                    = vshrq_n_s32(wt_res, 1);
+-    }
+-    return res;
+-}
+-
+-static INLINE void prepare_coeffs(const InterpFilterParams *const filter_params, const int subpel_q4,
+-                                  int16x8_t *const coeffs /* [4] */) {
+-    const int16_t  *filter = av1_get_interp_filter_subpel_kernel(*filter_params, subpel_q4 & SUBPEL_MASK);
+-    const int32x4_t coeff  = vld1q_s32((const int32_t *)filter);
+-
+-    // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeff, 0)));
+-    // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeff, 1)));
+-    // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeff, 2)));
+-    // coeffs 6 7 6 7 6 7 6 7
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeff, 3)));
+-}
+-
+-void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst0, int32_t dst_stride0,
+-                                        int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                        const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                        const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
+-    if (w <= 4) {
+-        svt_av1_highbd_jnt_convolve_y_c(src,
+-                                        src_stride,
+-                                        dst0,
+-                                        dst_stride0,
+-                                        w,
+-                                        h,
+-                                        filter_params_x,
+-                                        filter_params_y,
+-                                        subpel_x_q4,
+-                                        subpel_y_q4,
+-                                        conv_params,
+-                                        bd);
+-        return;
+-    }
+-    CONV_BUF_TYPE        *dst        = conv_params->dst;
+-    const int             dst_stride = conv_params->dst_stride;
+-    const int             fo_vert    = filter_params_y->taps / 2 - 1;
+-    const uint16_t *const src_ptr    = src - fo_vert * src_stride;
+-
+-    assert(bits >= 0);
+-    int       i, j;
+-    const int do_average       = conv_params->do_average;
+-    const int use_jnt_comp_avg = conv_params->use_jnt_comp_avg;
+-
+-    const int       w0            = conv_params->fwd_offset;
+-    const int       w1            = conv_params->bck_offset;
+-    const int32x4_t wt0           = vdupq_n_s32(w0);
+-    const int32x4_t wt1           = vdupq_n_s32(w1);
+-    const int32x4_t round_const_y = vdupq_n_s32(((1 << conv_params->round_1) >> 1));
+-
+-    const int        offset_0         = bd + 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const int        offset           = (1 << offset_0) + (1 << (offset_0 - 1));
+-    const int32x4_t  offset_const     = vdupq_n_s32(offset);
+-    const int        rounding_shift   = 2 * FILTER_BITS - conv_params->round_0 - conv_params->round_1;
+-    const uint16x8_t clip_pixel_to_bd = vdupq_n_u16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-    const uint16x8_t zero             = vdupq_n_u16(0);
+-    uint16x8_t       s[16];
+-    int16x8_t        coeffs_y[4];
+-
+-    prepare_coeffs(filter_params_y, subpel_y_q4, coeffs_y);
+-
+-    for (j = 0; j < w; j += 8) {
+-        const uint16_t *data = &src_ptr[j];
+-        /* Vertical filter */
+-        {
+-            uint16x8_t s0 = vld1q_u16(data + 0 * src_stride);
+-            uint16x8_t s1 = vld1q_u16(data + 1 * src_stride);
+-            uint16x8_t s2 = vld1q_u16(data + 2 * src_stride);
+-            uint16x8_t s3 = vld1q_u16(data + 3 * src_stride);
+-            uint16x8_t s4 = vld1q_u16(data + 4 * src_stride);
+-            uint16x8_t s5 = vld1q_u16(data + 5 * src_stride);
+-            uint16x8_t s6 = vld1q_u16(data + 6 * src_stride);
+-
+-            s[0] = vzip1q_u16(s0, s1);
+-            s[1] = vzip1q_u16(s2, s3);
+-            s[2] = vzip1q_u16(s4, s5);
+-
+-            s[4] = vzip2q_u16(s0, s1);
+-            s[5] = vzip2q_u16(s2, s3);
+-            s[6] = vzip2q_u16(s4, s5);
+-
+-            s[0 + 8] = vzip1q_u16(s1, s2);
+-            s[1 + 8] = vzip1q_u16(s3, s4);
+-            s[2 + 8] = vzip1q_u16(s5, s6);
+-
+-            s[4 + 8] = vzip2q_u16(s1, s2);
+-            s[5 + 8] = vzip2q_u16(s3, s4);
+-            s[6 + 8] = vzip2q_u16(s5, s6);
+-
+-            for (i = 0; i < h; i += 2) {
+-                data = &src_ptr[i * src_stride + j];
+-
+-                const uint16x8_t s7 = vld1q_u16(data + 7 * src_stride);
+-                const uint16x8_t s8 = vld1q_u16(data + 8 * src_stride);
+-
+-                s[3] = vzip1q_u16(s6, s7);
+-                s[7] = vzip2q_u16(s6, s7);
+-
+-                s[3 + 8] = vzip1q_u16(s7, s8);
+-                s[7 + 8] = vzip2q_u16(s7, s8);
+-
+-                const int32x4_t res_a0       = svt_aom_convolve(s, coeffs_y);
+-                int32x4_t       res_a_round0 = vshlq_s32(res_a0, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                res_a_round0 = vshlq_s32(vaddq_s32(res_a_round0, round_const_y), vdupq_n_s32(-conv_params->round_1));
+-
+-                const int32x4_t res_a1       = svt_aom_convolve(s + 8, coeffs_y);
+-                int32x4_t       res_a_round1 = vshlq_s32(res_a1, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                res_a_round1 = vshlq_s32(vaddq_s32(res_a_round1, round_const_y), vdupq_n_s32(-conv_params->round_1));
+-
+-                const int32x4_t res_unsigned_lo_0 = vaddq_s32(res_a_round0, offset_const);
+-                const int32x4_t res_unsigned_lo_1 = vaddq_s32(res_a_round1, offset_const);
+-
+-                if (w - j < 8) {
+-                    if (do_average) {
+-                        const uint16x8_t data_0 = vcombine_u16(vld1_u16(&dst[i * dst_stride + j]), vdup_n_u16(0));
+-                        const uint16x8_t data_1 = vcombine_u16(vld1_u16(&dst[i * dst_stride + j + dst_stride]),
+-                                                               vdup_n_u16(0));
+-
+-                        const uint16x8_t data_ref_0 = vzip1q_u16(data_0, zero);
+-                        const uint16x8_t data_ref_1 = vzip1q_u16(data_1, zero);
+-
+-                        const int32x4_t comp_avg_res_0 = highbd_comp_avg_neon(
+-                            &data_ref_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_1 = highbd_comp_avg_neon(
+-                            &data_ref_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                        const int32x4_t round_result_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_1, &offset_const, rounding_shift);
+-
+-                        const uint16x8_t res_16b_0  = vqmovun_high_s32(vqmovun_s32(round_result_0), round_result_0);
+-                        const uint16x8_t res_clip_0 = vminq_u16(res_16b_0, clip_pixel_to_bd);
+-                        const uint16x8_t res_16b_1  = vqmovun_high_s32(vqmovun_s32(round_result_1), round_result_1);
+-                        const uint16x8_t res_clip_1 = vminq_u16(res_16b_1, clip_pixel_to_bd);
+-
+-                        vst1_u16(&dst0[i * dst_stride0 + j], vget_low_u16(res_clip_0));
+-                        vst1_u16(&dst0[i * dst_stride0 + j + dst_stride0], vget_low_u16(res_clip_1));
+-
+-                    } else {
+-                        const uint16x8_t res_16b_0 = vqmovun_high_s32(vqmovun_s32(res_unsigned_lo_0),
+-                                                                      res_unsigned_lo_0);
+-
+-                        const uint16x8_t res_16b_1 = vqmovun_high_s32(vqmovun_s32(res_unsigned_lo_1),
+-                                                                      res_unsigned_lo_1);
+-
+-                        vst1_u16(&dst[i * dst_stride + j], vget_low_u16(res_16b_0));
+-                        vst1_u16(&dst[i * dst_stride + j + dst_stride], vget_low_u16(res_16b_1));
+-                    }
+-                } else {
+-                    const int32x4_t res_b0       = svt_aom_convolve(s + 4, coeffs_y);
+-                    int32x4_t       res_b_round0 = vshlq_s32(res_b0, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                    res_b_round0                 = vshlq_s32(vaddq_s32(res_b_round0, round_const_y),
+-                                             vdupq_n_s32(-conv_params->round_1));
+-
+-                    const int32x4_t res_b1       = svt_aom_convolve(s + 4 + 8, coeffs_y);
+-                    int32x4_t       res_b_round1 = vshlq_s32(res_b1, vdupq_n_s32(FILTER_BITS - conv_params->round_0));
+-                    res_b_round1                 = vshlq_s32(vaddq_s32(res_b_round1, round_const_y),
+-                                             vdupq_n_s32(-conv_params->round_1));
+-
+-                    int32x4_t res_unsigned_hi_0 = vaddq_s32(res_b_round0, offset_const);
+-                    int32x4_t res_unsigned_hi_1 = vaddq_s32(res_b_round1, offset_const);
+-
+-                    if (do_average) {
+-                        const uint16x8_t data_0          = vld1q_u16(&dst[i * dst_stride + j]);
+-                        const uint16x8_t data_1          = vld1q_u16(&dst[i * dst_stride + j + dst_stride]);
+-                        const uint16x8_t data_ref_0_lo_0 = vzip1q_u16(data_0, zero);
+-                        const uint16x8_t data_ref_0_lo_1 = vzip1q_u16(data_1, zero);
+-
+-                        const uint16x8_t data_ref_0_hi_0 = vzip2q_u16(data_0, zero);
+-                        const uint16x8_t data_ref_0_hi_1 = vzip2q_u16(data_1, zero);
+-
+-                        const int32x4_t comp_avg_res_lo_0 = highbd_comp_avg_neon(
+-                            &data_ref_0_lo_0, &res_unsigned_lo_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_lo_1 = highbd_comp_avg_neon(
+-                            &data_ref_0_lo_1, &res_unsigned_lo_1, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_0 = highbd_comp_avg_neon(
+-                            &data_ref_0_hi_0, &res_unsigned_hi_0, &wt0, &wt1, use_jnt_comp_avg);
+-                        const int32x4_t comp_avg_res_hi_1 = highbd_comp_avg_neon(
+-                            &data_ref_0_hi_1, &res_unsigned_hi_1, &wt0, &wt1, use_jnt_comp_avg);
+-
+-                        const int32x4_t round_result_lo_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_lo_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_lo_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_lo_1, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_hi_0 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_hi_0, &offset_const, rounding_shift);
+-                        const int32x4_t round_result_hi_1 = highbd_convolve_rounding_neon(
+-                            &comp_avg_res_hi_1, &offset_const, rounding_shift);
+-
+-                        const uint16x8_t res_16b_0  = vqmovun_high_s32(vqmovun_s32(round_result_lo_0),
+-                                                                      round_result_hi_0);
+-                        const uint16x8_t res_clip_0 = vminq_u16(res_16b_0, clip_pixel_to_bd);
+-
+-                        const uint16x8_t res_16b_1  = vqmovun_high_s32(vqmovun_s32(round_result_lo_1),
+-                                                                      round_result_hi_1);
+-                        const uint16x8_t res_clip_1 = vminq_u16(res_16b_1, clip_pixel_to_bd);
+-
+-                        vst1q_u16(&dst0[i * dst_stride0 + j], res_clip_0);
+-                        vst1q_u16(&dst0[i * dst_stride0 + j + dst_stride0], res_clip_1);
+-                    } else {
+-                        const uint16x8_t res_16bit0 = vqmovun_high_s32(vqmovun_s32(res_unsigned_lo_0),
+-                                                                       res_unsigned_hi_0);
+-                        const uint16x8_t res_16bit1 = vqmovun_high_s32(vqmovun_s32(res_unsigned_lo_1),
+-                                                                       res_unsigned_hi_1);
+-                        vst1q_u16(&dst[i * dst_stride + j], res_16bit0);
+-                        vst1q_u16(&dst[i * dst_stride + j + dst_stride], res_16bit1);
+-                    }
+-                }
+-                s[0] = s[1];
+-                s[1] = s[2];
+-                s[2] = s[3];
+-
+-                s[4] = s[5];
+-                s[5] = s[6];
+-                s[6] = s[7];
+-
+-                s[0 + 8] = s[1 + 8];
+-                s[1 + 8] = s[2 + 8];
+-                s[2 + 8] = s[3 + 8];
+-
+-                s[4 + 8] = s[5 + 8];
+-                s[5 + 8] = s[6 + 8];
+-                s[6 + 8] = s[7 + 8];
+-
+-                s6 = s8;
+-            }
+-        }
+-    }
+-}
+diff --git a/Source/Lib/ASM_NEON/mem_neon.h b/Source/Lib/ASM_NEON/mem_neon.h
+index 12d9274cc..8bfeba3ef 100644
+--- a/Source/Lib/ASM_NEON/mem_neon.h
++++ b/Source/Lib/ASM_NEON/mem_neon.h
+@@ -310,6 +310,15 @@ static INLINE void load_s16_4x5(const int16_t *s, ptrdiff_t p, int16x4_t *const
+     *s4 = vld1_s16(s);
+ }
+ 
++static INLINE void load_s16_4x3(const int16_t *s, ptrdiff_t p, int16x4_t *const s0, int16x4_t *const s1,
++                                int16x4_t *const s2) {
++    *s0 = vld1_s16(s);
++    s += p;
++    *s1 = vld1_s16(s);
++    s += p;
++    *s2 = vld1_s16(s);
++}
++
+ static INLINE void load_u16_4x5(const uint16_t *s, const ptrdiff_t p, uint16x4_t *const s0, uint16x4_t *const s1,
+                                 uint16x4_t *const s2, uint16x4_t *const s3, uint16x4_t *const s4) {
+     *s0 = vld1_u16(s);
+@@ -740,6 +749,15 @@ static INLINE void load_s16_8x4(const int16_t *s, ptrdiff_t p, int16x8_t *const
+     *s3 = vld1q_s16(s);
+ }
+ 
++static INLINE void load_s16_8x3(const int16_t *s, ptrdiff_t p, int16x8_t *const s0, int16x8_t *const s1,
++                                int16x8_t *const s2) {
++    *s0 = vld1q_s16(s);
++    s += p;
++    *s1 = vld1q_s16(s);
++    s += p;
++    *s2 = vld1q_s16(s);
++}
++
+ // Load 2 sets of 4 bytes when alignment is not guaranteed.
+ static INLINE uint8x8_t load_unaligned_u8(const uint8_t *buf, int stride) {
+     uint32_t a;
+-- 
+GitLab
+
+
+From 8f79914109b4f98092478fe76af62188d7131794 Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Fri, 5 Jul 2024 11:43:22 +0100
+Subject: [PATCH 4/6] Port libaom implementation of highbd_convolve_2d_sr_neon
+
+Replace the current Neon implementation of svt_av1_highbd_convolve_2d_sr
+with the one present in libaom. This new version includes specialized
+paths for each of the filter sizes. Also take the opportunity to move
+the function to highbd_convolve_neon.cc with the rest of the convolution
+functions.
+---
+ Source/Lib/ASM_NEON/CMakeLists.txt            |   1 -
+ Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c | 442 --------------
+ Source/Lib/ASM_NEON/highbd_convolve_neon.c    | 564 +++++++++++++++++-
+ 3 files changed, 561 insertions(+), 446 deletions(-)
+ delete mode 100644 Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
+
+diff --git a/Source/Lib/ASM_NEON/CMakeLists.txt b/Source/Lib/ASM_NEON/CMakeLists.txt
+index d4f181957..e9f390f86 100644
+--- a/Source/Lib/ASM_NEON/CMakeLists.txt
++++ b/Source/Lib/ASM_NEON/CMakeLists.txt
+@@ -37,7 +37,6 @@ target_sources(
+   PUBLIC encodetxb_neon.c
+   PUBLIC transforms_intrin_neon.c
+   PUBLIC hadmard_path_neon.c
+-  PUBLIC highbd_convolve_2d_neon.c
+   PUBLIC highbd_fwd_txfm_neon.c
+   PUBLIC highbd_inv_txfm_neon.c
+   PUBLIC intra_prediction_neon.c
+diff --git a/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c b/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
+deleted file mode 100644
+index 5f61ac636..000000000
+--- a/Source/Lib/ASM_NEON/highbd_convolve_2d_neon.c
++++ /dev/null
+@@ -1,442 +0,0 @@
+-/*
+- * Copyright (c) 2024, Alliance for Open Media. All rights reserved
+- *
+- * This source code is subject to the terms of the BSD 2 Clause License and
+- * the Alliance for Open Media Patent License 1.0. If the BSD 2 Clause License
+- * was not distributed with this source code in the LICENSE file, you can
+- * obtain it at www.aomedia.org/license/software. If the Alliance for Open
+- * Media Patent License 1.0 was not distributed with this source code in the
+- * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+- */
+-
+-#include <assert.h>
+-
+-#include <arm_neon.h>
+-
+-#include "definitions.h"
+-#include "common_dsp_rtcd.h"
+-#include "convolve.h"
+-
+-static INLINE void svt_prepare_coeffs_12tap(const int16_t *const filter, int16x8_t *coeffs /* [6] */) {
+-    int32x4_t coeffs_y  = vld1q_s32((int32_t const *)filter);
+-    int32x4_t coeffs_y2 = vld1q_s32((int32_t const *)(filter + 8));
+-
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 0))); // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 1))); // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 2))); // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 3))); // coeffs 6 7 6 7 6 7 6 7
+-
+-    coeffs[4] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y2, 0))); // coeffs 8 9 8 9 8 9 8 9
+-    coeffs[5] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y2, 1))); // coeffs 10 11 10 11 10 11 10 11
+-}
+-
+-static INLINE int32x4_t convolve_12tap(const int16x8_t *s, const int16x8_t *coeffs) {
+-    const int32x4_t d0     = vmull_s16(vget_low_s16(s[0]), vget_low_s16(coeffs[0]));
+-    const int32x4_t d1     = vmull_s16(vget_low_s16(s[1]), vget_low_s16(coeffs[1]));
+-    const int32x4_t d2     = vmull_s16(vget_low_s16(s[2]), vget_low_s16(coeffs[2]));
+-    const int32x4_t d3     = vmull_s16(vget_low_s16(s[3]), vget_low_s16(coeffs[3]));
+-    const int32x4_t d4     = vmull_s16(vget_low_s16(s[4]), vget_low_s16(coeffs[4]));
+-    const int32x4_t d5     = vmull_s16(vget_low_s16(s[5]), vget_low_s16(coeffs[5]));
+-    const int32x4_t d_0123 = vaddq_s32(vaddq_s32(d0, d1), vaddq_s32(d2, d3));
+-    const int32x4_t d      = vaddq_s32(vaddq_s32(d4, d5), d_0123);
+-    return d;
+-}
+-
+-static INLINE void prepare_coeffs(const int16_t *const filter, int16x8_t *const coeffs /* [4] */) {
+-    const int16x8_t coeff = vld1q_s16(filter);
+-
+-    // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 0)));
+-    // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 1)));
+-    // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 2)));
+-    // coeffs 6 7 6 7 6 7 6 7
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 3)));
+-}
+-
+-static INLINE int32x4_t svt_aom_convolve(const int16x8_t *const s, const int16x8_t *const coeffs) {
+-    const int32x4_t res_0 = vpaddq_s32(vmulq_s32(vmovl_s16(vget_low_s16(s[0])), vmovl_s16(vget_low_s16(coeffs[0]))),
+-                                       vmulq_s32(vmovl_s16(vget_high_s16(s[0])), vmovl_s16(vget_high_s16(coeffs[0]))));
+-    const int32x4_t res_1 = vpaddq_s32(vmulq_s32(vmovl_s16(vget_low_s16(s[1])), vmovl_s16(vget_low_s16(coeffs[1]))),
+-                                       vmulq_s32(vmovl_s16(vget_high_s16(s[1])), vmovl_s16(vget_high_s16(coeffs[1]))));
+-    const int32x4_t res_2 = vpaddq_s32(vmulq_s32(vmovl_s16(vget_low_s16(s[2])), vmovl_s16(vget_low_s16(coeffs[2]))),
+-                                       vmulq_s32(vmovl_s16(vget_high_s16(s[2])), vmovl_s16(vget_high_s16(coeffs[2]))));
+-    const int32x4_t res_3 = vpaddq_s32(vmulq_s32(vmovl_s16(vget_low_s16(s[3])), vmovl_s16(vget_low_s16(coeffs[3]))),
+-                                       vmulq_s32(vmovl_s16(vget_high_s16(s[3])), vmovl_s16(vget_high_s16(coeffs[3]))));
+-
+-    const int32x4_t res = vaddq_s32(vaddq_s32(res_0, res_1), vaddq_s32(res_2, res_3));
+-
+-    return res;
+-}
+-
+-void svt_av1_highbd_convolve_2d_sr_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
+-                                        int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                        const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                        const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
+-    DECLARE_ALIGNED(32, int16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP) * 8]);
+-    int                   im_h      = h + filter_params_y->taps - 1;
+-    int                   im_stride = 8;
+-    int                   i, j;
+-    const int             fo_vert  = filter_params_y->taps / 2 - 1;
+-    const int             fo_horiz = filter_params_x->taps / 2 - 1;
+-    const uint16_t *const src_ptr  = src - fo_vert * src_stride - fo_horiz;
+-
+-    // Check that, even with 12-bit input, the intermediate values will fit
+-    // into an unsigned 16-bit intermediate array.
+-    assert(bd + FILTER_BITS + 2 - conv_params->round_0 <= 16);
+-
+-    const int32x4_t round_const_x = vdupq_n_s32(((1 << conv_params->round_0) >> 1) + (1 << (bd + FILTER_BITS - 1)));
+-    const int32x4_t round_shift_x = vsetq_lane_s32(conv_params->round_0, vdupq_n_s32(0), 0);
+-
+-    const int32x4_t round_const_y = vdupq_n_s32(((1 << conv_params->round_1) >> 1) -
+-                                                (1 << (bd + 2 * FILTER_BITS - conv_params->round_0 - 1)));
+-    const int32x4_t round_shift_y = vsetq_lane_s32(conv_params->round_1, vdupq_n_s32(0), 0);
+-
+-    const int       bits             = FILTER_BITS * 2 - conv_params->round_0 - conv_params->round_1;
+-    const int32x4_t round_shift_bits = vsetq_lane_s32(bits, vdupq_n_s32(0), 0);
+-    const int32x4_t round_const_bits = vdupq_n_s32((1 << bits) >> 1);
+-    const int16x8_t clip_pixel       = vdupq_n_s16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-    const int16x8_t zero             = vdupq_n_s16(0);
+-
+-    const int16_t *const x_filter = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_q4 & SUBPEL_MASK);
+-    const int16_t *const y_filter = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_q4 & SUBPEL_MASK);
+-
+-    if (filter_params_x->taps == 12) {
+-        int16x8_t coeffs_x[6], coeffs_y[6], s[24];
+-        svt_prepare_coeffs_12tap(x_filter, coeffs_x);
+-        svt_prepare_coeffs_12tap(y_filter, coeffs_y);
+-
+-        for (j = 0; j < w; j += 8) {
+-            /* Horizontal filter */
+-            {
+-                for (i = 0; i < im_h; i += 1) {
+-                    const int16x8_t row00 = vld1q_s16((const int16_t *)&src_ptr[i * src_stride + j]);
+-                    const int16x8_t row01 = vld1q_s16((const int16_t *)&src_ptr[i * src_stride + (j + 8)]);
+-                    const int16x8_t row02 = vld1q_s16((const int16_t *)&src_ptr[i * src_stride + (j + 16)]);
+-
+-                    // even pixels
+-                    s[0] = vextq_s16(row00, row01, 0);
+-                    s[1] = vextq_s16(row00, row01, 2);
+-                    s[2] = vextq_s16(row00, row01, 4);
+-                    s[3] = vextq_s16(row00, row01, 6);
+-                    s[4] = vextq_s16(row01, row02, 0);
+-                    s[5] = vextq_s16(row01, row02, 2);
+-
+-                    int32x4_t res_even = convolve_12tap(s, coeffs_x);
+-
+-                    res_even = vshlq_s32(vaddq_s32(res_even, round_const_x), -round_shift_x);
+-
+-                    // odd pixels
+-                    s[0] = vextq_s16(row00, row01, 1);
+-                    s[1] = vextq_s16(row00, row01, 4);
+-                    s[2] = vextq_s16(row00, row01, 5);
+-                    s[3] = vextq_s16(row00, row01, 7);
+-                    s[4] = vextq_s16(row01, row02, 1);
+-                    s[5] = vextq_s16(row01, row02, 3);
+-
+-                    int32x4_t res_odd = convolve_12tap(s, coeffs_x);
+-                    res_odd           = vshlq_s32(vaddq_s32(res_odd, round_const_x), -round_shift_x);
+-
+-                    int16x8_t res_even1 = vqmovn_high_s32(vqmovn_s32(res_even), res_even);
+-                    int16x8_t res_odd1  = vqmovn_high_s32(vqmovn_s32(res_odd), res_odd);
+-                    int16x8_t res       = vzip1q_s16(res_even1, res_odd1);
+-
+-                    vst1q_s16(&im_block[i * im_stride], res);
+-                }
+-            }
+-
+-            /* Vertical filter */
+-            {
+-                int16x8_t s0  = vld1q_s16(im_block + 0 * im_stride);
+-                int16x8_t s1  = vld1q_s16(im_block + 1 * im_stride);
+-                int16x8_t s2  = vld1q_s16(im_block + 2 * im_stride);
+-                int16x8_t s3  = vld1q_s16(im_block + 3 * im_stride);
+-                int16x8_t s4  = vld1q_s16(im_block + 4 * im_stride);
+-                int16x8_t s5  = vld1q_s16(im_block + 5 * im_stride);
+-                int16x8_t s6  = vld1q_s16(im_block + 6 * im_stride);
+-                int16x8_t s7  = vld1q_s16(im_block + 7 * im_stride);
+-                int16x8_t s8  = vld1q_s16(im_block + 8 * im_stride);
+-                int16x8_t s9  = vld1q_s16(im_block + 9 * im_stride);
+-                int16x8_t s10 = vld1q_s16(im_block + 10 * im_stride);
+-
+-                s[0] = vzip1q_s16(s0, s1);
+-                s[1] = vzip1q_s16(s2, s3);
+-                s[2] = vzip1q_s16(s4, s5);
+-                s[3] = vzip1q_s16(s6, s7);
+-                s[4] = vzip1q_s16(s8, s9);
+-
+-                s[6]  = vzip2q_s16(s0, s1);
+-                s[7]  = vzip2q_s16(s2, s3);
+-                s[8]  = vzip2q_s16(s4, s5);
+-                s[9]  = vzip2q_s16(s6, s7);
+-                s[10] = vzip2q_s16(s8, s9);
+-
+-                s[12] = vzip1q_s16(s1, s2);
+-                s[13] = vzip1q_s16(s3, s4);
+-                s[14] = vzip1q_s16(s5, s6);
+-                s[15] = vzip1q_s16(s7, s8);
+-                s[16] = vzip1q_s16(s9, s10);
+-
+-                s[18] = vzip2q_s16(s1, s2);
+-                s[19] = vzip2q_s16(s3, s4);
+-                s[20] = vzip2q_s16(s5, s6);
+-                s[21] = vzip2q_s16(s7, s8);
+-                s[22] = vzip2q_s16(s9, s10);
+-
+-                for (i = 0; i < h; i += 2) {
+-                    const int16_t *data = &im_block[i * im_stride];
+-
+-                    int16x8_t s11 = vld1q_s16(data + 11 * im_stride);
+-                    int16x8_t s12 = vld1q_s16(data + 12 * im_stride);
+-
+-                    s[5]  = vzip1q_s16(s10, s11);
+-                    s[11] = vzip2q_s16(s10, s11);
+-
+-                    s[17] = vzip1q_s16(s11, s12);
+-                    s[23] = vzip2q_s16(s11, s12);
+-
+-                    const int32x4_t res_a0       = convolve_12tap(s, coeffs_y);
+-                    int32x4_t       res_a_round0 = vshlq_s32(vaddq_s32(res_a0, round_const_y), -round_shift_y);
+-                    res_a_round0 = vshlq_s32(vaddq_s32(res_a_round0, round_const_bits), -round_shift_bits);
+-
+-                    const int32x4_t res_a1       = convolve_12tap(s + 12, coeffs_y);
+-                    int32x4_t       res_a_round1 = vshlq_s32(vaddq_s32(res_a1, round_const_y), -round_shift_y);
+-                    res_a_round1 = vshlq_s32(vaddq_s32(res_a_round1, round_const_bits), -round_shift_bits);
+-
+-                    if (w - j > 4) {
+-                        const int32x4_t res_b0       = convolve_12tap(s + 6, coeffs_y);
+-                        int32x4_t       res_b_round0 = vshlq_s32(vaddq_s32(res_b0, round_const_y), -round_shift_y);
+-                        res_b_round0 = vshlq_s32(vaddq_s32(res_b_round0, round_const_bits), -round_shift_bits);
+-
+-                        const int32x4_t res_b1       = convolve_12tap(s + 18, coeffs_y);
+-                        int32x4_t       res_b_round1 = vshlq_s32(vaddq_s32(res_b1, round_const_y), -round_shift_y);
+-                        res_b_round1 = vshlq_s32(vaddq_s32(res_b_round1, round_const_bits), -round_shift_bits);
+-
+-                        int16x8_t res_16bit0 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_b_round0);
+-                        res_16bit0           = vminq_s16(res_16bit0, clip_pixel);
+-                        res_16bit0           = vmaxq_s16(res_16bit0, zero);
+-
+-                        int16x8_t res_16bit1 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_b_round1);
+-                        res_16bit1           = vminq_s16(res_16bit1, clip_pixel);
+-                        res_16bit1           = vmaxq_s16(res_16bit1, zero);
+-
+-                        vst1q_s16((int16_t *)&dst[i * dst_stride + j], res_16bit0);
+-                        vst1q_s16((int16_t *)&dst[i * dst_stride + j + dst_stride], res_16bit1);
+-                    } else if (w == 4) {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        vst1_s64((int64_t *)&dst[i * dst_stride + j],
+-                                 vreinterpret_s64_s16(vget_low_s16(res_a_round0_s16)));
+-                        vst1_s64((int64_t *)&dst[i * dst_stride + j + dst_stride],
+-                                 vreinterpret_s64_s16(vget_low_s16(res_a_round1_s16)));
+-                    } else {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        *((uint32_t *)(&dst[i * dst_stride + j])) = vgetq_lane_s32(
+-                            vreinterpretq_s32_s16(res_a_round0_s16), 0);
+-
+-                        *((uint32_t *)(&dst[i * dst_stride + j + dst_stride])) = vgetq_lane_s32(
+-                            vreinterpretq_s32_s16(res_a_round1_s16), 0);
+-                    }
+-                    s[0] = s[1];
+-                    s[1] = s[2];
+-                    s[2] = s[3];
+-                    s[3] = s[4];
+-                    s[4] = s[5];
+-
+-                    s[6]  = s[7];
+-                    s[7]  = s[8];
+-                    s[8]  = s[9];
+-                    s[9]  = s[10];
+-                    s[10] = s[11];
+-
+-                    s[12] = s[13];
+-                    s[13] = s[14];
+-                    s[14] = s[15];
+-                    s[15] = s[16];
+-                    s[16] = s[17];
+-
+-                    s[18] = s[19];
+-                    s[19] = s[20];
+-                    s[20] = s[21];
+-                    s[21] = s[22];
+-                    s[22] = s[23];
+-
+-                    s10 = s12;
+-                }
+-            }
+-        }
+-    } else {
+-        int16x8_t coeffs_x[4], coeffs_y[4], s[16];
+-        prepare_coeffs(x_filter, coeffs_x);
+-        prepare_coeffs(y_filter, coeffs_y);
+-
+-        for (j = 0; j < w; j += 8) {
+-            /* Horizontal filter */
+-            {
+-                for (i = 0; i < im_h; i += 1) {
+-                    const int16x8_t row00 = vld1q_s16((const int16_t *)&src_ptr[i * src_stride + j]);
+-                    const int16x8_t row01 = vld1q_s16((const int16_t *)&src_ptr[i * src_stride + (j + 8)]);
+-
+-                    // even pixels
+-                    s[0] = vextq_s16(row00, row01, 0);
+-                    s[1] = vextq_s16(row00, row01, 2);
+-                    s[2] = vextq_s16(row00, row01, 4);
+-                    s[3] = vextq_s16(row00, row01, 6);
+-
+-                    int32x4_t res_even = svt_aom_convolve(s, coeffs_x);
+-                    res_even           = vshlq_s32(vaddq_s32(res_even, round_const_x), vdupq_n_s32(-round_shift_x[0]));
+-
+-                    // odd pixels
+-                    s[0] = vextq_s16(row00, row01, 1);
+-                    s[1] = vextq_s16(row00, row01, 3);
+-                    s[2] = vextq_s16(row00, row01, 5);
+-                    s[3] = vextq_s16(row00, row01, 7);
+-
+-                    int32x4_t res_odd = svt_aom_convolve(s, coeffs_x);
+-                    res_odd           = vshlq_s32(vaddq_s32(res_odd, round_const_x), vdupq_n_s32(-round_shift_x[0]));
+-
+-                    int16x8_t res_even1 = vqmovn_high_s32(vqmovn_s32(res_even), res_even);
+-                    int16x8_t res_odd1  = vqmovn_high_s32(vqmovn_s32(res_odd), res_odd);
+-                    int16x8_t res       = vzip1q_s16(res_even1, res_odd1);
+-
+-                    vst1q_s16(&im_block[i * im_stride], res);
+-                }
+-            }
+-
+-            /* Vertical filter */
+-            {
+-                int16x8_t s0 = vld1q_s16(im_block + 0 * im_stride);
+-                int16x8_t s1 = vld1q_s16(im_block + 1 * im_stride);
+-                int16x8_t s2 = vld1q_s16(im_block + 2 * im_stride);
+-                int16x8_t s3 = vld1q_s16(im_block + 3 * im_stride);
+-                int16x8_t s4 = vld1q_s16(im_block + 4 * im_stride);
+-                int16x8_t s5 = vld1q_s16(im_block + 5 * im_stride);
+-                int16x8_t s6 = vld1q_s16(im_block + 6 * im_stride);
+-
+-                s[0] = vzip1q_s16(s0, s1);
+-                s[1] = vzip1q_s16(s2, s3);
+-                s[2] = vzip1q_s16(s4, s5);
+-
+-                s[4] = vzip2q_s16(s0, s1);
+-                s[5] = vzip2q_s16(s2, s3);
+-                s[6] = vzip2q_s16(s4, s5);
+-
+-                s[0 + 8] = vzip1q_s16(s1, s2);
+-                s[1 + 8] = vzip1q_s16(s3, s4);
+-                s[2 + 8] = vzip1q_s16(s5, s6);
+-
+-                s[4 + 8] = vzip2q_s16(s1, s2);
+-                s[5 + 8] = vzip2q_s16(s3, s4);
+-                s[6 + 8] = vzip2q_s16(s5, s6);
+-
+-                for (i = 0; i < h; i += 2) {
+-                    const int16_t *data = &im_block[i * im_stride];
+-
+-                    int16x8_t s7 = vld1q_s16(data + 7 * im_stride);
+-                    int16x8_t s8 = vld1q_s16(data + 8 * im_stride);
+-
+-                    s[3] = vzip1q_s16(s6, s7);
+-                    s[7] = vzip2q_s16(s6, s7);
+-
+-                    s[3 + 8] = vzip1q_s16(s7, s8);
+-                    s[7 + 8] = vzip2q_s16(s7, s8);
+-
+-                    const int32x4_t res_a0       = svt_aom_convolve(s, coeffs_y);
+-                    int32x4_t       res_a_round0 = vshlq_s32(vaddq_s32(res_a0, round_const_y),
+-                                                       vdupq_n_s32(-round_shift_y[0]));
+-                    res_a_round0                 = vshlq_s32(vaddq_s32(res_a_round0, round_const_bits),
+-                                             vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    const int32x4_t res_a1       = svt_aom_convolve(s + 8, coeffs_y);
+-                    int32x4_t       res_a_round1 = vshlq_s32(vaddq_s32(res_a1, round_const_y),
+-                                                       vdupq_n_s32(-round_shift_y[0]));
+-                    res_a_round1                 = vshlq_s32(vaddq_s32(res_a_round1, round_const_bits),
+-                                             vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    if (w - j > 4) {
+-                        const int32x4_t res_b0       = svt_aom_convolve(s + 4, coeffs_y);
+-                        int32x4_t       res_b_round0 = vshlq_s32(vaddq_s32(res_b0, round_const_y),
+-                                                           vdupq_n_s32(-round_shift_y[0]));
+-                        res_b_round0                 = vshlq_s32(vaddq_s32(res_b_round0, round_const_bits),
+-                                                 vdupq_n_s32(-round_shift_bits[0]));
+-
+-                        const int32x4_t res_b1       = svt_aom_convolve(s + 4 + 8, coeffs_y);
+-                        int32x4_t       res_b_round1 = vshlq_s32(vaddq_s32(res_b1, round_const_y),
+-                                                           vdupq_n_s32(-round_shift_y[0]));
+-                        res_b_round1                 = vshlq_s32(vaddq_s32(res_b_round1, round_const_bits),
+-                                                 vdupq_n_s32(-round_shift_bits[0]));
+-
+-                        int16x8_t res_16bit0 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_b_round0);
+-                        res_16bit0           = vminq_s16(res_16bit0, clip_pixel);
+-                        res_16bit0           = vmaxq_s16(res_16bit0, zero);
+-
+-                        int16x8_t res_16bit1 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_b_round1);
+-                        res_16bit1           = vminq_s16(res_16bit1, clip_pixel);
+-                        res_16bit1           = vmaxq_s16(res_16bit1, zero);
+-
+-                        vst1q_s16((int16_t *)&dst[i * dst_stride + j], res_16bit0);
+-                        vst1q_s16((int16_t *)&dst[i * dst_stride + j + dst_stride], res_16bit1);
+-                    } else if (w == 4) {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        vst1_s64((int64_t *)&dst[i * dst_stride + j],
+-                                 vreinterpret_s64_s16(vget_low_s16(res_a_round0_s16)));
+-                        vst1_s64((int64_t *)&dst[i * dst_stride + j + dst_stride],
+-                                 vreinterpret_s64_s16(vget_low_s16(res_a_round1_s16)));
+-                    } else {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        *((uint32_t *)(&dst[i * dst_stride + j])) = vgetq_lane_s32(
+-                            vreinterpretq_s32_s16(res_a_round0_s16), 0);
+-
+-                        *((uint32_t *)(&dst[i * dst_stride + j + dst_stride])) = vgetq_lane_s32(
+-                            vreinterpretq_s32_s16(res_a_round1_s16), 0);
+-                    }
+-                    s[0] = s[1];
+-                    s[1] = s[2];
+-                    s[2] = s[3];
+-
+-                    s[4] = s[5];
+-                    s[5] = s[6];
+-                    s[6] = s[7];
+-
+-                    s[0 + 8] = s[1 + 8];
+-                    s[1 + 8] = s[2 + 8];
+-                    s[2 + 8] = s[3 + 8];
+-
+-                    s[4 + 8] = s[5 + 8];
+-                    s[5 + 8] = s[6 + 8];
+-                    s[6 + 8] = s[7 + 8];
+-
+-                    s6 = s8;
+-                }
+-            }
+-        }
+-    }
+-}
+diff --git a/Source/Lib/ASM_NEON/highbd_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+index 73c1493d4..4f47b628f 100644
+--- a/Source/Lib/ASM_NEON/highbd_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+@@ -9,13 +9,13 @@
+  * PATENTS file, you can obtain it at www.aomedia.org/license/patent.
+  */
+ 
+-#include <assert.h>
+-
+ #include <arm_neon.h>
++#include <assert.h>
+ 
+-#include "definitions.h"
+ #include "common_dsp_rtcd.h"
+ #include "convolve.h"
++#include "definitions.h"
++#include "mem_neon.h"
+ 
+ static INLINE void svt_prepare_coeffs_12tap(const int16_t *const filter, int16x8_t *coeffs /* [6] */) {
+     int32x4_t coeffs_y  = vld1q_s32((int32_t const *)filter);
+@@ -347,3 +347,561 @@ void svt_av1_highbd_convolve_y_sr_neon(const uint16_t *src, int32_t src_stride,
+         }
+     }
+ }
++
++static INLINE uint16x4_t highbd_convolve6_4_2d_v(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x8_t y_filter, const int32x4_t round_shift,
++                                                 const int32x4_t offset, const uint16x4_t max) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, y_filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_4_7, 2);
++
++    sum            = vshlq_s32(sum, round_shift);
++    uint16x4_t res = vqmovun_s32(sum);
++    return vmin_u16(res, max);
++}
++
++static INLINE uint16x8_t highbd_convolve6_8_2d_v(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                                 const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                                 const int16x8_t y_filter, const int32x4_t round_shift,
++                                                 const int32x4_t offset, const uint16x8_t max) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), y_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), y_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_4_7, 2);
++
++    sum0 = vshlq_s32(sum0, round_shift);
++    sum1 = vshlq_s32(sum1, round_shift);
++
++    uint16x8_t res = vcombine_u16(vqmovun_s32(sum0), vqmovun_s32(sum1));
++    return vminq_u16(res, max);
++}
++
++static INLINE void highbd_convolve_2d_sr_vert_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                        int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                        ConvolveParams *conv_params, int bd, const int offset) {
++    const int16x8_t y_filter         = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_s32       = vdupq_n_s32(offset);
++    const int       round1_shift     = conv_params->round_1;
++    const int32x4_t round1_shift_s32 = vdupq_n_s32(-round1_shift);
++
++    if (w == 4) {
++        const uint16x4_t max = vdup_n_u16((1 << bd) - 1);
++        const int16_t   *s   = (const int16_t *)src_ptr;
++        uint16_t        *d   = dst_ptr;
++        int16x4_t        s0, s1, s2, s3, s4;
++        load_s16_4x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++        s += 5 * src_stride;
++
++        do {
++            int16x4_t s5, s6, s7, s8;
++            load_s16_4x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++            uint16x4_t d0 = highbd_convolve6_4_2d_v(
++                s0, s1, s2, s3, s4, s5, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d1 = highbd_convolve6_4_2d_v(
++                s1, s2, s3, s4, s5, s6, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d2 = highbd_convolve6_4_2d_v(
++                s2, s3, s4, s5, s6, s7, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d3 = highbd_convolve6_4_2d_v(
++                s3, s4, s5, s6, s7, s8, y_filter, round1_shift_s32, offset_s32, max);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
++
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++            int16x8_t      s0, s1, s2, s3, s4;
++            load_s16_8x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++            s += 5 * src_stride;
++
++            do {
++                int16x8_t s5, s6, s7, s8;
++                load_s16_8x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++                uint16x8_t d0 = highbd_convolve6_8_2d_v(
++                    s0, s1, s2, s3, s4, s5, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d1 = highbd_convolve6_8_2d_v(
++                    s1, s2, s3, s4, s5, s6, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d2 = highbd_convolve6_8_2d_v(
++                    s2, s3, s4, s5, s6, s7, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d3 = highbd_convolve6_8_2d_v(
++                    s3, s4, s5, s6, s7, s8, y_filter, round1_shift_s32, offset_s32, max);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x4_t highbd_convolve8_4_2d_v(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                                 const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                                 const int16x4_t s6, const int16x4_t s7, const int16x8_t y_filter,
++                                                 const int32x4_t round_shift, const int32x4_t offset,
++                                                 const uint16x4_t max) {
++    const int16x4_t y_filter_lo = vget_low_s16(y_filter);
++    const int16x4_t y_filter_hi = vget_high_s16(y_filter);
++
++    int32x4_t sum = vmlal_lane_s16(offset, s0, y_filter_lo, 0);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_lo, 1);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_lo, 2);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_lo, 3);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_hi, 0);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_hi, 1);
++    sum           = vmlal_lane_s16(sum, s6, y_filter_hi, 2);
++    sum           = vmlal_lane_s16(sum, s7, y_filter_hi, 3);
++
++    sum            = vshlq_s32(sum, round_shift);
++    uint16x4_t res = vqmovun_s32(sum);
++    return vmin_u16(res, max);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8_2d_v(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                                 const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                                 const int16x8_t s6, const int16x8_t s7, const int16x8_t y_filter,
++                                                 const int32x4_t round_shift, const int32x4_t offset,
++                                                 const uint16x8_t max) {
++    const int16x4_t y_filter_lo = vget_low_s16(y_filter);
++    const int16x4_t y_filter_hi = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s0), y_filter_lo, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_lo, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_lo, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_lo, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_hi, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_hi, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), y_filter_hi, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), y_filter_hi, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s0), y_filter_lo, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_lo, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_lo, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_lo, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_hi, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_hi, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), y_filter_hi, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), y_filter_hi, 3);
++
++    sum0 = vshlq_s32(sum0, round_shift);
++    sum1 = vshlq_s32(sum1, round_shift);
++
++    uint16x8_t res = vcombine_u16(vqmovun_s32(sum0), vqmovun_s32(sum1));
++    return vminq_u16(res, max);
++}
++
++static INLINE void highbd_convolve_2d_sr_vert_8tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                        int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                        ConvolveParams *conv_params, int bd, const int offset) {
++    const int16x8_t y_filter         = vld1q_s16(y_filter_ptr);
++    const int32x4_t offset_s32       = vdupq_n_s32(offset);
++    const int       round1_shift     = conv_params->round_1;
++    const int32x4_t round1_shift_s32 = vdupq_n_s32(-round1_shift);
++
++    if (w == 4) {
++        const uint16x4_t max = vdup_n_u16((1 << bd) - 1);
++        const int16_t   *s   = (const int16_t *)src_ptr;
++        uint16_t        *d   = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4, s5, s6;
++        load_s16_4x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++        s += 7 * src_stride;
++
++        do {
++            int16x4_t s7, s8, s9, s10;
++            load_s16_4x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++            uint16x4_t d0 = highbd_convolve8_4_2d_v(
++                s0, s1, s2, s3, s4, s5, s6, s7, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d1 = highbd_convolve8_4_2d_v(
++                s1, s2, s3, s4, s5, s6, s7, s8, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d2 = highbd_convolve8_4_2d_v(
++                s2, s3, s4, s5, s6, s7, s8, s9, y_filter, round1_shift_s32, offset_s32, max);
++            uint16x4_t d3 = highbd_convolve8_4_2d_v(
++                s3, s4, s5, s6, s7, s8, s9, s10, y_filter, round1_shift_s32, offset_s32, max);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s5 = s9;
++            s6 = s10;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
++
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4, s5, s6;
++            load_s16_8x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++            s += 7 * src_stride;
++
++            do {
++                int16x8_t s7, s8, s9, s10;
++                load_s16_8x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++                uint16x8_t d0 = highbd_convolve8_8_2d_v(
++                    s0, s1, s2, s3, s4, s5, s6, s7, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d1 = highbd_convolve8_8_2d_v(
++                    s1, s2, s3, s4, s5, s6, s7, s8, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d2 = highbd_convolve8_8_2d_v(
++                    s2, s3, s4, s5, s6, s7, s8, s9, y_filter, round1_shift_s32, offset_s32, max);
++                uint16x8_t d3 = highbd_convolve8_8_2d_v(
++                    s3, s4, s5, s6, s7, s8, s9, s10, y_filter, round1_shift_s32, offset_s32, max);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s5 = s9;
++                s6 = s10;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++static INLINE uint16x8_t highbd_convolve6_8_2d_h(const int16x8_t s[6], const int16x8_t x_filter,
++                                                 const int32x4_t shift_s32, const int32x4_t offset) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t x_filter_0_3 = vget_low_s16(x_filter);
++    const int16x4_t x_filter_4_7 = vget_high_s16(x_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s[0]), x_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[1]), x_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[2]), x_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[3]), x_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[4]), x_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[5]), x_filter_4_7, 2);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s[0]), x_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[1]), x_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[2]), x_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[3]), x_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[4]), x_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[5]), x_filter_4_7, 2);
++
++    sum0 = vqrshlq_s32(sum0, shift_s32);
++    sum1 = vqrshlq_s32(sum1, shift_s32);
++
++    return vcombine_u16(vqmovun_s32(sum0), vqmovun_s32(sum1));
++}
++
++static INLINE void highbd_convolve_2d_sr_horiz_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                         int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                         ConvolveParams *conv_params, const int offset) {
++    // The smallest block height processed by the SIMD functions is 4, and the
++    // horizontal convolution needs to process an extra (filter_taps/2 - 1) lines
++    // for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t shift_s32  = vdupq_n_s32(-conv_params->round_0);
++    const int32x4_t offset_s32 = vdupq_n_s32(offset);
++
++    const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++    int             height   = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8_2d_h(s0, x_filter, shift_s32, offset_s32);
++            uint16x8_t d1 = highbd_convolve6_8_2d_h(s1, x_filter, shift_s32, offset_s32);
++            uint16x8_t d2 = highbd_convolve6_8_2d_h(s2, x_filter, shift_s32, offset_s32);
++            uint16x8_t d3 = highbd_convolve6_8_2d_h(s3, x_filter, shift_s32, offset_s32);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height > 4);
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6];
++            load_s16_8x6(s, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8_2d_h(s0, x_filter, shift_s32, offset_s32);
++            vst1q_u16(d, d0);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++        src_ptr += src_stride;
++        dst_ptr += dst_stride;
++    } while (--height != 0);
++}
++
++static INLINE uint16x4_t highbd_convolve4_4_2d_h(const int16x4_t s[4], const int16x4_t x_filter,
++                                                 const int32x4_t shift_s32, const int32x4_t offset) {
++    int32x4_t sum = vmlal_lane_s16(offset, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    sum = vqrshlq_s32(sum, shift_s32);
++    return vqmovun_s32(sum);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8_2d_h(const int16x8_t s[8], const int16x8_t x_filter,
++                                                 const int32x4_t shift_s32, const int32x4_t offset) {
++    const int16x4_t x_filter_0_3 = vget_low_s16(x_filter);
++    const int16x4_t x_filter_4_7 = vget_high_s16(x_filter);
++
++    int32x4_t sum0 = vmlal_lane_s16(offset, vget_low_s16(s[0]), x_filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[1]), x_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[2]), x_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[3]), x_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[4]), x_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[5]), x_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[6]), x_filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[7]), x_filter_4_7, 3);
++
++    int32x4_t sum1 = vmlal_lane_s16(offset, vget_high_s16(s[0]), x_filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[1]), x_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[2]), x_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[3]), x_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[4]), x_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[5]), x_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[6]), x_filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[7]), x_filter_4_7, 3);
++
++    sum0 = vqrshlq_s32(sum0, shift_s32);
++    sum1 = vqrshlq_s32(sum1, shift_s32);
++
++    return vcombine_u16(vqmovun_s32(sum0), vqmovun_s32(sum1));
++}
++
++static INLINE void highbd_convolve_2d_sr_horiz_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                    int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                    ConvolveParams *conv_params, const int offset) {
++    // The smallest block height processed by the SIMD functions is 4, and the
++    // horizontal convolution needs to process an extra (filter_taps/2 - 1) lines
++    // for the vertical convolution.
++    assert(h >= 5);
++    const int32x4_t shift_s32  = vdupq_n_s32(-conv_params->round_0);
++    const int32x4_t offset_s32 = vdupq_n_s32(offset);
++
++    if (w == 4) {
++        // 4-tap filters are used for blocks having width <= 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 1);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_2d_h(s0, x_filter, shift_s32, offset_s32);
++            uint16x4_t d1 = highbd_convolve4_4_2d_h(s1, x_filter, shift_s32, offset_s32);
++            uint16x4_t d2 = highbd_convolve4_4_2d_h(s2, x_filter, shift_s32, offset_s32);
++            uint16x4_t d3 = highbd_convolve4_4_2d_h(s3, x_filter, shift_s32, offset_s32);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h > 4);
++
++        do {
++            int16x4_t s0[4];
++            load_s16_4x4(s, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_2d_h(s0, x_filter, shift_s32, offset_s32);
++
++            vst1_u16(d, d0);
++
++            s += src_stride;
++            d += dst_stride;
++        } while (--h != 0);
++    } else {
++        const int16x8_t x_filter = vld1q_s16(x_filter_ptr);
++        int             height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8_2d_h(s0, x_filter, shift_s32, offset_s32);
++                uint16x8_t d1 = highbd_convolve8_8_2d_h(s1, x_filter, shift_s32, offset_s32);
++                uint16x8_t d2 = highbd_convolve8_8_2d_h(s2, x_filter, shift_s32, offset_s32);
++                uint16x8_t d3 = highbd_convolve8_8_2d_h(s3, x_filter, shift_s32, offset_s32);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height > 4);
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8_2d_h(s0, x_filter, shift_s32, offset_s32);
++                vst1q_u16(d, d0);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += src_stride;
++            dst_ptr += dst_stride;
++        } while (--height != 0);
++    }
++}
++
++void svt_av1_highbd_convolve_2d_sr_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w,
++                                        int h, const InterpFilterParams *filter_params_x,
++                                        const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                        const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
++    if (w == 2 || h == 2) {
++        svt_av1_highbd_convolve_2d_sr_c(src,
++                                        src_stride,
++                                        dst,
++                                        dst_stride,
++                                        w,
++                                        h,
++                                        filter_params_x,
++                                        filter_params_y,
++                                        subpel_x_qn,
++                                        subpel_y_qn,
++                                        conv_params,
++                                        bd);
++        return;
++    }
++    DECLARE_ALIGNED(16, uint16_t, im_block[(MAX_SB_SIZE + MAX_FILTER_TAP) * MAX_SB_SIZE]);
++    const int x_filter_taps  = get_filter_tap(filter_params_x, subpel_x_qn);
++    const int clamped_x_taps = x_filter_taps < 6 ? 6 : x_filter_taps;
++
++    const int y_filter_taps    = get_filter_tap(filter_params_y, subpel_y_qn);
++    const int clamped_y_taps   = y_filter_taps < 6 ? 6 : y_filter_taps;
++    const int im_h             = h + clamped_y_taps - 1;
++    const int im_stride        = MAX_SB_SIZE;
++    const int vert_offset      = clamped_y_taps / 2 - 1;
++    const int horiz_offset     = clamped_x_taps / 2 - 1;
++    const int x_offset_initial = (1 << (bd + FILTER_BITS - 1));
++    const int y_offset_bits    = bd + 2 * FILTER_BITS - conv_params->round_0;
++    // The extra shim of (1 << (conv_params->round_1 - 1)) allows us to do a
++    // simple shift left instead of a rounding saturating shift left.
++    const int y_offset = (1 << (conv_params->round_1 - 1)) - (1 << (y_offset_bits - 1));
++
++    const uint16_t *src_ptr = src - vert_offset * src_stride - horiz_offset;
++
++    const int16_t *x_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_qn & SUBPEL_MASK);
++    const int16_t *y_filter_ptr = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_qn & SUBPEL_MASK);
++
++    if (x_filter_taps <= 6 && w != 4) {
++        highbd_convolve_2d_sr_horiz_6tap_neon(
++            src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, conv_params, x_offset_initial);
++    } else {
++        highbd_convolve_2d_sr_horiz_neon(
++            src_ptr, src_stride, im_block, im_stride, w, im_h, x_filter_ptr, conv_params, x_offset_initial);
++    }
++
++    if (y_filter_taps <= 6) {
++        highbd_convolve_2d_sr_vert_6tap_neon(
++            im_block, im_stride, dst, dst_stride, w, h, y_filter_ptr, conv_params, bd, y_offset);
++    } else {
++        highbd_convolve_2d_sr_vert_8tap_neon(
++            im_block, im_stride, dst, dst_stride, w, h, y_filter_ptr, conv_params, bd, y_offset);
++    }
++}
+-- 
+GitLab
+
+
+From 831854581f5283681623f090b0be2dcc357e7fcc Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Fri, 5 Jul 2024 12:11:07 +0100
+Subject: [PATCH 5/6] Add Neon implementation of
+ svt_av1_highbd_convolve_x_sr_neon
+
+Add a Neon implementation of svt_av1_highbd_convolve_x_sr. This version
+is a port of the implementation present in libaom.
+---
+ Source/Lib/ASM_NEON/highbd_convolve_neon.c | 208 +++++++++++++++++++++
+ Source/Lib/Codec/common_dsp_rtcd.c         |   2 +-
+ Source/Lib/Codec/common_dsp_rtcd.h         |   1 +
+ test/convolve_test.cc                      |   7 +-
+ 4 files changed, 213 insertions(+), 5 deletions(-)
+
+diff --git a/Source/Lib/ASM_NEON/highbd_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+index 4f47b628f..2876baca7 100644
+--- a/Source/Lib/ASM_NEON/highbd_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+@@ -348,6 +348,214 @@ void svt_av1_highbd_convolve_y_sr_neon(const uint16_t *src, int32_t src_stride,
+     }
+ }
+ 
++static INLINE uint16x8_t highbd_convolve6_8_x(const int16x8_t s[6], const int16x8_t x_filter, const int32x4_t offset,
++                                              const uint16x8_t max) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t x_filter_0_3 = vget_low_s16(x_filter);
++    const int16x4_t x_filter_4_7 = vget_high_s16(x_filter);
++
++    int32x4_t sum0 = offset;
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[0]), x_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[1]), x_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[2]), x_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[3]), x_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[4]), x_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[5]), x_filter_4_7, 2);
++
++    int32x4_t sum1 = offset;
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[0]), x_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[1]), x_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[2]), x_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[3]), x_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[4]), x_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[5]), x_filter_4_7, 2);
++
++    uint16x8_t res = vcombine_u16(vqrshrun_n_s32(sum0, FILTER_BITS), vqrshrun_n_s32(sum1, FILTER_BITS));
++    return vminq_u16(res, max);
++}
++
++static INLINE void highbd_convolve_x_sr_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                  int dst_stride, int w, int h, const int16_t *x_filter_ptr,
++                                                  ConvolveParams *conv_params, int bd) {
++    const int16x8_t  x_filter = vld1q_s16(x_filter_ptr);
++    const uint16x8_t max      = vdupq_n_u16((1 << bd) - 1);
++    // This shim allows to do only one rounding shift instead of two.
++    const int32x4_t offset = vdupq_n_s32(1 << (conv_params->round_0 - 1));
++
++    int height = h;
++
++    do {
++        int            width = w;
++        const int16_t *s     = (const int16_t *)src_ptr;
++        uint16_t      *d     = dst_ptr;
++
++        do {
++            int16x8_t s0[6], s1[6], s2[6], s3[6];
++            load_s16_8x6(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5]);
++            load_s16_8x6(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5]);
++            load_s16_8x6(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5]);
++            load_s16_8x6(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5]);
++
++            uint16x8_t d0 = highbd_convolve6_8_x(s0, x_filter, offset, max);
++            uint16x8_t d1 = highbd_convolve6_8_x(s1, x_filter, offset, max);
++            uint16x8_t d2 = highbd_convolve6_8_x(s2, x_filter, offset, max);
++            uint16x8_t d3 = highbd_convolve6_8_x(s3, x_filter, offset, max);
++
++            store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 8;
++            d += 8;
++            width -= 8;
++        } while (width != 0);
++
++        src_ptr += 4 * src_stride;
++        dst_ptr += 4 * dst_stride;
++        height -= 4;
++    } while (height != 0);
++}
++
++static INLINE uint16x4_t highbd_convolve4_4_x(const int16x4_t s[4], const int16x4_t x_filter, const int32x4_t offset,
++                                              const uint16x4_t max) {
++    int32x4_t sum = offset;
++    sum           = vmlal_lane_s16(sum, s[0], x_filter, 0);
++    sum           = vmlal_lane_s16(sum, s[1], x_filter, 1);
++    sum           = vmlal_lane_s16(sum, s[2], x_filter, 2);
++    sum           = vmlal_lane_s16(sum, s[3], x_filter, 3);
++
++    uint16x4_t res = vqrshrun_n_s32(sum, FILTER_BITS);
++    return vmin_u16(res, max);
++}
++
++static INLINE uint16x8_t highbd_convolve8_8_x(const int16x8_t s[8], const int16x8_t x_filter, const int32x4_t offset,
++                                              const uint16x8_t max) {
++    const int16x4_t x_filter_0_3 = vget_low_s16(x_filter);
++    const int16x4_t x_filter_4_7 = vget_high_s16(x_filter);
++
++    int32x4_t sum0 = offset;
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[0]), x_filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[1]), x_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[2]), x_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[3]), x_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[4]), x_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[5]), x_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[6]), x_filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s[7]), x_filter_4_7, 3);
++
++    int32x4_t sum1 = offset;
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[0]), x_filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[1]), x_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[2]), x_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[3]), x_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[4]), x_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[5]), x_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[6]), x_filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s[7]), x_filter_4_7, 3);
++
++    uint16x8_t res = vcombine_u16(vqrshrun_n_s32(sum0, FILTER_BITS), vqrshrun_n_s32(sum1, FILTER_BITS));
++    return vminq_u16(res, max);
++}
++
++static INLINE void highbd_convolve_x_sr_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr, int dst_stride,
++                                             int w, int h, const int16_t *x_filter_ptr, ConvolveParams *conv_params,
++                                             int bd) {
++    // This shim allows to do only one rounding shift instead of two.
++    const int32x4_t offset = vdupq_n_s32(1 << (conv_params->round_0 - 1));
++
++    if (w == 4) {
++        const uint16x4_t max = vdup_n_u16((1 << bd) - 1);
++        // 4-tap filters are used for blocks having width == 4.
++        const int16x4_t x_filter = vld1_s16(x_filter_ptr + 2);
++        const int16_t  *s        = (const int16_t *)(src_ptr + 2);
++        uint16_t       *d        = dst_ptr;
++
++        do {
++            int16x4_t s0[4], s1[4], s2[4], s3[4];
++            load_s16_4x4(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3]);
++            load_s16_4x4(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3]);
++            load_s16_4x4(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3]);
++            load_s16_4x4(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3]);
++
++            uint16x4_t d0 = highbd_convolve4_4_x(s0, x_filter, offset, max);
++            uint16x4_t d1 = highbd_convolve4_4_x(s1, x_filter, offset, max);
++            uint16x4_t d2 = highbd_convolve4_4_x(s2, x_filter, offset, max);
++            uint16x4_t d3 = highbd_convolve4_4_x(s3, x_filter, offset, max);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const uint16x8_t max      = vdupq_n_u16((1 << bd) - 1);
++        const int16x8_t  x_filter = vld1q_s16(x_filter_ptr);
++        int              height   = h;
++
++        do {
++            int            width = w;
++            const int16_t *s     = (const int16_t *)src_ptr;
++            uint16_t      *d     = dst_ptr;
++
++            do {
++                int16x8_t s0[8], s1[8], s2[8], s3[8];
++                load_s16_8x8(s + 0 * src_stride, 1, &s0[0], &s0[1], &s0[2], &s0[3], &s0[4], &s0[5], &s0[6], &s0[7]);
++                load_s16_8x8(s + 1 * src_stride, 1, &s1[0], &s1[1], &s1[2], &s1[3], &s1[4], &s1[5], &s1[6], &s1[7]);
++                load_s16_8x8(s + 2 * src_stride, 1, &s2[0], &s2[1], &s2[2], &s2[3], &s2[4], &s2[5], &s2[6], &s2[7]);
++                load_s16_8x8(s + 3 * src_stride, 1, &s3[0], &s3[1], &s3[2], &s3[3], &s3[4], &s3[5], &s3[6], &s3[7]);
++
++                uint16x8_t d0 = highbd_convolve8_8_x(s0, x_filter, offset, max);
++                uint16x8_t d1 = highbd_convolve8_8_x(s1, x_filter, offset, max);
++                uint16x8_t d2 = highbd_convolve8_8_x(s2, x_filter, offset, max);
++                uint16x8_t d3 = highbd_convolve8_8_x(s3, x_filter, offset, max);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s += 8;
++                d += 8;
++                width -= 8;
++            } while (width != 0);
++            src_ptr += 4 * src_stride;
++            dst_ptr += 4 * dst_stride;
++            height -= 4;
++        } while (height != 0);
++    }
++}
++
++void svt_av1_highbd_convolve_x_sr_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w, int h,
++                                       const InterpFilterParams *filter_params_x,
++                                       const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                       const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
++    (void)filter_params_y;
++    (void)subpel_y_qn;
++    if (w == 2 || h == 2) {
++        svt_av1_highbd_convolve_x_sr_c(src,
++                                       src_stride,
++                                       dst,
++                                       dst_stride,
++                                       w,
++                                       h,
++                                       filter_params_x,
++                                       filter_params_y,
++                                       subpel_x_qn,
++                                       subpel_y_qn,
++                                       conv_params,
++                                       bd);
++        return;
++    }
++    const int      x_filter_taps = get_filter_tap(filter_params_x, subpel_x_qn);
++    const int      horiz_offset  = filter_params_x->taps / 2 - 1;
++    const int16_t *x_filter_ptr  = av1_get_interp_filter_subpel_kernel(*filter_params_x, subpel_x_qn & SUBPEL_MASK);
++
++    src -= horiz_offset;
++
++    if (x_filter_taps <= 6 && w != 4) {
++        highbd_convolve_x_sr_6tap_neon(src + 1, src_stride, dst, dst_stride, w, h, x_filter_ptr, conv_params, bd);
++        return;
++    }
++
++    highbd_convolve_x_sr_neon(src, src_stride, dst, dst_stride, w, h, x_filter_ptr, conv_params, bd);
++}
++
+ static INLINE uint16x4_t highbd_convolve6_4_2d_v(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
+                                                  const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
+                                                  const int16x8_t y_filter, const int32x4_t round_shift,
+diff --git a/Source/Lib/Codec/common_dsp_rtcd.c b/Source/Lib/Codec/common_dsp_rtcd.c
+index 80785592a..3fcb34b14 100644
+--- a/Source/Lib/Codec/common_dsp_rtcd.c
++++ b/Source/Lib/Codec/common_dsp_rtcd.c
+@@ -1014,7 +1014,7 @@ void svt_aom_setup_common_rtcd_internal(EbCpuFlags flags) {
+     SET_ONLY_C(svt_av1_highbd_jnt_convolve_2d_copy, svt_av1_highbd_jnt_convolve_2d_copy_c);
+     SET_NEON(svt_av1_highbd_jnt_convolve_y, svt_av1_highbd_jnt_convolve_y_c, svt_av1_highbd_jnt_convolve_y_neon);
+     SET_NEON(svt_av1_highbd_jnt_convolve_x, svt_av1_highbd_jnt_convolve_x_c, svt_av1_highbd_jnt_convolve_x_neon);
+-    SET_ONLY_C(svt_av1_highbd_convolve_x_sr, svt_av1_highbd_convolve_x_sr_c);
++    SET_NEON(svt_av1_highbd_convolve_x_sr, svt_av1_highbd_convolve_x_sr_c, svt_av1_highbd_convolve_x_sr_neon);
+     SET_NEON(svt_av1_convolve_2d_sr, svt_av1_convolve_2d_sr_c, svt_av1_convolve_2d_sr_neon);
+     SET_NEON(svt_av1_convolve_2d_copy_sr, svt_av1_convolve_2d_copy_sr_c, svt_av1_convolve_2d_copy_sr_neon);
+     SET_NEON(svt_av1_convolve_x_sr, svt_av1_convolve_x_sr_c, svt_av1_convolve_x_sr_neon);
+diff --git a/Source/Lib/Codec/common_dsp_rtcd.h b/Source/Lib/Codec/common_dsp_rtcd.h
+index 4049bb303..ca562b7f9 100644
+--- a/Source/Lib/Codec/common_dsp_rtcd.h
++++ b/Source/Lib/Codec/common_dsp_rtcd.h
+@@ -1383,6 +1383,7 @@ extern "C" {
+                                            const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+                                            const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+     void svt_av1_highbd_jnt_convolve_y_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
++    void svt_av1_highbd_convolve_x_sr_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+     void svt_av1_highbd_convolve_y_sr_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+     void svt_av1_highbd_jnt_convolve_x_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride, int32_t w, int32_t h, const InterpFilterParams *filter_params_x, const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4, const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd);
+     void svt_enc_msb_un_pack2d_neon(uint16_t *in16_bit_buffer, uint32_t in_stride,
+diff --git a/test/convolve_test.cc b/test/convolve_test.cc
+index eafdb3b92..90d5ad3fb 100644
+--- a/test/convolve_test.cc
++++ b/test/convolve_test.cc
+@@ -1051,10 +1051,9 @@ INSTANTIATE_TEST_SUITE_P(
+ INSTANTIATE_TEST_SUITE_P(ConvolveTest2D_NEON, AV1HbdSrConvolveTest,
+                          BuildParamsHbd(1, 1,
+                                         svt_av1_highbd_convolve_2d_sr_neon));
+-// Not yet implemented
+-// INSTANTIATE_TEST_SUITE_P(ConvolveTestX_NEON, AV1HbdSrConvolveTest,
+-//                         BuildParamsHbd(1, 0,
+-//                         svt_av1_highbd_convolve_x_sr_neon));
++INSTANTIATE_TEST_SUITE_P(ConvolveTestX_NEON, AV1HbdSrConvolveTest,
++                         BuildParamsHbd(1, 0,
++                                        svt_av1_highbd_convolve_x_sr_neon));
+ INSTANTIATE_TEST_SUITE_P(ConvolveTestY_NEON, AV1HbdSrConvolveTest,
+                          BuildParamsHbd(0, 1,
+                                         svt_av1_highbd_convolve_y_sr_neon));
+-- 
+GitLab
+
+
+From 55ecd3bc675ada835cfc9bd39d41c189fb84aca2 Mon Sep 17 00:00:00 2001
+From: Salome Thirot <salome.thirot@arm.com>
+Date: Fri, 5 Jul 2024 12:16:49 +0100
+Subject: [PATCH 6/6] Port libaom implementation of highbd_convolve_y_sr_neon
+
+Replace the current Neon implementation of svt_av1_highbd_convolve_y_sr
+with the one present in libaom. This version includes specialized paths
+for the various filter sizes.
+---
+ Source/Lib/ASM_NEON/highbd_convolve_neon.c | 577 ++++++++++-----------
+ 1 file changed, 263 insertions(+), 314 deletions(-)
+
+diff --git a/Source/Lib/ASM_NEON/highbd_convolve_neon.c b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+index 2876baca7..31c0b5255 100644
+--- a/Source/Lib/ASM_NEON/highbd_convolve_neon.c
++++ b/Source/Lib/ASM_NEON/highbd_convolve_neon.c
+@@ -17,335 +17,284 @@
+ #include "definitions.h"
+ #include "mem_neon.h"
+ 
+-static INLINE void svt_prepare_coeffs_12tap(const int16_t *const filter, int16x8_t *coeffs /* [6] */) {
+-    int32x4_t coeffs_y  = vld1q_s32((int32_t const *)filter);
+-    int32x4_t coeffs_y2 = vld1q_s32((int32_t const *)(filter + 8));
++static INLINE uint16x4_t highbd_convolve6_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                              const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                              const int16x8_t y_filter, const uint16x4_t max) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
+ 
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 0))); // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 1))); // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 2))); // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y, 3))); // coeffs 6 7 6 7 6 7 6 7
++    int32x4_t sum = vmull_lane_s16(s0, y_filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_4_7, 2);
+ 
+-    coeffs[4] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y2, 0))); // coeffs 8 9 8 9 8 9 8 9
+-    coeffs[5] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(coeffs_y2, 1))); // coeffs 10 11 10 11 10 11 10 11
++    uint16x4_t res = vqrshrun_n_s32(sum, COMPOUND_ROUND1_BITS);
++    return vmin_u16(res, max);
+ }
+ 
+-static INLINE void prepare_coeffs(const int16_t *const filter, int16x8_t *const coeffs /* [4] */) {
+-    const int16x8_t coeff = vld1q_s16(filter);
+-
+-    // coeffs 0 1 0 1 0 1 0 1
+-    coeffs[0] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 0)));
+-    // coeffs 2 3 2 3 2 3 2 3
+-    coeffs[1] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 1)));
+-    // coeffs 4 5 4 5 4 5 4 5
+-    coeffs[2] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 2)));
+-    // coeffs 6 7 6 7 6 7 6 7
+-    coeffs[3] = vreinterpretq_s16_s32(vdupq_n_s32(vgetq_lane_s32(vreinterpretq_s32_s16(coeff), 3)));
++static INLINE uint16x8_t highbd_convolve6_8_y(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                              const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                              const int16x8_t y_filter, const uint16x8_t max) {
++    // Values at indices 0 and 7 of y_filter are zero.
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmull_lane_s16(vget_low_s16(s0), y_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_4_7, 2);
++
++    int32x4_t sum1 = vmull_lane_s16(vget_high_s16(s0), y_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_4_7, 2);
++
++    uint16x8_t res = vcombine_u16(vqrshrun_n_s32(sum0, COMPOUND_ROUND1_BITS),
++                                  vqrshrun_n_s32(sum1, COMPOUND_ROUND1_BITS));
++    return vminq_u16(res, max);
+ }
+ 
+-static INLINE int32x4_t convolve_12tap(const uint16x8_t *s, const int16x8_t *coeffs) {
+-    const int32x4_t d0     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0]));
+-    const int32x4_t d1     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[1])), vget_low_s16(coeffs[1]));
+-    const int32x4_t d2     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[2])), vget_low_s16(coeffs[2]));
+-    const int32x4_t d3     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[3])), vget_low_s16(coeffs[3]));
+-    const int32x4_t d4     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[4])), vget_low_s16(coeffs[4]));
+-    const int32x4_t d5     = vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[5])), vget_low_s16(coeffs[5]));
+-    const int32x4_t d_0123 = vaddq_s32(vaddq_s32(d0, d1), vaddq_s32(d2, d3));
+-    const int32x4_t d      = vaddq_s32(vaddq_s32(d4, d5), d_0123);
+-    return d;
++static INLINE void highbd_convolve_y_sr_6tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                  int dst_stride, int w, int h, const int16_t *y_filter_ptr,
++                                                  const int bd) {
++    const int16x8_t y_filter_0_7 = vld1q_s16(y_filter_ptr);
++
++    if (w == 4) {
++        const uint16x4_t max = vdup_n_u16((1 << bd) - 1);
++        const int16_t   *s   = (const int16_t *)(src_ptr + src_stride);
++        uint16_t        *d   = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4;
++        load_s16_4x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++        s += 5 * src_stride;
++
++        do {
++            int16x4_t s5, s6, s7, s8;
++            load_s16_4x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++            uint16x4_t d0 = highbd_convolve6_4_y(s0, s1, s2, s3, s4, s5, y_filter_0_7, max);
++            uint16x4_t d1 = highbd_convolve6_4_y(s1, s2, s3, s4, s5, s6, y_filter_0_7, max);
++            uint16x4_t d2 = highbd_convolve6_4_y(s2, s3, s4, s5, s6, s7, y_filter_0_7, max);
++            uint16x4_t d3 = highbd_convolve6_4_y(s3, s4, s5, s6, s7, s8, y_filter_0_7, max);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
++        // Width is a multiple of 8 and height is a multiple of 4.
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)(src_ptr + src_stride);
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4;
++            load_s16_8x5(s, src_stride, &s0, &s1, &s2, &s3, &s4);
++            s += 5 * src_stride;
++
++            do {
++                int16x8_t s5, s6, s7, s8;
++                load_s16_8x4(s, src_stride, &s5, &s6, &s7, &s8);
++
++                uint16x8_t d0 = highbd_convolve6_8_y(s0, s1, s2, s3, s4, s5, y_filter_0_7, max);
++                uint16x8_t d1 = highbd_convolve6_8_y(s1, s2, s3, s4, s5, s6, y_filter_0_7, max);
++                uint16x8_t d2 = highbd_convolve6_8_y(s2, s3, s4, s5, s6, s7, y_filter_0_7, max);
++                uint16x8_t d3 = highbd_convolve6_8_y(s3, s4, s5, s6, s7, s8, y_filter_0_7, max);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
+ }
+ 
+-static INLINE int32x4_t svt_aom_convolve(const uint16x8_t *const s, const int16x8_t *const coeffs) {
+-    const int32x4_t res_0 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[0])), vget_low_s16(coeffs[0])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[0])), vget_high_s16(coeffs[0])));
+-    const int32x4_t res_1 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[1])), vget_low_s16(coeffs[1])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[1])), vget_high_s16(coeffs[1])));
+-    const int32x4_t res_2 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[2])), vget_low_s16(coeffs[2])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[2])), vget_high_s16(coeffs[2])));
+-    const int32x4_t res_3 = vpaddq_s32(vmull_s16(vget_low_s16(vreinterpretq_s16_u16(s[3])), vget_low_s16(coeffs[3])),
+-                                       vmull_s16(vget_high_s16(vreinterpretq_s16_u16(s[3])), vget_high_s16(coeffs[3])));
++static INLINE uint16x4_t highbd_convolve8_4_y(const int16x4_t s0, const int16x4_t s1, const int16x4_t s2,
++                                              const int16x4_t s3, const int16x4_t s4, const int16x4_t s5,
++                                              const int16x4_t s6, const int16x4_t s7, const int16x8_t y_filter,
++                                              const uint16x4_t max) {
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
+ 
+-    const int32x4_t res = vaddq_s32(vaddq_s32(res_0, res_1), vaddq_s32(res_2, res_3));
++    int32x4_t sum = vmull_lane_s16(s0, y_filter_0_3, 0);
++    sum           = vmlal_lane_s16(sum, s1, y_filter_0_3, 1);
++    sum           = vmlal_lane_s16(sum, s2, y_filter_0_3, 2);
++    sum           = vmlal_lane_s16(sum, s3, y_filter_0_3, 3);
++    sum           = vmlal_lane_s16(sum, s4, y_filter_4_7, 0);
++    sum           = vmlal_lane_s16(sum, s5, y_filter_4_7, 1);
++    sum           = vmlal_lane_s16(sum, s6, y_filter_4_7, 2);
++    sum           = vmlal_lane_s16(sum, s7, y_filter_4_7, 3);
+ 
+-    return res;
++    uint16x4_t res = vqrshrun_n_s32(sum, COMPOUND_ROUND1_BITS);
++    return vmin_u16(res, max);
+ }
+ 
+-void svt_av1_highbd_convolve_y_sr_neon(const uint16_t *src, int32_t src_stride, uint16_t *dst, int32_t dst_stride,
+-                                       int32_t w, int32_t h, const InterpFilterParams *filter_params_x,
+-                                       const InterpFilterParams *filter_params_y, const int32_t subpel_x_q4,
+-                                       const int32_t subpel_y_q4, ConvolveParams *conv_params, int32_t bd) {
++static INLINE uint16x8_t highbd_convolve8_8_y(const int16x8_t s0, const int16x8_t s1, const int16x8_t s2,
++                                              const int16x8_t s3, const int16x8_t s4, const int16x8_t s5,
++                                              const int16x8_t s6, const int16x8_t s7, const int16x8_t y_filter,
++                                              const uint16x8_t max) {
++    const int16x4_t y_filter_0_3 = vget_low_s16(y_filter);
++    const int16x4_t y_filter_4_7 = vget_high_s16(y_filter);
++
++    int32x4_t sum0 = vmull_lane_s16(vget_low_s16(s0), y_filter_0_3, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s1), y_filter_0_3, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s2), y_filter_0_3, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s3), y_filter_0_3, 3);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s4), y_filter_4_7, 0);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s5), y_filter_4_7, 1);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s6), y_filter_4_7, 2);
++    sum0           = vmlal_lane_s16(sum0, vget_low_s16(s7), y_filter_4_7, 3);
++
++    int32x4_t sum1 = vmull_lane_s16(vget_high_s16(s0), y_filter_0_3, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s1), y_filter_0_3, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s2), y_filter_0_3, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s3), y_filter_0_3, 3);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s4), y_filter_4_7, 0);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s5), y_filter_4_7, 1);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s6), y_filter_4_7, 2);
++    sum1           = vmlal_lane_s16(sum1, vget_high_s16(s7), y_filter_4_7, 3);
++
++    uint16x8_t res = vcombine_u16(vqrshrun_n_s32(sum0, COMPOUND_ROUND1_BITS),
++                                  vqrshrun_n_s32(sum1, COMPOUND_ROUND1_BITS));
++    return vminq_u16(res, max);
++}
++
++static INLINE void highbd_convolve_y_sr_8tap_neon(const uint16_t *src_ptr, int src_stride, uint16_t *dst_ptr,
++                                                  int dst_stride, int w, int h, const int16_t *y_filter_ptr, int bd) {
++    const int16x8_t y_filter = vld1q_s16(y_filter_ptr);
++
++    if (w == 4) {
++        const uint16x4_t max = vdup_n_u16((1 << bd) - 1);
++        const int16_t   *s   = (const int16_t *)src_ptr;
++        uint16_t        *d   = dst_ptr;
++
++        int16x4_t s0, s1, s2, s3, s4, s5, s6;
++        load_s16_4x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++        s += 7 * src_stride;
++
++        do {
++            int16x4_t s7, s8, s9, s10;
++            load_s16_4x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++            uint16x4_t d0 = highbd_convolve8_4_y(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, max);
++            uint16x4_t d1 = highbd_convolve8_4_y(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, max);
++            uint16x4_t d2 = highbd_convolve8_4_y(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, max);
++            uint16x4_t d3 = highbd_convolve8_4_y(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, max);
++
++            store_u16_4x4(d, dst_stride, d0, d1, d2, d3);
++
++            s0 = s4;
++            s1 = s5;
++            s2 = s6;
++            s3 = s7;
++            s4 = s8;
++            s5 = s9;
++            s6 = s10;
++            s += 4 * src_stride;
++            d += 4 * dst_stride;
++            h -= 4;
++        } while (h != 0);
++    } else {
++        const uint16x8_t max = vdupq_n_u16((1 << bd) - 1);
++
++        do {
++            int            height = h;
++            const int16_t *s      = (const int16_t *)src_ptr;
++            uint16_t      *d      = dst_ptr;
++
++            int16x8_t s0, s1, s2, s3, s4, s5, s6;
++            load_s16_8x7(s, src_stride, &s0, &s1, &s2, &s3, &s4, &s5, &s6);
++            s += 7 * src_stride;
++
++            do {
++                int16x8_t s7, s8, s9, s10;
++                load_s16_8x4(s, src_stride, &s7, &s8, &s9, &s10);
++
++                uint16x8_t d0 = highbd_convolve8_8_y(s0, s1, s2, s3, s4, s5, s6, s7, y_filter, max);
++                uint16x8_t d1 = highbd_convolve8_8_y(s1, s2, s3, s4, s5, s6, s7, s8, y_filter, max);
++                uint16x8_t d2 = highbd_convolve8_8_y(s2, s3, s4, s5, s6, s7, s8, s9, y_filter, max);
++                uint16x8_t d3 = highbd_convolve8_8_y(s3, s4, s5, s6, s7, s8, s9, s10, y_filter, max);
++
++                store_u16_8x4(d, dst_stride, d0, d1, d2, d3);
++
++                s0 = s4;
++                s1 = s5;
++                s2 = s6;
++                s3 = s7;
++                s4 = s8;
++                s5 = s9;
++                s6 = s10;
++                s += 4 * src_stride;
++                d += 4 * dst_stride;
++                height -= 4;
++            } while (height != 0);
++            src_ptr += 8;
++            dst_ptr += 8;
++            w -= 8;
++        } while (w != 0);
++    }
++}
++
++void svt_av1_highbd_convolve_y_sr_neon(const uint16_t *src, int src_stride, uint16_t *dst, int dst_stride, int w, int h,
++                                       const InterpFilterParams *filter_params_x,
++                                       const InterpFilterParams *filter_params_y, const int subpel_x_qn,
++                                       const int subpel_y_qn, ConvolveParams *conv_params, int bd) {
+     (void)filter_params_x;
+-    (void)subpel_x_q4;
++    (void)subpel_x_qn;
+     (void)conv_params;
+-    int                   i, j;
+-    const int             fo_vert = filter_params_y->taps / 2 - 1;
+-    const uint16_t *const src_ptr = src - fo_vert * src_stride;
+-    const int             bits    = FILTER_BITS;
+-
+-    const int32x4_t round_shift_bits = vsetq_lane_s32(bits, vdupq_n_s32(0), 0);
+-    const int32x4_t round_const_bits = vdupq_n_s32((1 << bits) >> 1);
+-    const int16x8_t clip_pixel       = vdupq_n_s16(bd == 10 ? 1023 : (bd == 12 ? 4095 : 255));
+-    const int16x8_t zero             = vdupq_n_s16(0);
+-
+-    if (filter_params_y->taps == 12) {
+-        uint16x8_t           s[24];
+-        int16x8_t            coeffs_y[6];
+-        const int16_t *const y_filter = av1_get_interp_filter_subpel_kernel(*filter_params_y,
+-                                                                            subpel_y_q4 & SUBPEL_MASK);
+-        svt_prepare_coeffs_12tap(y_filter, coeffs_y);
+-
+-        for (j = 0; j < w; j += 8) {
+-            const uint16_t *data = &src_ptr[j];
+-            /* Vertical filter */
+-            uint16x8_t s0  = vld1q_u16(data + 0 * src_stride);
+-            uint16x8_t s1  = vld1q_u16(data + 1 * src_stride);
+-            uint16x8_t s2  = vld1q_u16(data + 2 * src_stride);
+-            uint16x8_t s3  = vld1q_u16(data + 3 * src_stride);
+-            uint16x8_t s4  = vld1q_u16(data + 4 * src_stride);
+-            uint16x8_t s5  = vld1q_u16(data + 5 * src_stride);
+-            uint16x8_t s6  = vld1q_u16(data + 6 * src_stride);
+-            uint16x8_t s7  = vld1q_u16(data + 7 * src_stride);
+-            uint16x8_t s8  = vld1q_u16(data + 8 * src_stride);
+-            uint16x8_t s9  = vld1q_u16(data + 9 * src_stride);
+-            uint16x8_t s10 = vld1q_u16(data + 10 * src_stride);
+-
+-            s[0] = vzip1q_u16(s0, s1);
+-            s[1] = vzip1q_u16(s2, s3);
+-            s[2] = vzip1q_u16(s4, s5);
+-            s[3] = vzip1q_u16(s6, s7);
+-            s[4] = vzip1q_u16(s8, s9);
+-
+-            s[6]  = vzip2q_u16(s0, s1);
+-            s[7]  = vzip2q_u16(s2, s3);
+-            s[8]  = vzip2q_u16(s4, s5);
+-            s[9]  = vzip2q_u16(s6, s7);
+-            s[10] = vzip2q_u16(s8, s9);
+-
+-            s[12] = vzip1q_u16(s1, s2);
+-            s[13] = vzip1q_u16(s3, s4);
+-            s[14] = vzip1q_u16(s5, s6);
+-            s[15] = vzip1q_u16(s7, s8);
+-            s[16] = vzip1q_u16(s9, s10);
+-
+-            s[18] = vzip2q_u16(s1, s2);
+-            s[19] = vzip2q_u16(s3, s4);
+-            s[20] = vzip2q_u16(s5, s6);
+-            s[21] = vzip2q_u16(s7, s8);
+-            s[22] = vzip2q_u16(s9, s10);
+-
+-            for (i = 0; i < h; i += 2) {
+-                data = &src_ptr[i * src_stride + j];
+-
+-                uint16x8_t s11 = vld1q_u16(data + 11 * src_stride);
+-                uint16x8_t s12 = vld1q_u16(data + 12 * src_stride);
+-
+-                s[5]  = vzip1q_u16(s10, s11);
+-                s[11] = vzip2q_u16(s10, s11);
+-
+-                s[17] = vzip1q_u16(s11, s12);
+-                s[23] = vzip2q_u16(s11, s12);
+-
+-                const int32x4_t res_a0       = convolve_12tap(s, coeffs_y);
+-                int32x4_t       res_a_round0 = vshlq_s32(vaddq_s32(res_a0, round_const_bits),
+-                                                   vdupq_n_s32(-round_shift_bits[0]));
+-
+-                const int32x4_t res_a1       = convolve_12tap(s + 12, coeffs_y);
+-                int32x4_t       res_a_round1 = vshlq_s32(vaddq_s32(res_a1, round_const_bits),
+-                                                   vdupq_n_s32(-round_shift_bits[0]));
+-
+-                if (w - j > 4) {
+-                    const int32x4_t res_b0       = convolve_12tap(s + 6, coeffs_y);
+-                    int32x4_t       res_b_round0 = vshlq_s32(vaddq_s32(res_b0, round_const_bits),
+-                                                       vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    const int32x4_t res_b1       = convolve_12tap(s + 18, coeffs_y);
+-                    int32x4_t       res_b_round1 = vshlq_s32(vaddq_s32(res_b1, round_const_bits),
+-                                                       vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    int16x8_t res_16bit0 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_b_round0);
+-                    res_16bit0           = vminq_s16(res_16bit0, clip_pixel);
+-                    res_16bit0           = vmaxq_s16(res_16bit0, zero);
+-
+-                    int16x8_t res_16bit1 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_b_round1);
+-                    res_16bit1           = vminq_s16(res_16bit1, clip_pixel);
+-                    res_16bit1           = vmaxq_s16(res_16bit1, zero);
+-
+-                    vst1q_u16(&dst[i * dst_stride + j], vreinterpretq_u16_s16(res_16bit0));
+-                    vst1q_u16(&dst[i * dst_stride + j + dst_stride], vreinterpretq_u16_s16(res_16bit1));
+-                } else if (w == 4) {
+-                    int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                    res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                    res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                    int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                    res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                    res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                    vst1_u16(&dst[i * dst_stride + j], vget_low_u16(vreinterpretq_u16_s16(res_a_round0_s16)));
+-                    vst1_u16(&dst[i * dst_stride + j + dst_stride],
+-                             vget_low_u16(vreinterpretq_u16_s16(res_a_round1_s16)));
+-                } else {
+-                    int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                    res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                    res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                    int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                    res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                    res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                    *((uint32_t *)(&dst[i * dst_stride + j])) = vgetq_lane_u32(vreinterpretq_u32_s16(res_a_round0_s16),
+-                                                                               0);
+-                    *((uint32_t *)(&dst[i * dst_stride + j + dst_stride])) = vgetq_lane_u32(
+-                        vreinterpretq_u32_s16(res_a_round1_s16), 0);
+-                }
+-
+-                s[0] = s[1];
+-                s[1] = s[2];
+-                s[2] = s[3];
+-                s[3] = s[4];
+-                s[4] = s[5];
+-
+-                s[6]  = s[7];
+-                s[7]  = s[8];
+-                s[8]  = s[9];
+-                s[9]  = s[10];
+-                s[10] = s[11];
+-
+-                s[12] = s[13];
+-                s[13] = s[14];
+-                s[14] = s[15];
+-                s[15] = s[16];
+-                s[16] = s[17];
+-
+-                s[18] = s[19];
+-                s[19] = s[20];
+-                s[20] = s[21];
+-                s[21] = s[22];
+-                s[22] = s[23];
+-
+-                s10 = s12;
+-            }
+-        }
+-    } else {
+-        uint16x8_t     s[16];
+-        int16x8_t      coeffs_y[4];
+-        const int16_t *filter = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_q4 & SUBPEL_MASK);
+-        prepare_coeffs(filter, coeffs_y);
+-
+-        for (j = 0; j < w; j += 8) {
+-            const uint16_t *data = &src_ptr[j];
+-            /* Vertical filter */
+-            {
+-                uint16x8_t s0 = vld1q_u16(data + 0 * src_stride);
+-                uint16x8_t s1 = vld1q_u16(data + 1 * src_stride);
+-                uint16x8_t s2 = vld1q_u16(data + 2 * src_stride);
+-                uint16x8_t s3 = vld1q_u16(data + 3 * src_stride);
+-                uint16x8_t s4 = vld1q_u16(data + 4 * src_stride);
+-                uint16x8_t s5 = vld1q_u16(data + 5 * src_stride);
+-                uint16x8_t s6 = vld1q_u16(data + 6 * src_stride);
+-
+-                s[0] = vzip1q_u16(s0, s1);
+-                s[1] = vzip1q_u16(s2, s3);
+-                s[2] = vzip1q_u16(s4, s5);
+-
+-                s[4] = vzip2q_u16(s0, s1);
+-                s[5] = vzip2q_u16(s2, s3);
+-                s[6] = vzip2q_u16(s4, s5);
+-
+-                s[0 + 8] = vzip1q_u16(s1, s2);
+-                s[1 + 8] = vzip1q_u16(s3, s4);
+-                s[2 + 8] = vzip1q_u16(s5, s6);
+-
+-                s[4 + 8] = vzip2q_u16(s1, s2);
+-                s[5 + 8] = vzip2q_u16(s3, s4);
+-                s[6 + 8] = vzip2q_u16(s5, s6);
+-
+-                for (i = 0; i < h; i += 2) {
+-                    data = &src_ptr[i * src_stride + j];
+-
+-                    uint16x8_t s7 = vld1q_u16(data + 7 * src_stride);
+-                    uint16x8_t s8 = vld1q_u16(data + 8 * src_stride);
+-
+-                    s[3] = vzip1q_u16(s6, s7);
+-                    s[7] = vzip2q_u16(s6, s7);
+-
+-                    s[3 + 8] = vzip1q_u16(s7, s8);
+-                    s[7 + 8] = vzip2q_u16(s7, s8);
+-
+-                    const int32x4_t res_a0       = svt_aom_convolve(s, coeffs_y);
+-                    int32x4_t       res_a_round0 = vshlq_s32(vaddq_s32(res_a0, round_const_bits),
+-                                                       vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    const int32x4_t res_a1       = svt_aom_convolve(s + 8, coeffs_y);
+-                    int32x4_t       res_a_round1 = vshlq_s32(vaddq_s32(res_a1, round_const_bits),
+-                                                       vdupq_n_s32(-round_shift_bits[0]));
+-
+-                    if (w - j > 4) {
+-                        const int32x4_t res_b0       = svt_aom_convolve(s + 4, coeffs_y);
+-                        int32x4_t       res_b_round0 = vshlq_s32(vaddq_s32(res_b0, round_const_bits),
+-                                                           vdupq_n_s32(-round_shift_bits[0]));
+-
+-                        const int32x4_t res_b1       = svt_aom_convolve(s + 4 + 8, coeffs_y);
+-                        int32x4_t       res_b_round1 = vshlq_s32(vaddq_s32(res_b1, round_const_bits),
+-                                                           vdupq_n_s32(-round_shift_bits[0]));
+-                        int16x8_t       res_16bit0   = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_b_round0);
+-                        res_16bit0                   = vminq_s16(res_16bit0, clip_pixel);
+-                        res_16bit0                   = vmaxq_s16(res_16bit0, zero);
+-
+-                        int16x8_t res_16bit1 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_b_round1);
+-                        res_16bit1           = vminq_s16(res_16bit1, clip_pixel);
+-                        res_16bit1           = vmaxq_s16(res_16bit1, zero);
+-
+-                        vst1q_u16(&dst[i * dst_stride + j], vreinterpretq_u16_s16(res_16bit0));
+-                        vst1q_u16(&dst[i * dst_stride + j + dst_stride], vreinterpretq_u16_s16(res_16bit1));
+-                    } else if (w == 4) {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        vst1_u16(&dst[i * dst_stride + j], vget_low_u16(vreinterpretq_u16_s16(res_a_round0_s16)));
+-                        vst1_u16(&dst[i * dst_stride + j + dst_stride],
+-                                 vget_low_u16(vreinterpretq_u16_s16(res_a_round1_s16)));
+-                    } else {
+-                        int16x8_t res_a_round0_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round0), res_a_round0);
+-                        res_a_round0_s16           = vminq_s16(res_a_round0_s16, clip_pixel);
+-                        res_a_round0_s16           = vmaxq_s16(res_a_round0_s16, zero);
+-
+-                        int16x8_t res_a_round1_s16 = vqmovn_high_s32(vqmovn_s32(res_a_round1), res_a_round1);
+-                        res_a_round1_s16           = vminq_s16(res_a_round1_s16, clip_pixel);
+-                        res_a_round1_s16           = vmaxq_s16(res_a_round1_s16, zero);
+-
+-                        *((uint32_t *)(&dst[i * dst_stride + j])) = vgetq_lane_u32(
+-                            vreinterpretq_u32_s16(res_a_round0_s16), 0);
+-                        *((uint32_t *)(&dst[i * dst_stride + j + dst_stride])) = vgetq_lane_u32(
+-                            vreinterpretq_u32_s16(res_a_round1_s16), 0);
+-                    }
+-
+-                    s[0] = s[1];
+-                    s[1] = s[2];
+-                    s[2] = s[3];
+-
+-                    s[4] = s[5];
+-                    s[5] = s[6];
+-                    s[6] = s[7];
+-
+-                    s[0 + 8] = s[1 + 8];
+-                    s[1 + 8] = s[2 + 8];
+-                    s[2 + 8] = s[3 + 8];
+-
+-                    s[4 + 8] = s[5 + 8];
+-                    s[5 + 8] = s[6 + 8];
+-                    s[6 + 8] = s[7 + 8];
+-
+-                    s6 = s8;
+-                }
+-            }
+-        }
++    if (w == 2 || h == 2) {
++        svt_av1_highbd_convolve_y_sr_c(src,
++                                       src_stride,
++                                       dst,
++                                       dst_stride,
++                                       w,
++                                       h,
++                                       filter_params_x,
++                                       filter_params_y,
++                                       subpel_x_qn,
++                                       subpel_y_qn,
++                                       conv_params,
++                                       bd);
++        return;
+     }
++    const int      y_filter_taps = get_filter_tap(filter_params_y, subpel_y_qn);
++    const int      vert_offset   = filter_params_y->taps / 2 - 1;
++    const int16_t *y_filter_ptr  = av1_get_interp_filter_subpel_kernel(*filter_params_y, subpel_y_qn & SUBPEL_MASK);
++
++    src -= vert_offset * src_stride;
++
++    if (y_filter_taps < 8) {
++        highbd_convolve_y_sr_6tap_neon(src, src_stride, dst, dst_stride, w, h, y_filter_ptr, bd);
++        return;
++    }
++
++    highbd_convolve_y_sr_8tap_neon(src, src_stride, dst, dst_stride, w, h, y_filter_ptr, bd);
+ }
+ 
+ static INLINE uint16x8_t highbd_convolve6_8_x(const int16x8_t s[6], const int16x8_t x_filter, const int32x4_t offset,
+-- 
+GitLab
+

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/SVT-AV1-v2.1.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.1.0/SVT-AV1-v2.1.0.tar.gz
-SVT-AV1.FETCH.sha256  = 72a076807544f3b269518ab11656f77358284da7782cece497781ab64ed4cb8a
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v2.2.0.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.2.0/SVT-AV1-v2.2.0.tar.gz
+SVT-AV1.FETCH.sha256  = d5b3094b2583eb9c15705efa92a8b413f01d718ca0adce6826ae1f0f1c69b4fd
 
 SVT-AV1.GCC.args.c_std =
 


### PR DESCRIPTION
> [2.2.0] - 2024-08-19
> Encoder
> 
> Improve the tradeoffs for the random access mode across presets:
> Speedup of ~15% across presets M0 - M8 while maintaining similar quality levels ([!2253](https://github.com/AOMediaCodec/SVT-AV1/-/merge_requests/2253))
> Improve the tradeoffs for the low-delay mode across presets ([!2260](https://github.com/AOMediaCodec/SVT-AV1/-/merge_requests/2260))
> Increased temporal resolution setting to 6L for 4k resolutions by default
> Added ARM optimizations for functions with c_only equivalent yielding an average speedup of ~13% for 4k10bit
> 
> Cleanup Build and bug fixes and documentation
> 
> Profile-guided-optimized helper build overhaul
> Major cleanup and fixing of Neon unit test suite
> Address stylecheck dependence on public repositories

and https://gitlab.com/AOMediaCodec/SVT-AV1/-/merge_requests/2261 that didn't make it for time reasons, but it's such a big speedup.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux