### PR TITLE
encavcodec: set MF AVScenario to ARCHIVE by default

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -603,6 +603,10 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
             snprintf(quality, 7, "%d", (int)job->vquality);
             av_dict_set(&av_opts, "rate_control", "quality", 0);
             av_dict_set(&av_opts, "quality", quality, 0);
+            if (!av_dict_get(av_opts, "scenario", NULL, 0))
+            {
+                av_dict_set(&av_opts, "scenario", "archive", 0);
+            }
         }
         else
         {


### PR DESCRIPTION
For general transcode use cases, AVScenario ICODEC property to be set to ARCHIVE for the MediaFoundation encoders.
This PR sets the default AVScenario to ARCHIVE, if its not already set by the user.




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux