### PR TITLE
hwaccel: fix regression

### DIFF
--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -715,7 +715,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
     {
         hw_decode = HB_DECODE_SUPPORT_VIDEOTOOLBOX;
     }
-    else if (data->hw_decode & HB_DECODE_SUPPORT_MF &&
+    else if (data->hw_decode == HB_DECODE_SUPPORT_MF &&
              hb_hwaccel_available(title->video_codec_param, "d3d11va"))
     {
         hw_decode = HB_DECODE_SUPPORT_MF;


### PR DESCRIPTION
Fix regression in CLI binary after commit https://github.com/HandBrake/HandBrake/commit/4546b29e08c77537de5d91b81a6c0a7dcaae7881

if `hw_decode` is not set it has default value `-1` which is  `0xFF`, `data->hw_decode & HB_DECODE_SUPPORT_MF` is always `true`.

All other HW vendors use an equality operator above.