### PR TITLE
contrib: update libdav1d to 1.5.0

### DIFF
--- a/contrib/libdav1d/A99-pkgconfig-location.patch
+++ b/contrib/libdav1d/A99-pkgconfig-location.patch
@@ -1,6 +1,6 @@
 --- dav1d-1.4.0/src/meson.build	2024-02-14 19:06:02.000000000 +0100
 +++ dav1d-1.4.0-patched/src/meson.build	2024-02-15 17:27:23.400210200 +0100
-@@ -370,6 +370,7 @@
+@@ -400,6 +400,7 @@
  #
  pkg_mod = import('pkgconfig')
  pkg_mod.generate(libraries: libdav1d,

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.4.3.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.4.3/dav1d-1.4.3.tar.bz2
-LIBDAV1D.FETCH.sha256  = 2a7e68a17b22d1c060d31a7af84c8e033a145fca1d63ef36d57f0f39eb4dd0df
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.5.0.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.5.0/dav1d-1.5.0.tar.bz2
+LIBDAV1D.FETCH.sha256  = a6ca64e34cec56ae1c2d359e1da5c5386ecd7a3a62f931d026ac4f2ff72ade64
 
 LIBDAV1D.build_dir     = build/
 


### PR DESCRIPTION
**Changes for 1.5.0 "Sonic":**

**WARNING:
Some of the SSE2 optimizations are removed, so if you care about systems without SSSE3, you should be careful when updating!**
- Add Arm OpenBSD run-time CPU feature
- Optimize index offset calculations for decode_coefs
- picture: copy HDR10+ and T35 metadata only to visible frames
- SSSE3 new optimizations for 6-tap (8bit and hbd)
- AArch64/SVE: Add HBD subpel filters using 128-bit SVE2
- AArch64: Add USMMLA implempentation for 6-tap H/HV
- AArch64: Optimize Armv8.0 NEON for HBD horizontal filters and 6-tap filters
- Power9: Optimized ITX till 16x4.
- Loongarch: numerous optimizations
- RISC-V optimizations for pal, cdef_filter, ipred, mc_blend, mc_bdir, itx
- Allow playing videos in full-screen mode in dav1dplay

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux

Do any further adjustments/patches need to be made to HandBrake due to the loss of SSE2 support?