### PR TITLE
contrib: Correct string "Finish Current, Start Next"

### DIFF
--- a/gtk/po/af.po
+++ b/gtk/po/af.po
@@ -2315,7 +2315,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Kanselleer Huidige, Begin Volgende"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/bg.po
+++ b/gtk/po/bg.po
@@ -2418,7 +2418,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Отмени настоящо, започни следващо"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ca.po
+++ b/gtk/po/ca.po
@@ -2430,7 +2430,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Cancel·la l'actual, comença el següent"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/co.po
+++ b/gtk/po/co.po
@@ -2504,7 +2504,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Abbandunà l’attuale, principià u seguente"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Piantà l’attuale, principià u seguente"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/cs.po
+++ b/gtk/po/cs.po
@@ -2383,7 +2383,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Zrušit nynější, začít další"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/de.po
+++ b/gtk/po/de.po
@@ -2488,7 +2488,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Breche aktuelle Aufgabe ab, starte nächsten"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Momentanes fertigstellen, starte nächste"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/es.po
+++ b/gtk/po/es.po
@@ -2466,7 +2466,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Cancelar y Comenzar siguiente"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Finalizar y Comenzar siguiente"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/eu.po
+++ b/gtk/po/eu.po
@@ -2457,7 +2457,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Utzi unekoa eta hasi hurrengoa"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/fi.po
+++ b/gtk/po/fi.po
@@ -2484,7 +2484,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Peru nykyinen ja aloita seuraava"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Päätä nykyinen, aloita seuraava"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/fr.po
+++ b/gtk/po/fr.po
@@ -2506,7 +2506,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Annuler l'actuel, commencer le suivant"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Terminer l'actuel, commencer le suivant"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -2257,7 +2257,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/he.po
+++ b/gtk/po/he.po
@@ -2232,7 +2232,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/hr.po
+++ b/gtk/po/hr.po
@@ -2238,7 +2238,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/it.po
+++ b/gtk/po/it.po
@@ -2402,7 +2402,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Annulla corrente, avvia successivo"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ja.po
+++ b/gtk/po/ja.po
@@ -2429,7 +2429,7 @@ msgid "Cancel Current, Start Next"
 msgstr "現在のエンコードをキャンセルして次を開始"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "現在のエンコードを完了して次を開始"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ka.po
+++ b/gtk/po/ka.po
@@ -2233,7 +2233,7 @@ msgid "Cancel Current, Start Next"
 msgstr "მიმდინარის გაუქმება და შემდეგის გაშვება"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ko.po
+++ b/gtk/po/ko.po
@@ -2394,7 +2394,7 @@ msgid "Cancel Current, Start Next"
 msgstr "현재 작업 취소 및 다음 작업 시작"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/nl.po
+++ b/gtk/po/nl.po
@@ -2502,7 +2502,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Huidige annuleren, start volgende"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Huidige voltooien, volgende starten"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/no.po
+++ b/gtk/po/no.po
@@ -2247,7 +2247,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Avbryt Nåværende, Start Neste"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/pl.po
+++ b/gtk/po/pl.po
@@ -2234,7 +2234,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/pt.po
+++ b/gtk/po/pt.po
@@ -2244,7 +2244,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Cancelar Atual, Começar o Próximo"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/pt_BR.po
+++ b/gtk/po/pt_BR.po
@@ -2498,7 +2498,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Cancelar o atual, começar um novo"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Concluir o atual, iniciar o próximo"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ro.po
+++ b/gtk/po/ro.po
@@ -2277,7 +2277,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Anulează curent, pornește următoarea"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/ru.po
+++ b/gtk/po/ru.po
@@ -2385,7 +2385,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Отменить текущий, начать следующий"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/si.po
+++ b/gtk/po/si.po
@@ -2228,7 +2228,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/sk.po
+++ b/gtk/po/sk.po
@@ -2241,7 +2241,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Zrušiť aktuálne a spustiť ďalšie"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/sl_SI.po
+++ b/gtk/po/sl_SI.po
@@ -2280,7 +2280,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/sv.po
+++ b/gtk/po/sv.po
@@ -2489,7 +2489,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Avbryt pågående, starta nästa"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr "Slutför aktuell, starta nästa"
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/th.po
+++ b/gtk/po/th.po
@@ -2310,7 +2310,7 @@ msgid "Cancel Current, Start Next"
 msgstr "ยกเลิกรายการปัจจุบัน, เริ่มรายการถัดไป"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/tr.po
+++ b/gtk/po/tr.po
@@ -2251,7 +2251,7 @@ msgid "Cancel Current, Start Next"
 msgstr "Şimdikini İptal Et, Sıradakini Başlat"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/uk_UA.po
+++ b/gtk/po/uk_UA.po
@@ -2273,7 +2273,7 @@ msgid "Cancel Current, Start Next"
 msgstr ""
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/po/zh_TW.po
+++ b/gtk/po/zh_TW.po
@@ -2255,7 +2255,7 @@ msgid "Cancel Current, Start Next"
 msgstr "取消目前的，並開始下一個"
 
 #: src/callbacks.c:4100
-msgid "Finish Current, Start Next"
+msgid "Finish Current and Stop"
 msgstr ""
 
 #: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -4098,7 +4098,7 @@ ghb_stop_encode_dialog_show (signal_user_data_t *ud)
     GtkWidget *dialog = ghb_cancel_dialog_new(window, _("Stop Encoding?"),
         _("Your movie will be lost if you don't continue encoding."),
         _("Cancel Current and Stop"), _("Cancel Current, Start Next"),
-        _("Finish Current, Start Next"), _("Continue Encoding"));
+        _("Finish Current and Stop"), _("Continue Encoding"));
     g_signal_connect(dialog, "response",
                      G_CALLBACK(stop_encode_dialog_response), ud);
     gtk_widget_show(dialog);


### PR DESCRIPTION
**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
On Linux, the button that will finish the current job, then stop encoding the rest of the queue is written as "Finish Current, Start Next". This string has been replaced in all files referencing it with the text of "Finish Current and Stop" as this is the current behavior of this button.

Issue 6109: https://github.com/HandBrake/HandBrake/issues/6109


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
