### PR TITLE
comb_detect_filter_work and blend_filter_line neon optimizations

### DIFF
--- a/libhb/templates/comb_detect_template.c
+++ b/libhb/templates/comb_detect_template.c
@@ -15,6 +15,9 @@
 #   define FUNC(name) name##_##8
 #endif
 
+#if defined(__aarch64__) && defined(_WIN32)
+    #include <arm_neon.h>
+#endif
 static inline void FUNC(draw_mask_box)(hb_filter_private_t *pv)
 {
     const int x = pv->mask_box_x;
@@ -131,6 +134,157 @@ static void FUNC(apply_mask)(hb_filter_private_t *pv, hb_buffer_t *b)
     }
 }
 
+#if defined(__aarch64__) && defined(_WIN32)
+static void FUNC(detect_gamma_combed_segment)(hb_filter_private_t *pv,
+                                              int segment_start, int segment_stop)
+{
+    // A mishmash of various comb detection tricks
+    // picked up from neuron2's Decomb plugin for
+    // AviSynth and tritical's IsCombedT and
+    // IsCombedTIVTC plugins.
+
+    // Comb scoring algorithm
+    const float mthresh  = pv->gamma_motion_threshold;
+    const float athresh  = pv->gamma_spatial_threshold;
+    const float athresh6 = pv->gamma_spatial_threshold6;
+
+    // One pass for Y
+    const int stride_prev  = pv->ref[0]->plane[0].stride / pv->bps;
+    const int stride_cur   = pv->ref[1]->plane[0].stride / pv->bps;
+    const int stride_next  = pv->ref[2]->plane[0].stride / pv->bps;
+    const int width   = pv->ref[0]->plane[0].width;
+    const int height  = pv->ref[0]->plane[0].height;
+    const int mask_stride = pv->mask->plane[0].stride;
+
+    // Comb detection has to start at y = 2 and end at
+    // y = height - 2, because it needs to examine
+    // 2 pixels above and 2 below the current pixel.
+    if (segment_start < 2)
+    {
+        segment_start = 2;
+    }
+    if (segment_stop > height - 2)
+    {
+        segment_stop = height - 2;
+    }
+
+    // These are just to make the buffer locations easier to read.
+    const int up_1_prev    = -1 * stride_prev;
+    const int down_1_prev  =      stride_prev;
+
+    const int up_2    = -2 * stride_cur;
+    const int up_1    = -1 * stride_cur;
+    const int down_1  =      stride_cur;
+    const int down_2  =  2 * stride_cur;
+
+    const int up_1_next    = -1 * stride_next;
+    const int down_1_next =       stride_next;
+
+    float32x4_t v_athresh = vdupq_n_f32(athresh);
+    float32x4_t v_athresh_neg = vdupq_n_f32(-athresh);
+    float32x4_t v_mthresh = vdupq_n_f32(mthresh);
+    float32x4_t v_athresh6 = vdupq_n_f32(athresh6);
+    float32x4_t v_four = vdupq_n_f32(4.0f);
+    float32x4_t v_three = vdupq_n_f32(3.0f);
+    uint32x4_t v_one = vdupq_n_u32(1);
+    uint32x4_t v_exhaustive_check = vdupq_n_u32(pv->force_exaustive_check);
+
+    for (int y = segment_start; y < segment_stop; y++)
+    {
+        // We need to examine a column of 5 pixels
+        // in the prev, cur, and next frames.
+        const pixel *prev = &((const pixel *)pv->ref[0]->plane[0].data)[y * stride_prev];
+        const pixel *cur  = &((const pixel *)pv->ref[1]->plane[0].data)[y * stride_cur];
+        const pixel *next = &((const pixel *)pv->ref[2]->plane[0].data)[y * stride_next];
+        uint8_t *mask = &pv->mask->plane[0].data[y * mask_stride];
+        memset(mask, 0, mask_stride);
+        uint32_t mask32[4];
+
+        for (int x = 0; x < width; x += 4)
+        {
+            uint32x4_t mask_vec = vdupq_n_u32(0);
+
+            float32x4_t cur_vec = {pv->gamma_lut[cur[0]], pv->gamma_lut[cur[1]], pv->gamma_lut[cur[2]], pv->gamma_lut[cur[3]]};
+            float32x4_t cur_up1_vec = {pv->gamma_lut[cur[up_1 + 0]], pv->gamma_lut[cur[up_1 + 1]], pv->gamma_lut[cur[up_1 + 2]], pv->gamma_lut[cur[up_1 + 3]]};
+            float32x4_t cur_down1_vec = {pv->gamma_lut[cur[down_1 + 0]], pv->gamma_lut[cur[down_1 + 1]], pv->gamma_lut[cur[down_1 + 2]], pv->gamma_lut[cur[down_1 + 3]]};
+
+            float32x4_t up_diff1 = vsubq_f32(cur_vec, cur_up1_vec);
+            float32x4_t down_diff1 = vsubq_f32(cur_vec, cur_down1_vec);
+
+            uint32x4_t cond1 = vcgtq_f32(up_diff1, v_athresh);
+            uint32x4_t cond2 = vcgtq_f32(down_diff1, v_athresh);
+            uint32x4_t cond3 = vcltq_f32(up_diff1, v_athresh_neg);
+            uint32x4_t cond4 = vcltq_f32(down_diff1, v_athresh_neg);
+
+            uint32x4_t condition1 = vandq_u32(cond1, cond2);
+            uint32x4_t condition2 = vandq_u32(cond3, cond4);
+            uint32x4_t condition = vorrq_u32(condition1, condition2);
+
+            if(vmaxvq_u32(condition) > 0)
+            {
+                uint32x4_t motion = vdupq_n_u32(0);
+                uint32x4_t motion1 = vdupq_n_u32(0);
+                if (mthresh > 0)
+                {
+                    float32x4_t prev_vec = {pv->gamma_lut[prev[0]], pv->gamma_lut[prev[1]], pv->gamma_lut[prev[2]], pv->gamma_lut[prev[3]]};
+                    float32x4_t next_vec = {pv->gamma_lut[next[0]], pv->gamma_lut[next[1]], pv->gamma_lut[next[2]], pv->gamma_lut[next[3]]};
+                    float32x4_t next_up_1_vec =  {pv->gamma_lut[next[up_1_next + 0]], pv->gamma_lut[next[up_1_next + 1]], pv->gamma_lut[next[up_1_next + 2]], pv->gamma_lut[next[up_1_next + 3]]};
+                    float32x4_t next_down_1_vec =  {pv->gamma_lut[next[down_1_next + 0]], pv->gamma_lut[next[down_1_next + 1]], pv->gamma_lut[next[down_1_next + 2]], pv->gamma_lut[next[down_1_next + 3]]};
+                    float32x4_t abs_diff1 = vabsq_f32(vsubq_f32(prev_vec, cur_vec));
+                    float32x4_t abs_diff2 = vabsq_f32(vsubq_f32(cur_up1_vec, next_up_1_vec));
+                    float32x4_t abs_diff3 = vabsq_f32(vsubq_f32(cur_down1_vec,next_down_1_vec));
+
+                    uint32x4_t motion_cond1 = vcgtq_f32(abs_diff1, v_mthresh);
+                    uint32x4_t motion_cond2 = vcgtq_f32(abs_diff2, v_mthresh);
+                    uint32x4_t motion_cond3 = vcgtq_f32(abs_diff3, v_mthresh);
+
+                    motion = vandq_u32(vandq_u32(motion_cond1, motion_cond2), motion_cond3);
+
+                    float32x4_t prev_up_1_vec =  {pv->gamma_lut[prev[up_1_prev + 0]], pv->gamma_lut[prev[up_1_prev + 1]], pv->gamma_lut[prev[up_1_prev + 2]], pv->gamma_lut[prev[up_1_prev + 3]]};
+                    float32x4_t prev_down_1_vec =  {pv->gamma_lut[prev[down_1_prev + 0]], pv->gamma_lut[prev[down_1_prev + 1]], pv->gamma_lut[prev[down_1_prev + 2]], pv->gamma_lut[prev[down_1_prev + 3]]};
+                    float32x4_t abs_diff4 = vabsq_f32(vsubq_f32(next_vec, cur_vec));
+                    float32x4_t abs_diff5 = vabsq_f32(vsubq_f32(prev_up_1_vec, cur_up1_vec));
+                    float32x4_t abs_diff6 = vabsq_f32(vsubq_f32(prev_down_1_vec, cur_down1_vec));
+
+                    uint32x4_t motion_cond4 = vcgtq_f32(abs_diff4, v_mthresh);
+                    uint32x4_t motion_cond5 = vcgtq_f32(abs_diff5, v_mthresh);
+                    uint32x4_t motion_cond6 = vcgtq_f32(abs_diff6, v_mthresh);
+                    motion1 = vandq_u32(vandq_u32(motion_cond4, motion_cond5), motion_cond6);
+                    motion = vorrq_u32(motion, motion1);
+                }
+                else
+                {
+                    motion = vdupq_n_u32(1);
+                }
+
+                uint32x4_t motion_check = vorrq_u32(motion, v_exhaustive_check);
+                motion_check = vcgtq_u32(motion_check, mask_vec);
+
+                float32x4_t cur_up2_vec = {pv->gamma_lut[cur[up_2 + 0]], pv->gamma_lut[cur[up_2 + 1]], pv->gamma_lut[cur[up_2 + 2]], pv->gamma_lut[cur[up_2 + 3]]};
+                float32x4_t cur_down2_vec = {pv->gamma_lut[cur[down_2 + 0]], pv->gamma_lut[cur[down_2 + 1]], pv->gamma_lut[cur[down_2 + 2]], pv->gamma_lut[cur[down_2 + 3]]};
+
+                float32x4_t combing1 = vabsq_f32(vsubq_f32(vaddq_f32(vaddq_f32(cur_up2_vec, vmulq_f32(cur_vec, v_four)),cur_down2_vec), vmulq_f32(vaddq_f32(cur_up1_vec, cur_down1_vec), v_three)));
+
+                uint32x4_t combing_cond = vcgtq_f32(combing1, v_athresh6);
+                mask_vec = vandq_u32(combing_cond, motion_check);
+                mask_vec = vandq_u32(mask_vec, condition);
+                mask_vec = vandq_u32(mask_vec, v_one);
+
+                vst1q_u32(&mask32, mask_vec);
+
+                mask[0] = mask32[0];
+                mask[1] = mask32[1];
+                mask[2] = mask32[2];
+                mask[3] = mask32[3];
+            }
+            cur+=4;
+            prev+=4;
+            next+=4;
+            mask+=4;
+        }
+    }
+}
+#else
 static void FUNC(detect_gamma_combed_segment)(hb_filter_private_t *pv,
                                               int segment_start, int segment_stop)
 {
@@ -246,6 +400,391 @@ static void FUNC(detect_gamma_combed_segment)(hb_filter_private_t *pv,
         }
     }
 }
+#endif
+
+#if defined(__aarch64__) && defined(_WIN32)
+#if BIT_DEPTH > 8
+static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
+                                        int segment_start, int segment_stop)
+{
+    // A mishmash of various comb detection tricks
+    // picked up from neuron2's Decomb plugin for
+    // AviSynth and tritical's IsCombedT and
+    // IsCombedTIVTC plugins.
+
+    // Comb scoring algorithm
+    const int spatial_metric  = pv->spatial_metric;
+    const int mthresh         = pv->motion_threshold;
+    const int athresh         = pv->spatial_threshold;
+    const int athresh_squared = pv->spatial_threshold_squared;
+    const int athresh6        = pv->spatial_threshold6;
+
+    // One pass for Y
+    const int stride_prev  = pv->ref[0]->plane[0].stride / pv->bps;
+    const int stride_cur   = pv->ref[1]->plane[0].stride / pv->bps;
+    const int stride_next  = pv->ref[2]->plane[0].stride / pv->bps;
+    const int width   = pv->ref[0]->plane[0].width;
+    const int height  = pv->ref[0]->plane[0].height;
+    const int mask_stride = pv->mask->plane[0].stride;
+
+    // Comb detection has to start at y = 2 and end at
+    // y = height - 2, because it needs to examine
+    // 2 pixels above and 2 below the current pixel.
+    if (segment_start < 2)
+    {
+        segment_start = 2;
+    }
+    if (segment_stop > height - 2)
+    {
+        segment_stop = height - 2;
+    }
+
+    // These are just to make the buffer locations easier to read.
+    const int up_1_prev    = -1 * stride_prev;
+    const int down_1_prev  =      stride_prev;
+
+    const int up_2    = -2 * stride_cur;
+    const int up_1    = -1 * stride_cur;
+    const int down_1  =      stride_cur;
+    const int down_2  =  2 * stride_cur;
+
+    const int up_1_next    = -1 * stride_next;
+    const int down_1_next =       stride_next;
+
+    int32x4_t v_athresh = vdupq_n_s32(athresh);
+    int32x4_t v_athresh_neg = vdupq_n_s32(-athresh);
+    int32x4_t v_mthresh = vdupq_n_s32(mthresh);
+    int32x4_t v_athresh6 = vdupq_n_s32(athresh6);
+    int32x4_t v_athresh_squared = vdupq_n_s32(athresh_squared);
+    int32x4_t v_four = vdupq_n_s32(4);
+    int32x4_t v_three = vdupq_n_s32(3);
+    uint32x4_t v_one = vdupq_n_u32(1);
+    int32x4_t v_c32detect_min = vdupq_n_s32(pv->comb32detect_min);
+    int32x4_t v_c32detect_max = vdupq_n_s32(pv->comb32detect_max);
+    uint32x4_t v_exhaustive_check = vdupq_n_u32(pv->force_exaustive_check);
+
+    for (int y = segment_start; y < segment_stop; y++)
+    {
+        // We need to examine a column of 5 pixels
+        // in the prev, cur, and next frames.
+        const pixel *prev = &((const pixel *)pv->ref[0]->plane[0].data)[y * stride_prev];
+        const pixel *cur  = &((const pixel *)pv->ref[1]->plane[0].data)[y * stride_cur];
+        const pixel *next = &((const pixel *)pv->ref[2]->plane[0].data)[y * stride_next];
+        uint8_t *mask = &pv->mask->plane[0].data[y * mask_stride];
+
+        memset(mask, 0, mask_stride);
+        uint32_t mask32[4];
+        for (int x = 0; x < width; x+=4)
+        {
+            uint32x4_t mask_vec = vdupq_n_u32(0);
+
+            uint32x4_t cur_vec = vmovl_u16(vld1_u16(cur));
+            uint32x4_t cur_up1_vec = vmovl_u16(vld1_u16(cur + up_1));
+            uint32x4_t cur_down1_vec = vmovl_u16(vld1_u16(cur + down_1));
+
+            int32x4_t up_diff_vec = vsubq_s32(cur_vec, cur_up1_vec);
+            int32x4_t down_diff_vec = vsubq_s32(cur_vec, cur_down1_vec);
+
+            uint32x4_t cond1 = vcgtq_s32(up_diff_vec, v_athresh);
+            uint32x4_t cond2 = vcgtq_s32(down_diff_vec, v_athresh);
+            uint32x4_t cond3 = vcltq_s32(up_diff_vec, v_athresh_neg);
+            uint32x4_t cond4 = vcltq_s32(down_diff_vec, v_athresh_neg);
+
+            uint32x4_t condition1 = vandq_u32(cond1, cond2);
+            uint32x4_t condition2 = vandq_u32(cond3, cond4);
+            uint32x4_t condition = vorrq_u32(condition1, condition2);
+
+            if(vmaxvq_u32(condition) > 0)
+            {
+                uint32x4_t motion = vdupq_n_u32(0);
+                uint32x4_t motion1 = vdupq_n_u32(0);
+                if (mthresh > 0)
+                {
+                    uint32x4_t prev_vec = vmovl_u16(vld1_u16(prev));
+                    uint32x4_t next_up1_vec = vmovl_u16(vld1_u16(next + up_1_next));
+                    uint32x4_t next_down1_vec = vmovl_u16(vld1_u16(next + down_1_next));
+                    int32x4_t abs_diff1 = vabsq_s32(vsubq_s32(prev_vec, cur_vec));
+                    int32x4_t abs_diff2 = vabsq_s32(vsubq_s32(cur_up1_vec, next_up1_vec));
+                    int32x4_t abs_diff3 = vabsq_s32(vsubq_s32(cur_down1_vec, next_down1_vec));
+
+                    uint32x4_t motion_cond1 = vcgtq_s32(abs_diff1, v_mthresh);
+                    uint32x4_t motion_cond2 = vcgtq_s32(abs_diff2, v_mthresh);
+                    uint32x4_t motion_cond3 = vcgtq_s32(abs_diff3, v_mthresh);
+
+                    motion = vandq_u32(vandq_u32(motion_cond1, motion_cond2), motion_cond3);
+
+                    uint32x4_t next_vec = vmovl_u16(vld1_u16(next));
+                    uint32x4_t prev_up1_vec = vmovl_u16(vld1_u16(prev + up_1_prev));
+                    uint32x4_t prev_down1_vec = vmovl_u16(vld1_u16(prev + down_1_prev));
+                    int32x4_t abs_diff4 = vabsq_s32(vsubq_s32(next_vec, cur_vec));
+                    int32x4_t abs_diff5 = vabsq_s32(vsubq_s32(prev_up1_vec, cur_up1_vec));
+                    int32x4_t abs_diff6 = vabsq_s32(vsubq_s32(prev_down1_vec, cur_down1_vec));
+
+                    uint32x4_t motion_cond4 = vcgtq_s32(abs_diff4, v_mthresh);
+                    uint32x4_t motion_cond5 = vcgtq_s32(abs_diff5, v_mthresh);
+                    uint32x4_t motion_cond6 = vcgtq_s32(abs_diff6, v_mthresh);
+
+                    motion1 = vandq_u32(vandq_u32(motion_cond4, motion_cond5), motion_cond6);
+                    motion = vorrq_u32(motion, motion1);
+                }
+                else
+                {
+                    motion = vdupq_n_u32(1);
+                }
+                uint32x4_t motion_check = vorrq_u32(motion, v_exhaustive_check);
+                motion_check = vcgtq_u32(motion_check, mask_vec);
+
+                uint32x4_t cur_up2_vec = vmovl_u16(vld1_u16(cur + up_2));
+                uint32x4_t cur_down2_vec = vmovl_u16(vld1_u16(cur + down_2));
+
+
+                switch(spatial_metric)
+                {
+                    case 0:
+                    {
+                        uint32x4_t cond_c32_detect_min = vcltq_s32(vabsq_s32(vsubq_s32(cur_vec, cur_down2_vec)), v_c32detect_min);
+                        uint32x4_t cond_c32_detect_max = vcgtq_s32(vabsq_s32(vsubq_s32(cur_vec, cur_down1_vec)), v_c32detect_max);
+
+                        uint32x4_t s_metric_0_vec = vandq_u32(cond_c32_detect_min, cond_c32_detect_max);
+                        mask_vec = vandq_u32(s_metric_0_vec, motion_check);
+                        mask_vec = vandq_u32(mask_vec, condition);
+                        mask_vec = vandq_u32(mask_vec, v_one);
+
+                        vst1q_u32(&mask32, mask_vec);
+
+                        mask[0] = mask32[0];
+                        mask[1] = mask32[1];
+                        mask[2] = mask32[2];
+                        mask[3] = mask32[3];
+                        break;
+                    }
+                    case 1:
+                    {
+                        int32x4_t s_metric_1_diff1 = vsubq_s32(cur_up1_vec, cur_vec);
+                        int32x4_t s_metric_1_diff2 = vsubq_s32(cur_down1_vec, cur_vec);
+                        int32x4_t s_metric_1_mul = vmulq_s32(s_metric_1_diff1, s_metric_1_diff2);
+                        uint32x4_t s_metric_1_vec = vcgtq_s32(s_metric_1_mul, v_athresh_squared);
+                        mask_vec = vandq_u32(s_metric_1_vec, motion_check);
+                        mask_vec = vandq_u32(mask_vec, condition);
+                        mask_vec = vandq_u32(mask_vec, v_one);
+
+                        vst1q_u32(&mask32, mask_vec);
+
+                        mask[0] = mask32[0];
+                        mask[1] = mask32[1];
+                        mask[2] = mask32[2];
+                        mask[3] = mask32[3];
+                        break;
+                    }
+                    case 2:
+                    {
+                        int32x4_t combing1 = vabsq_s32(vsubq_s32(vaddq_u32(vaddq_u32(cur_up2_vec, vmulq_u32(cur_vec, v_four)),cur_down2_vec), vmulq_u32(vaddq_u32(cur_up1_vec, cur_down1_vec), v_three)));
+                        uint32x4_t s_metric_2_vec = vcgtq_s32(combing1, v_athresh6);
+
+                        mask_vec = vandq_u32(s_metric_2_vec, motion_check);
+                        mask_vec = vandq_u32(mask_vec, condition);
+                        mask_vec = vandq_u32(mask_vec, v_one);
+
+                        vst1q_u32(&mask32, mask_vec);
+
+                        mask[0] = mask32[0];
+                        mask[1] = mask32[1];
+                        mask[2] = mask32[2];
+                        mask[3] = mask32[3];
+                        break;
+                    }
+                }
+
+            }
+            cur+=4;
+            prev+=4;
+            next+=4;
+            mask+=4;
+        }
+    }
+}
+#else
+static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
+                                        int segment_start, int segment_stop)
+{
+    // A mishmash of various comb detection tricks
+    // picked up from neuron2's Decomb plugin for
+    // AviSynth and tritical's IsCombedT and
+    // IsCombedTIVTC plugins.
+
+    // Comb scoring algorithm
+    const int spatial_metric  = pv->spatial_metric;
+    const int mthresh         = pv->motion_threshold;
+    const int athresh         = pv->spatial_threshold;
+    const int athresh_squared = pv->spatial_threshold_squared;
+    const int athresh6        = pv->spatial_threshold6;
+
+    // One pass for Y
+    const int stride_prev  = pv->ref[0]->plane[0].stride / pv->bps;
+    const int stride_cur   = pv->ref[1]->plane[0].stride / pv->bps;
+    const int stride_next  = pv->ref[2]->plane[0].stride / pv->bps;
+    const int width   = pv->ref[0]->plane[0].width;
+    const int height  = pv->ref[0]->plane[0].height;
+    const int mask_stride = pv->mask->plane[0].stride;
+
+    // Comb detection has to start at y = 2 and end at
+    // y = height - 2, because it needs to examine
+    // 2 pixels above and 2 below the current pixel.
+    if (segment_start < 2)
+    {
+        segment_start = 2;
+    }
+    if (segment_stop > height - 2)
+    {
+        segment_stop = height - 2;
+    }
+
+    // These are just to make the buffer locations easier to read.
+    const int up_1_prev    = -1 * stride_prev;
+    const int down_1_prev  =      stride_prev;
+
+    const int up_2    = -2 * stride_cur;
+    const int up_1    = -1 * stride_cur;
+    const int down_1  =      stride_cur;
+    const int down_2  =  2 * stride_cur;
+
+    const int up_1_next    = -1 * stride_next;
+    const int down_1_next =       stride_next;
+
+    int16x8_t v_athresh = vdupq_n_s16(athresh);
+    int16x8_t v_athresh_neg = vdupq_n_s16(-athresh);
+    int16x8_t v_mthresh = vdupq_n_s16(mthresh);
+    int16x8_t v_athresh6 = vdupq_n_s16(athresh6);
+    int16x8_t v_athresh_squared = vdupq_n_s16(athresh_squared);
+    int16x8_t v_four = vdupq_n_s16(4);
+    int16x8_t v_three = vdupq_n_s16(3);
+    uint16x8_t v_one = vdupq_n_u16(1);
+    int16x8_t v_c32detect_min = vdupq_n_s16(pv->comb32detect_min);
+    int16x8_t v_c32detect_max = vdupq_n_s16(pv->comb32detect_max);
+    uint16x8_t v_exhaustive_check = vdupq_n_u16(pv->force_exaustive_check);
+
+    for (int y = segment_start; y < segment_stop; y++)
+    {
+        // We need to examine a column of 5 pixels
+        // in the prev, cur, and next frames.
+        const pixel *prev = &((const pixel *)pv->ref[0]->plane[0].data)[y * stride_prev];
+        const pixel *cur  = &((const pixel *)pv->ref[1]->plane[0].data)[y * stride_cur];
+        const pixel *next = &((const pixel *)pv->ref[2]->plane[0].data)[y * stride_next];
+        uint8_t *mask = &pv->mask->plane[0].data[y * mask_stride];
+
+        memset(mask, 0, mask_stride);
+        for (int x = 0; x < width; x+=8)
+        {
+            uint16x8_t mask_vec = vdupq_n_u16(0);
+
+            uint16x8_t cur_vec = vmovl_u8(vld1_u8((uint8_t*)cur));
+            uint16x8_t cur_up1_vec = vmovl_u8(vld1_u8((uint8_t*)cur + up_1));
+            uint16x8_t cur_down1_vec = vmovl_u8(vld1_u8((uint8_t*)cur + down_1));
+
+            int16x8_t up_diff_vec = vsubq_s16(cur_vec, cur_up1_vec);
+            int16x8_t down_diff_vec = vsubq_s16(cur_vec, cur_down1_vec);
+
+            uint16x8_t cond1 = vcgtq_s16(up_diff_vec, v_athresh);
+            uint16x8_t cond2 = vcgtq_s16(down_diff_vec, v_athresh);
+            uint16x8_t cond3 = vcltq_s16(up_diff_vec, v_athresh_neg);
+            uint16x8_t cond4 = vcltq_s16(down_diff_vec, v_athresh_neg);
+
+            uint16x8_t condition1 = vandq_u16(cond1, cond2);
+            uint16x8_t condition2 = vandq_u16(cond3, cond4);
+            uint16x8_t condition = vorrq_u16(condition1, condition2);
+
+            if(vmaxvq_u16(condition) > 0)
+            {
+                uint16x8_t motion = vdupq_n_u16(0);
+                uint16x8_t motion1 = vdupq_n_u16(0);
+                if (mthresh > 0)
+                {
+                    uint16x8_t prev_vec = vmovl_u8(vld1_u8((uint8_t*)prev));
+                    uint16x8_t next_up1_vec = vmovl_u8(vld1_u8((uint8_t*)next + up_1_next));
+                    uint16x8_t next_down1_vec = vmovl_u8(vld1_u8((uint8_t*)next + down_1_next));
+                    int16x8_t abs_diff1 = vabsq_s16(vsubq_s16(prev_vec, cur_vec));
+                    int16x8_t abs_diff2 = vabsq_s16(vsubq_s16(cur_up1_vec, next_up1_vec));
+                    int16x8_t abs_diff3 = vabsq_s16(vsubq_s16(cur_down1_vec, next_down1_vec));
+
+                    uint16x8_t motion_cond1 = vcgtq_s16(abs_diff1, v_mthresh);
+                    uint16x8_t motion_cond2 = vcgtq_s16(abs_diff2, v_mthresh);
+                    uint16x8_t motion_cond3 = vcgtq_s16(abs_diff3, v_mthresh);
+
+                    motion = vandq_u16(vandq_u16(motion_cond1, motion_cond2), motion_cond3);
+
+                    uint16x8_t next_vec = vmovl_u8(vld1_u8((uint8_t*)next));
+                    uint16x8_t prev_up1_vec = vmovl_u8(vld1_u8((uint8_t*)prev + up_1_prev));
+                    uint16x8_t prev_down1_vec = vmovl_u8(vld1_u8((uint8_t*)prev + down_1_prev));
+                    int16x8_t abs_diff4 = vabsq_s16(vsubq_s16(next_vec, cur_vec));
+                    int16x8_t abs_diff5 = vabsq_s16(vsubq_s16(prev_up1_vec, cur_up1_vec));
+                    int16x8_t abs_diff6 = vabsq_s16(vsubq_s16(prev_down1_vec, cur_down1_vec));
+
+                    uint16x8_t motion_cond4 = vcgtq_s16(abs_diff4, v_mthresh);
+                    uint16x8_t motion_cond5 = vcgtq_s16(abs_diff5, v_mthresh);
+                    uint16x8_t motion_cond6 = vcgtq_s16(abs_diff6, v_mthresh);
+
+                    motion1 = vandq_u16(vandq_u16(motion_cond4, motion_cond5), motion_cond6);
+                    motion = vorrq_u16(motion, motion1);
+                }
+                else
+                {
+                    motion = vdupq_n_u16(1);
+                }
+                uint16x8_t motion_check = vorrq_u16(motion, v_exhaustive_check);
+                motion_check = vcgtq_u16(motion_check, mask_vec);
+
+                uint16x8_t cur_up2_vec = vmovl_u8(vld1_u8((uint8_t*)cur + up_2));
+                uint16x8_t cur_down2_vec = vmovl_u8(vld1_u8((uint8_t*)cur + down_2));
+                switch(spatial_metric)
+                {
+                    case 0:
+                    {
+                        uint16x8_t cond_c32_detect_min = vcltq_s16(vabsq_s16(vsubq_s16(cur_vec, cur_down2_vec)), v_c32detect_min);
+                        uint16x8_t cond_c32_detect_max = vcgtq_s16(vabsq_s16(vsubq_s16(cur_vec, cur_down1_vec)), v_c32detect_max);
+
+                        uint16x8_t s_metric_0_vec = vandq_u16(cond_c32_detect_min, cond_c32_detect_max);
+                        mask_vec = vandq_u16(s_metric_0_vec, motion_check);
+                        mask_vec = vandq_u16(mask_vec, condition);
+                        mask_vec = vandq_u16(mask_vec, v_one);
+
+                        vst1_u8(&mask[x], vmovn_u16(mask_vec));
+                        break;
+                    }
+                    case 1:
+                    {
+                        int16x8_t s_metric_1_diff1 = vsubq_s16(cur_up1_vec, cur_vec);
+                        int16x8_t s_metric_1_diff2 = vsubq_s16(cur_down1_vec, cur_vec);
+                        int16x8_t s_metric_1_mul = vmulq_s16(s_metric_1_diff1, s_metric_1_diff2);
+                        uint16x8_t s_metric_1_vec = vcgtq_s16(s_metric_1_mul, v_athresh_squared);
+                        mask_vec = vandq_u16(s_metric_1_vec, motion_check);
+                        mask_vec = vandq_u16(mask_vec, condition);
+                        mask_vec = vandq_u16(mask_vec, v_one);
+
+                        vst1_u8(&mask[x], vmovn_u16(mask_vec));
+                        break;
+                    }
+                    case 2:
+                    {
+                        int16x8_t combing1 = vabsq_s16(vsubq_s16(vaddq_u16(vaddq_u16(cur_up2_vec, vmulq_u16(cur_vec, v_four)),cur_down2_vec), vmulq_u16(vaddq_u16(cur_up1_vec, cur_down1_vec), v_three)));
+                        uint16x8_t s_metric_2_vec = vcgtq_s16(combing1, v_athresh6);
+
+                        mask_vec = vandq_u16(s_metric_2_vec, motion_check);
+                        mask_vec = vandq_u16(mask_vec, condition);
+                        mask_vec = vandq_u16(mask_vec, v_one);
+                        vst1_u8(&mask[x], vmovn_u16(mask_vec));
+                        break;
+                    }
+                }
+
+            }
+            cur+=8;
+            prev+=8;
+            next+=8;
+        }
+    }
+}
+#endif
+#else
 
 static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
                                         int segment_start, int segment_stop)
@@ -392,6 +931,7 @@ static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
         }
     }
 }
+#endif
 
 #undef pixel
 #undef FUNC

--- a/libhb/templates/decomb_template.c
+++ b/libhb/templates/decomb_template.c
@@ -15,6 +15,9 @@
 #   define FUNC(name) name##_##8
 #endif
 
+#if defined(__aarch64__) && defined(_WIN32)
+    #include <arm_neon.h>
+#endif
 #include "handbrake/eedi2.h"
 
 static void FUNC(init_crop_table)(void **crop_table_out, const int max_value)
@@ -103,6 +106,176 @@ static inline void FUNC(cubic_interpolate_line)(pixel *dst,
     }
 }
 
+#if defined(__aarch64__) && defined(_WIN32)
+#if BIT_DEPTH > 8
+static void FUNC(blend_filter_line)(const filter_param_t *filter,
+                                    const pixel *crop_table,
+                                    pixel *dst,
+                                    const pixel *cur,
+                                    const int width,
+                                    const int height,
+                                    const int stride,
+                                    const int y)
+{
+    int up1, up2, down1, down2;
+    if (y > 1 && y < (height - 2))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == 0)
+    {
+        up1 = up2 = 0;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == 1)
+    {
+        up1 = up2 = -1 * stride;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == (height - 2))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = down2 = 1 * stride;
+    }
+    else if (y == (height - 1))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = down2 = 0;
+    }
+    else
+    {
+        hb_error("Invalid value y %d height %d", y, height);
+        return;
+    }
+
+    int32x4_t tap0 = vdupq_n_s32(filter->tap[0]);
+    int32x4_t tap1 = vdupq_n_s32(filter->tap[1]);
+    int32x4_t tap2 = vdupq_n_s32(filter->tap[2]);
+    int32x4_t tap3 = vdupq_n_s32(filter->tap[3]);
+    int32x4_t tap4 = vdupq_n_s32(filter->tap[4]);
+
+    int32x4_t filter_norm_vec = vdupq_n_s32(-filter->normalize);
+    uint32x4_t offset = vdupq_n_u32(1024);
+    for (int x = 0; x < width; x += 4)
+    {
+        uint32_t cr_table_vec[4];
+        uint32x4_t up2_pixels = vmovl_u16(vld1_u16(cur + x + up2));
+        uint32x4_t up1_pixels = vmovl_u16(vld1_u16(cur + x + up1));
+        uint32x4_t current_pixels = vmovl_u16(vld1_u16(cur + x ));
+        uint32x4_t down1_pixels = vmovl_u16(vld1_u16(cur + x + down1));
+        uint32x4_t down2_pixels = vmovl_u16(vld1_u16(cur + x + down2));
+
+        int32x4_t result = vmulq_s32(up2_pixels, tap0);
+        result = vmlaq_s32(result, up1_pixels, tap1);
+        result = vmlaq_s32(result, current_pixels, tap2);
+        result = vmlaq_s32(result, down1_pixels, tap3);
+        result = vmlaq_s32(result, down2_pixels, tap4);
+
+        result = vshrq_n_s32(result, 3);
+
+        uint32x4_t result_u32 = vaddq_u32(result, offset);
+        vst1q_u32(&cr_table_vec, result_u32);
+        dst[x+0] = crop_table[cr_table_vec[0]];
+        dst[x+1] = crop_table[cr_table_vec[1]];
+        dst[x+2] = crop_table[cr_table_vec[2]];
+        dst[x+3] = crop_table[cr_table_vec[3]];
+    }
+}
+#else
+
+static void FUNC(blend_filter_line)(const filter_param_t *filter,
+                                    const pixel *crop_table,
+                                    pixel *dst,
+                                    const pixel *cur,
+                                    const int width,
+                                    const int height,
+                                    const int stride,
+                                    const int y)
+{
+    int up1, up2, down1, down2;
+    if (y > 1 && y < (height - 2))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == 0)
+    {
+        up1 = up2 = 0;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == 1)
+    {
+        up1 = up2 = -1 * stride;
+        down1 = 1 * stride;
+        down2 = 2 * stride;
+    }
+    else if (y == (height - 2))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = down2 = 1 * stride;
+    }
+    else if (y == (height - 1))
+    {
+        up1 = -1 * stride;
+        up2 = -2 * stride;
+        down1 = down2 = 0;
+    }
+    else
+    {
+        hb_error("Invalid value y %d height %d", y, height);
+        return;
+    }
+
+    int16x8_t tap0 = vdupq_n_s16(filter->tap[0]);
+    int16x8_t tap1 = vdupq_n_s16(filter->tap[1]);
+    int16x8_t tap2 = vdupq_n_s16(filter->tap[2]);
+    int16x8_t tap3 = vdupq_n_s16(filter->tap[3]);
+    int16x8_t tap4 = vdupq_n_s16(filter->tap[4]);
+
+    int16x8_t filter_norm_vec = vdupq_n_s16(-filter->normalize);
+    uint16x8_t offset = vdupq_n_u16(1024);
+    for (int x = 0; x < width; x += 8)
+    {
+        uint16_t cr_table_vec[8];
+        uint16x8_t up2_pixels = vmovl_u8(vld1_u8(cur + x + up2));
+        uint16x8_t up1_pixels = vmovl_u8(vld1_u8(cur + x + up1));
+        uint16x8_t current_pixels = vmovl_u8(vld1_u8(cur + x ));
+        uint16x8_t down1_pixels = vmovl_u8(vld1_u8(cur + x + down1));
+        uint16x8_t down2_pixels = vmovl_u8(vld1_u8(cur + x + down2));
+
+        int16x8_t result = vmulq_s16(up2_pixels, tap0);
+        result = vmlaq_s16(result, up1_pixels, tap1);
+        result = vmlaq_s16(result, current_pixels, tap2);
+        result = vmlaq_s16(result, down1_pixels, tap3);
+        result = vmlaq_s16(result, down2_pixels, tap4);
+
+        result = vshrq_n_s16(result, 3);
+
+        uint16x8_t result_u16 = vaddq_u16(result, offset);
+        vst1q_u16(&cr_table_vec, result_u16);
+        dst[x+0] = crop_table[cr_table_vec[0]];
+        dst[x+1] = crop_table[cr_table_vec[1]];
+        dst[x+2] = crop_table[cr_table_vec[2]];
+        dst[x+3] = crop_table[cr_table_vec[3]];
+        dst[x+4] = crop_table[cr_table_vec[4]];
+        dst[x+5] = crop_table[cr_table_vec[5]];
+        dst[x+6] = crop_table[cr_table_vec[6]];
+        dst[x+7] = crop_table[cr_table_vec[7]];
+    }
+}
+#endif
+#else
 static inline int FUNC(blend_filter_pixel)(const filter_param_t *filter,
                                            const pixel *crop_table,
                                            const int up2, const int up1,
@@ -186,6 +359,7 @@ static void FUNC(blend_filter_line)(const filter_param_t *filter,
         cur++;
     }
 }
+#endif
 
 /// This function calls all the eedi2 filters in sequence for a given plane.
 /// It outputs the final interpolated image to pv->eedi_full[DST2PF].


### PR DESCRIPTION
**Description of Change:**
I have optimized the below functions using arm neon intrinsics and I have observed around ~15% increase in the application speed for different test cases and presets in Windows-arm device. As this optimization doesn't seems to give good improvements for Mac, I have decided to guard it for windows-arm devices only.

1. detect_gamma_combed_segment()
2. detect_combed_segment()
3. blend_filter_pixel()



**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
