### PR TITLE
contrib: update fribidi to 1.0.16

### DIFF
--- a/contrib/fribidi/module.defs
+++ b/contrib/fribidi/module.defs
@@ -1,10 +1,10 @@
 $(eval $(call import.MODULE.defs,FRIBIDI,fribidi))
 $(eval $(call import.CONTRIB.defs,FRIBIDI))
 
-FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/fribidi-1.0.15.tar.gz
-FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.15.tar.gz
-FRIBIDI.FETCH.sha256   = 0db5f0621b6fbfae5960c30da4f132009fd72bf4687f1b04a87a4cfc2a08ea38
-FRIBIDI.FETCH.basename = fribidi-1.0.15.tar.gz
+FRIBIDI.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/fribidi-1.0.16.tar.gz
+FRIBIDI.FETCH.url     += https://github.com/fribidi/fribidi/archive/v1.0.16.tar.gz
+FRIBIDI.FETCH.sha256   = 5a1d187a33daa58fcee2ad77f0eb9d136dd6fa4096239199ba31e850d397e8a8
+FRIBIDI.FETCH.basename = fribidi-1.0.16.tar.gz
 
 FRIBIDI.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -I m4 -fiv;
 


### PR DESCRIPTION
**fribidi 1.0.16:**

- Updated Unicode tables to version 16.0

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux