### PR TITLE
WinGUI: add info tooltip for DirectX decoding

### DIFF
--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.Designer.cs
@@ -791,7 +791,18 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("SubtitleView_SubtitleDefaults", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Disable Hardware Acceleration in "Tools Menu -&gt; Preferences -&gt; Video" for best performance..
+        /// </summary>
+        public static string VideoView_DisableHwaccelHint
+        {
+            get
+            {
+                return ResourceManager.GetString("VideoView_DisableHwaccelHint", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   Looks up a localized string similar to Set the average bitrate.
         ///

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
@@ -560,4 +560,7 @@ Bitrate will vary source to source.</value>
   <data name="Options_RemovePunctuation" xml:space="preserve">
     <value>Dash (-), Period (.) and Comma (,)</value>
   </data>
+  <data name="VideoView_DisableHwaccelHint" xml:space="preserve">
+    <value>Disable DirectX Decoding in "Tools Menu -&gt; Preferences -&gt; Video" for best performance</value>
+  </data>
 </root>

--- a/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/VideoViewModel.cs
@@ -24,6 +24,7 @@ namespace HandBrakeWPF.ViewModels
     using HandBrakeWPF.Services.Interfaces;
     using HandBrakeWPF.Services.Presets.Model;
     using HandBrakeWPF.Services.Scan.Model;
+    using HandBrakeWPF.Utilities;
     using HandBrakeWPF.ViewModels.Interfaces;
 
     using Clipboard = System.Windows.Clipboard;
@@ -54,6 +55,7 @@ namespace HandBrakeWPF.ViewModels
         private bool displayTuneControls;
         private bool displayLevelControl;
         private bool displayProfileControl;
+        private bool isHwAccelHintVisible;
         private Dictionary<string, string> encoderOptions = new Dictionary<string, string>();
 
         public VideoViewModel(IUserSettingService userSettingService, IErrorService errorService)
@@ -137,7 +139,17 @@ namespace HandBrakeWPF.ViewModels
         public bool? IsQualitySupported => this.SelectedVideoEncoder?.SupportsQuality;
         public bool? IsQualityAdjustmentSupported => this.SelectedVideoEncoder?.SupportsQualityAdjustment;
         public bool? IsBitrateSupported => this.SelectedVideoEncoder?.SupportsBitrate;
-        
+
+        public bool IsHwAccelHintVisible
+        {
+            get => isHwAccelHintVisible;
+            set
+            {
+                isHwAccelHintVisible = value;
+                NotifyOfPropertyChange(() => IsHwAccelHintVisible);
+            }
+        }
+
         public bool IsPeakFramerate
         {
             get => this.Task.FramerateMode == FramerateMode.PFR;
@@ -329,6 +341,10 @@ namespace HandBrakeWPF.ViewModels
                     this.HandleRFChange();
                     this.OnTabStatusChanged(null);
 
+                    if (SystemInfo.IsArmDevice)
+                    {
+                        IsHwAccelHintVisible = value.IsMediaFoundation && this.UserSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding);
+                    }
                     this.OnTabStatusChanged(new TabStatusEventArgs("filters", ChangedOption.Encoder));
 
                     this.NotifyOfPropertyChange(() => this.IsQualitySupported);

--- a/win/CS/HandBrakeWPF/Views/VideoView.xaml
+++ b/win/CS/HandBrakeWPF/Views/VideoView.xaml
@@ -55,7 +55,29 @@
                     </ComboBox>
 
                 </StackPanel>
-
+                <Border Background="#E3F2FD" 
+                        HorizontalAlignment="Left"
+                        BorderBrush="#64B5F6" 
+                        BorderThickness="1" 
+                        CornerRadius="5" 
+                        Padding="5" 
+                        Margin="0,0,0,10" 
+                        Visibility="{Binding IsHwAccelHintVisible, Converter={StaticResource boolToVisConverter}}" >
+                    <StackPanel Orientation="Horizontal">
+                        <TextBlock Text="ℹ️" 
+                                   Foreground="#64B5F6" 
+                                   FontSize="12"
+                                   FontWeight="Bold" 
+                                   VerticalAlignment="Center"
+                                   Margin="0,0,5,0" />
+                        <TextBlock Text="{x:Static Properties:ResourcesTooltips.VideoView_DisableHwaccelHint}"
+                                   MaxWidth="250"
+                                   Foreground="#1E88E5" 
+                                   VerticalAlignment="Center"
+                                   TextWrapping="Wrap"
+                                   FontSize="12" />
+                    </StackPanel>
+                </Border>
                 <StackPanel Orientation="Horizontal">
                     <TextBlock Text="{x:Static Properties:Resources.VideoView_Framerate}" VerticalAlignment="Top" Margin="0,5,0,0" Width="100"/>
                     <StackPanel Orientation="Vertical">


### PR DESCRIPTION
Add a info tooltip to let uses know better performance (in terms of speed) can be achieved when DirectX decoding is disabled for MF encoders. The tooltip will be shown only when MF encoder is selected and when DirectX decoding is enabled in the preferences.

This PR closes #6333 



**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
![image](https://github.com/user-attachments/assets/d4a7788c-4e74-480a-87e4-15ab2f32804f)
