### PR TITLE
libhb: improve scanning of DTS audio

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -652,28 +652,28 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
 
     if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H264)
     {
-        context->profile = FF_PROFILE_UNKNOWN;
+        context->profile = AV_PROFILE_UNKNOWN;
         if (job->encoder_profile != NULL && *job->encoder_profile)
         {
             if (!strcasecmp(job->encoder_profile, "baseline"))
-                context->profile = FF_PROFILE_H264_BASELINE;
+                context->profile = AV_PROFILE_H264_BASELINE;
             else if (!strcasecmp(job->encoder_profile, "main"))
-                 context->profile = FF_PROFILE_H264_MAIN;
+                 context->profile = AV_PROFILE_H264_MAIN;
             else if (!strcasecmp(job->encoder_profile, "high"))
-                context->profile = FF_PROFILE_H264_HIGH;
+                context->profile = AV_PROFILE_H264_HIGH;
         }
     }
     else if (job->vcodec == HB_VCODEC_FFMPEG_VCE_H265 || job->vcodec == HB_VCODEC_FFMPEG_VCE_H265_10BIT)
     {
-        context->profile = FF_PROFILE_UNKNOWN;
+        context->profile = AV_PROFILE_UNKNOWN;
         if (job->encoder_profile != NULL && *job->encoder_profile)
         {
             if (!strcasecmp(job->encoder_profile, "main")) {
-                 context->profile = FF_PROFILE_HEVC_MAIN;
+                 context->profile = AV_PROFILE_HEVC_MAIN;
             }
 
             if (!strcasecmp(job->encoder_profile, "main10")) {
-                 context->profile = FF_PROFILE_HEVC_MAIN_10;
+                 context->profile = AV_PROFILE_HEVC_MAIN_10;
             }
         }
 
@@ -682,11 +682,11 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     }
     else if (job->vcodec == HB_VCODEC_FFMPEG_VCE_AV1)
     {
-        context->profile = FF_PROFILE_UNKNOWN;
+        context->profile = AV_PROFILE_UNKNOWN;
         if (job->encoder_profile != NULL && *job->encoder_profile)
         {
             if (!strcasecmp(job->encoder_profile, "main"))
-                 context->profile = FF_PROFILE_AV1_MAIN;
+                 context->profile = AV_PROFILE_AV1_MAIN;
         }
     }
     else if (job->vcodec == HB_VCODEC_FFMPEG_NVENC_H264 ||
@@ -735,15 +735,15 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
     {
         if (job->vcodec == HB_VCODEC_FFMPEG_MF_H264)
         {
-            context->profile = FF_PROFILE_UNKNOWN;
+            context->profile = AV_PROFILE_UNKNOWN;
             if (job->encoder_profile != NULL && *job->encoder_profile)
             {
                 if (!strcasecmp(job->encoder_profile, "baseline"))
-                    context->profile = FF_PROFILE_H264_BASELINE;
+                    context->profile = AV_PROFILE_H264_BASELINE;
                 else if (!strcasecmp(job->encoder_profile, "main"))
-                    context->profile = FF_PROFILE_H264_MAIN;
+                    context->profile = AV_PROFILE_H264_MAIN;
                 else if (!strcasecmp(job->encoder_profile, "high"))
-                    context->profile = FF_PROFILE_H264_HIGH;
+                    context->profile = AV_PROFILE_H264_HIGH;
             }
         }
         else if (job->vcodec == HB_VCODEC_FFMPEG_MF_H265)

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -75,7 +75,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
     enum AVCodecID codec_id        = AV_CODEC_ID_NONE;
     enum AVSampleFormat sample_fmt = AV_SAMPLE_FMT_FLTP;
     int bits_per_raw_sample        = 0;
-    int profile                    = FF_PROFILE_UNKNOWN;
+    int profile                    = AV_PROFILE_UNKNOWN;
 
     // override with encoder-specific values
     switch (audio->config.out.codec)
@@ -100,10 +100,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             switch (audio->config.out.codec)
             {
                 case HB_ACODEC_FDK_HAAC:
-                    profile = FF_PROFILE_AAC_HE;
+                    profile = AV_PROFILE_AAC_HE;
                     break;
                 default:
-                    profile = FF_PROFILE_AAC_LOW;
+                    profile = AV_PROFILE_AAC_LOW;
                     break;
             }
             // FFmpeg's libfdk-aac wrapper expects back channels for 5.1

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1568,7 +1568,7 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
         const AVCodec *codec = avcodec_find_decoder(audio->config.in.codec_param);
         if (codec != NULL)
         {
-            if (info.profile != FF_PROFILE_UNKNOWN)
+            if (info.profile != AV_PROFILE_UNKNOWN)
             {
                 profile_name = av_get_profile_name(codec, info.profile);
             }

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1525,6 +1525,41 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
     audio->config.in.flags = info.flags;
     audio->config.in.mode = info.mode;
 
+    // Under some circumstances, ffmpeg fails to probe the DTS profile
+    // during it's initial scan of DTS audio tracks. The profile gets
+    // picked up during our more indepth scan here.
+    if (audio->config.in.codec == HB_ACODEC_FFMPEG)
+    {
+        switch (audio->config.in.codec_param)
+        {
+            case AV_CODEC_ID_DTS:
+            {
+                switch (info.profile)
+                {
+                    case AV_PROFILE_DTS:
+                    case AV_PROFILE_DTS_ES:
+                    case AV_PROFILE_DTS_96_24:
+                    case AV_PROFILE_DTS_EXPRESS:
+                        audio->config.in.codec = HB_ACODEC_DCA;
+                        break;
+
+                    case AV_PROFILE_DTS_HD_MA:
+                    case AV_PROFILE_DTS_HD_HRA:
+                    case AV_PROFILE_DTS_HD_MA_X:
+                    case AV_PROFILE_DTS_HD_MA_X_IMAX:
+                        audio->config.in.codec = HB_ACODEC_DCA_HD;
+                        break;
+
+                    default:
+                        break;
+                }
+            } break;
+
+            default:
+                break;
+        }
+    }
+
     // now that we have all the info, set the audio description
     const char *codec_name   = NULL;
     const char *profile_name = NULL;

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -4087,19 +4087,19 @@ static int probe_dts_profile( hb_stream_t *stream, hb_pes_stream_t *pes )
     }
     switch (info.profile)
     {
-        case FF_PROFILE_DTS:
-        case FF_PROFILE_DTS_ES:
-        case FF_PROFILE_DTS_96_24:
-        case FF_PROFILE_DTS_EXPRESS:
+        case AV_PROFILE_DTS:
+        case AV_PROFILE_DTS_ES:
+        case AV_PROFILE_DTS_96_24:
+        case AV_PROFILE_DTS_EXPRESS:
             pes->codec = HB_ACODEC_DCA;
             pes->stream_type = 0x82;
             pes->stream_kind = A;
             break;
 
-        case FF_PROFILE_DTS_HD_HRA:
-        case FF_PROFILE_DTS_HD_MA:
-        case FF_PROFILE_DTS_HD_MA_X:
-        case FF_PROFILE_DTS_HD_MA_X_IMAX:
+        case AV_PROFILE_DTS_HD_HRA:
+        case AV_PROFILE_DTS_HD_MA:
+        case AV_PROFILE_DTS_HD_MA_X:
+        case AV_PROFILE_DTS_HD_MA_X_IMAX:
             pes->stream_type = 0;
             pes->stream_kind = A;
             break;
@@ -5554,17 +5554,17 @@ static void add_ffmpeg_audio(hb_title_t *title, hb_stream_t *stream, int id)
         {
             switch (codecpar->profile)
             {
-                case FF_PROFILE_DTS:
-                case FF_PROFILE_DTS_ES:
-                case FF_PROFILE_DTS_96_24:
-                case FF_PROFILE_DTS_EXPRESS:
+                case AV_PROFILE_DTS:
+                case AV_PROFILE_DTS_ES:
+                case AV_PROFILE_DTS_96_24:
+                case AV_PROFILE_DTS_EXPRESS:
                     audio->config.in.codec = HB_ACODEC_DCA;
                     break;
 
-                case FF_PROFILE_DTS_HD_MA:
-                case FF_PROFILE_DTS_HD_HRA:
-                case FF_PROFILE_DTS_HD_MA_X:
-                case FF_PROFILE_DTS_HD_MA_X_IMAX:
+                case AV_PROFILE_DTS_HD_MA:
+                case AV_PROFILE_DTS_HD_HRA:
+                case AV_PROFILE_DTS_HD_MA_X:
+                case AV_PROFILE_DTS_HD_MA_X_IMAX:
                     audio->config.in.codec = HB_ACODEC_DCA_HD;
                     break;
 


### PR DESCRIPTION
It seems ffmpeg's stream probe does not always go deep enough to trigger the decoder to fill in the DTS profile. HandBrake's subsequent audio probe during scan picks up the profile.

Fixes https://github.com/HandBrake/HandBrake/issues/6237


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
