### PR TITLE
fifo improvements

### DIFF
--- a/libhb/comb_detect.c
+++ b/libhb/comb_detect.c
@@ -1505,7 +1505,7 @@ static void process_frame(hb_filter_private_t *pv)
     if (((pv->mode & MODE_MASK) || (pv->mode & MODE_COMPOSITE)) && combed)
     {
         hb_buffer_t *out;
-        out = hb_buffer_dup(pv->ref[1]);
+        out = hb_buffer_shallow_dup(pv->ref[1]);
         pv->apply_mask(pv, out);
         out->s.combed = combed;
         hb_buffer_list_append(&pv->out_list, out);
@@ -1532,7 +1532,7 @@ static int comb_detect_work(hb_filter_object_t *filter,
     if (in->s.flags & HB_BUF_FLAG_EOF)
     {
         // Duplicate last frame and process refs
-        store_ref(pv, hb_buffer_dup(pv->ref[2]));
+        store_ref(pv, hb_buffer_shallow_dup(pv->ref[2]));
         if (pv->ref[0] != NULL)
         {
             pv->force_exaustive_check = 1;
@@ -1548,7 +1548,7 @@ static int comb_detect_work(hb_filter_object_t *filter,
     if (!pv->comb_detect_ready)
     {
         // If not ready, store duplicate ref and return HB_FILTER_DELAY
-        store_ref(pv, hb_buffer_dup(in));
+        store_ref(pv, hb_buffer_shallow_dup(in));
         store_ref(pv, in);
         pv->comb_detect_ready = 1;
         // Wait for next

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -490,7 +490,7 @@ static void process_frame(hb_filter_private_t *pv)
         pv->ref[1]->s.combed == HB_COMB_NONE)
     {
         // Input buffer is not combed.  Just make a dup of it.
-        hb_buffer_t *buf = hb_buffer_dup(pv->ref[1]);
+        hb_buffer_t *buf = hb_buffer_shallow_dup(pv->ref[1]);
         hb_buffer_list_append(&pv->out_list, buf);
         pv->frames++;
         pv->unfiltered++;
@@ -571,7 +571,7 @@ static int hb_decomb_work(hb_filter_object_t *filter,
         if (pv->ref[2] != NULL)
         {
             // Duplicate last frame and process refs
-            store_ref(pv, hb_buffer_dup(pv->ref[2]));
+            store_ref(pv, hb_buffer_shallow_dup(pv->ref[2]));
             process_frame(pv);
         }
         hb_buffer_list_append(&pv->out_list, in);
@@ -584,7 +584,7 @@ static int hb_decomb_work(hb_filter_object_t *filter,
     if (!pv->ready)
     {
         // If yadif is not ready, store another ref and return HB_FILTER_DELAY
-        store_ref(pv, hb_buffer_dup(in));
+        store_ref(pv, hb_buffer_shallow_dup(in));
         store_ref(pv, in);
         pv->ready = 1;
         // Wait for next

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -190,6 +190,7 @@ void          hb_video_buffer_realloc( hb_buffer_t * b, int w, int h );
 void          hb_buffer_reduce( hb_buffer_t * b, int size );
 void          hb_buffer_close( hb_buffer_t ** );
 hb_buffer_t * hb_buffer_dup( const hb_buffer_t * src );
+hb_buffer_t * hb_buffer_shallow_dup( const hb_buffer_t *src );
 int           hb_buffer_copy( hb_buffer_t * dst, const hb_buffer_t * src );
 void          hb_buffer_swap_copy( hb_buffer_t *src, hb_buffer_t *dst );
 hb_image_t  * hb_image_init(int pix_fmt, int width, int height);

--- a/libhb/platform/macosx/deinterlace_vt.m
+++ b/libhb/platform/macosx/deinterlace_vt.m
@@ -11,6 +11,7 @@
 #include "handbrake/decomb.h"
 #include "cv_utils.h"
 #include "metal_utils.h"
+#include "vt_common.h"
 
 extern char hb_yadif_vt_metallib_data[];
 extern unsigned int hb_yadif_vt_metallib_len;
@@ -325,7 +326,7 @@ static void process_frame(hb_filter_private_t *pv)
          pv->ref[CURR]->s.combed == HB_COMB_NONE)
     {
         // Input buffer is not combed, just make a dup of it
-        hb_buffer_t *buf = hb_buffer_dup(pv->ref[CURR]);
+        hb_buffer_t *buf = hb_vt_buffer_dup(pv->ref[CURR]);
         hb_buffer_list_append(&pv->out_list, buf);
     }
     else

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -337,7 +337,7 @@ static hb_buffer_t * adjust_frame_rate( hb_filter_private_t * pv,
         for (; excess >= pv->frame_duration; excess -= pv->frame_duration)
         {
             /* next frame too far ahead - dup current frame */
-            hb_buffer_t *dup = hb_buffer_dup( out );
+            hb_buffer_t *dup = hb_buffer_shallow_dup( out );
             dup->s.new_chap = 0;
             dup->s.start = cfr_stop;
             cfr_stop += pv->frame_duration;


### PR DESCRIPTION
Adds a hb_buffer_shallow_dup() function to avoid copying the hb_buffer data when possible (when it's a wrapped avframe), this allows to avoid a full buffer copy in comb_detect and one in decomb, and in vfr.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux