### PR TITLE
hwaccel: selectively enable directx hwaccel for snapdragon

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -312,6 +312,33 @@ hb_encoder_internal_t hb_video_encoders[]  =
     { { "Theora",                      "theora",           "Theora (libtheora)",             HB_VCODEC_THEORA,                                             HB_MUX_MASK_MKV, }, NULL, 0, 1, HB_GID_VCODEC_THEORA,     },
 };
 int hb_video_encoders_count = sizeof(hb_video_encoders) / sizeof(hb_video_encoders[0]);
+
+#if HB_PROJECT_FEATURE_MF
+int hb_is_hw_decoding_supported(const char *preset_name, const char *vcodec) 
+{
+    if (!vcodec) {
+        if (strcmp(preset_name, "Very Fast 720p30") == 0 || strcmp(preset_name, "Very Fast 1080p30") == 0)
+        {
+            return 0;
+        }
+        else
+        {
+            return 1;
+        }
+    }
+
+    int vcodec_id = hb_video_encoder_get_from_name(vcodec);
+    switch (vcodec_id)
+    {
+        case HB_VCODEC_FFMPEG_MF_H264:
+        case HB_VCODEC_FFMPEG_MF_H265:
+            return 0;
+        default:
+            return 1;
+    }
+}
+#endif
+
 static int hb_video_encoder_is_enabled(int encoder, int disable_hardware)
 {
     // Hardware Encoders

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -489,6 +489,10 @@ const char*         hb_video_encoder_get_long_name(int encoder);
 const char*         hb_video_encoder_sanitize_name(const char *name);
 const hb_encoder_t* hb_video_encoder_get_next(const hb_encoder_t *last);
 
+#if HB_PROJECT_FEATURE_MF
+int                 hb_is_hw_decoding_supported(const char *preset_name, const char *vcodec);
+#endif
+
 /*
  * hb_audio_encoder_get_fallback_for_passthru() will sanitize a passthru codec
  * to the matching audio encoder (if any is available).

--- a/test/test.c
+++ b/test/test.c
@@ -3243,6 +3243,12 @@ static int ParseOptions( int argc, char ** argv )
         }
 
     }
+#if HB_PROJECT_FEATURE_MF
+    if (hw_decode == -1 && hb_is_hw_decoding_supported(preset_name, vcodec))
+    {
+        hw_decode = HB_DECODE_SUPPORT_MF;
+    }
+#endif
 
     if (deblock != NULL)
     {

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1953,6 +1953,12 @@ namespace HandBrakeWPF.ViewModels
                         }
                     }
 
+                    if (SystemInfo.IsArmDevice && (preset.Name == "Very Fast 720p30" || preset.Name == "Very Fast 1080p30"))
+                    {
+                        this.userSettingService.SetUserSetting(UserSettingConstants.EnableDirectXDecoding, false);
+
+                    }
+
                     return true;
                 }
             }

--- a/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
@@ -24,6 +24,7 @@ namespace HandBrakeWPF.ViewModels
     using HandBrakeWPF.Services.Interfaces;
     using HandBrakeWPF.Services.Presets.Model;
     using HandBrakeWPF.Services.Scan.Model;
+    using HandBrakeWPF.Utilities;
     using HandBrakeWPF.ViewModels.Interfaces;
 
     using Clipboard = System.Windows.Clipboard;
@@ -329,6 +330,10 @@ namespace HandBrakeWPF.ViewModels
                     this.HandleRFChange();
                     this.OnTabStatusChanged(null);
 
+                    if (SystemInfo.IsArmDevice)
+                    {
+                        this.userSettingService.SetUserSetting(UserSettingConstants.EnableDirectXDecoding, !value.IsMediaFoundation);
+                    }
                     this.OnTabStatusChanged(new TabStatusEventArgs("filters", ChangedOption.Encoder));
 
                     this.NotifyOfPropertyChange(() => this.IsQualitySupported);


### PR DESCRIPTION
**Description of Change:**
- This PR enables hwaccel using DirectX for Snapdragon devices by default for all the recommended cases
- It was observed that hardware accelerated decoding was speeding up most of the complex transcodes (4K, HQ, Super HQ, etc), but for Very Fast 720p and 1080p x264 encodes, it wasn't providing much benefit
- Also when Hardware encoders are used, the intermediate data transfer between GPU and CPU is causing an overhead thereby reducing the overall FPS. Hence hwaccel is disabled for these cases and enabled for the rest by default




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux