### PR TITLE
Optimization for H.264 encoder quality

### DIFF
--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -14,7 +14,7 @@ int            hb_vce_h264_available();
 int            hb_vce_h265_available();
 int            hb_vce_av1_available();
 
-static const char * const hb_vce_h264_profile_names[] = { "baseline", "main", "high",  NULL, };
+static const char * const hb_vce_h264_profile_names[] = { "auto", "baseline", "main", "high",  NULL, };
 static const char * const hb_vce_h265_profile_names[] = { "main", NULL, };
 static const char * const hb_vce_h265_10bit_profile_names[] = { "main10", NULL, };
 static const char * const hb_vce_av1_profile_names[]  = { "main", NULL, };


### PR DESCRIPTION
**Description of Change:**
This is a optimization for H.264 AMD VCE encoder quality
This PR will change the H.264 AMD VCE encoder profile to "auto" by default. 
Therefore, the H.264 encoder profile will follow AMD VCE default setting. 

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux