### PR TITLE
WinGUI: set hyper encode to off by default

### DIFF
--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -317,7 +317,7 @@ namespace HandBrakeWPF.Services
             bool nvidiaDefaultSetting = HandBrakeHardwareEncoderHelper.IsNVEncH264Available;
 
             defaults.Add(UserSettingConstants.EnableQuickSyncDecoding, intelDefaultSetting);
-            defaults.Add(UserSettingConstants.EnableQuickSyncHyperEncode, intelDefaultSetting);
+            defaults.Add(UserSettingConstants.EnableQuickSyncHyperEncode, false);
             defaults.Add(UserSettingConstants.UseQSVDecodeForNonQSVEnc, false);
             defaults.Add(UserSettingConstants.EnableNvDecSupport, nvidiaDefaultSetting);
             defaults.Add(UserSettingConstants.EnableQuickSyncLowPower, true);


### PR DESCRIPTION
By default prefer to use this setting disabled, especially when this is no second GPU it limits number of simultaneous encodes to 1.
https://github.com/HandBrake/HandBrake/blob/14904d6cb0d4b5f289b60304ec0becb13a8c209c/win/CS/HandBrakeWPF/Services/Queue/QueueResourceService.cs#L81 