### PR TITLE
contrib: update libjpeg-turbo to 3.0.4

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libjpeg-turbo-3.0.3.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.3.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = a649205a90e39a548863a3614a9576a3fb4465f8e8e66d54999f127957c25b21
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.0.4.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.0.4.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 0270f9496ad6d69e743f1e7b9e3e9398f5b4d606b6a47744df4b73df50f62e38
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.0.4:**

Significant changes relative to 3.0.3:

- Fixed an issue whereby the CPU usage of the default marker processor in the decompressor grew exponentially with the number of markers. This caused an unreasonable slow-down in jpeg_read_header() if an application called jpeg_save_markers() to save markers of a particular type and then attempted to decompress a JPEG image containing an excessive number of markers of that type.

- Hardened the default marker processor in the decompressor to guard against an issue (exposed by 3.0 beta2[6]) whereby attempting to decompress a specially-crafted malformed JPEG image (specifically an image with a complete 12-bit-per-sample Start Of Frame segment followed by an incomplete 8-bit-per-sample Start Of Frame segment) using buffered-image mode and input prefetching caused a segfault if the fill_input_buffer() method in the calling application's custom source manager incorrectly returned FALSE in response to a prematurely-terminated JPEG data stream.

- Fixed an issue in cjpeg whereby, when generating a 12-bit-per-sample or 16-bit-per-sample lossless JPEG image, specifying a point transform value greater than 7 resulted in an error ("Invalid progressive/lossless parameters") unless the -precision option was specified before the -lossless option.

- Fixed a regression introduced by 3.0.3[3] that made it impossible for calling applications to generate 12-bit-per-sample arithmetic-coded lossy JPEG images using the TurboJPEG API.

- Fixed an error ("Destination buffer is not large enough") that occurred when attempting to generate a full-color lossless JPEG image using the TurboJPEG Java API's byte[] TJCompressor.compress() method if the value of TJ.PARAM_SUBSAMP was not TJ.SAMP_444.

- Fixed a segfault in djpeg that occurred if a negative width was specified with the -crop option. Since the cropping region width was read into an unsigned 32-bit integer, a negative width was interpreted as a very large value. With certain negative width and positive left boundary values, the bounds checks in djpeg and jpeg_crop_scanline() overflowed and did not detect the out-of-bounds width, which caused a buffer overrun in the upsampling or color conversion routine. Both bounds checks now use 64-bit integers to guard against overflow, and djpeg now checks for negative numbers when it parses the crop specification from the command line.

- Fixed an issue whereby the TurboJPEG lossless transformation function and methods checked the specified cropping region against the source image dimensions and level of chrominance subsampling rather than the destination image dimensions and level of chrominance subsampling, which caused some cropping regions to be unduly rejected when performing 90-degree rotation, 270-degree rotation, transposition, transverse transposition, or grayscale conversion.

- Fixed an issue whereby the TurboJPEG lossless transformation function and methods did not honor TJXOPT_COPYNONE/TJTransform.OPT_COPYNONE unless it was specified for all lossless transforms.
	
**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux