### PR TITLE
Fix crashing if "When Done" is set under Japanese locale.

### DIFF
--- a/gtk/po/ja.po
+++ b/gtk/po/ja.po
@@ -2410,7 +2410,7 @@ msgstr "HandBrakeを再起動する必要があります。"
 #: src/callbacks.c:3920
 #, c-format
 msgid "%s in %d seconds…"
-msgstr "%d秒で%s"
+msgstr "%sまで後 %d 秒"
 
 #: src/callbacks.c:4097
 msgid "Stop Encoding?"
@@ -2521,15 +2521,15 @@ msgstr "エンコードが完了しました。"
 
 #: src/callbacks.c:5479
 msgid "Quitting HandBrake"
-msgstr "HandBrakeを閉じています"
+msgstr "HandBrake を終了する"
 
 #: src/callbacks.c:5486
 msgid "Putting computer to sleep"
-msgstr "コンピューターをスリープします"
+msgstr "コンピューターをスリープする"
 
 #: src/callbacks.c:5494
 msgid "Shutting down the computer"
-msgstr "コンピューターをシャットダウンします"
+msgstr "コンピューターをシャットダウンする"
 
 #. Add filters
 #: src/callbacks.c:5608 src/chapters.c:458 src/chapters.c:487


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

The order of '%s' and '%d' must be as same as the English message. Change the Japanese translation to keep the order. Updated messages what HandBrake will do when encoding is done to keep consistent with "When Done" select box.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] FreeBSD

**Screenshots (If relevant):**


**Log file output (If relevant):**
