### PR TITLE
contrib: update HarfBuzz to 10.1.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.0.1.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.0.1/harfbuzz-10.0.1.tar.xz
-HARFBUZZ.FETCH.sha256  = b2cb13bd351904cb9038f907dc0dee0ae07127061242fe3556b2795c4e9748fc
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.1.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.1.0/harfbuzz-10.1.0.tar.xz
+HARFBUZZ.FETCH.sha256  = 6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 10.1.0:**

What's Changed
- Fix the sign of fallback vertical glyph advance (used when font has no vertical advance data).
- Increase maximum “CFF” operands limit 20 times to support more complex fonts.
- Add “--face-loader” option to command line utilities.
- Support “COLR” v0 table in hb_font_get_glyph_extents().
- Add support for font functions that use Core Text APIs, similar to FreeType font functions. This allows, for example, using drawing fonts that use the new (and undocumented) “hvgl” table.
- Update IANA and OT language registries, as well ase USE data files.
- Fix build with ICU 76.
- Various compiler warnings and build fixes.
- Various subsetter fixes.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux