### PR TITLE
Windows-GUI: Make some "Filter" drop down menus text translatable

### DIFF
--- a/win/CS/HandBrakeWPF/Model/Filters/CombDetect.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/CombDetect.cs
@@ -30,11 +30,9 @@ namespace HandBrakeWPF.Model.Filters
         [ShortName("default")]
         Default,
 
-        [DisplayName(typeof(Resources), "CombDetect_LessSensitive")]
         [ShortName("permissive")]
         LessSensitive,
 
-        [DisplayName(typeof(Resources), "CombDetect_Fast")]
         [ShortName("fast")]
         Fast
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/CombDetect.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/CombDetect.cs
@@ -11,23 +11,30 @@ namespace HandBrakeWPF.Model.Filters
 {
     using HandBrake.Interop.Attributes;
 
+    using HandBrakeWPF.Properties;
+
     /// <summary>
     /// The CombDetect Type.
     /// </summary>
     public enum CombDetect
     {
-        [ShortName("off")]
+        [DisplayName(typeof(Resources), "CombDetect_Off")]
+		[ShortName("off")]
         Off,
 
+        [DisplayName(typeof(Resources), "CombDetect_Custom")]
         [ShortName("custom")]
         Custom,
 
+        [DisplayName(typeof(Resources), "CombDetect_Default")]
         [ShortName("default")]
         Default,
 
+        [DisplayName(typeof(Resources), "CombDetect_LessSensitive")]
         [ShortName("permissive")]
         LessSensitive,
 
+        [DisplayName(typeof(Resources), "CombDetect_Fast")]
         [ShortName("fast")]
         Fast
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
@@ -11,20 +11,26 @@ namespace HandBrakeWPF.Model.Filters
 {
     using HandBrake.Interop.Attributes;
 
+    using HandBrakeWPF.Properties;
+
     /// <summary>
     /// The deinterlace.
     /// </summary>
     public enum DeinterlaceFilter
     {
+        [DisplayName(typeof(Resources), "DeinterlaceFilter_Off")]
         [ShortName("off")]
         Off = 0,
 
+        [DisplayName(typeof(Resources), "DeinterlaceFilter_Yadif")]
         [ShortName("Yadif")]
         Yadif = 1,
 
+        [DisplayName(typeof(Resources), "DeinterlaceFilter_Decomb")]
         [ShortName("Decomb")]
         Decomb = 2,
 
+        [DisplayName(typeof(Resources), "DeinterlaceFilter_Bwdif")]
         [ShortName("Bwdif")]
         Bwdif = 3,
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/DeinterlaceFilter.cs
@@ -22,15 +22,12 @@ namespace HandBrakeWPF.Model.Filters
         [ShortName("off")]
         Off = 0,
 
-        [DisplayName(typeof(Resources), "DeinterlaceFilter_Yadif")]
         [ShortName("Yadif")]
         Yadif = 1,
 
-        [DisplayName(typeof(Resources), "DeinterlaceFilter_Decomb")]
         [ShortName("Decomb")]
         Decomb = 2,
 
-        [DisplayName(typeof(Resources), "DeinterlaceFilter_Bwdif")]
         [ShortName("Bwdif")]
         Bwdif = 3,
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/Denoise.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/Denoise.cs
@@ -11,17 +11,22 @@ namespace HandBrakeWPF.Model.Filters
 {
     using HandBrake.Interop.Attributes;
 
+    using HandBrakeWPF.Properties;
+
     /// <summary>
     /// The denoise.
     /// </summary>
     public enum Denoise
     {
-        [ShortName("off")]
+        [DisplayName(typeof(Resources), "Denoise_Off")]        
+		[ShortName("off")]
         Off = 0,
 
+        [DisplayName(typeof(Resources), "Denoise_Hqdn3d")]
         [ShortName("hqdn3d")]
         hqdn3d = 1,
 
+        [DisplayName(typeof(Resources), "Denoise_NLMeans")]
         [ShortName("nlmeans")]
         NLMeans = 2,
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/Denoise.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/Denoise.cs
@@ -22,11 +22,9 @@ namespace HandBrakeWPF.Model.Filters
 		[ShortName("off")]
         Off = 0,
 
-        [DisplayName(typeof(Resources), "Denoise_Hqdn3d")]
         [ShortName("hqdn3d")]
         hqdn3d = 1,
 
-        [DisplayName(typeof(Resources), "Denoise_NLMeans")]
         [ShortName("nlmeans")]
         NLMeans = 2,
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/Detelecine.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/Detelecine.cs
@@ -11,15 +11,22 @@ namespace HandBrakeWPF.Model.Filters
 {
     using HandBrake.Interop.Attributes;
 
+    using HandBrakeWPF.Properties;
+
     /// <summary>
     /// The detelecine.
     /// </summary>
     public enum Detelecine
     {
+        [DisplayName(typeof(Resources), "Detelecine_Off")]		
         [ShortName("off")]
         Off = 0,
+		
+        [DisplayName(typeof(Resources), "Detelecine_Default")]
         [ShortName("default")]
         Default = 2,
+		
+        [DisplayName(typeof(Resources), "Detelecine_Custom")]
         [ShortName("custom")]
         Custom = 1
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/Sharpen.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/Sharpen.cs
@@ -22,11 +22,9 @@ namespace HandBrakeWPF.Model.Filters
 		[ShortName("off")]
         Off,
 
-        [DisplayName(typeof(Resources), "Sharpen_Unsharp")]
         [ShortName("unsharp")]
         UnSharp,
 
-        [DisplayName(typeof(Resources), "Sharpen_LapSharp")]
         [ShortName("lapsharp")]
         LapSharp
     }

--- a/win/CS/HandBrakeWPF/Model/Filters/Sharpen.cs
+++ b/win/CS/HandBrakeWPF/Model/Filters/Sharpen.cs
@@ -11,17 +11,22 @@ namespace HandBrakeWPF.Model.Filters
 {
     using HandBrake.Interop.Attributes;
 
+    using HandBrakeWPF.Properties;
+
     /// <summary>
     /// The Sharpen.
     /// </summary>
     public enum Sharpen
     {
-        [ShortName("off")]
+        [DisplayName(typeof(Resources), "Sharpen_Off")]
+		[ShortName("off")]
         Off,
 
+        [DisplayName(typeof(Resources), "Sharpen_Unsharp")]
         [ShortName("unsharp")]
         UnSharp,
 
+        [DisplayName(typeof(Resources), "Sharpen_LapSharp")]
         [ShortName("lapsharp")]
         LapSharp
     }

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -8181,25 +8181,7 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("CombDetect_Default", resourceCulture);
             }
         }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to CombDetect LessSensitive.
-        /// </summary>
-        public static string CombDetect_LessSensitive {
-            get {
-                return ResourceManager.GetString("CombDetect_LessSensitive", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to CombDetect Fast.
-        /// </summary>
-        public static string CombDetect_Fast {
-            get {
-                return ResourceManager.GetString("CombDetect_Fast", resourceCulture);
-            }
-        }
-		
+				
 		/// <summary>
         ///   Looks up a localized string similar to DeinterlaceFilter Off.
         /// </summary>
@@ -8208,34 +8190,7 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("DeinterlaceFilter_Off", resourceCulture);
             }
         }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to DeinterlaceFilter Yadif.
-        /// </summary>
-        public static string DeinterlaceFilter_Yadif {
-            get {
-                return ResourceManager.GetString("DeinterlaceFilter_Yadif", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to DeinterlaceFilter Decomb.
-        /// </summary>
-        public static string DeinterlaceFilter_Decomb {
-            get {
-                return ResourceManager.GetString("DeinterlaceFilter_Decomb", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to DeinterlaceFilter Bwdif.
-        /// </summary>
-        public static string DeinterlaceFilter_Bwdif {
-            get {
-                return ResourceManager.GetString("DeinterlaceFilter_Bwdif", resourceCulture);
-            }
-        }
-		
+				
 		/// <summary>
         ///   Looks up a localized string similar to Denoise Off.
         /// </summary>
@@ -8244,25 +8199,7 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("Denoise_Off", resourceCulture);
             }
         }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to Denoise Hqdn3d.
-        /// </summary>
-        public static string Denoise_Hqdn3d {
-            get {
-                return ResourceManager.GetString("Denoise_Hqdn3d", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to Denoise NLMeans.
-        /// </summary>
-        public static string Denoise_NLMeans {
-            get {
-                return ResourceManager.GetString("Denoise_NLMeans", resourceCulture);
-            }
-        }
-		
+				
 		/// <summary>
         ///   Looks up a localized string similar to Detelecine Off.
         /// </summary>
@@ -8296,24 +8233,6 @@ namespace HandBrakeWPF.Properties {
         public static string Sharpen_Off {
             get {
                 return ResourceManager.GetString("Sharpen_Off", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to Sharpen Unsharp.
-        /// </summary>
-        public static string Sharpen_Unsharp {
-            get {
-                return ResourceManager.GetString("Sharpen_Unsharp", resourceCulture);
-            }
-        }
-		
-		/// <summary>
-        ///   Looks up a localized string similar to Sharpen LapSharp.
-        /// </summary>
-        public static string Sharpen_LapSharp {
-            get {
-                return ResourceManager.GetString("Sharpen_LapSharp", resourceCulture);
             }
         }
     }

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -8154,5 +8154,167 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("Yes", resourceCulture);
             }
         }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to CombDetect Off.
+        /// </summary>
+        public static string CombDetect_Off {
+            get {
+                return ResourceManager.GetString("CombDetect_Off", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to CombDetect Custom.
+        /// </summary>
+        public static string CombDetect_Custom {
+            get {
+                return ResourceManager.GetString("CombDetect_Custom", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to CombDetect Default.
+        /// </summary>
+        public static string CombDetect_Default {
+            get {
+                return ResourceManager.GetString("CombDetect_Default", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to CombDetect LessSensitive.
+        /// </summary>
+        public static string CombDetect_LessSensitive {
+            get {
+                return ResourceManager.GetString("CombDetect_LessSensitive", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to CombDetect Fast.
+        /// </summary>
+        public static string CombDetect_Fast {
+            get {
+                return ResourceManager.GetString("CombDetect_Fast", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to DeinterlaceFilter Off.
+        /// </summary>
+        public static string DeinterlaceFilter_Off {
+            get {
+                return ResourceManager.GetString("DeinterlaceFilter_Off", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to DeinterlaceFilter Yadif.
+        /// </summary>
+        public static string DeinterlaceFilter_Yadif {
+            get {
+                return ResourceManager.GetString("DeinterlaceFilter_Yadif", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to DeinterlaceFilter Decomb.
+        /// </summary>
+        public static string DeinterlaceFilter_Decomb {
+            get {
+                return ResourceManager.GetString("DeinterlaceFilter_Decomb", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to DeinterlaceFilter Bwdif.
+        /// </summary>
+        public static string DeinterlaceFilter_Bwdif {
+            get {
+                return ResourceManager.GetString("DeinterlaceFilter_Bwdif", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Denoise Off.
+        /// </summary>
+        public static string Denoise_Off {
+            get {
+                return ResourceManager.GetString("Denoise_Off", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Denoise Hqdn3d.
+        /// </summary>
+        public static string Denoise_Hqdn3d {
+            get {
+                return ResourceManager.GetString("Denoise_Hqdn3d", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Denoise NLMeans.
+        /// </summary>
+        public static string Denoise_NLMeans {
+            get {
+                return ResourceManager.GetString("Denoise_NLMeans", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Detelecine Off.
+        /// </summary>
+        public static string Detelecine_Off {
+            get {
+                return ResourceManager.GetString("Detelecine_Off", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Detelecine Default.
+        /// </summary>
+        public static string Detelecine_Default {
+            get {
+                return ResourceManager.GetString("Detelecine_Default", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Detelecine Custom.
+        /// </summary>
+        public static string Detelecine_Custom {
+            get {
+                return ResourceManager.GetString("Detelecine_Custom", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Sharpen Off.
+        /// </summary>
+        public static string Sharpen_Off {
+            get {
+                return ResourceManager.GetString("Sharpen_Off", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Sharpen Unsharp.
+        /// </summary>
+        public static string Sharpen_Unsharp {
+            get {
+                return ResourceManager.GetString("Sharpen_Unsharp", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Sharpen LapSharp.
+        /// </summary>
+        public static string Sharpen_LapSharp {
+            get {
+                return ResourceManager.GetString("Sharpen_LapSharp", resourceCulture);
+            }
+        }
     }
 }

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2897,32 +2897,11 @@ To allow multiple simultaneous encodes, turn on "Process Isolation" in Tools Men
   <data name="CombDetect_Default" xml:space="preserve">
     <value>Default</value>
   </data>
-  <data name="CombDetect_LessSensitive" xml:space="preserve">
-    <value>LessSensitive</value>
-  </data>
-  <data name="CombDetect_Fast" xml:space="preserve">
-    <value>Fast</value>
-  </data>
   <data name="DeinterlaceFilter_Off" xml:space="preserve">
     <value>Off</value>
   </data>
-  <data name="DeinterlaceFilter_Yadif" xml:space="preserve">
-    <value>Yadif</value>
-  </data>
-  <data name="DeinterlaceFilter_Decomb" xml:space="preserve">
-    <value>Decomb</value>
-  </data>
-  <data name="DeinterlaceFilter_Bwdif" xml:space="preserve">
-    <value>Bwdif</value>
-  </data>
   <data name="Denoise_Off" xml:space="preserve">
     <value>Off</value>
-  </data>
-  <data name="Denoise_Hqdn3d" xml:space="preserve">
-    <value>Hqdn3d</value>
-  </data>
-  <data name="Denoise_NLMeans" xml:space="preserve">
-    <value>NLMeans</value>
   </data>
   <data name="Detelecine_Off" xml:space="preserve">
     <value>Off</value>
@@ -2932,14 +2911,8 @@ To allow multiple simultaneous encodes, turn on "Process Isolation" in Tools Men
   </data>
   <data name="Detelecine_Custom" xml:space="preserve">
     <value>Custom</value>
-  </data>  
+  </data>
   <data name="Sharpen_Off" xml:space="preserve">
     <value>Off</value>
-  </data>
-  <data name="Sharpen_Unsharp" xml:space="preserve">
-    <value>Unsharp</value>
-  </data>
-  <data name="Sharpen_LapSharp" xml:space="preserve">
-    <value>LapSharp</value>
   </data>
 </root>

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2888,4 +2888,58 @@ To allow multiple simultaneous encodes, turn on "Process Isolation" in Tools Men
   <data name="AnamorphicMode_Automatic" xml:space="preserve">
     <value>Automatic</value>
   </data>
+  <data name="CombDetect_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="CombDetect_Custom" xml:space="preserve">
+    <value>Custom</value>
+  </data>
+  <data name="CombDetect_Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="CombDetect_LessSensitive" xml:space="preserve">
+    <value>LessSensitive</value>
+  </data>
+  <data name="CombDetect_Fast" xml:space="preserve">
+    <value>Fast</value>
+  </data>
+  <data name="DeinterlaceFilter_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="DeinterlaceFilter_Yadif" xml:space="preserve">
+    <value>Yadif</value>
+  </data>
+  <data name="DeinterlaceFilter_Decomb" xml:space="preserve">
+    <value>Decomb</value>
+  </data>
+  <data name="DeinterlaceFilter_Bwdif" xml:space="preserve">
+    <value>Bwdif</value>
+  </data>
+  <data name="Denoise_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Denoise_Hqdn3d" xml:space="preserve">
+    <value>Hqdn3d</value>
+  </data>
+  <data name="Denoise_NLMeans" xml:space="preserve">
+    <value>NLMeans</value>
+  </data>
+  <data name="Detelecine_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Detelecine_Default" xml:space="preserve">
+    <value>Default</value>
+  </data>
+  <data name="Detelecine_Custom" xml:space="preserve">
+    <value>Custom</value>
+  </data>  
+  <data name="Sharpen_Off" xml:space="preserve">
+    <value>Off</value>
+  </data>
+  <data name="Sharpen_Unsharp" xml:space="preserve">
+    <value>Unsharp</value>
+  </data>
+  <data name="Sharpen_LapSharp" xml:space="preserve">
+    <value>LapSharp</value>
+  </data>
 </root>


### PR DESCRIPTION
I still try make some drop-down menus text translatable but I could not translate these parts of it:

![grafik](https://github.com/user-attachments/assets/caad4bdb-f6c2-4441-a892-a1c77f3a1e56)
![grafik](https://github.com/user-attachments/assets/20302417-7ea6-49e9-a54a-abbfd0a43ae1)
![grafik](https://github.com/user-attachments/assets/8d8a4205-8d6c-4d32-8511-12171b574f6c)
![grafik](https://github.com/user-attachments/assets/f7225c4f-16d5-4051-bd75-40ef755b030a)
![grafik](https://github.com/user-attachments/assets/66747a8d-e433-4db9-8db9-7f9e421f0989)
![grafik](https://github.com/user-attachments/assets/785d96b5-f339-467d-88fa-95ace8c7a001)
![grafik](https://github.com/user-attachments/assets/74a76cf7-3fbc-439a-8320-6d4d4efc446b)
![grafik](https://github.com/user-attachments/assets/163ccc86-b1db-4f50-a567-63c2b9e34dec)
![grafik](https://github.com/user-attachments/assets/64c395bd-8a1c-4aa6-b110-735f51499616)
![grafik](https://github.com/user-attachments/assets/f36aba7f-4732-4aa5-9a5a-d96eac5a483f)

This options is also not text translatable currently:
![grafik](https://github.com/user-attachments/assets/57e54529-e8f1-4187-8f5d-f521634c6371)

I found out that these options are "hardcoded" in HandBrake\libh\param.c:

```
static hb_filter_param_t nlmeans_presets[] =
{
    { 1, "Custom",      "custom",     NULL              },
    { 5, "Ultralight",  "ultralight", NULL              },
    { 2, "Light",       "light",      NULL              },
    { 3, "Medium",      "medium",     NULL              },
    { 4, "Strong",      "strong",     NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t nlmeans_tunes[] =
{
    { 0, "None",        "none",       NULL              },
    { 1, "Film",        "film",       NULL              },
    { 2, "Grain",       "grain",      NULL              },
    { 3, "High Motion", "highmotion", NULL              },
    { 4, "Animation",   "animation",  NULL              },
    { 5, "Tape",        "tape",       NULL              },
    { 6, "Sprite",      "sprite",     NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t deblock_presets[] =
{
    { 0, "Off",         "off",        "disable=1"                  },
    { 1, "Custom",      "custom",     NULL                         },
    { 2, "Ultralight",  "ultralight", "strength=weak:thresh=20"    },
    { 3, "Light",       "light",      "strength=weak:thresh=50"    },
    { 4, "Medium",      "medium",     "strength=strong:thresh=20"  },
    { 5, "Strong",      "strong",     "strength=strong:thresh=50"  },
    { 5, "Stronger",    "stronger",   "strength=strong:thresh=75"  },
    { 5, "Very Strong", "verystrong", "strength=strong:thresh=100" },
    { 0, NULL,          NULL,         NULL                         }
};

static hb_filter_param_t deblock_tunes[] =
{
    { 1, "Small (4x4)",   "small",  "blocksize=4"  },
    { 2, "Medium (8x8)",  "medium", NULL           },
    { 3, "Large (16x16)", "large",  "blocksize=16" },
    { 0, NULL,            NULL,     NULL           }
};

static hb_filter_param_t hqdn3d_presets[] =
{
    { 1, "Custom",      "custom",     NULL              },
    { 5, "Ultralight",  "ultralight",
      "y-spatial=1:cb-spatial=0.7:cr-spatial=0.7:"
      "y-temporal=1:cb-temporal=2:cr-temporal=2"
                                                        },
    { 2, "Light",       "light",
      "y-spatial=2:cb-spatial=1:cr-spatial=1:"
      "y-temporal=2:cb-temporal=3:cr-temporal=3"
                                                        },
    { 3, "Medium",      "medium",
      "y-spatial=3:cb-spatial=2:cr-spatial=2:"
      "y-temporal=2:cb-temporal=3:cr-temporal=3"
                                                        },
    { 4, "Strong",      "strong",
      "y-spatial=7:cb-spatial=7:cr-spatial=7:"
      "y-temporal=5:cb-temporal=5:cr-temporal=5"
                                                        },
    { 0, NULL,          NULL,         NULL              },
    // Legacy and aliases go below the NULL
    { 2, "Weak",        "weak",
      "y-spatial=2:cb-spatial=1:cr-spatial=1:"
      "y-temporal=2:cb-temporal=3:cr-temporal=3"
                                                        },
    { 2, "Default",     "default",
      "y-spatial=2:cb-spatial=1:cr-spatial=1:"
      "y-temporal=2:cb-temporal=3:cr-temporal=3"
                                                        },
};

static hb_filter_param_t chroma_smooth_presets[] =
{
    { 0, "Off",         "off",        NULL              },
    { 1, "Custom",      "custom",     NULL              },
    { 2, "Ultralight",  "ultralight", NULL              },
    { 3, "Light",       "light",      NULL              },
    { 4, "Medium",      "medium",     NULL              },
    { 5, "Strong",      "strong",     NULL              },
    { 6, "Stronger",    "stronger",   NULL              },
    { 7, "Very Strong", "verystrong", NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t chroma_smooth_tunes[] =
{
    { 0, "None",        "none",       NULL              },
    { 1, "Tiny",        "tiny",       NULL              },
    { 2, "Small",       "small",      NULL              },
    { 3, "Medium",      "medium",     NULL              },
    { 4, "Wide",        "wide",       NULL              },
    { 5, "Very Wide",   "verywide",   NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t colorspace_presets[] =
{
    { 0, "Off",             "off",          NULL        },
    { 1, "Custom",          "custom",       NULL        },
    { 2, "BT.2020",         "bt2020",       "primaries=bt2020:transfer=bt2020-10:matrix=bt2020ncl:tonemap=hable:desat=0" },
    { 3, "BT.709",          "bt709",        "primaries=bt709:transfer=bt709:matrix=bt709:tonemap=hable:desat=0"          },
    { 4, "BT.601 SMPTE-C",  "bt601-6-525",  "primaries=smpte170m:transfer=bt709:matrix=smpte170m:tonemap=hable:desat=0"  },
    { 5, "BT.601 EBU",      "bt601-6-625",  "primaries=bt470bg:transfer=bt709:matrix=smpte170m:tonemap=hable:desat=0"    },
    { 0, NULL,              NULL,           NULL        }
};

static hb_filter_param_t unsharp_presets[] =
{
    { 1, "Custom",      "custom",     NULL              },
    { 2, "Ultralight",  "ultralight", NULL              },
    { 3, "Light",       "light",      NULL              },
    { 4, "Medium",      "medium",     NULL              },
    { 5, "Strong",      "strong",     NULL              },
    { 6, "Stronger",    "stronger",   NULL              },
    { 7, "Very Strong", "verystrong", NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t unsharp_tunes[] =
{
    { 0, "None",          "none",         NULL              },
    { 1, "Ultrafine",     "ultrafine",    NULL              },
    { 2, "Fine",          "fine",         NULL              },
    { 3, "Medium",        "medium",       NULL              },
    { 4, "Coarse",        "coarse",       NULL              },
    { 5, "Very Coarse",   "verycoarse",   NULL              },
    { 0, NULL,            NULL,           NULL              }
};

static hb_filter_param_t lapsharp_presets[] =
{
    { 1, "Custom",      "custom",     NULL              },
    { 2, "Ultralight",  "ultralight", NULL              },
    { 3, "Light",       "light",      NULL              },
    { 4, "Medium",      "medium",     NULL              },
    { 5, "Strong",      "strong",     NULL              },
    { 6, "Stronger",    "stronger",   NULL              },
    { 7, "Very Strong", "verystrong", NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t lapsharp_tunes[] =
{
    { 0, "None",        "none",       NULL              },
    { 1, "Film",        "film",       NULL              },
    { 2, "Grain",       "grain",      NULL              },
    { 3, "Animation",   "animation",  NULL              },
    { 4, "Sprite",      "sprite",     NULL              },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t detelecine_presets[] =
{
    { 0, "Off",         "off",        "disable=1"       },
    { 1, "Custom",      "custom",     NULL              },
    { 2, "Default",     "default",
      "skip-top=4:skip-bottom=4:skip-left=1:skip-right=1:plane=0"
                                                        },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t comb_detect_presets[] =
{
    { 0, "Off",             "off",        "disable=1"       },
    { 1, "Custom",          "custom",     NULL              },
    { 2, "Default",         "default",
      "mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:"
      "filter-mode=2:block-thresh=40:block-width=16:block-height=16"
                                                            },
    { 3, "Less Sensitive",  "permissive",
      "mode=3:spatial-metric=2:motion-thresh=3:spatial-thresh=3:"
      "filter-mode=2:block-thresh=40:block-width=16:block-height=16"
                                                            },
    { 4, "Fast",            "fast",
      "mode=0:spatial-metric=2:motion-thresh=2:spatial-thresh=3:"
      "filter-mode=1:block-thresh=80:block-width=16:block-height=16"
                                                            },
    { 0, NULL,              NULL,         NULL              }
};

static hb_filter_param_t decomb_presets[] =
{
    { 1, "Custom",      "custom",     NULL              },
    { 2, "Default",     "default",    "mode=7"          },
    { 4, "Bob",         "bob",        "mode=23"         },
    { 3, "EEDI2",       "eedi2",      "mode=15"         },
    { 4, "EEDI2 Bob",   "eedi2bob",   "mode=31"         },
    { 0, NULL,          NULL,         NULL              }
};

static hb_filter_param_t yadif_presets[] =
{
    { 1, "Custom",             "custom",       NULL             },
    { 3, "Default",            "default",      "mode=3"         },
    { 2, "Skip Spatial Check", "skip-spatial", "mode=1"         },
    { 5, "Bob",                "bob",          "mode=7"         },
    { 0,  NULL,                NULL,           NULL             },
    { 2, "Fast",               "fast",         "mode=1"         },
    { 3, "Slow",               "slow",         "mode=1"         },
    { 4, "Slower",             "slower",       "mode=3"         },
};

static hb_filter_param_t bwdif_presets[] =
{
    { 1, "Custom",             "custom",       NULL             },
    { 3, "Default",            "default",      "mode=3"         },
    { 2, "Bob",                "bob",          "mode=7"         },
    { 0,  NULL,                NULL,           NULL             },
};
```

Unfortunately, my programming knowledge is not sufficient to carry out the rest of the translation.
Perhaps someone can make the remaining adjustments?