### PR TITLE
build: add -march=native flag for mingw arm64 builds

### DIFF
--- a/make/variant/mingw.defs
+++ b/make/variant/mingw.defs
@@ -10,3 +10,6 @@ GCC.args.g.std  = -g2
 GCC.args.g.max  = -g3
 
 GCC.args.extra += -mno-ms-bitfields
+ifeq (aarch64,$(HOST.machine))
+    GCC.args.extra   += -march=native
+endif


### PR DESCRIPTION
Adds `-march=native` flag to automatically detect CPU features during build time to generate code optimized specifically for that device's CPU architecture




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux