### PR TITLE
qsv: enable av1 screen content coding

### DIFF
--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -86,6 +86,8 @@ typedef struct hb_qsv_info_s
 #define HB_QSV_CAP_AV1_BITSTREAM     (1LL << 41)
     // mfxExtHyperModeParam
 #define HB_QSV_CAP_HYPERENCODE       (1LL << 42)
+    // mfxExtAV1ScreenContentTools
+#define HB_QSV_CAP_AV1_SCREENCONTENT (1LL << 43)
 
     // TODO: add maximum encode resolution, etc.
 } hb_qsv_info_t;
@@ -163,12 +165,13 @@ typedef struct
      * This should cover all encode-compatible extended
      * buffers that can be attached to an mfxVideoParam.
      */
-#define HB_QSV_ENC_NUM_EXT_PARAM_MAX 10
+#define HB_QSV_ENC_NUM_EXT_PARAM_MAX 16
     mfxExtBuffer*         ExtParamArray[HB_QSV_ENC_NUM_EXT_PARAM_MAX];
     mfxExtCodingOption    codingOption;
     mfxExtCodingOption2   codingOption2;
     mfxExtVideoSignalInfo videoSignalInfo;
     mfxExtHyperModeParam hyperEncodeParam;
+    mfxExtAV1ScreenContentTools av1ScreenContentToolsParam;
     mfxExtChromaLocInfo   chromaLocInfo;
     mfxExtMasteringDisplayColourVolume masteringDisplayColourVolume;
     mfxExtContentLightLevelInfo        contentLightLevelInfo;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -995,8 +995,8 @@ static void init_ext_av1screencontent_tools(mfxExtAV1ScreenContentTools *extScre
     memset(extScreenContentTools, 0, sizeof(mfxExtAV1ScreenContentTools));
     extScreenContentTools->Header.BufferId = MFX_EXTBUFF_AV1_SCREEN_CONTENT_TOOLS;
     extScreenContentTools->Header.BufferSz = sizeof(mfxExtAV1ScreenContentTools);
-    extScreenContentTools->IntraBlockCopy  = MFX_CODINGOPTION_ON;
-    extScreenContentTools->Palette         = MFX_CODINGOPTION_ON;
+    extScreenContentTools->IntraBlockCopy  = MFX_CODINGOPTION_OFF;
+    extScreenContentTools->Palette         = MFX_CODINGOPTION_OFF;
 }
 
 static int query_capabilities(mfxSession session, int index, mfxVersion version, hb_qsv_info_t *info, int lowpower)
@@ -1489,7 +1489,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
             videoParam.NumExtParam = 1;
 
             status = MFXVideoENCODE_Query(session, NULL, &videoParam);
-            if (status >= MFX_ERR_NONE)
+            if (status >= MFX_ERR_NONE && extAV1ScreenContentToolsParam.IntraBlockCopy != 0)
             {
                 info->capabilities |= HB_QSV_CAP_AV1_SCREENCONTENT;
             }

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -984,6 +984,20 @@ static void init_ext_av1bitstream_option(mfxExtAV1BitstreamParam *extAV1Bitstrea
     extAV1BitstreamParam->WriteIVFHeaders = MFX_CODINGOPTION_OFF;
 }
 
+static void init_ext_av1screencontent_tools(mfxExtAV1ScreenContentTools *extScreenContentTools)
+{
+    if (extScreenContentTools == NULL)
+    {
+        return;
+    }
+
+    memset(extScreenContentTools, 0, sizeof(mfxExtAV1ScreenContentTools));
+    extScreenContentTools->Header.BufferId = MFX_EXTBUFF_AV1_SCREEN_CONTENT_TOOLS;
+    extScreenContentTools->Header.BufferSz = sizeof(mfxExtAV1ScreenContentTools);
+    extScreenContentTools->IntraBlockCopy  = MFX_CODINGOPTION_ON;
+    extScreenContentTools->Palette         = MFX_CODINGOPTION_ON;
+}
+
 static int query_capabilities(mfxSession session, int index, mfxVersion version, hb_qsv_info_t *info, int lowpower)
 {
     /*
@@ -1002,7 +1016,6 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
      * - MFXVideoENCODE_Query should sanitize all unsupported parameters
      */
     mfxStatus     status;
-
     mfxExtBuffer *videoExtParam[1];
     mfxVideoParam videoParam, inputParam;
     mfxExtCodingOption    extCodingOption;
@@ -1012,6 +1025,7 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
     mfxExtMasteringDisplayColourVolume  extMasteringDisplayColourVolume;
     mfxExtContentLightLevelInfo         extContentLightLevelInfo;
     mfxExtAV1BitstreamParam extAV1BitstreamParam;
+    mfxExtAV1ScreenContentTools extAV1ScreenContentToolsParam;
     mfxExtHyperModeParam extHyperEncodeParam;
 
     /* Reset capabilities before querying */
@@ -1462,6 +1476,23 @@ static int query_capabilities(mfxSession session, int index, mfxVersion version,
                 info->capabilities |= HB_QSV_CAP_AV1_BITSTREAM;
             }
         }
+        if ((lowpower == MFX_CODINGOPTION_ON) && (info->codec_id == MFX_CODEC_AV1))
+        {
+            init_video_param(&videoParam);
+            videoParam.mfx.CodecId = info->codec_id;
+            videoParam.mfx.LowPower = lowpower;
+            init_ext_av1screencontent_tools(&extAV1ScreenContentToolsParam);
+
+            videoParam.ExtParam    = videoExtParam;
+            videoParam.ExtParam[0] = (mfxExtBuffer*)&extAV1ScreenContentToolsParam;
+            videoParam.NumExtParam = 1;
+
+            status = MFXVideoENCODE_Query(session, NULL, &videoParam);
+            if (status >= MFX_ERR_NONE)
+            {
+                info->capabilities |= HB_QSV_CAP_AV1_SCREENCONTENT;
+            }
+        }
     }
 
     return 0;
@@ -1902,6 +1933,10 @@ static void log_encoder_capabilities(const int log_level, const uint64_t caps, c
         {
             strcat(buffer, "+nmpslice");
         }
+    }
+    if (caps & HB_QSV_CAP_AV1_SCREENCONTENT)
+    {
+        strcat(buffer, " av1screencontent");
     }
     if (caps & HB_QSV_CAP_HYPERENCODE)
     {
@@ -2975,6 +3010,36 @@ int hb_qsv_param_parse(hb_qsv_param_t *param, hb_qsv_info_t *info, hb_job_t *job
             param->hyperEncodeParam.Mode = mode->value;
         }
     }
+    else if (!strcasecmp(key, "palette"))
+    {
+        if (info->capabilities & HB_QSV_CAP_AV1_SCREENCONTENT)
+        {
+            ivalue = hb_qsv_atobool(value, &error);
+            if (!error)
+            {
+                param->av1ScreenContentToolsParam.Palette = ivalue ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+            }
+        }
+        else
+        {
+            return HB_QSV_PARAM_UNSUPPORTED;
+        }
+    }
+    else if (!strcasecmp(key, "intrabc"))
+    {
+        if (info->capabilities & HB_QSV_CAP_AV1_SCREENCONTENT)
+        {
+            ivalue = hb_qsv_atobool(value, &error);
+            if (!error)
+            {
+                param->av1ScreenContentToolsParam.IntraBlockCopy = ivalue ? MFX_CODINGOPTION_ON : MFX_CODINGOPTION_OFF;
+            }
+        }
+        else
+        {
+            return HB_QSV_PARAM_UNSUPPORTED;
+        }
+    }
     else if (!strcasecmp(key, "async-depth"))
     {
         int async_depth = hb_qsv_atoi(value, &error);
@@ -3461,6 +3526,12 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         param->av1BitstreamParam.Header.BufferId = MFX_EXTBUFF_AV1_BITSTREAM_PARAM;
         param->av1BitstreamParam.Header.BufferSz = sizeof(mfxExtAV1BitstreamParam);
         param->av1BitstreamParam.WriteIVFHeaders = MFX_CODINGOPTION_OFF;
+        // introduced in API 2.11
+        memset(&param->av1ScreenContentToolsParam, 0, sizeof(mfxExtAV1ScreenContentTools));
+        param->av1ScreenContentToolsParam.Header.BufferId = MFX_EXTBUFF_AV1_SCREEN_CONTENT_TOOLS;
+        param->av1ScreenContentToolsParam.Header.BufferSz = sizeof(mfxExtAV1ScreenContentTools);
+        param->av1ScreenContentToolsParam.IntraBlockCopy  = MFX_CODINGOPTION_OFF;
+        param->av1ScreenContentToolsParam.Palette         = MFX_CODINGOPTION_OFF;
 
         // GOP & rate control
         param->gop.b_pyramid          =  1; // enabled by default (if supported)
@@ -3534,6 +3605,10 @@ int hb_qsv_param_default(hb_qsv_param_t *param, mfxVideoParam *videoParam,
         if (info->capabilities & HB_QSV_CAP_AV1_BITSTREAM)
         {
             param->videoParam->ExtParam[param->videoParam->NumExtParam++] = (mfxExtBuffer*)&param->av1BitstreamParam;
+        }
+        if (info->capabilities & HB_QSV_CAP_AV1_SCREENCONTENT)
+        {
+            param->videoParam->ExtParam[param->videoParam->NumExtParam++] = (mfxExtBuffer*)&param->av1ScreenContentToolsParam;
         }
 #if defined(_WIN32) || defined(__MINGW32__)
         if (info->capabilities & HB_QSV_CAP_LOWPOWER_ENCODE)

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -464,6 +464,7 @@ int qsv_map_mfx_platform_codename(int mfx_platform_codename)
     case MFX_PLATFORM_ALDERLAKE_N:
     case MFX_PLATFORM_KEEMBAY:
     case MFX_PLATFORM_METEORLAKE:
+    case MFX_PLATFORM_BATTLEMAGE:
     case MFX_PLATFORM_ARROWLAKE:
         platform = HB_CPU_PLATFORM_INTEL_DG2;
         break;


### PR DESCRIPTION
Enable AV1 screen content coding(SCC) feature which is available on Lunar Lake (Xe2 Graphics)

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux