### PR TITLE
Force swscale filter instead of zscale for snapdragon devices

### DIFF
--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -788,6 +788,13 @@ int hb_av_can_use_zscale(enum AVPixelFormat pix_fmt,
                          int in_width, int in_height,
                          int out_width, int out_height)
 {
+
+#if defined (__aarch64__) && defined(_WIN32)
+    {
+        return 0;
+    }
+#endif
+
     if ((in_width % 2)  != 0 || (in_height % 2)  != 0 ||
         (out_width % 2) != 0 || (out_height % 2) != 0)
     {


### PR DESCRIPTION
This PR disables zcsale filter for Snapdragon devices. swscale gives upto 10% better performance for 1080p and 720p presets on Snapdragon devices.




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux