### PR TITLE
[macOS] Add swedish language

### DIFF
--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -949,6 +949,43 @@
 		A9F5E34E2215D85A0046FA4B /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/ChaptersTitles.strings; sourceTree = "<group>"; };
 		A9F7102419A475EC00F61301 /* HBDockTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = HBDockTile.h; sourceTree = "<group>"; };
 		A9F7102519A475EC00F61301 /* HBDockTile.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = HBDockTile.m; sourceTree = "<group>"; };
+		D011F3E02CE104B200B934D3 /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D011F3E12CE104D600B934D3 /* uk_UA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk_UA; path = uk_UA.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D012B4832CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AddPreset.strings; sourceTree = "<group>"; };
+		D012B4842CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Audio.strings; sourceTree = "<group>"; };
+		D012B4852CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/AudioDefaults.strings; sourceTree = "<group>"; };
+		D012B4862CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/ChaptersTitles.strings; sourceTree = "<group>"; };
+		D012B4872CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/ExceptionAlert.strings; sourceTree = "<group>"; };
+		D012B4882CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBAddCategoryController.strings; sourceTree = "<group>"; };
+		D012B4892CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBCroppingView.strings; sourceTree = "<group>"; };
+		D012B48A2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBEncodingProgressHUDController.strings; sourceTree = "<group>"; };
+		D012B48B2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBFiltersViewController.strings; sourceTree = "<group>"; };
+		D012B48C2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBPictureHUDController.strings; sourceTree = "<group>"; };
+		D012B48D2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBPictureViewController.strings; sourceTree = "<group>"; };
+		D012B48E2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBPlayerHUDController.strings; sourceTree = "<group>"; };
+		D012B48F2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBPreviewViewController.strings; sourceTree = "<group>"; };
+		D012B4902CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBQueueInfoViewController.strings; sourceTree = "<group>"; };
+		D012B4912CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBQueueTableViewController.strings; sourceTree = "<group>"; };
+		D012B4922CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBRenamePresetController.strings; sourceTree = "<group>"; };
+		D012B4932CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBSummaryViewController.strings; sourceTree = "<group>"; };
+		D012B4942CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBTitleSelection.strings; sourceTree = "<group>"; };
+		D012B4962CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/HBTrackTitleViewController.strings; sourceTree = "<group>"; };
+		D012B4972CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		D012B4982CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/MainWindow.strings; sourceTree = "<group>"; };
+		D012B4992CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/OutputPanel.strings; sourceTree = "<group>"; };
+		D012B49A2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/PicturePreview.strings; sourceTree = "<group>"; };
+		D012B49B2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Preferences.strings; sourceTree = "<group>"; };
+		D012B49C2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Presets.strings; sourceTree = "<group>"; };
+		D012B49D2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Queue.strings; sourceTree = "<group>"; };
+		D012B49E2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Subtitles.strings; sourceTree = "<group>"; };
+		D012B49F2CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/SubtitlesDefaults.strings; sourceTree = "<group>"; };
+		D012B4A02CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Video.strings; sourceTree = "<group>"; };
+		D012B4A42CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		D012B4A52CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D012B4A62CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = "sv.lproj/HandBrakeXPCService1-InfoPlist.strings"; sourceTree = "<group>"; };
+		D012B4A72CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = "sv.lproj/HandBrakeXPCService2-InfoPlist.strings"; sourceTree = "<group>"; };
+		D012B4A82CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = "sv.lproj/HandBrakeXPCService3-InfoPlist.strings"; sourceTree = "<group>"; };
+		D012B4A92CE100D000748C2F /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = "sv.lproj/HandBrakeXPCService4-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0530E9B2706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/AddPreset.strings; sourceTree = "<group>"; };
 		D0530E9C2706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/Audio.strings; sourceTree = "<group>"; };
 		D0530E9D2706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = zh.lproj/AudioDefaults.strings; sourceTree = "<group>"; };
@@ -984,6 +1021,11 @@
 		D0530EBE2706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = "zh.lproj/HandBrakeXPCService2-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0530EBF2706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = "zh.lproj/HandBrakeXPCService3-InfoPlist.strings"; sourceTree = "<group>"; };
 		D0530EC02706DF6A00CB946A /* zh */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = zh; path = "zh.lproj/HandBrakeXPCService4-InfoPlist.strings"; sourceTree = "<group>"; };
+		D05B49672CE2A38D00928D0A /* bg */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = bg; path = bg.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D05B49682CE2A3A700928D0A /* ja_JP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja_JP; path = ja_JP.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D05B49692CE2A3B700928D0A /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D05B496A2CE2A3C700928D0A /* sv */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sv; path = sv.lproj/Localizable.strings; sourceTree = "<group>"; };
+		D05B496B2CE2A3D300928D0A /* uk_UA */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk_UA; path = uk_UA.lproj/Localizable.strings; sourceTree = "<group>"; };
 		D062DF6422FAE05700A65A9E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/HBQueueTableViewController.strings; sourceTree = "<group>"; };
 		D062DF6522FAE06000A65A9E /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/HBQueueInfoViewController.strings; sourceTree = "<group>"; };
 		D0924607280B72B900B79A40 /* ja_JP */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja_JP; path = ja_JP.lproj/AddPreset.strings; sourceTree = "<group>"; };
@@ -2270,6 +2312,7 @@
 				ko,
 				bg,
 				uk_UA,
+				sv,
 			);
 			mainGroup = 273F1FDE14AD9DA40021BE6D;
 			packageReferences = (
@@ -2679,6 +2722,7 @@
 				D0A185F12AD5BDE60056C7BD /* ko */,
 				D0E25A652AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9B2BA7775B0015F453 /* uk_UA */,
+				D012B4922CE100D000748C2F /* sv */,
 			);
 			name = HBRenamePresetController.xib;
 			sourceTree = "<group>";
@@ -2706,6 +2750,7 @@
 				D0A185F22AD5BDE60056C7BD /* ko */,
 				D0E25A662AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9C2BA7775B0015F453 /* uk_UA */,
+				D012B4932CE100D000748C2F /* sv */,
 			);
 			name = HBSummaryViewController.xib;
 			sourceTree = "<group>";
@@ -2721,6 +2766,11 @@
 				A9D2DDE524B3B1C2009C92DA /* pt_BR */,
 				A91CAB55270726B300006BEA /* co */,
 				A91CAB54270726B000006BEA /* zh */,
+				D05B49682CE2A3A700928D0A /* ja_JP */,
+				D05B49692CE2A3B700928D0A /* ko */,
+				D05B49672CE2A38D00928D0A /* bg */,
+				D05B496B2CE2A3D300928D0A /* uk_UA */,
+				D05B496A2CE2A3C700928D0A /* sv */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2740,6 +2790,7 @@
 				D0A185E72AD5BDE60056C7BD /* ko */,
 				D0E25A5B2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB912BA7775B0015F453 /* uk_UA */,
+				D012B4882CE100D000748C2F /* sv */,
 			);
 			name = HBAddCategoryController.xib;
 			sourceTree = "<group>";
@@ -2759,6 +2810,7 @@
 				D0A185E22AD5BDE60056C7BD /* ko */,
 				D0E25A562AD5BE3600D1B3F5 /* bg */,
 				D0B6CB8C2BA7775B0015F453 /* uk_UA */,
+				D012B4832CE100D000748C2F /* sv */,
 			);
 			name = AddPreset.xib;
 			sourceTree = "<group>";
@@ -2777,6 +2829,7 @@
 				D0A186022AD5BDE60056C7BD /* ko */,
 				D0E25A762AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAC2BA7775B0015F453 /* uk_UA */,
+				D012B4A62CE100D000748C2F /* sv */,
 			);
 			name = "HandBrakeXPCService1-InfoPlist.strings";
 			sourceTree = "<group>";
@@ -2795,6 +2848,7 @@
 				D0A186032AD5BDE60056C7BD /* ko */,
 				D0E25A772AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAD2BA7775B0015F453 /* uk_UA */,
+				D012B4A72CE100D000748C2F /* sv */,
 			);
 			name = "HandBrakeXPCService2-InfoPlist.strings";
 			sourceTree = "<group>";
@@ -2813,6 +2867,7 @@
 				D0A186042AD5BDE60056C7BD /* ko */,
 				D0E25A782AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAE2BA7775B0015F453 /* uk_UA */,
+				D012B4A82CE100D000748C2F /* sv */,
 			);
 			name = "HandBrakeXPCService3-InfoPlist.strings";
 			sourceTree = "<group>";
@@ -2831,6 +2886,7 @@
 				D0A186052AD5BDE60056C7BD /* ko */,
 				D0E25A792AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAF2BA7775B0015F453 /* uk_UA */,
+				D012B4A92CE100D000748C2F /* sv */,
 			);
 			name = "HandBrakeXPCService4-InfoPlist.strings";
 			sourceTree = "<group>";
@@ -2850,6 +2906,7 @@
 				D0A185F62AD5BDE60056C7BD /* ko */,
 				D0E25A6A2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA02BA7775B0015F453 /* uk_UA */,
+				D012B4982CE100D000748C2F /* sv */,
 			);
 			name = MainWindow.xib;
 			sourceTree = "<group>";
@@ -2869,6 +2926,7 @@
 				D0A185F02AD5BDE60056C7BD /* ko */,
 				D0E25A642AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9A2BA7775B0015F453 /* uk_UA */,
+				D012B4912CE100D000748C2F /* sv */,
 			);
 			name = HBQueueTableViewController.xib;
 			sourceTree = "<group>";
@@ -2888,6 +2946,7 @@
 				D0A185EF2AD5BDE60056C7BD /* ko */,
 				D0E25A632AD5BE3600D1B3F5 /* bg */,
 				D0B6CB992BA7775B0015F453 /* uk_UA */,
+				D012B4902CE100D000748C2F /* sv */,
 			);
 			name = HBQueueInfoViewController.xib;
 			sourceTree = "<group>";
@@ -2905,6 +2964,8 @@
 				A94D0454280D488600E24AA6 /* ja_JP */,
 				D0A185FF2AD5BDE60056C7BD /* ko */,
 				D0E25A732AD5BE3600D1B3F5 /* bg */,
+				D011F3E12CE104D600B934D3 /* uk_UA */,
+				D011F3E02CE104B200B934D3 /* sv */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -2932,6 +2993,7 @@
 				D0A185EB2AD5BDE60056C7BD /* ko */,
 				D0E25A5F2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB952BA7775B0015F453 /* uk_UA */,
+				D012B48C2CE100D000748C2F /* sv */,
 			);
 			name = HBPictureHUDController.xib;
 			sourceTree = "<group>";
@@ -2951,6 +3013,7 @@
 				D0A185E92AD5BDE60056C7BD /* ko */,
 				D0E25A5D2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB932BA7775B0015F453 /* uk_UA */,
+				D012B48A2CE100D000748C2F /* sv */,
 			);
 			name = HBEncodingProgressHUDController.xib;
 			sourceTree = "<group>";
@@ -2970,6 +3033,7 @@
 				D0A185ED2AD5BDE60056C7BD /* ko */,
 				D0E25A612AD5BE3600D1B3F5 /* bg */,
 				D0B6CB972BA7775B0015F453 /* uk_UA */,
+				D012B48E2CE100D000748C2F /* sv */,
 			);
 			name = HBPlayerHUDController.xib;
 			sourceTree = "<group>";
@@ -2989,6 +3053,7 @@
 				D0A185F52AD5BDE60056C7BD /* ko */,
 				D0E25A692AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9F2BA7775B0015F453 /* uk_UA */,
+				D012B4972CE100D000748C2F /* sv */,
 			);
 			name = MainMenu.xib;
 			sourceTree = "<group>";
@@ -3008,6 +3073,7 @@
 				D0A185FA2AD5BDE60056C7BD /* ko */,
 				D0E25A6E2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA42BA7775B0015F453 /* uk_UA */,
+				D012B49C2CE100D000748C2F /* sv */,
 			);
 			name = Presets.xib;
 			sourceTree = "<group>";
@@ -3027,6 +3093,7 @@
 				D0A185F32AD5BDE60056C7BD /* ko */,
 				D0E25A672AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9D2BA7775B0015F453 /* uk_UA */,
+				D012B4942CE100D000748C2F /* sv */,
 			);
 			name = HBTitleSelection.xib;
 			sourceTree = "<group>";
@@ -3046,6 +3113,7 @@
 				D0A185EC2AD5BDE60056C7BD /* ko */,
 				D0E25A602AD5BE3600D1B3F5 /* bg */,
 				D0B6CB962BA7775B0015F453 /* uk_UA */,
+				D012B48D2CE100D000748C2F /* sv */,
 			);
 			name = HBPictureViewController.xib;
 			sourceTree = "<group>";
@@ -3065,6 +3133,7 @@
 				D0A185EA2AD5BDE60056C7BD /* ko */,
 				D0E25A5E2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB942BA7775B0015F453 /* uk_UA */,
+				D012B48B2CE100D000748C2F /* sv */,
 			);
 			name = HBFiltersViewController.xib;
 			sourceTree = "<group>";
@@ -3084,6 +3153,7 @@
 				D0A185FE2AD5BDE60056C7BD /* ko */,
 				D0E25A722AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA82BA7775B0015F453 /* uk_UA */,
+				D012B4A02CE100D000748C2F /* sv */,
 			);
 			name = Video.xib;
 			sourceTree = "<group>";
@@ -3103,6 +3173,7 @@
 				D0A185E32AD5BDE60056C7BD /* ko */,
 				D0E25A572AD5BE3600D1B3F5 /* bg */,
 				D0B6CB8D2BA7775B0015F453 /* uk_UA */,
+				D012B4842CE100D000748C2F /* sv */,
 			);
 			name = Audio.xib;
 			sourceTree = "<group>";
@@ -3122,6 +3193,7 @@
 				D0A185E42AD5BDE60056C7BD /* ko */,
 				D0E25A582AD5BE3600D1B3F5 /* bg */,
 				D0B6CB8E2BA7775B0015F453 /* uk_UA */,
+				D012B4852CE100D000748C2F /* sv */,
 			);
 			name = AudioDefaults.xib;
 			sourceTree = "<group>";
@@ -3141,6 +3213,7 @@
 				D0A185FC2AD5BDE60056C7BD /* ko */,
 				D0E25A702AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA62BA7775B0015F453 /* uk_UA */,
+				D012B49E2CE100D000748C2F /* sv */,
 			);
 			name = Subtitles.xib;
 			sourceTree = "<group>";
@@ -3160,6 +3233,7 @@
 				D0A185FD2AD5BDE60056C7BD /* ko */,
 				D0E25A712AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA72BA7775B0015F453 /* uk_UA */,
+				D012B49F2CE100D000748C2F /* sv */,
 			);
 			name = SubtitlesDefaults.xib;
 			sourceTree = "<group>";
@@ -3179,6 +3253,7 @@
 				D0A185E52AD5BDE60056C7BD /* ko */,
 				D0E25A592AD5BE3600D1B3F5 /* bg */,
 				D0B6CB8F2BA7775B0015F453 /* uk_UA */,
+				D012B4862CE100D000748C2F /* sv */,
 			);
 			name = ChaptersTitles.xib;
 			sourceTree = "<group>";
@@ -3198,6 +3273,7 @@
 				D0A185FB2AD5BDE60056C7BD /* ko */,
 				D0E25A6F2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA52BA7775B0015F453 /* uk_UA */,
+				D012B49D2CE100D000748C2F /* sv */,
 			);
 			name = Queue.xib;
 			sourceTree = "<group>";
@@ -3217,6 +3293,7 @@
 				D0A185E82AD5BDE60056C7BD /* ko */,
 				D0E25A5C2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB922BA7775B0015F453 /* uk_UA */,
+				D012B4892CE100D000748C2F /* sv */,
 			);
 			name = HBCroppingView.xib;
 			sourceTree = "<group>";
@@ -3236,6 +3313,7 @@
 				D0A185F82AD5BDE60056C7BD /* ko */,
 				D0E25A6C2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA22BA7775B0015F453 /* uk_UA */,
+				D012B49A2CE100D000748C2F /* sv */,
 			);
 			name = PicturePreview.xib;
 			sourceTree = "<group>";
@@ -3255,6 +3333,7 @@
 				D0A185F72AD5BDE60056C7BD /* ko */,
 				D0E25A6B2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA12BA7775B0015F453 /* uk_UA */,
+				D012B4992CE100D000748C2F /* sv */,
 			);
 			name = OutputPanel.xib;
 			sourceTree = "<group>";
@@ -3274,6 +3353,7 @@
 				D0A185F92AD5BDE60056C7BD /* ko */,
 				D0E25A6D2AD5BE3600D1B3F5 /* bg */,
 				D0B6CBA32BA7775B0015F453 /* uk_UA */,
+				D012B49B2CE100D000748C2F /* sv */,
 			);
 			name = Preferences.xib;
 			sourceTree = "<group>";
@@ -3293,6 +3373,7 @@
 				D0A185EE2AD5BDE60056C7BD /* ko */,
 				D0E25A622AD5BE3600D1B3F5 /* bg */,
 				D0B6CB982BA7775B0015F453 /* uk_UA */,
+				D012B48F2CE100D000748C2F /* sv */,
 			);
 			name = HBPreviewViewController.xib;
 			sourceTree = "<group>";
@@ -3312,6 +3393,7 @@
 				D0A185F42AD5BDE60056C7BD /* ko */,
 				D0E25A682AD5BE3600D1B3F5 /* bg */,
 				D0B6CB9E2BA7775B0015F453 /* uk_UA */,
+				D012B4962CE100D000748C2F /* sv */,
 			);
 			name = HBTrackTitleViewController.xib;
 			sourceTree = "<group>";
@@ -3331,6 +3413,7 @@
 				D0A186002AD5BDE60056C7BD /* ko */,
 				D0E25A742AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAA2BA7775B0015F453 /* uk_UA */,
+				D012B4A42CE100D000748C2F /* sv */,
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";
@@ -3349,6 +3432,7 @@
 				D0A186012AD5BDE60056C7BD /* ko */,
 				D0E25A752AD5BE3600D1B3F5 /* bg */,
 				D0B6CBAB2BA7775B0015F453 /* uk_UA */,
+				D012B4A52CE100D000748C2F /* sv */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";
@@ -3368,6 +3452,7 @@
 				D0A185E62AD5BDE60056C7BD /* ko */,
 				D0E25A5A2AD5BE3600D1B3F5 /* bg */,
 				D0B6CB902BA7775B0015F453 /* uk_UA */,
+				D012B4872CE100D000748C2F /* sv */,
 			);
 			name = ExceptionAlert.xib;
 			sourceTree = "<group>";

--- a/macosx/HandBrakeKit/sv.lproj/InfoPlist.strings
+++ b/macosx/HandBrakeKit/sv.lproj/InfoPlist.strings
@@ -1,0 +1,3 @@
+/* Bundle name */
+"CFBundleName" = "$(PRODUCT_NAME)";
+

--- a/macosx/HandBrakeKit/sv.lproj/Localizable.strings
+++ b/macosx/HandBrakeKit/sv.lproj/Localizable.strings
@@ -1,0 +1,417 @@
+/* HBStateFormatter -> work time format */
+" (%.2f fps, avg %.2f fps, ETA %@)" = " (%1$.2f bilder/s, genomsnitt %2$.2f bilder/s, Klar om %3$@)";
+
+/* HBStateFormatter -> work time format */
+" (%.2f fps, avg %.2f fps)" = " (%1$.2f bilder/s, genomsnitt %2$.2f bilder/s)";
+
+/* HBStateFormatter -> search time format
+HBStateFormatter -> work time format */
+" (ETA %@)" = " (Klar om %@)";
+
+/* HBJob -> video short description framerate */
+" FPS CFR" = " FPS CFR";
+
+/* HBJob -> video short description framerate */
+" FPS PFR" = " FPS PFR";
+
+/* Title short description -> audio format */
+", %d audio tracks" = ", %d ljudspår";
+
+/* Title short description -> subtitles format */
+", %d subtitles tracks" = ", %d undertextspår";
+
+/* Title short description -> audio format */
+", 1 audio track" = ", 1 ljudspår";
+
+/* Title short description -> subtitles format */
+", 1 subtitles track" = ", 1 undertextspår";
+
+/* Format description */
+", Align A/V Start" = ", Justera ljud-/videostart";
+
+/* HBPicture -> summary */
+", Border: %d/%d/%d/%d" = ", Sorgkant: %1$d/%2$d/%3$d/%4$d";
+
+/* HBJob -> subtitles short description */
+", Burned" = ", Inbränd";
+
+/* Format description */
+", Chapter Markers" = ", Kapitelmarkörer";
+
+/* HBPicture -> summary */
+", Crop: %@ %d/%d/%d/%d" = ", Beskär: %1$@ %2$d/%3$d/%4$d/%5$d";
+
+/* Format description */
+", iPod 5G Support" = ", iPod 5G-stöd";
+
+/* Format description */
+", Web Optimized" = ", Webboptimerad";
+
+/* Title short description -> video format */
+"%.6g FPS" = "%.6g bilder/s";
+
+/* Audio description */
+"%@ ▸ Encoder: %@" = "%1$@ ▸ Enkodare: %2$@";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d" = "%1$@Utdata: %2$dx%3$d";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d, Anamorphic: %dx%d Automatic" = "%1$@Utdata: %2$dx%3$d, Anamorfisk: %4$dx%5$d Automatisk";
+
+/* HBPicture -> short info */
+"%@Output: %dx%d, Anamorphic: %dx%d Custom" = "%1$@Utdata: %2$dx%3$d, Anamorfisk: %4$dx%5$d Anpassad";
+
+/* HBPicture -> short non anamorphic info */
+"%dx%d" = "%1$dx%2$d";
+
+/* HBPicture -> short info */
+"%dx%d Storage, %dx%d Display" = "%1$dx%2$d Lagring, %3$dx%4$d Skärm";
+
+/* HBJob -> audio short description */
+"+ %lu additional audio tracks" = "+ %lu ytterligare ljudspår";
+
+/* HBJob -> subtitles short description */
+"+ %lu additional subtitles tracks" = "+ %lu ytterligare undertextspår";
+
+/* HBJob -> audio short description */
+"+ 1 additional audio track" = "+ 1 ytterligare ljudspår";
+
+/* HBJob -> subtitles short description */
+"+ 1 additional subtitles track" = "+ 1 ytterligare undertextspår";
+
+/* HBAudio -> Mixdown */
+"5.1 Channels" = "5.1 kanaler";
+
+/* HBAudio -> Mixdown */
+"6.1 Channels" = "6.1 kanaler";
+
+/* HBAudio -> Mixdown */
+"7.1 (5F/2R/LFE)" = "7.1 (5F/2R/LFE)";
+
+/* HBAudio -> Mixdown */
+"7.1 Channels" = "7.1 kanaler";
+
+/* Audio description */
+"Audio:" = "Ljud:";
+
+/* HBPicture -> summary */
+"Automatic" = "Automatisk";
+
+/* Video description */
+"Bitrate: %d kbps" = "Bitfrekvens: %d kbps";
+
+/* Subtitles description */
+"Burned In" = "Inbränd";
+
+/* HBFilters -> filter display name */
+"Bwdif" = "Bwdif";
+
+/* Title -> chapter name
+Title description */
+"Chapter %d" = "Kapitel %d";
+
+/* HBJob -> chapters short description */
+"Chapter Markers" = "Kapitelmarkörer";
+
+/* HBRange -> display name */
+"Chapters" = "Kapitel";
+
+/* Title description */
+"Chapters %d through %d" = "Kapitel %1$d till %2$d";
+
+/* Filters description
+HBJob -> filters short description */
+"Chroma Smooth" = "Chroma Smooth";
+
+/* Filters description
+HBJob -> filters short description */
+"Colorspace" = "Färgrymd";
+
+/* HBJob -> filters short description */
+"Comb Detect" = "Comb Detect";
+
+/* Video description */
+"Constant Quality: %.2f %s" = "Konstant kvalitet: %1$.2f %2$s";
+
+/* HBJob -> video short description framerate */
+"CRF" = "CRF";
+
+/* HBFilters -> custom display name
+HBPicture -> summary */
+"Custom" = "Anpassad";
+
+/* Filters description
+HBJob -> filters short description */
+"Deblock" = "Deblock";
+
+/* HBFilters -> filter display name */
+"Decomb" = "Decomb";
+
+/* HBFilters -> default display name
+Subtitles description */
+"Default" = "Standard";
+
+/* Video description */
+"default settings" = "standardinställningar";
+
+/* HBFilters -> invalid filter custom settings error recovery suggestion */
+"Default: " = "Standard:";
+
+/* Filters description */
+"Denoise" = "Denoise";
+
+/* Destination description */
+"Destination:" = "Mål:";
+
+/* Dimensions description
+HBJob -> filters short description */
+"Detelecine" = "Detelecine";
+
+/* Dimensions description */
+"Dimensions:" = "Dimensioner:";
+
+/* HBAudio -> Mixdown */
+"Dolby Pro Logic II" = "Dolby Pro Logic II";
+
+/* HBAudio -> Mixdown */
+"Dolby Surround" = "Dolby Surround";
+
+/* Audio description */
+"DRC: %.2f" = "DRC: %.2f";
+
+/* Video description */
+"Encoder: %@, " = "Enkodare: %@, ";
+
+/* HBStateFormatter -> work pass display name */
+"Encoding %@ " = "Enkodar %@ ";
+
+/* Filters description */
+"Filters:" = "Filter:";
+
+/* Subtitles description */
+"Forced Only" = "Endast tvingad";
+
+/* HBSubtitles -> search pass name */
+"Foreign Audio Search" = "Utländsk ljudsökning";
+
+/* Format description */
+"Format:" = "Format:";
+
+/* Video description */
+"Framerate: " = "Bildfrekvens:";
+
+/* HBRange -> display name */
+"Frames" = "Bildrutor";
+
+/* Title description */
+"Frames %d through %d" = "Bildrutor %1$d till %2$d";
+
+/* Audio description */
+"Gain: %.2f" = "Gain: %.2f";
+
+/* Filters description
+HBJob -> filters short description */
+"Grayscale" = "Gråskala";
+
+/* HBFilters -> filter display name */
+"HQDN3D" = "HQDN3D";
+
+/* HBFilters -> invalid Bwdif custom string description */
+"Invalid Bwdif custom settings." = "Ogiltiga anpassade inställningar för Bwdif.";
+
+/* HBFilters -> invalid chroma smooth custom string description */
+"Invalid chroma smooth custom settings." = "Ogiltiga anpassade inställningar för chroma smooth.";
+
+/* HBFilters -> invalid chroma smooth custom string description */
+"Invalid colorspace custom settings." = "Ogiltiga anpassade inställningar för färgrymd.";
+
+/* HBFilters -> invalid comb detect custom string description */
+"Invalid custom comb detect settings." = "Ogiltiga anpassade inställningar för comb.";
+
+/* HBFilters -> invalid detelecine custom string description */
+"Invalid custom detelecine settings." = "Ogiltiga anpassade inställningar för detelecine.";
+
+/* HBFilters -> invalid denoise custom string description */
+"Invalid custom HQDN3D settings" = "Ogiltiga anpassade inställningar för HQDN3D.";
+
+/* HBFilters -> invalid denoise custom string description */
+"Invalid custom NLMeans settings" = "Ogiltiga anpassade inställningar för NLMeans.";
+
+/* HBFilters -> invalid deblock custom string description */
+"Invalid deblock custom settings." = "Ogiltiga anpassade inställningar för deblock.";
+
+/* HBFilters -> invalid Decomb custom string description */
+"Invalid Decomb custom settings." = "Ogiltiga anpassade inställningar för Decomb.";
+
+/* HBFilters -> invalid lapsharp custom string description */
+"Invalid lapsharp custom settings." = "Ogiltiga anpassade inställningar för lapsharp.";
+
+/* HBJob -> invalid name error description */
+"Invalid name" = "Ogiltigt namn";
+
+/* HBJob -> invalid preset */
+"Invalid preset" = "Ogiltigt förval";
+
+/* HBFilters -> invalid unsharp custom string description */
+"Invalid unsharp custom settings." = "Ogiltiga anpassade inställningar för unsharp.";
+
+/* HBFilters -> invalid Yadif custom string description */
+"Invalid Yadif custom settings." = "Ogiltiga anpassade inställningar för Yadif.";
+
+/* HBFilters -> filter display name */
+"Lapsharp" = "Lapsharp";
+
+/* Video description */
+"Level: %@" = "Nivå: %@";
+
+/* Audio description */
+"Mixdown: %@, Samplerate: %@, Bitrate: %d kbps" = "Mixa om: %1$@, Samplingsfrekvens: %2$@, Bifrekvens: %3$d kbps";
+
+/* HBAudio -> Mixdown */
+"Mono" = "Mono";
+
+/* HBAudio -> Mixdown */
+"Mono (Left Only)" = "Mono (endast vänster)";
+
+/* HBAudio -> Mixdown */
+"Mono (Right Only)" = "Mono (endast höger)";
+
+/* HBStateFormatter -> pass display name */
+"Muxing…" = "Muxar…";
+
+/* HBFilters -> filter display name */
+"NLMeans" = "NLMeans";
+
+/* HBVideo -> tune */
+"none" = "ingen";
+
+/* HBAudio -> Mixdown
+HBAudio -> none track name
+HBJob -> filters short description
+HBSubtitles -> none track name */
+"None" = "Ingen";
+
+/* HBFilters -> filter display name
+HBFilters -> off display name */
+"Off" = "Av";
+
+/* Video description */
+"Options: %@" = "Alternativ: %@";
+
+/* HBStateFormatter -> work pass number format */
+"Pass %d %@ of %d, %.2f %%" = "Pass %1$d %2$@ av %3$d, %4$.2f %%";
+
+/* HBStateFormatter -> work pass number format */
+"Pass %d of %d, %.2f %%" = "Pass %1$d av %2$d, %3$.2f %%";
+
+/* HBStateFormatter -> work first pass number format */
+"Pass 1" = "Pass 1";
+
+/* HBStateFormatter -> pass display name */
+"Paused" = "Pausad";
+
+/* Preset description */
+"Preset:" = "Förval:";
+
+/* Video description */
+"Preset: %@" = "Förval: %@";
+
+/* Video description */
+"Profile: %@" = "Profil: %@";
+
+/* Range description */
+"Range:" = "Omfång:";
+
+/* HBVideo -> frame rates display name */
+"Same as source" = "Samma som källa";
+
+/* Video description */
+"Same as source (constant)" = "Samma som källa (konstant)";
+
+/* Video description */
+"Same as source (variable)" = "Samma som källa (variabel)";
+
+/* HBStateFormatter -> scan pass format */
+"Scanning title %d of %d, preview %d…" = "Läs in titel %1$d av %2$d, förhandsvisning %3$d…";
+
+/* HBStateFormatter -> scan pass format */
+"Scanning title %d of %d…" = "Läser in titel %1$d av %2$d…";
+
+/* HBStateFormatter -> search pass display name */
+"Searching for start point:  %.2f %%" = "Letar efter startpunkt:  %.2f %%";
+
+/* HBRange -> display name */
+"Seconds" = "Sekunder";
+
+/* Title description */
+"Seconds %d through %d" = "Sekunder %1$d till %2$d";
+
+/* Filters description */
+"Sharpen" = "Sharpen";
+
+/* Source description */
+"Source:" = "Källa:";
+
+/* HBPicture -> short info */
+"Source: %dx%d, " = "Källa: %1$dx%2$d, ";
+
+/* HBAudio -> Mixdown */
+"Stereo" = "Stereo";
+
+/* Subtitles description */
+"Subtitles:" = "Undertexter:";
+
+/* HBFilters -> invalid filter custom settings error recovery suggestion */
+"Syntax: " = "Syntax: ";
+
+/* HBJob -> invalid name error recovery suggestion */
+"The file name can't be empty." = "Filnamnet får inte vara tomt.";
+
+/* HBJob -> invalid name error recovery suggestion */
+"The file name can't contain the / character." = "Filnamnet får inte innehålla /-tecknet.";
+
+/* Preset -> import error description */
+"The preset \"%@\" could not be imported." = "Förvalet \"%@\" kunde inte importeras.";
+
+/* Job preset -> invalid preset recovery suggestion */
+"The preset is not a valid, try to select a different one." = "Förvalet är inte giltigt. Prova att välja ett annat.";
+
+/* Preset -> import error reason */
+"The selected preset is invalid." = "Det valda förvalet är inte giltigt.";
+
+/* Preset -> import error reason */
+"The selected preset was created with a newer version of HandBrake." = "Det valda förvalet skapades med en nyare version av HandBrake.";
+
+/* Title description */
+"Title %d, %@" = "Titel %1$d, %2$@";
+
+/* Title description */
+"Title %d, %@, %@" = "Titel %1$d, %2$@, %3$@";
+
+/* Audio track title description
+Subtitles track title description */
+"Title: %@" = "Titel: %@";
+
+/* Video description */
+"Tune: " = "Justera:";
+
+/* HBJob -> video short description encoder name
+Video description */
+"Unknown" = "Okänt";
+
+/* HBFilters -> filter display name */
+"Unsharp" = "Unsharp";
+
+/* HBJob -> video short description framerate */
+"VFR" = "VFR";
+
+/* Video description */
+"Video Options:" = "Videoalternativ:";
+
+/* Video description */
+"Video:" = "Video:";
+
+/* HBFilters -> filter display name */
+"Yadif" = "Yadif";
+

--- a/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService1-InfoPlist.strings
+++ b/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService1-InfoPlist.strings
@@ -1,0 +1,6 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "HandBrakeXPCService";
+
+/* Bundle name */
+"CFBundleName" = "HandBrakeXPCService";
+

--- a/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService2-InfoPlist.strings
+++ b/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService2-InfoPlist.strings
@@ -1,0 +1,6 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "HandBrakeXPCService";
+
+/* Bundle name */
+"CFBundleName" = "HandBrakeXPCService2";
+

--- a/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService3-InfoPlist.strings
+++ b/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService3-InfoPlist.strings
@@ -1,0 +1,6 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "HandBrakeXPCService";
+
+/* Bundle name */
+"CFBundleName" = "HandBrakeXPCService3";
+

--- a/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService4-InfoPlist.strings
+++ b/macosx/HandBrakeXPCService/sv.lproj/HandBrakeXPCService4-InfoPlist.strings
@@ -1,0 +1,6 @@
+/* Bundle display name */
+"CFBundleDisplayName" = "HandBrakeXPCService";
+
+/* Bundle name */
+"CFBundleName" = "HandBrakeXPCService4";
+

--- a/macosx/HandBrakeXPCService/sv.lproj/Localizable.strings
+++ b/macosx/HandBrakeXPCService/sv.lproj/Localizable.strings
@@ -1,0 +1,4 @@
+/* 
+  Localizable.strings
+  HandBrake  
+*/

--- a/macosx/sv.lproj/AddPreset.strings
+++ b/macosx/sv.lproj/AddPreset.strings
@@ -1,0 +1,54 @@
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "5Xb-gz-QEa"; */
+"5Xb-gz-QEa.title" = "Avbryt";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Enter a description for the new preset. The description will be shown when hovering the cursor over the preset in the presets list."; ObjectID = "8kl-Sh-Gh7"; */
+"8kl-Sh-Gh7.ibShadowedToolTip" = "Ange en beskrivning av det nya förvalet. Beskrivningen kommer att visas när du hovrar med markören över förvalet i förvalslistan.";
+
+/* Class = "NSTextFieldCell"; title = "Resolution Limit:"; ObjectID = "75B-xq-Qbe"; */
+"75B-xq-Qbe.title" = "Upplösningsgräns:";
+
+/* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "a0j-nw-n23"; */
+"a0j-nw-n23.title" = "Valbeteende...";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Enter a name for the new preset. This name will be displayed in the presets list."; ObjectID = "aKg-n4-OUS"; */
+"aKg-n4-OUS.ibShadowedToolTip" = "Ange ett namn för det nya förvalet. Detta namn kommer att visas i förvalslistan.";
+
+/* Class = "NSWindow"; title = "New Preset"; ObjectID = "dbZ-Wo-9nG"; */
+"dbZ-Wo-9nG.title" = "Nytt förval";
+
+/* Class = "NSButtonCell"; title = "Add"; ObjectID = "Deg-rS-mRc"; */
+"Deg-rS-mRc.title" = "Lägg till";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Picture Width"; ObjectID = "gOg-oO-8ar"; */
+"gOg-oO-8ar.ibExternalAccessibilityDescription" = "Bildbredd";
+
+/* Class = "NSTextFieldCell"; title = "Description:"; ObjectID = "hc8-1h-Jye"; */
+"hc8-1h-Jye.title" = "Beskrivning:";
+
+/* Class = "NSTextFieldCell"; title = "Audio:"; ObjectID = "HKp-K9-MF4"; */
+"HKp-K9-MF4.title" = "Ljud:";
+
+/* Class = "NSTextFieldCell"; title = "Category:"; ObjectID = "IyE-Lz-32s"; */
+"IyE-Lz-32s.title" = "Kategori:";
+
+/* Class = "NSTextFieldCell"; title = "Preset Name:"; ObjectID = "jhj-Et-ncF"; */
+"jhj-Et-ncF.title" = "Förvalsnamn:";
+
+/* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "LPX-Rc-KLa"; */
+"LPX-Rc-KLa.title" = "Valbeteende...";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Picture Height"; ObjectID = "Mga-dS-8BF"; */
+"Mga-dS-8BF.ibExternalAccessibilityDescription" = "Bildhöjd";
+
+/* Class = "NSTextFieldCell"; title = "x"; ObjectID = "Nfk-ix-xIv"; */
+"Nfk-ix-xIv.title" = "x";
+
+/* Class = "NSTextFieldCell"; title = "Subtitles:"; ObjectID = "OYE-GG-Vo3"; */
+"OYE-GG-Vo3.title" = "Undertexter:";
+
+/* Class = "NSMenuItem"; title = "New Category…"; ObjectID = "Sf8-HP-mhE"; */
+"Sf8-HP-mhE.title" = "Ny kategori...";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Resolution Limit allows you to set a maximum width and/or height."; ObjectID = "z6B-ig-ouq"; */
+"z6B-ig-ouq.ibShadowedToolTip" = "Upplösningsgräns tillåter dig att ange en maximal bredd och/eller höjd.";
+

--- a/macosx/sv.lproj/Audio.strings
+++ b/macosx/sv.lproj/Audio.strings
@@ -1,0 +1,120 @@
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Gain"; ObjectID = "2c7-G5-4KL"; */
+"2c7-G5-4KL.ibExternalAccessibilityDescription" = "Gain";
+
+/* Class = "NSTableColumn"; headerCell.title = "Gain"; ObjectID = "5xO-DR-4cR"; */
+"5xO-DR-4cR.headerCell.title" = "Gain";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Selected track"; ObjectID = "6iN-2G-JDF"; */
+"6iN-2G-JDF.ibExternalAccessibilityDescription" = "Valt spår";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio language and type."; ObjectID = "6iN-2G-JDF"; */
+"6iN-2G-JDF.ibShadowedToolTip" = "Ljudspråk och typ.";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "6Iz-D8-zzz"; */
+"6Iz-D8-zzz.title" = "Textcell";
+
+/* Class = "NSTableColumn"; headerCell.title = "Track"; ObjectID = "7sz-4X-5jA"; */
+"7sz-4X-5jA.headerCell.title" = "Spår";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "aaP-HB-s4f"; */
+"aaP-HB-s4f.title" = "Textcell";
+
+/* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "AMA-Ul-v2f"; */
+"AMA-Ul-v2f.title" = "Lägg till alla spår";
+
+/* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "aYF-d5-Ya6"; */
+"aYF-d5-Ya6.title" = "Valbeteende...";
+
+/* Class = "NSSliderCell"; ibExternalAccessibilityDescription = "Gain"; ObjectID = "BBQ-FP-aQN"; */
+"BBQ-FP-aQN.ibExternalAccessibilityDescription" = "Gain";
+
+/* Class = "NSTableColumn"; headerCell.title = "DRC"; ObjectID = "eAS-E5-fip"; */
+"eAS-E5-fip.headerCell.title" = "DRC";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "eFn-1M-3hk"; */
+"eFn-1M-3hk.title" = "Textcell";
+
+/* Class = "NSMenuItem"; title = "Remove All Tracks"; ObjectID = "fqs-Q8-hNY"; */
+"fqs-Q8-hNY.title" = "Ta bort alla spår";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "HKE-hO-jOm"; */
+"HKE-hO-jOm.title" = "Textcell";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "Auto"; ObjectID = "hlm-8l-ATk"; */
+"hlm-8l-ATk.ibShadowedIsNilPlaceholder" = "Auto";
+
+/* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "HM0-a4-pm5"; */
+"HM0-a4-pm5.title" = "Lägg till alla spår";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "Ifq-hI-oCs"; */
+"Ifq-hI-oCs.title" = "0";
+
+/* Class = "NSTableColumn"; headerCell.title = "Samplerate"; ObjectID = "jub-Uq-qYL"; */
+"jub-Uq-qYL.headerCell.title" = "Samplingsfrekvens";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "kmi-ru-dRe"; */
+"kmi-ru-dRe.title" = "Textcell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "l8E-uG-8fo"; */
+"l8E-uG-8fo.title" = "Textcell";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Mixdown"; ObjectID = "LLW-KN-65P"; */
+"LLW-KN-65P.ibExternalAccessibilityDescription" = "Mixa om";
+
+/* Class = "NSTableColumn"; headerCell.title = "Codec"; ObjectID = "lnO-sZ-6xv"; */
+"lnO-sZ-6xv.headerCell.title" = "Kodek";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "MZ7-W1-uGl"; */
+"MZ7-W1-uGl.title" = "Textcell";
+
+/* Class = "NSSliderCell"; ibExternalAccessibilityDescription = "DRC"; ObjectID = "nII-CW-aWc"; */
+"nII-CW-aWc.ibExternalAccessibilityDescription" = "DRC";
+
+/* Class = "NSTableColumn"; headerCell.title = "Bitrate"; ObjectID = "obP-lK-sY0"; */
+"obP-lK-sY0.headerCell.title" = "Bitfrekvens";
+
+/* Class = "NSMenuItem"; title = "Tracks"; ObjectID = "Pfh-Bc-83k"; */
+"Pfh-Bc-83k.title" = "Spår";
+
+/* Class = "NSButtonCell"; title = "Reload"; ObjectID = "q2P-Tg-cBJ"; */
+"q2P-Tg-cBJ.title" = "Läs om";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "Q4T-80-wxf"; */
+"Q4T-80-wxf.title" = "0";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Samplerate"; ObjectID = "QA9-1y-Pyj"; */
+"QA9-1y-Pyj.ibExternalAccessibilityDescription" = "Samplingsfrekvens";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio sample rate in kilohertz (kHz). Auto is recommended."; ObjectID = "QA9-1y-Pyj"; */
+"QA9-1y-Pyj.ibShadowedToolTip" = "Samplingsfrekvens för ljud i kilohertz (kHz). Auto är rekommenderat.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Bitrate"; ObjectID = "Qg1-iw-07b"; */
+"Qg1-iw-07b.ibExternalAccessibilityDescription" = "Bitfrekvens";
+
+/* Class = "NSTableColumn"; headerCell.title = "Mixdown"; ObjectID = "qS7-Xr-9N8"; */
+"qS7-Xr-9N8.headerCell.title" = "Mixa om";
+
+/* Class = "NSMenuItem"; title = "Reload"; ObjectID = "sq7-Ux-T6D"; */
+"sq7-Ux-T6D.title" = "Läs om";
+
+/* Class = "NSMenuItem"; title = "Selection Behavior…"; ObjectID = "TK6-fY-4Sk"; */
+"TK6-fY-4Sk.title" = "Valbeteende...";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Codec"; ObjectID = "tYY-w7-ZIq"; */
+"tYY-w7-ZIq.ibExternalAccessibilityDescription" = "Kodek";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder."; ObjectID = "tYY-w7-ZIq"; */
+"tYY-w7-ZIq.ibShadowedToolTip" = "Ljudenkodare.";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "U4U-1b-rQF"; */
+"U4U-1b-rQF.title" = "Textcell";
+
+/* Class = "NSTableView"; ibExternalAccessibilityDescription = "Audio tracks"; ObjectID = "yix-PF-sqH"; */
+"yix-PF-sqH.ibExternalAccessibilityDescription" = "Ljudspår";
+
+/* Class = "NSMenuItem"; title = "Remove All Tracks"; ObjectID = "YlA-ue-5oE"; */
+"YlA-ue-5oE.title" = "Ta bort alla spår";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "DRC"; ObjectID = "yPh-4R-HRQ"; */
+"yPh-4R-HRQ.ibExternalAccessibilityDescription" = "DRC";
+

--- a/macosx/sv.lproj/AudioDefaults.strings
+++ b/macosx/sv.lproj/AudioDefaults.strings
@@ -1,0 +1,192 @@
+/* Class = "NSTableColumn"; headerCell.title = "Mixdown"; ObjectID = "0kT-0J-3k2"; */
+"0kT-0J-3k2.headerCell.title" = "Mixa om";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "1XC-VS-X3g"; */
+"1XC-VS-X3g.title" = "Textcell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "3o5-Gn-Vao"; */
+"3o5-Gn-Vao.title" = "Textcell";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Codec"; ObjectID = "6lx-af-rBL"; */
+"6lx-af-rBL.ibExternalAccessibilityDescription" = "Kodek";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder."; ObjectID = "6lx-af-rBL"; */
+"6lx-af-rBL.ibShadowedToolTip" = "Ljudenkodare.";
+
+/* Class = "NSTextFieldCell"; title = "Audio encoder settings for each selected track:"; ObjectID = "007-WM-RmC"; */
+"007-WM-RmC.title" = "Inställningar för ljudenkodare för varje valt spår:";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "7sl-o7-pUh"; */
+"7sl-o7-pUh.title" = "Textcell";
+
+/* Class = "NSButtonCell"; title = "DTS"; ObjectID = "8mC-Wx-myL"; */
+"8mC-Wx-myL.title" = "DTS";
+
+/* Class = "NSButtonCell"; title = "Use only first encoder for secondary audio"; ObjectID = "66v-2g-DHn"; */
+"66v-2g-DHn.title" = "Använd endast första enkodaren för sekundärt ljud";
+
+/* Class = "NSScrollView"; ibExternalAccessibilityDescription = "Audio Track Languages"; ObjectID = "aTC-39-h6S"; */
+"aTC-39-h6S.ibExternalAccessibilityDescription" = "Språk för ljudspår";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "DRC"; ObjectID = "BaY-Lo-8xn"; */
+"BaY-Lo-8xn.ibExternalAccessibilityDescription" = "DRC";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports E-AC3. This permits E-AC3 passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "BK7-c4-kkk"; */
+"BK7-c4-kkk.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för E-AC3. Detta tillåter att E-AC3-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSButtonCell"; title = "AAC"; ObjectID = "cUX-iP-UAs"; */
+"cUX-iP-UAs.title" = "AAC";
+
+/* Class = "NSSlider"; ibExternalAccessibilityDescription = "Gain"; ObjectID = "DbI-6O-BzA"; */
+"DbI-6O-BzA.ibExternalAccessibilityDescription" = "Gain";
+
+/* Class = "NSSlider"; ibExternalAccessibilityDescription = "DRC"; ObjectID = "DGi-Dl-5nh"; */
+"DGi-Dl-5nh.ibExternalAccessibilityDescription" = "DRC";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "dpw-He-8eZ"; */
+"dpw-He-8eZ.title" = "Textcell";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "Auto"; ObjectID = "DxT-bF-prJ"; */
+"DxT-bF-prJ.ibShadowedIsNilPlaceholder" = "Auto";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports DTS. This permits DTS passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "E93-Md-aWa"; */
+"E93-Md-aWa.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för DTS. Detta tillåter att DTS-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSButtonCell"; title = "Opus"; ObjectID = "eA6-za-Up0"; */
+"eA6-za-Up0.title" = "Opus";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports AC3. This permits AC3 passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "fgl-Ev-ELt"; */
+"fgl-Ev-ELt.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för AC3. Detta tillåter att AC3-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "fH9-oV-QdJ"; */
+"fH9-oV-QdJ.title" = "Textcell";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports AAC. This permits AAC passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "fzd-MO-xaB"; */
+"fzd-MO-xaB.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för AAC. Detta tillåter att AAC-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSTextFieldCell"; title = "Track Selection Behavior:"; ObjectID = "GbM-vm-RC2"; */
+"GbM-vm-RC2.title" = "Beteende för spårval:";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports MP2. This permits MP2 passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "GHJ-25-kZl"; */
+"GHJ-25-kZl.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för MP2. Detta tillåter att MP2-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports FLAC. This permits FLAC passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "gOm-E9-8K7"; */
+"gOm-E9-8K7.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för FLAC. Detta tillåter att FLAC-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSMenuItem"; title = "All Matching Selected Languages"; ObjectID = "GZP-q7-SYy"; */
+"GZP-q7-SYy.title" = "Alla matchande valda språk";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Bitrate"; ObjectID = "hHP-dw-nba"; */
+"hHP-dw-nba.ibExternalAccessibilityDescription" = "Bitfrekvens";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Mixdown"; ObjectID = "igm-hS-rrD"; */
+"igm-hS-rrD.ibExternalAccessibilityDescription" = "Mixa om";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports DTS-HD. This permits DTS-HD passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "IxI-o9-jMs"; */
+"IxI-o9-jMs.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för DTS-HD. Detta tillåter att DTS-HD-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSMenuItem"; title = "First Matching Selected Languages"; ObjectID = "jDd-Ji-7Sm"; */
+"jDd-Ji-7Sm.title" = "Första matchande valda språken";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "Jn4-1L-J1g"; */
+"Jn4-1L-J1g.title" = "Avbryt";
+
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "kDe-1L-VkD"; */
+"kDe-1L-VkD.title" = "Ok";
+
+/* Class = "NSWindow"; title = "Audio Selection Behaviour"; ObjectID = "kwM-lz-5lG"; */
+"kwM-lz-5lG.title" = "Beteende för ljudval";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio encoder to use when a track suitable for passthru is unavailable."; ObjectID = "LdN-Cx-ZJY"; */
+"LdN-Cx-ZJY.ibShadowedToolTip" = "Ljudenkodare att använda när ett spår inte hittas som är lämpligt för genomströmning.";
+
+/* Class = "NSButtonCell"; title = "DTS-HD"; ObjectID = "LX6-kc-5vq"; */
+"LX6-kc-5vq.title" = "DTS-HD";
+
+/* Class = "NSTableColumn"; headerCell.title = "Samplerate"; ObjectID = "LxC-Qx-psh"; */
+"LxC-Qx-psh.headerCell.title" = "Samplingsfrekvens";
+
+/* Class = "NSTextFieldCell"; title = "Languages:"; ObjectID = "mAT-Jp-SG1"; */
+"mAT-Jp-SG1.title" = "Språk:";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "MiI-OV-waZ"; */
+"MiI-OV-waZ.title" = "0";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "mvw-Hg-JFM"; */
+"mvw-Hg-JFM.title" = "Ingen";
+
+/* Class = "NSTableColumn"; headerCell.title = "Gain"; ObjectID = "N7h-CJ-quV"; */
+"N7h-CJ-quV.headerCell.title" = "Gain";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports TrueHD. This permits TrueHD passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "os0-Jl-OXF"; */
+"os0-Jl-OXF.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för TrueHD. Detta tillåter att TrueHD-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSSegmentedCell"; otA-K4-TxM.ibShadowedToolTips[0] = "Add Audio Track"; ObjectID = "otA-K4-TxM"; */
+"otA-K4-TxM.ibShadowedToolTips[0]" = "Lägg till ljudspår";
+
+/* Class = "NSSegmentedCell"; otA-K4-TxM.ibShadowedToolTips[1] = "Remove Selected Audio Track"; ObjectID = "otA-K4-TxM"; */
+"otA-K4-TxM.ibShadowedToolTips[1]" = "Ta bort valt ljudspår";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "OVr-Jm-VrK"; */
+"OVr-Jm-VrK.title" = "0";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports Opus. This permits Opus passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "OWh-gZ-JcF"; */
+"OWh-gZ-JcF.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för Opus. Detta tillåter att Opus-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSTableColumn"; headerCell.title = "Codec"; ObjectID = "pR9-d4-SNf"; */
+"pR9-d4-SNf.headerCell.title" = "Kodek";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Samplerate"; ObjectID = "r80-yv-59n"; */
+"r80-yv-59n.ibExternalAccessibilityDescription" = "Samplingsfrekvens";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Audio sample rate in kilohertz (kHz). Auto is recommended."; ObjectID = "r80-yv-59n"; */
+"r80-yv-59n.ibShadowedToolTip" = "Samplingsfrekvens för ljud i kilohertz (kHz). Auto är rekommenderat.";
+
+/* Class = "NSButtonCell"; title = "Vorbis"; ObjectID = "rXl-qc-MHk"; */
+"rXl-qc-MHk.title" = "Vorbis";
+
+/* Class = "NSButtonCell"; title = "ALAC"; ObjectID = "S0X-gJ-f6A"; */
+"S0X-gJ-f6A.title" = "ALAC";
+
+/* Class = "NSTextFieldCell"; title = "Auto Passthru:"; ObjectID = "s6s-EH-5CB"; */
+"s6s-EH-5CB.title" = "Auto genomström:";
+
+/* Class = "NSButtonCell"; title = "MP3"; ObjectID = "sdZ-Rx-JoG"; */
+"sdZ-Rx-JoG.title" = "MP3";
+
+/* Class = "NSButtonCell"; title = "FLAC"; ObjectID = "sJU-xA-Jo1"; */
+"sJU-xA-Jo1.title" = "FLAC";
+
+/* Class = "NSButtonCell"; title = "E-AC3"; ObjectID = "u9h-dn-wcK"; */
+"u9h-dn-wcK.title" = "E-AC3";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "uFK-z7-8Yj"; */
+"uFK-z7-8Yj.title" = "Textcell";
+
+/* Class = "NSMenuItem"; title = "Item"; ObjectID = "UJy-A2-Bb1"; */
+"UJy-A2-Bb1.title" = "Objekt";
+
+/* Class = "NSTableColumn"; headerCell.title = "Bitrate"; ObjectID = "vhn-7C-4aZ"; */
+"vhn-7C-4aZ.headerCell.title" = "Bitfrekvens";
+
+/* Class = "NSButtonCell"; title = "AC3"; ObjectID = "VnE-3R-bUf"; */
+"VnE-3R-bUf.title" = "AC3";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Enable this if your playback device supports MP3. This permits MP3 passthru to be selected when automatic passthru selecion is enabled."; ObjectID = "vUx-OV-W5T"; */
+"vUx-OV-W5T.ibShadowedToolTip" = "Aktivera detta om din uppspelningsenhet har stöd för MP3. Detta tillåter att MP3-genomströmning kan väljas när valet automatisk genomströmning är aktiverat.";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "XKL-2e-Dlv"; */
+"XKL-2e-Dlv.title" = "Tabellvycell";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Gain"; ObjectID = "xnA-03-Bul"; */
+"xnA-03-Bul.ibExternalAccessibilityDescription" = "Gain";
+
+/* Class = "NSButtonCell"; title = "MP2"; ObjectID = "Z8O-AS-UdA"; */
+"Z8O-AS-UdA.title" = "MP2";
+
+/* Class = "NSButtonCell"; title = "TrueHD"; ObjectID = "z9d-P3-6UP"; */
+"z9d-P3-6UP.title" = "TrueHD";
+
+/* Class = "NSTableColumn"; headerCell.title = "DRC"; ObjectID = "zX9-T9-wKy"; */
+"zX9-T9-wKy.headerCell.title" = "DRC";
+

--- a/macosx/sv.lproj/ChaptersTitles.strings
+++ b/macosx/sv.lproj/ChaptersTitles.strings
@@ -1,0 +1,57 @@
+/* Class = "NSTableColumn"; headerCell.title = "Index"; ObjectID = "0iF-eL-NOC"; */
+"0iF-eL-NOC.headerCell.title" = "Index";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Export the list of chapter names to a CSV file."; ObjectID = "3SP-6e-RPS"; */
+"3SP-6e-RPS.ibShadowedToolTip" = "Exportera listan för kapitelnamn till en csv-fil.";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Add a chapter markers track to the video."; ObjectID = "7Xf-c0-jsr"; */
+"7Xf-c0-jsr.ibShadowedToolTip" = "Lägg till ett spår för kapitelmarkörer till videon.";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "All-Bz-NLv"; */
+"All-Bz-NLv.title" = "Textcell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "FyM-2X-9xs"; */
+"FyM-2X-9xs.title" = "Textcell";
+
+/* Class = "NSTextFieldCell"; title = "1"; ObjectID = "G9p-Cg-wyC"; */
+"G9p-Cg-wyC.title" = "1";
+
+/* Class = "NSButtonCell"; title = "Export Chapters…"; ObjectID = "h0O-zg-OF9"; */
+"h0O-zg-OF9.title" = "Exportera kapitel...";
+
+/* Class = "NSTableView"; ibExternalAccessibilityDescription = "Chapter titles"; ObjectID = "InF-gR-Lia"; */
+"InF-gR-Lia.ibExternalAccessibilityDescription" = "Kapiteltitlar";
+
+/* Class = "NSButtonCell"; title = "Create chapter markers"; ObjectID = "lJL-wX-DVP"; */
+"lJL-wX-DVP.title" = "Skapa kapitelmarkörer";
+
+/* Class = "NSTableColumn"; headerCell.title = "Start"; ObjectID = "NlF-th-Cg9"; */
+"NlF-th-Cg9.headerCell.title" = "Starta";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "ozt-ED-g1M"; */
+"ozt-ED-g1M.title" = "Textcell";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "pAo-XM-bvP"; */
+"pAo-XM-bvP.title" = "Textcell";
+
+/* Class = "NSButtonCell"; title = "Import Chapters…"; ObjectID = "PM3-Ue-0kW"; */
+"PM3-Ue-0kW.title" = "Importera kapitel...";
+
+/* Class = "NSTableColumn"; headerCell.title = "Duration"; ObjectID = "QVB-Cw-DJD"; */
+"QVB-Cw-DJD.headerCell.title" = "Speltid";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Import a list of chapter names from a CSV file."; ObjectID = "Ron-3B-rYg"; */
+"Ron-3B-rYg.ibShadowedToolTip" = "Importera en lista för kapitelnamn från en csv-fil.";
+
+/* Class = "NSTextFieldCell"; title = "Title"; ObjectID = "UjY-nz-uSt"; */
+"UjY-nz-uSt.title" = "Titel";
+
+/* Class = "NSTextFieldCell"; title = "Duration"; ObjectID = "Vmq-zJ-NEA"; */
+"Vmq-zJ-NEA.title" = "Speltid";
+
+/* Class = "NSTableColumn"; headerCell.title = "Title"; ObjectID = "Z6H-lJ-ipr"; */
+"Z6H-lJ-ipr.headerCell.title" = "Titel";
+
+/* Class = "NSTextFieldCell"; title = "Timestamp"; ObjectID = "zaN-qY-tke"; */
+"zaN-qY-tke.title" = "Tidsstämpel";
+

--- a/macosx/sv.lproj/ExceptionAlert.strings
+++ b/macosx/sv.lproj/ExceptionAlert.strings
@@ -1,0 +1,15 @@
+/* Class = "NSWindow"; title = "Internal Error"; ObjectID = "1"; */
+"1.title" = "Internt fel";
+
+/* Class = "NSTextFieldCell"; title = "An internal error has occurred. You can choose to continue in an unstable state, or crash."; ObjectID = "10"; */
+"10.title" = "Ett internt fel har inträffat. Du kan välja att fortsätta köra i ett instabilt tillstånd eller krascha.";
+
+/* Class = "NSTextFieldCell"; title = "Reason contents go here."; ObjectID = "12"; */
+"12.title" = "Anledningen anges här.";
+
+/* Class = "NSButtonCell"; title = "Crash"; ObjectID = "14"; */
+"14.title" = "Krasch";
+
+/* Class = "NSButtonCell"; title = "Continue"; ObjectID = "16"; */
+"16.title" = "Fortsätt";
+

--- a/macosx/sv.lproj/HBAddCategoryController.strings
+++ b/macosx/sv.lproj/HBAddCategoryController.strings
@@ -1,0 +1,15 @@
+/* Class = "NSWindow"; title = "New Category"; ObjectID = "C4G-OG-ksc"; */
+"C4G-OG-ksc.title" = "Ny kategori";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "N2f-jz-YyX"; */
+"N2f-jz-YyX.title" = "Avbryt";
+
+/* Class = "NSTextFieldCell"; title = "untitled category"; ObjectID = "NQn-fS-Rbd"; */
+"NQn-fS-Rbd.title" = "kategori utan namn";
+
+/* Class = "NSTextFieldCell"; title = "Name of the new category:"; ObjectID = "Pe0-gr-Yv4"; */
+"Pe0-gr-Yv4.title" = "Namn för nya kategorin:";
+
+/* Class = "NSButtonCell"; title = "Create"; ObjectID = "Z9M-dc-5Ml"; */
+"Z9M-dc-5Ml.title" = "Skapa";
+

--- a/macosx/sv.lproj/HBCroppingView.strings
+++ b/macosx/sv.lproj/HBCroppingView.strings
@@ -1,0 +1,39 @@
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop bottom"; ObjectID = "6Gj-ZU-E1E"; */
+"6Gj-ZU-E1E.ibExternalAccessibilityDescription" = "Beskär botten";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop top"; ObjectID = "8e5-zI-IBg"; */
+"8e5-zI-IBg.ibExternalAccessibilityDescription" = "Beskär toppen";
+
+/* Class = "NSMenuItem"; title = "Conservative"; ObjectID = "8Vn-fL-hvM"; */
+"8Vn-fL-hvM.title" = "Konservativ";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop top"; ObjectID = "Cp5-xz-x1h"; */
+"Cp5-xz-x1h.ibExternalAccessibilityDescription" = "Beskär toppen";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Rotate the picture clockwise in 90 degree increments."; ObjectID = "cWv-q0-EN9"; */
+"cWv-q0-EN9.ibShadowedToolTip" = "Rotera bilden 90 grader medurs inkrementellt.";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "dD5-og-dxx"; */
+"dD5-og-dxx.title" = "Anpassad";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop right"; ObjectID = "php-p6-Nz6"; */
+"php-p6-Nz6.ibExternalAccessibilityDescription" = "Beskär höger";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "Pqk-fS-pyy"; */
+"Pqk-fS-pyy.title" = "Ingen";
+
+/* Class = "NSMenuItem"; title = "Automatic"; ObjectID = "sUG-Cw-nQU"; */
+"sUG-Cw-nQU.title" = "Automatisk";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop bottom"; ObjectID = "sWf-fq-lvl"; */
+"sWf-fq-lvl.ibExternalAccessibilityDescription" = "Beskär botten";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop left"; ObjectID = "Td7-sa-0TV"; */
+"Td7-sa-0TV.ibExternalAccessibilityDescription" = "Beskär vänster";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop right"; ObjectID = "y7P-yk-q46"; */
+"y7P-yk-q46.ibExternalAccessibilityDescription" = "Beskär höger";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop left"; ObjectID = "Yua-R6-mWU"; */
+"Yua-R6-mWU.ibExternalAccessibilityDescription" = "Beskär vänster";
+

--- a/macosx/sv.lproj/HBEncodingProgressHUDController.strings
+++ b/macosx/sv.lproj/HBEncodingProgressHUDController.strings
@@ -1,0 +1,9 @@
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "Ha0-iE-RLa"; */
+"Ha0-iE-RLa.title" = "Avbryt";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Cancel Live Preview Encode"; ObjectID = "SEa-H6-T26"; */
+"SEa-H6-T26.ibShadowedToolTip" = "Avbryt enkodning av direkt förhandsvisning";
+
+/* Class = "NSTextFieldCell"; title = "Preparing Preview"; ObjectID = "tM8-gj-kBo"; */
+"tM8-gj-kBo.title" = "Förbereder förhandsvisning";
+

--- a/macosx/sv.lproj/HBFiltersViewController.strings
+++ b/macosx/sv.lproj/HBFiltersViewController.strings
@@ -1,0 +1,114 @@
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Denoise Tune"; ObjectID = "1XQ-md-5cQ"; */
+"1XQ-md-5cQ.ibExternalAccessibilityDescription" = "Justera denoise";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "5Vt-0j-92R"; */
+"5Vt-0j-92R.title" = "Justera:";
+
+/* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "8am-ve-1Xl"; */
+"8am-ve-1Xl.title" = "Förval:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "aem-qz-Cqk"; */
+"aem-qz-Cqk.title" = "Anpassad:";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Sharpen Tune"; ObjectID = "bRd-Km-Wa8"; */
+"bRd-Km-Wa8.ibExternalAccessibilityDescription" = "Justera sharpen";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Deblock Preset"; ObjectID = "bz8-FC-vYp"; */
+"bz8-FC-vYp.ibExternalAccessibilityDescription" = "Deblock-förval";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "CFV-ur-emt"; */
+"CFV-ur-emt.title" = "Anpassad:";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Sharpen Preset"; ObjectID = "cG4-79-P9J"; */
+"cG4-79-P9J.ibExternalAccessibilityDescription" = "Sharpen-förval";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Sharpen filter preset. Sets the strength of the filter."; ObjectID = "cG4-79-P9J"; */
+"cG4-79-P9J.ibShadowedToolTip" = "Förval för filtret sharpen. Anger styrkan för filtret.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Denoise Preset"; ObjectID = "cTy-PO-BSd"; */
+"cTy-PO-BSd.ibExternalAccessibilityDescription" = "Denoise-förval";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Denoise filter preset. Sets the strength of the filter."; ObjectID = "cTy-PO-BSd"; */
+"cTy-PO-BSd.ibShadowedToolTip" = "Förval för filtret denoise. Anger styrkan för filtret.";
+
+/* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "D7G-kY-TSj"; */
+"D7G-kY-TSj.title" = "Förval:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "Da7-pY-5vu"; */
+"Da7-pY-5vu.title" = "Anpassad:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "DvX-m9-Q6u"; */
+"DvX-m9-Q6u.title" = "Anpassad:";
+
+/* Class = "NSTextFieldCell"; title = "Deblock:"; ObjectID = "gKq-xF-AZE"; */
+"gKq-xF-AZE.title" = "Deblock:";
+
+/* Class = "NSButtonCell"; title = "Grayscale"; ObjectID = "h7g-eE-vgv"; */
+"h7g-eE-vgv.title" = "Gråskala";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Sharpen Tune"; ObjectID = "Hcn-5m-N9x"; */
+"Hcn-5m-N9x.ibExternalAccessibilityDescription" = "Justera sharpen";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Chroma Smooth Preset"; ObjectID = "hiK-Va-rbJ"; */
+"hiK-Va-rbJ.ibExternalAccessibilityDescription" = "Chroma Smooth-förval";
+
+/* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "HVj-4g-OVv"; */
+"HVj-4g-OVv.title" = "Färgrymd:";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "hyH-QP-Zdi"; */
+"hyH-QP-Zdi.title" = "Justera:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Custom deleteline settings."; ObjectID = "ipJ-z3-XnJ"; */
+"ipJ-z3-XnJ.ibExternalAccessibilityDescription" = "Anpassade inställningar för deleteline.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Chroma Smooth Tune"; ObjectID = "jFk-Eg-o2W"; */
+"jFk-Eg-o2W.ibExternalAccessibilityDescription" = "Justera Chroma Smooth";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "KiY-kz-54k"; */
+"KiY-kz-54k.title" = "Anpassad:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "n6U-tH-vo0"; */
+"n6U-tH-vo0.title" = "Anpassad:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "oWz-qF-JYk"; */
+"oWz-qF-JYk.title" = "Anpassad:";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Grayscale removes the color component of the video. Often referred to as Black & White video."; ObjectID = "Psx-nN-XiT"; */
+"Psx-nN-XiT.ibShadowedToolTip" = "Gråskala tar bort färgkomponenten i videon. Ofta refererad till som svartvitt video.";
+
+/* Class = "NSTextFieldCell"; title = "Denoise:"; ObjectID = "Rxe-Xm-vXj"; */
+"Rxe-Xm-vXj.title" = "Denoise:";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Colorspace Preset"; ObjectID = "ScE-ad-pHc"; */
+"ScE-ad-pHc.ibExternalAccessibilityDescription" = "Färgrymd-förval";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "tje-4P-jKt"; */
+"tje-4P-jKt.title" = "Justera:";
+
+/* Class = "NSTextFieldCell"; title = "Sharpen:"; ObjectID = "TwB-ag-L1L"; */
+"TwB-ag-L1L.title" = "Sharpen:";
+
+/* Class = "NSTextFieldCell"; title = "Color:"; ObjectID = "uDH-ts-vs5"; */
+"uDH-ts-vs5.title" = "Färg:";
+
+/* Class = "NSTextFieldCell"; title = "Deinterlace:"; ObjectID = "VsK-mC-9Pj"; */
+"VsK-mC-9Pj.title" = "Deinterlace:";
+
+/* Class = "NSTextFieldCell"; title = "Detelecine:"; ObjectID = "vTS-MJ-8nt"; */
+"vTS-MJ-8nt.title" = "Detelecine:";
+
+/* Class = "NSTextFieldCell"; title = "Interlace Detection:"; ObjectID = "xHD-vC-ePQ"; */
+"xHD-vC-ePQ.title" = "Identifiera interlace:";
+
+/* Class = "NSTextFieldCell"; title = "Custom:"; ObjectID = "xqk-dM-L3o"; */
+"xqk-dM-L3o.title" = "Anpassad:";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "ydN-tP-vpt"; */
+"ydN-tP-vpt.title" = "Justera:";
+
+/* Class = "NSTextFieldCell"; title = "Chroma Smooth:"; ObjectID = "ZLl-Q6-HpE"; */
+"ZLl-Q6-HpE.title" = "Chroma Smooth:";
+
+/* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "zvZ-ZX-yKE"; */
+"zvZ-ZX-yKE.title" = "Förval:";
+

--- a/macosx/sv.lproj/HBPictureHUDController.strings
+++ b/macosx/sv.lproj/HBPictureHUDController.strings
@@ -1,0 +1,30 @@
+/* Class = "NSButton"; ibShadowedToolTip = "Scale preview to fill the display."; ObjectID = "12K-c3-Z7A"; */
+"12K-c3-Z7A.ibShadowedToolTip" = "Skala förhandsvisning för att fylla skärmen.";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Encode and play a preview video using current settings."; ObjectID = "16b-R9-bBU"; */
+"16b-R9-bBU.ibShadowedToolTip" = "Enkoda och spela upp en förhandsvisning av videon med aktuella inställningar.";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Duration to encode in seconds."; ObjectID = "ASA-X8-16P"; */
+"ASA-X8-16P.ibShadowedToolTip" = "Längd att enkoda i sekunder.";
+
+/* Class = "NSTextFieldCell"; title = "sec"; ObjectID = "ksF-Ma-hB1"; */
+"ksF-Ma-hB1.title" = "s";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Show cropping settings"; ObjectID = "mV7-hU-tMt"; */
+"mV7-hU-tMt.ibShadowedToolTip" = "Visa beskärningsinställningar";
+
+/* Class = "NSButtonCell"; title = "Crop"; ObjectID = "NWd-Lq-c1A"; */
+"NWd-Lq-c1A.title" = "Beskär";
+
+/* Class = "NSButtonCell"; title = "Scale To Screen"; ObjectID = "STc-Po-p1X"; */
+"STc-Po-p1X.title" = "Skala till skärm";
+
+/* Class = "NSTextFieldCell"; title = "Duration:"; ObjectID = "USR-Qf-N5v"; */
+"USR-Qf-N5v.title" = "Speltid:";
+
+/* Class = "NSSlider"; ibExternalAccessibilityDescription = "preview image"; ObjectID = "wUk-SQ-GhS"; */
+"wUk-SQ-GhS.ibExternalAccessibilityDescription" = "förhandsbild";
+
+/* Class = "NSMenuItem"; title = "240"; ObjectID = "XYh-Ls-slf"; */
+"XYh-Ls-slf.title" = "240";
+

--- a/macosx/sv.lproj/HBPictureViewController.strings
+++ b/macosx/sv.lproj/HBPictureViewController.strings
@@ -1,0 +1,303 @@
+/* Class = "NSButtonCell"; title = "Allow Upscaling"; ObjectID = "0kU-Uy-P4P"; */
+"0kU-Uy-P4P.title" = "Tillåt uppskalning";
+
+/* Class = "NSTextFieldCell"; title = "Display Size:"; ObjectID = "1AB-bM-qTs"; */
+"1AB-bM-qTs.title" = "Visningsstorlek:";
+
+/* Class = "NSMenuItem"; title = "Off"; ObjectID = "1O3-th-4M5"; */
+"1O3-th-4M5.title" = "Av";
+
+/* Class = "NSMenuItem"; title = "Conservative"; ObjectID = "1Pn-6x-bhx"; */
+"1Pn-6x-bhx.title" = "Konservativ";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop bottom"; ObjectID = "1Z0-JT-vst"; */
+"1Z0-JT-vst.ibExternalAccessibilityDescription" = "Beskär botten";
+
+/* Class = "NSMenuItem"; title = "2160p 4K Ultra HD"; ObjectID = "1Zm-mM-8Tb"; */
+"1Zm-mM-8Tb.title" = "2160p 4K Ultra HD";
+
+/* Class = "NSMenuItem"; title = "180°"; ObjectID = "1zy-53-Bvd"; */
+"1zy-53-Bvd.title" = "180°";
+
+/* Class = "NSMenuItem"; title = "1440p 2.5K Quad HD"; ObjectID = "2ax-HE-Amt"; */
+"2ax-HE-Amt.title" = "1440p 2.5K Quad HD";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "2fq-yE-LSA"; */
+"2fq-yE-LSA.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "-"; ObjectID = "2jg-kg-z9e"; */
+"2jg-kg-z9e.ibShadowedIsNilPlaceholder" = "-";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Storage Height"; ObjectID = "2s0-5k-fjU"; */
+"2s0-5k-fjU.ibExternalAccessibilityDescription" = "Lagringshöjd";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Storage Height"; ObjectID = "3HN-8C-yAS"; */
+"3HN-8C-yAS.ibExternalAccessibilityDescription" = "Lagringshöjd";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "-"; ObjectID = "3Ze-5A-gL3"; */
+"3Ze-5A-gL3.ibShadowedIsNilPlaceholder" = "-";
+
+/* Class = "NSTextFieldCell"; title = "x"; ObjectID = "5Tj-xw-QuU"; */
+"5Tj-xw-QuU.title" = "x";
+
+/* Class = "NSTextFieldCell"; title = "Aspect Ratio:"; ObjectID = "5Vi-N9-9kM"; */
+"5Vi-N9-9kM.title" = "Bildförhållande:";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "6Qy-ik-hiE"; */
+"6Qy-ik-hiE.title" = "Ingen";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop bottom"; ObjectID = "6W6-RI-fBx"; */
+"6W6-RI-fBx.ibExternalAccessibilityDescription" = "Beskär botten";
+
+/* Class = "NSTextFieldCell"; title = "Anamorphic:"; ObjectID = "8vS-Mw-bny"; */
+"8vS-Mw-bny.title" = "Anamorfisk:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Scaled Width"; ObjectID = "9hH-As-JSa"; */
+"9hH-As-JSa.ibExternalAccessibilityDescription" = "Skalad bredd";
+
+/* Class = "NSMenuItem"; title = "480p NTSC SD"; ObjectID = "21C-Hg-mk4"; */
+"21C-Hg-mk4.title" = "480p NTSC SD";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop top"; ObjectID = "41c-48-2XJ"; */
+"41c-48-2XJ.ibExternalAccessibilityDescription" = "Beskär toppen";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Custom border color"; ObjectID = "aby-WS-tzS"; */
+"aby-WS-tzS.ibExternalAccessibilityDescription" = "Anpassad ramfärg";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Custom border color"; ObjectID = "aby-WS-tzS"; */
+"aby-WS-tzS.ibShadowedToolTip" = "Anpassad ramfärg";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Display width"; ObjectID = "Ag1-Tk-hCm"; */
+"Ag1-Tk-hCm.ibExternalAccessibilityDescription" = "Visningsbredd";
+
+/* Class = "NSTextFieldCell"; title = "Resolution & Scaling"; ObjectID = "aVx-b3-2AK"; */
+"aVx-b3-2AK.title" = "Upplösning och skalning";
+
+/* Class = "NSTextFieldCell"; title = "0 x 0"; ObjectID = "byr-LI-ap5"; */
+"byr-LI-ap5.title" = "0 x 0";
+
+/* Class = "NSTextFieldCell"; title = "x"; ObjectID = "C6R-PR-3gu"; */
+"C6R-PR-3gu.title" = "x";
+
+/* Class = "NSTextFieldCell"; title = "0 x 0"; ObjectID = "c9F-IW-Rln"; */
+"c9F-IW-Rln.title" = "0 x 0";
+
+/* Class = "NSTextFieldCell"; title = "Resolution Limit:"; ObjectID = "d0T-QG-WXU"; */
+"d0T-QG-WXU.title" = "Upplösningsgräns:";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop right"; ObjectID = "Ddg-4D-el9"; */
+"Ddg-4D-el9.ibExternalAccessibilityDescription" = "Beskär höger";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "DN4-KZ-LRc"; */
+"DN4-KZ-LRc.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSTextFieldCell"; title = "1:1"; ObjectID = "dnG-b9-LQR"; */
+"dnG-b9-LQR.title" = "1:1";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = " "; ObjectID = "E5O-kn-GYm"; */
+"E5O-kn-GYm.ibExternalAccessibilityDescription" = "ceaa80fca5ba3e8646366fa50fbb4322_tr";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Display height"; ObjectID = "eEF-b3-4o9"; */
+"eEF-b3-4o9.ibExternalAccessibilityDescription" = "Visningshöjd";
+
+/* Class = "NSMenuItem"; title = "Black"; ObjectID = "EM5-tR-x3U"; */
+"EM5-tR-x3U.title" = "Svart";
+
+/* Class = "NSButtonCell"; title = "Automatic"; ObjectID = "eOi-50-jLK"; */
+"eOi-50-jLK.title" = "Automatisk";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "-"; ObjectID = "ePc-i4-vPZ"; */
+"ePc-i4-vPZ.ibShadowedIsNilPlaceholder" = "-";
+
+/* Class = "NSButtonCell"; title = "Horizontal"; ObjectID = "EqJ-eR-Fz7"; */
+"EqJ-eR-Fz7.title" = "Horisontell";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "f12-Dh-fDw"; */
+"f12-Dh-fDw.title" = "Anpassad";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "fau-iA-M1E"; */
+"fau-iA-M1E.title" = "Ingen";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Maximum height"; ObjectID = "FGm-oJ-FVW"; */
+"FGm-oJ-FVW.ibExternalAccessibilityDescription" = "Maximal höjd";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Use highest resolution permitted by above settings"; ObjectID = "fjj-ZH-nqb"; */
+"fjj-ZH-nqb.ibShadowedToolTip" = "Använd högsta upplösningen som tillåts med ovanstående inställningar";
+
+/* Class = "NSMenuItem"; title = "White"; ObjectID = "fQM-vV-sUg"; */
+"fQM-vV-sUg.title" = "Vit";
+
+/* Class = "NSButtonCell"; title = "Optimal Size"; ObjectID = "FUA-5p-imC"; */
+"FUA-5p-imC.title" = "Optimal storlek";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Storage Width"; ObjectID = "FwZ-6T-zJe"; */
+"FwZ-6T-zJe.ibExternalAccessibilityDescription" = "Lagringsbredd";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "gWL-mx-RIK"; */
+"gWL-mx-RIK.title" = "Ingen";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Storage Height"; ObjectID = "Hkl-7Z-J2e"; */
+"Hkl-7Z-J2e.ibExternalAccessibilityDescription" = "Lagringshöjd";
+
+/* Class = "NSTextFieldCell"; title = "x"; ObjectID = "hN1-S9-zl8"; */
+"hN1-S9-zl8.title" = "x";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "-"; ObjectID = "hTi-U4-PGY"; */
+"hTi-U4-PGY.ibShadowedIsNilPlaceholder" = "-";
+
+/* Class = "NSTextFieldCell"; title = "Fill:"; ObjectID = "iqM-GW-fCe"; */
+"iqM-GW-fCe.title" = "Fyll:";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Storage Width"; ObjectID = "iuc-JG-bhU"; */
+"iuc-JG-bhU.ibExternalAccessibilityDescription" = "Lagringsbredd";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Display width"; ObjectID = "jru-UG-Rf6"; */
+"jru-UG-Rf6.ibExternalAccessibilityDescription" = "Visningsbredd";
+
+/* Class = "NSMenuItem"; title = "Automatic"; ObjectID = "JyN-AK-Hae"; */
+"JyN-AK-Hae.title" = "Automatisk";
+
+/* Class = "NSMenuItem"; title = "Gray"; ObjectID = "K6n-ea-Zty"; */
+"K6n-ea-Zty.title" = "Grå";
+
+/* Class = "NSMenuItem"; title = "Automatic"; ObjectID = "Kay-sv-ssX"; */
+"Kay-sv-ssX.title" = "Automatisk";
+
+/* Class = "NSTextFieldCell"; title = "Storage Size:"; ObjectID = "kOg-k4-0N2"; */
+"kOg-k4-0N2.title" = "Lagringsstorlek:";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "krD-da-wuz"; */
+"krD-da-wuz.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSTextFieldCell"; title = "Scaled Size:"; ObjectID = "L7V-2e-qf9"; */
+"L7V-2e-qf9.title" = "Skalad storlek:";
+
+/* Class = "NSTextFieldCell"; title = "1:1"; ObjectID = "lIt-eN-Uyd"; */
+"lIt-eN-Uyd.title" = "1:1";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "LQm-LK-6tr"; */
+"LQm-LK-6tr.title" = "Anpassad";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop left"; ObjectID = "LTu-ic-Ty9"; */
+"LTu-ic-Ty9.ibExternalAccessibilityDescription" = "Beskär vänster";
+
+/* Class = "NSTextFieldCell"; title = "Aspect Ratio:"; ObjectID = "Lz1-Cx-d30"; */
+"Lz1-Cx-d30.title" = "Bildförhållande:";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop top"; ObjectID = "Mke-9L-LvB"; */
+"Mke-9L-LvB.ibExternalAccessibilityDescription" = "Beskär toppen";
+
+/* Class = "NSMenuItem"; title = "Width & Height"; ObjectID = "N5d-nG-TZV"; */
+"N5d-nG-TZV.title" = "Bredd och höjd";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Maximum width"; ObjectID = "NRy-vc-8qX"; */
+"NRy-vc-8qX.ibExternalAccessibilityDescription" = "Maximal bredd";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "ob5-QF-mOC"; */
+"ob5-QF-mOC.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSTextFieldCell"; title = "Color:"; ObjectID = "OCX-n7-THw"; */
+"OCX-n7-THw.title" = "Färg:";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "owa-gb-koC"; */
+"owa-gb-koC.title" = "Anpassad";
+
+/* Class = "NSMenuItem"; title = "Height (Letterbox)"; ObjectID = "p7U-Ee-kt4"; */
+"p7U-Ee-kt4.title" = "Höjd (Letterbox)";
+
+/* Class = "NSMenuItem"; title = "Dark Gray"; ObjectID = "pWs-NL-FVO"; */
+"pWs-NL-FVO.title" = "Mörkgrå";
+
+/* Class = "NSMenuItem"; title = "0°"; ObjectID = "qsi-r7-kNQ"; */
+"qsi-r7-kNQ.title" = "0°";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "QSp-61-LWu"; */
+"QSp-61-LWu.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSMenuItem"; title = "1080p HD"; ObjectID = "qzy-K8-2tY"; */
+"qzy-K8-2tY.title" = "1080p HD";
+
+/* Class = "NSStepper"; ibExternalAccessibilityDescription = "Crop left"; ObjectID = "r9l-cH-pFW"; */
+"r9l-cH-pFW.ibExternalAccessibilityDescription" = "Beskär vänster";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "sg1-tR-fnw"; */
+"sg1-tR-fnw.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "-"; ObjectID = "SGn-b9-JVZ"; */
+"SGn-b9-JVZ.ibShadowedIsNilPlaceholder" = "-";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "sut-JO-hwX"; */
+"sut-JO-hwX.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSMenuItem"; title = "270°"; ObjectID = "tIU-4H-3Xm"; */
+"tIU-4H-3Xm.title" = "270°";
+
+/* Class = "NSTextFieldCell"; title = "Source Dimensions"; ObjectID = "Trk-C5-Npx"; */
+"Trk-C5-Npx.title" = "Källans dimensioner";
+
+/* Class = "NSTextFieldCell"; title = "Orientation & Cropping"; ObjectID = "u2U-SJ-szy"; */
+"u2U-SJ-szy.title" = "Orientering och beskäring";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = " "; ObjectID = "uqQ-uA-3xF"; */
+"uqQ-uA-3xF.ibExternalAccessibilityDescription" = "0b36a71978ca057bf0594fec41410ec0_tr";
+
+/* Class = "NSTextFieldCell"; title = ":"; ObjectID = "uuL-JR-73C"; */
+"uuL-JR-73C.title" = ":";
+
+/* Class = "NSTextFieldCell"; title = "Final Dimensions"; ObjectID = "Ux1-Pc-XSD"; */
+"Ux1-Pc-XSD.title" = "Slutgiltiga dimensioner";
+
+/* Class = "NSMenuItem"; title = "90°"; ObjectID = "V1G-sQ-eqd"; */
+"V1G-sQ-eqd.title" = "90°";
+
+/* Class = "NSTextFieldCell"; title = "Rotation:"; ObjectID = "vb2-DA-Pgr"; */
+"vb2-DA-Pgr.title" = "Rotering:";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "How to apply crop settings"; ObjectID = "vfx-ON-9ys"; */
+"vfx-ON-9ys.ibShadowedToolTip" = "Hur man tillämpar beskäringsinställningar";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Add a border around the video"; ObjectID = "vKr-fn-Ujh"; */
+"vKr-fn-Ujh.ibShadowedToolTip" = "Lägg till en sorgkant runt videon";
+
+/* Class = "NSMenuItem"; title = "4320p 8K Ultra HD"; ObjectID = "Vrx-BH-ry2"; */
+"Vrx-BH-ry2.title" = "4320p 8K Ultra HD";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "vzz-ej-1nx"; */
+"vzz-ej-1nx.title" = "Anpassad";
+
+/* Class = "NSMenuItem"; title = "Width (Pillarbox)"; ObjectID = "W5p-nd-4WK"; */
+"W5p-nd-4WK.title" = "Bredd (Pillarbox)";
+
+/* Class = "NSTextFieldCell"; title = "Display Size:"; ObjectID = "WBD-tH-x3h"; */
+"WBD-tH-x3h.title" = "Visningsstorlek:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Crop right"; ObjectID = "wsq-TS-cC6"; */
+"wsq-TS-cC6.ibExternalAccessibilityDescription" = "Beskär höger";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "0"; ObjectID = "x0H-9t-WiF"; */
+"x0H-9t-WiF.ibShadowedIsNilPlaceholder" = "0";
+
+/* Class = "NSMenuItem"; title = "720p HD"; ObjectID = "Xao-1P-xPT"; */
+"Xao-1P-xPT.title" = "720p HD";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Flips (mirrors) the picture on the horizontal axis"; ObjectID = "xNB-9k-4uD"; */
+"xNB-9k-4uD.ibShadowedToolTip" = "Vänder (speglar) bilder på den horisontella axeln.";
+
+/* Class = "NSMenuItem"; title = "Custom"; ObjectID = "Xun-U2-N6F"; */
+"Xun-U2-N6F.title" = "Anpassad";
+
+/* Class = "NSMenuItem"; title = "576p PAL SD"; ObjectID = "yue-jq-T1X"; */
+"yue-jq-T1X.title" = "576p PAL SD";
+
+/* Class = "NSTextFieldCell"; title = "Borders"; ObjectID = "ywF-EG-IYr"; */
+"ywF-EG-IYr.title" = "Sorgkanter";
+
+/* Class = "NSTextFieldCell"; title = "Cropping:"; ObjectID = "zsq-Le-41g"; */
+"zsq-Le-41g.title" = "Beskärning:";
+
+/* Class = "NSTextFieldCell"; title = "0 x 0"; ObjectID = "ZTy-fJ-cDa"; */
+"ZTy-fJ-cDa.title" = "0 x 0";
+
+/* Class = "NSTextFieldCell"; title = "Storage Size:"; ObjectID = "ZZ9-XW-Uib"; */
+"ZZ9-XW-Uib.title" = "Lagringsstorlek:";
+

--- a/macosx/sv.lproj/HBPlayerHUDController.strings
+++ b/macosx/sv.lproj/HBPlayerHUDController.strings
@@ -1,0 +1,66 @@
+/* Class = "NSTextFieldCell"; title = "00:00:00"; ObjectID = "6A0-9h-5UY"; */
+"6A0-9h-5UY.title" = "00:00:00";
+
+/* Class = "NSMenuItem"; title = "Tracks"; ObjectID = "6BQ-wU-p2C"; */
+"6BQ-wU-p2C.title" = "Spår";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Exit player and return to still image previews."; ObjectID = "84p-08-fGK"; */
+"84p-08-fGK.ibShadowedToolTip" = "Avsluta spelaren och återgå till bildförhandsvisning.";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Go To End"; ObjectID = "CQ0-pk-SFk"; */
+"CQ0-pk-SFk.ibExternalAccessibilityDescription" = "Gå till slutet";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Go To End"; ObjectID = "CQ0-pk-SFk"; */
+"CQ0-pk-SFk.ibShadowedToolTip" = "Gå till slutet";
+
+/* Class = "NSTextFieldCell"; title = "00:00:00"; ObjectID = "dGi-LK-P1E"; */
+"dGi-LK-P1E.title" = "00:00:00";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Mute Volume"; ObjectID = "euL-Tg-dmT"; */
+"euL-Tg-dmT.ibExternalAccessibilityDescription" = "Tyst volym";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Mute Volume"; ObjectID = "euL-Tg-dmT"; */
+"euL-Tg-dmT.ibShadowedToolTip" = "Tyst volym";
+
+/* Class = "NSSlider"; ibExternalAccessibilityDescription = "Volume Control"; ObjectID = "gzA-no-jdv"; */
+"gzA-no-jdv.ibExternalAccessibilityDescription" = "Volymkontroll";
+
+/* Class = "NSSlider"; ibShadowedToolTip = "Drag to change volume."; ObjectID = "gzA-no-jdv"; */
+"gzA-no-jdv.ibShadowedToolTip" = "Dra för att ändra ljudvolymen.";
+
+/* Class = "NSSlider"; ibExternalAccessibilityDescription = "Timeline"; ObjectID = "lBp-JT-ehn"; */
+"lBp-JT-ehn.ibExternalAccessibilityDescription" = "Tidslinje";
+
+/* Class = "NSSlider"; ibShadowedToolTip = "Drag to change timeline position."; ObjectID = "lBp-JT-ehn"; */
+"lBp-JT-ehn.ibShadowedToolTip" = "Dra för att ändra tidslinjens position.";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Play/Pause"; ObjectID = "mLA-ei-4sK"; */
+"mLA-ei-4sK.ibExternalAccessibilityDescription" = "Spela upp/Paus";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Toggle Play/Pause"; ObjectID = "mLA-ei-4sK"; */
+"mLA-ei-4sK.ibShadowedToolTip" = "Växla Spela upp/Paus";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Time Remaining"; ObjectID = "PVD-pq-1ZG"; */
+"PVD-pq-1ZG.ibExternalAccessibilityDescription" = "Återstående tid";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Time remaining."; ObjectID = "PVD-pq-1ZG"; */
+"PVD-pq-1ZG.ibShadowedToolTip" = "Återstående tid.";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Current Timeline Position"; ObjectID = "uYx-2C-8et"; */
+"uYx-2C-8et.ibExternalAccessibilityDescription" = "Aktuell position på tidslinjen";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Current timeline position."; ObjectID = "uYx-2C-8et"; */
+"uYx-2C-8et.ibShadowedToolTip" = "Aktuell position på tidslinjen.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Tracks Selection"; ObjectID = "Vj1-Za-AUV"; */
+"Vj1-Za-AUV.ibExternalAccessibilityDescription" = "Spårval";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Enable or disable tracks."; ObjectID = "Vj1-Za-AUV"; */
+"Vj1-Za-AUV.ibShadowedToolTip" = "Aktivera eller inaktivera spår.";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Go To Beginning"; ObjectID = "WuP-9l-8AN"; */
+"WuP-9l-8AN.ibExternalAccessibilityDescription" = "Gå till början";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Go To Beginning"; ObjectID = "WuP-9l-8AN"; */
+"WuP-9l-8AN.ibShadowedToolTip" = "Gå till början";
+

--- a/macosx/sv.lproj/HBPreviewViewController.strings
+++ b/macosx/sv.lproj/HBPreviewViewController.strings
@@ -1,0 +1,18 @@
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Previous Preview Image"; ObjectID = "1o6-MG-Jbu"; */
+"1o6-MG-Jbu.ibExternalAccessibilityDescription" = "Föregående förhandsbild";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Previous Preview Image"; ObjectID = "1o6-MG-Jbu"; */
+"1o6-MG-Jbu.ibShadowedToolTip" = "Föregående förhandsbild";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Next Preview Image"; ObjectID = "5po-M6-Hqa"; */
+"5po-M6-Hqa.ibExternalAccessibilityDescription" = "Nästa förhandsbild";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Next Preview Image"; ObjectID = "5po-M6-Hqa"; */
+"5po-M6-Hqa.ibShadowedToolTip" = "Nästa förhandsbild";
+
+/* Class = "NSButtonCell"; title = "‹"; ObjectID = "EWx-of-C7c"; */
+"EWx-of-C7c.title" = "‹";
+
+/* Class = "NSButtonCell"; title = "›"; ObjectID = "Izx-9B-XA3"; */
+"Izx-9B-XA3.title" = "›";
+

--- a/macosx/sv.lproj/HBQueueInfoViewController.strings
+++ b/macosx/sv.lproj/HBQueueInfoViewController.strings
@@ -1,0 +1,24 @@
+/* Class = "NSTextFieldCell"; title = "Statistics"; ObjectID = "aCP-yp-iZy"; */
+"aCP-yp-iZy.title" = "Statistik";
+
+/* Class = "NSTextFieldCell"; title = "Summary"; ObjectID = "cx1-rC-AMC"; */
+"cx1-rC-AMC.title" = "Sammandrag";
+
+/* Class = "NSButtonCell"; title = "Edit"; ObjectID = "erY-5X-50l"; */
+"erY-5X-50l.title" = "Redigera";
+
+/* Class = "NSTextFieldCell"; title = "Summary"; ObjectID = "GaR-qk-UW7"; */
+"GaR-qk-UW7.title" = "Sammandrag";
+
+/* Class = "NSButtonCell"; title = "Reset"; ObjectID = "hgl-N3-x4S"; */
+"hgl-N3-x4S.title" = "Nollställ";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Reset the job state"; ObjectID = "oq4-g0-srt"; */
+"oq4-g0-srt.ibShadowedToolTip" = "Nollställ jobbtillstånd";
+
+/* Class = "NSTextFieldCell"; title = "Statistics"; ObjectID = "S15-bh-qKU"; */
+"S15-bh-qKU.title" = "Statistik";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Open the job in the main window for editing"; ObjectID = "Z14-gh-hWn"; */
+"Z14-gh-hWn.ibShadowedToolTip" = "Öppna jobbet i huvudfönstret för redigering";
+

--- a/macosx/sv.lproj/HBQueueTableViewController.strings
+++ b/macosx/sv.lproj/HBQueueTableViewController.strings
@@ -1,0 +1,42 @@
+/* Class = "NSMenuItem"; title = "Remove All Jobs"; ObjectID = "5AR-we-iHC"; */
+"5AR-we-iHC.title" = "Ta bort alla jobb";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "5Rl-P0-bhc"; */
+"5Rl-P0-bhc.title" = "Tabellvycell";
+
+/* Class = "NSMenuItem"; title = "Show Destination in Finder"; ObjectID = "c1Z-ZC-b8b"; */
+"c1Z-ZC-b8b.title" = "Visa mål i Finder";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "DTF-om-j0l"; */
+"DTF-om-j0l.title" = "Redigera";
+
+/* Class = "NSTextFieldCell"; title = "Encoding status"; ObjectID = "eEU-Dr-Qh8"; */
+"eEU-Dr-Qh8.title" = "Enkodningsstatus";
+
+/* Class = "NSMenuItem"; title = "Remove"; ObjectID = "egD-8R-PTJ"; */
+"egD-8R-PTJ.title" = "Ta bort";
+
+/* Class = "NSMenuItem"; title = "Remove Completed Jobs"; ObjectID = "gNj-D1-wa7"; */
+"gNj-D1-wa7.title" = "Ta bort färdiga jobb";
+
+/* Class = "NSMenuItem"; title = "Move to Bottom"; ObjectID = "HwR-LP-IK8"; */
+"HwR-LP-IK8.title" = "Flytta nederst";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "K6c-HW-um8"; */
+"K6c-HW-um8.title" = "Textcell";
+
+/* Class = "NSMenuItem"; title = "Move to Top"; ObjectID = "NN5-Yq-Cth"; */
+"NN5-Yq-Cth.title" = "Flytta överst";
+
+/* Class = "NSMenuItem"; title = "Show Source in Finder"; ObjectID = "Pps-jm-zcd"; */
+"Pps-jm-zcd.title" = "Visa källa i Finder";
+
+/* Class = "NSMenuItem"; title = "Reset"; ObjectID = "xMs-43-lL0"; */
+"xMs-43-lL0.title" = "Nollställ";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "xSd-Hl-5Qk"; */
+"xSd-Hl-5Qk.title" = "Tabellvycell";
+
+/* Class = "NSMenuItem"; title = "Show Activity Log in Finder"; ObjectID = "zA7-r8-i4L"; */
+"zA7-r8-i4L.title" = "Visa aktivitetslogg i Finder";
+

--- a/macosx/sv.lproj/HBRenamePresetController.strings
+++ b/macosx/sv.lproj/HBRenamePresetController.strings
@@ -1,0 +1,15 @@
+/* Class = "NSWindow"; title = "Rename Preset"; ObjectID = "C4G-OG-ksc"; */
+"C4G-OG-ksc.title" = "Byt namn på förval";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "N2f-jz-YyX"; */
+"N2f-jz-YyX.title" = "Avbryt";
+
+/* Class = "NSTextFieldCell"; title = "Untitled"; ObjectID = "NQn-fS-Rbd"; */
+"NQn-fS-Rbd.title" = "Inget namn";
+
+/* Class = "NSTextFieldCell"; title = "New preset name:"; ObjectID = "Pe0-gr-Yv4"; */
+"Pe0-gr-Yv4.title" = "Nytt förvalsnamn:";
+
+/* Class = "NSButtonCell"; title = "Rename"; ObjectID = "Z9M-dc-5Ml"; */
+"Z9M-dc-5Ml.title" = "Byt namn";
+

--- a/macosx/sv.lproj/HBSummaryViewController.strings
+++ b/macosx/sv.lproj/HBSummaryViewController.strings
@@ -1,0 +1,48 @@
+/* Class = "NSTextFieldCell"; title = "Tracks:"; ObjectID = "3mF-Bb-Gon"; */
+"3mF-Bb-Gon.title" = "Spår:";
+
+/* Class = "NSTextFieldCell"; title = "Size:"; ObjectID = "B4a-co-0ly"; */
+"B4a-co-0ly.title" = "Storlek:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Filters summary"; ObjectID = "BHq-Mt-3eA"; */
+"BHq-Mt-3eA.ibExternalAccessibilityDescription" = "Sammandrag av filter";
+
+/* Class = "NSButtonCell"; title = "Passthru Common Metadata"; ObjectID = "CZZ-bW-jZc"; */
+"CZZ-bW-jZc.title" = "Skicka igenom vanliga metadata";
+
+/* Class = "NSButtonCell"; title = "Align A/V Start"; ObjectID = "De0-Je-MAm"; */
+"De0-Je-MAm.title" = "Justera ljud-/videostart";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Copy metadata from source to output"; ObjectID = "eJx-BO-rhL"; */
+"eJx-BO-rhL.ibShadowedToolTip" = "Kopiera metadata från källa till utdata";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Size summary"; ObjectID = "Jaw-pH-rhf"; */
+"Jaw-pH-rhf.ibExternalAccessibilityDescription" = "Sammandrag av storlek";
+
+/* Class = "NSView"; ibExternalAccessibilityDescription = "Preview"; ObjectID = "m5a-0z-QQ4"; */
+"m5a-0z-QQ4.ibExternalAccessibilityDescription" = "Förhandsvisning";
+
+/* Class = "NSTextFieldCell"; title = "Filters:"; ObjectID = "OCw-f6-uA0"; */
+"OCw-f6-uA0.title" = "Filter:";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "RIB-ME-Yhh"; */
+"RIB-ME-Yhh.title" = "Ingen";
+
+/* Class = "NSTextFieldCell"; title = "Format:"; ObjectID = "RXJ-DZ-4mh"; */
+"RXJ-DZ-4mh.title" = "Format:";
+
+/* Class = "NSButtonCell"; title = "Web Optimized"; ObjectID = "wcc-5d-Dgj"; */
+"wcc-5d-Dgj.title" = "Webboptimerad";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "xmy-Jl-mR4"; */
+"xmy-Jl-mR4.title" = "Ingen";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "xzc-qg-AMn"; */
+"xzc-qg-AMn.title" = "Ingen";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Tracks summary"; ObjectID = "yRE-5c-FhX"; */
+"yRE-5c-FhX.ibExternalAccessibilityDescription" = "Spårsammandrag";
+
+/* Class = "NSButtonCell"; title = "iPod 5G Support"; ObjectID = "zz5-qY-GSA"; */
+"zz5-qY-GSA.title" = "iPod 5G-stöd";
+

--- a/macosx/sv.lproj/HBTitleSelection.strings
+++ b/macosx/sv.lproj/HBTitleSelection.strings
@@ -1,0 +1,51 @@
+/* Class = "NSTableColumn"; headerCell.title = "Title"; ObjectID = "4XY-C0-SwE"; */
+"4XY-C0-SwE.headerCell.title" = "Titel";
+
+/* Class = "NSTextFieldCell"; title = "Select the titles to add to the queue:"; ObjectID = "5tD-fg-g4t"; */
+"5tD-fg-g4t.title" = "Välj de titlar att lägga till i kön:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Duration"; ObjectID = "a6r-ky-REh"; */
+"a6r-ky-REh.headerCell.title" = "Speltid";
+
+/* Class = "NSMenuItem"; title = "Disable"; ObjectID = "d4k-bC-FZa"; */
+"d4k-bC-FZa.title" = "Inaktivera";
+
+/* Class = "NSMenuItem"; title = "Enable All"; ObjectID = "D7Y-wr-PDj"; */
+"D7Y-wr-PDj.title" = "Aktivera alla";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "dsG-Ho-vsT"; */
+"dsG-Ho-vsT.title" = "Tabellvycell";
+
+/* Class = "NSWindow"; title = "Window"; ObjectID = "F0z-JX-Cv5"; */
+"F0z-JX-Cv5.title" = "Fönster";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "Fcv-FE-8Fv"; */
+"Fcv-FE-8Fv.title" = "Textcell";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "FQY-Ye-g0f"; */
+"FQY-Ye-g0f.headerCell.title" = "Namn";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "hQc-RA-phB"; */
+"hQc-RA-phB.title" = "0";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "jHg-nh-9NJ"; */
+"jHg-nh-9NJ.title" = "Avbryt";
+
+/* Class = "NSMenuItem"; title = "Disable All"; ObjectID = "MIb-bL-Z6i"; */
+"MIb-bL-Z6i.title" = "Inaktivera alla";
+
+/* Class = "NSButtonCell"; title = "Add"; ObjectID = "mOe-XL-tl1"; */
+"mOe-XL-tl1.title" = "Lägg till";
+
+/* Class = "NSMenuItem"; title = "Enable"; ObjectID = "pR6-xS-FyO"; */
+"pR6-xS-FyO.title" = "Aktivera";
+
+/* Class = "NSMenuItem"; title = "Invert state"; ObjectID = "tp1-g5-7XN"; */
+"tp1-g5-7XN.title" = "Invertera tillstånd";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedDisplayPattern = "%{value1}@"; ObjectID = "xTt-zi-wf0"; */
+"xTt-zi-wf0.ibShadowedDisplayPattern" = "%{value1}@";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "zwi-rc-q6x"; */
+"zwi-rc-q6x.title" = "Textcell";
+

--- a/macosx/sv.lproj/HBTitleSelectionRange.strings
+++ b/macosx/sv.lproj/HBTitleSelectionRange.strings
@@ -1,0 +1,45 @@
+/* Class = "NSButtonCell"; title = "Range:"; ObjectID = "4nB-36-clJ"; */
+"4nB-36-clJ.title" = "Omfång:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Start time in seconds"; ObjectID = "5mE-y0-UqZ"; */
+"5mE-y0-UqZ.ibExternalAccessibilityDescription" = "Starttid i sekunder";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "First second to encode."; ObjectID = "5mE-y0-UqZ"; */
+"5mE-y0-UqZ.ibShadowedToolTip" = "Första sekunden att enkoda.";
+
+/* Class = "NSMenuItem"; title = "To"; ObjectID = "6gI-bi-QlH"; */
+"6gI-bi-QlH.title" = "Till";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "End time in seconds"; ObjectID = "7ug-HX-q9j"; */
+"7ug-HX-q9j.ibExternalAccessibilityDescription" = "Sluttid i sekunder";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Last second to encode."; ObjectID = "7ug-HX-q9j"; */
+"7ug-HX-q9j.ibShadowedToolTip" = "Sista sekunden att enkoda.";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Last frame to encode."; ObjectID = "aeA-ul-8yt"; */
+"aeA-ul-8yt.ibShadowedToolTip" = "Sista bildrutan att enkoda.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Range Selection"; ObjectID = "aM2-P8-m4w"; */
+"aM2-P8-m4w.ibExternalAccessibilityDescription" = "Omfångsval";
+
+/* Class = "NSMenuItem"; title = "To"; ObjectID = "eap-Rn-0qW"; */
+"eap-Rn-0qW.title" = "Till";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Start Chapter"; ObjectID = "eoO-dc-hc3"; */
+"eoO-dc-hc3.ibExternalAccessibilityDescription" = "Första kapitlet";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "First chapter to encode."; ObjectID = "eoO-dc-hc3"; */
+"eoO-dc-hc3.ibShadowedToolTip" = "Första kapitlet att enkoda.";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "First frame to encode."; ObjectID = "guU-KE-TeY"; */
+"guU-KE-TeY.ibShadowedToolTip" = "Första bildrutan att enkoda.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "End Chapter"; ObjectID = "OHn-dK-gFi"; */
+"OHn-dK-gFi.ibExternalAccessibilityDescription" = "Sista kapitlet";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Last chapter to encode."; ObjectID = "OHn-dK-gFi"; */
+"OHn-dK-gFi.ibShadowedToolTip" = "Sista kapitlet att enkoda.";
+
+/* Class = "NSMenuItem"; title = "To"; ObjectID = "YpG-jj-qV2"; */
+"YpG-jj-qV2.title" = "Till";
+

--- a/macosx/sv.lproj/HBTrackTitleViewController.strings
+++ b/macosx/sv.lproj/HBTrackTitleViewController.strings
@@ -1,0 +1,9 @@
+/* Class = "NSTextFieldCell"; title = "Name:"; ObjectID = "eBw-qE-Hyb"; */
+"eBw-qE-Hyb.title" = "Namn:";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Track name"; ObjectID = "FpM-Jx-vLD"; */
+"FpM-Jx-vLD.ibExternalAccessibilityDescription" = "Spårnamn";
+
+/* Class = "NSButtonCell"; title = "Done"; ObjectID = "Vzr-yd-VKe"; */
+"Vzr-yd-VKe.title" = "Färdig";
+

--- a/macosx/sv.lproj/Localizable.strings
+++ b/macosx/sv.lproj/Localizable.strings
@@ -1,0 +1,574 @@
+/* Job statistics */
+" (%@ %% of the source file)" = " (%@ %% av källfilen)";
+
+/* Preview -> size info label */
+" Scaled To Screen" = "Skalad till skärm";
+
+/* No comment provided by engineer. */
+"- --:--" = "- --:--";
+
+/* No comment provided by engineer. */
+"--:--" = "--:--";
+
+/* Preview -> size info label */
+"(%.0f%% actual size)" = "(%.0f%% faktisk storlek)";
+
+/* Preview -> size info label */
+"(Actual size)" = "(faktisk storlek)";
+
+/* Main Window -> preset modified */
+"(Modified)" = "(ändrad)";
+
+/* Job statistics */
+"%@ fps" = "%@ bilder/s";
+
+/* Queue status */
+"%lu encode pending" = "%lu enkodning väntar";
+
+/* Queue status */
+"%lu encodes pending" = "%lu enkodningar väntar";
+
+/* No comment provided by engineer. */
+"%lu jobs selected" = "%lu jobb valt";
+
+/* Add preset window -> picture setting */
+"480p NTSC SD" = "480p NTSC SD";
+
+/* Add preset window -> picture setting */
+"576p PAL SD" = "576p PAL SD";
+
+/* Add preset window -> picture setting */
+"720p HD" = "720p HD";
+
+/* Add preset window -> picture setting */
+"1080p HD" = "1080p HD";
+
+/* Add preset window -> picture setting */
+"1440p 2.5K Quad HD" = "1440p 2.5K Quad HD";
+
+/* Add preset window -> picture setting */
+"2160p 4K Ultra HD" = "2160p 4K Ultra HD";
+
+/* Add preset window -> picture setting */
+"4320p 8K Ultra HD" = "4320p 8K Ultra HD";
+
+/* Destination same as source alert -> message
+File already exists alert -> message */
+"A file already exists at the selected destination." = "En fil finns redan i valt mål.";
+
+/* Queue Window Action Toolbar Item */
+"Action" = "Åtgärd";
+
+/* Main Window Activity Toolbar Item */
+"Activity" = "Aktivitet";
+
+/* Picture HUD -> scale button */
+"Actual Scale" = "Faktisk skala";
+
+/* Main Window Add Toolbar Item */
+"Add All Titles To Queue" = "Lägg till alla titlar i kö";
+
+/* Queue undo action name */
+"Add Job To Queue" = "Lägg till jobb i kö";
+
+/* Queue undo action name */
+"Add Jobs To Queue" = "Lägg till jobb i kö";
+
+/* Touch bar */
+"Add Preset" = "Lägg till förval";
+
+/* Touch bar */
+"Add Titles To Queue" = "Lägg till titlar i kö";
+
+/* Main Window Add Toolbar Item */
+"Add Titles To Queue…" = "Lägg till titlar i kö...";
+
+/* Main Window Add Toolbar Item
+Touch bar */
+"Add To Queue" = "Lägg till i kö";
+
+/* Preferences Advanced Toolbar Item */
+"Advanced" = "Avancerat";
+
+/* Main Window -> Same as source destination open panel */
+"Allow" = "Tillåt";
+
+/* HBLanguage -> Any language */
+"Any" = "Alla";
+
+/* Delete preset alert -> message */
+"Are you sure you want to permanently delete the selected preset?" = "Är du säker på att du vill permanent ta bort valt förval?";
+
+/* Delete preset alert -> message */
+"Are you sure you want to permanently delete the selected presets?" = "Är du säker på att du vill permanent ta bort valda förval?";
+
+/* Quit Alert -> message */
+"Are you sure you want to quit HandBrake?" = "Är du säker på att du vill avsluta HandBrake?";
+
+/* Copy Protection Alert -> first button */
+"Attempt Scan Anyway" = "Försök läsa in ändå";
+
+/* Player HUD -> audio menu */
+"Audio" = "Ljud";
+
+/* Job statistics */
+"Average speed:" = "Genomsnittlig hastighet:";
+
+/* Preferences -> Output Name Token */
+"Bit Depth" = "Bitdjup";
+
+/* Copy Protection Alert -> second button
+Delete preset alert -> second button
+File already exists alert -> first button
+File already exists in queue alert -> first button
+Preview -> live preview alert alternate button
+Touch bar */
+"Cancel" = "Avbryt";
+
+/* Touch bar */
+"Cancel Encoding" = "Avbryt enkodning";
+
+/* Toolbar Open/Cancel Item
+Touch bar */
+"Cancel Scan" = "Avbryt inläsning";
+
+/* Toolbar Open/Cancel Item */
+"Cancel Scanning Source" = "Avbryt inläsning av källa";
+
+/* HBRange -> display name
+Preferences -> Output Name Token */
+"Chapters" = "Kapitel";
+
+/* Main Window -> Destination open panel */
+"Choose" = "Välj";
+
+/* Preferences -> Output Name Token */
+"Codec" = "Kodek";
+
+/* Queue Alert -> cancel rip first button */
+"Continue Encoding" = "Fortsätt enkodning";
+
+/* Copy Protection Alert -> message */
+"Copy-Protected sources are not supported." = "Kopieringsskyddade källor stöds inte.";
+
+/* Touch bar */
+"Current Time" = "Aktuell tid";
+
+/* Add preset window -> picture setting */
+"Custom" = "Anpassad";
+
+/* Preferences -> Output Name Token */
+"Date" = "Datum";
+
+/* Delete preset alert -> first button */
+"Delete Preset" = "Ta bort förval";
+
+/* Delete preset alert -> first button */
+"Delete Presets" = "Ta bort förval";
+
+/* Queue Window Details Toolbar Item */
+"Details" = "Information";
+
+/* Queue Window When Done Toolbar Item */
+"Do Nothing" = "Gör ingenting";
+
+/* File already exists alert -> informative text
+File already exists in queue alert -> informative text */
+"Do you want to overwrite %@?" = "Vill du skriva över %@?";
+
+/* Quit Alert -> second button */
+"Don't Quit" = "Avsluta inte";
+
+/* Touch bar */
+"Done" = "Färdig";
+
+/* HBQueueItemView -> Encode state accessibility label */
+"Encode canceled" = "Enkodning avbröts";
+
+/* HBQueueItemView -> Encode state accessibility label */
+"Encode complete" = "Enkodning färdig";
+
+/* HBQueueItemView -> Encode state accessibility label
+Queue done notification failed message */
+"Encode failed" = "Enkodning misslyckades";
+
+/* HBQueueItemView -> Encode state accessibility label */
+"Encode ready" = "Enkodningen är färdig";
+
+/* HBQueueItemView -> Encode state accessibility label */
+"Encode working" = "Enkodningen pågår";
+
+/* Preferences -> Output Name Token */
+"Encoder" = "Enkodare";
+
+/* No comment provided by engineer. */
+"Encoding %lu Jobs" = "Enkodar %lu jobb";
+
+/* No comment provided by engineer. */
+"Encoding Job: %@" = "Enkodar jobb: %@";
+
+/* Export presets save panel title */
+"Export preset" = "Exportera förval";
+
+/* Export presets save panel title */
+"Export presets" = "Exportera förval";
+
+/* Default name for a newly added excluded file extension */
+"extension" = "filändelse";
+
+/* File already exists alert -> message */
+"File already exists." = "Filen finns redan.";
+
+/* Preferences Output File Name Toolbar Item */
+"File name" = "Filnamn";
+
+/* HBRange -> display name */
+"Frames" = "Bildrutor";
+
+/* Preferences General Toolbar Item */
+"General" = "Allmänt";
+
+/* Main Window -> title */
+"HandBrake" = "HandBrake";
+
+/* Preview -> live preview alert message */
+"HandBrake can't open the preview." = "HandBrake kan inte öppna förhandsvisningen.";
+
+/* Preferences -> Output Name Token */
+"Height" = "Höjd";
+
+/* Import preset open panel title */
+"Import presets" = "Importera förval";
+
+/* Chapters import -> invalid CSV line count description */
+"Incorrect line count" = "Felaktigt radantal";
+
+/* Chapters import -> invalid CSV description */
+"Invalid chapters CSV file" = "Ogiltiga kapitel i CSV-filen";
+
+/* Queue Edit Alert -> stop and edit first button
+Queue Stop Alert -> stop and remove first button */
+"Keep Encoding" = "Fortsätt enkodning";
+
+/* Preferences -> Output Name Token */
+"Modification-Date" = "Ändringsdatum";
+
+/* Preferences -> Output Name Token */
+"Modification-Time" = "Ändringstid";
+
+/* Queue undo action name */
+"Move Job in Queue" = "Flytta jobb i kö";
+
+/* Queue undo action name */
+"Move Jobs in Queue" = "Flytta jobb i kö";
+
+/* Add preset window -> My Presets */
+"My Presets" = "Mina förval";
+
+/* Queue status */
+"No encode pending" = "Ingen enkodning väntar";
+
+/* Preview -> accessibility label */
+"No image" = "Ingen bild";
+
+/* No comment provided by engineer. */
+"No job selected" = "Inget jobb valt";
+
+/* Main Window -> Info text */
+"No Valid Preset" = "Inget giltigt förval";
+
+/* Main Window -> Info text */
+"No Valid Source Found" = "Ingen giltig källa hittades";
+
+/* Add preset window -> picture setting */
+"None" = "Ingen";
+
+/* Queue Done Alert -> shut down first button
+Queue Done Alert -> sleep first button */
+"OK" = "Ok";
+
+/* File already exists alert -> informative text */
+"One or more file already exists. Do you want to overwrite?" = "En eller flera filer finns redan. Vill du skriva över?";
+
+/* Preview -> live preview alert default button */
+"Open in external player" = "Öppna i extern uppspelare";
+
+/* Main Window Open Toolbar Item
+Toolbar Open/Cancel Item
+Touch bar */
+"Open Source" = "Öppna källa";
+
+/* File already exists alert -> second button
+File already exists in queue alert -> second button */
+"Overwrite" = "Skriv över";
+
+/* Main Window Pause Toolbar Item
+Toolbar Pause Item */
+"Pause" = "Paus";
+
+/* Queue -> pause/resume menu
+Toolbar Pause Item
+Touch bar */
+"Pause Encoding" = "Pausa enkodning";
+
+/* Main Window Pause Toolbar Item
+Touch bar */
+"Pause/Resume Encoding" = "Pausa/Återuppta enkodningen";
+
+/* Job statistics */
+"Paused time:" = "Pausad tid:";
+
+/* Touch bar */
+"Play/Pause" = "Spela upp/Paus";
+
+/* Add preset window -> name alert informative text
+Rename preset window -> name alert informative text */
+"Please enter a name." = "Ange ett namn.";
+
+/* Queue Done Alert -> shut down second button
+Queue Done Alert -> sleep second button */
+"Preferences…" = "Inställningar...";
+
+/* Preferences -> Output Name Token */
+"Preset" = "Förval";
+
+/* Main Window Presets Toolbar Item */
+"Presets" = "Förval";
+
+/* Preview -> progress formatter title */
+"preview" = "förhandsvisa";
+
+/* Main Window Preview Toolbar Item
+Preview -> window title */
+"Preview" = "Förhandsvisning";
+
+/* Preview -> window title format */
+"Preview - %@ %@" = "Förhandsvisning - %1$@ %2$@";
+
+/* Preview -> accessibility label */
+"Preview Image, Size: %zu x %zu, Scale: %.0f%%" = "Förhandsvisa bild, Storlek: %1$zu x %2$zu, Skala: %3$.0f%%";
+
+/* Queue Window When Done Toolbar Item */
+"Put Computer to Sleep" = "Försätt datorn i sömnläge";
+
+/* Queue notification alert message */
+"Put down that cocktail…" = "Ställ ner din cocktail...";
+
+/* Preferences -> Output Name Token */
+"Quality Type" = "Kvalitetstyp";
+
+/* Preferences -> Output Name Token */
+"Quality/Bitrate" = "Kvalitet/Bitfrekvens";
+
+/* Main Window Presets Toolbar Item
+Preferences Queue Toolbar Item
+Queue window title */
+"Queue" = "Kö";
+
+/* Queue window title */
+"Queue (%@)" = "Kö (%@)";
+
+/* Quit Alert -> first button */
+"Quit" = "Avsluta";
+
+/* Queue Window When Done Toolbar Item */
+"Quit HandBrake" = "Avsluta HandBrake";
+
+/* Touch bar */
+"Remaining Time" = "Återstående tid";
+
+/* Queue Window Action Toolbar Item */
+"Remove All Jobs" = "Ta bort alla jobb";
+
+/* Queue Window Action Toolbar Item */
+"Remove Completed Jobs" = "Ta bort färdiga jobb";
+
+/* HBQueueItemView -> Remove button accessibility label */
+"Remove job" = "Ta bort jobb";
+
+/* Queue undo action name */
+"Remove Job From Queue" = "Ta bort jobb från kö";
+
+/* Queue undo action name */
+"Remove Jobs From Queue" = "Ta bort jobb från kö";
+
+/* Queue Window Action Toolbar Item */
+"Reset All Jobs" = "Nollställ alla jobb";
+
+/* Queue Window Action Toolbar Item */
+"Reset Failed Jobs" = "Nollställ misslyckade jobb";
+
+/* Toolbar Pause Item */
+"Resume" = "Återuppta";
+
+/* Queue -> pause/resume men
+Toolbar Pause Item */
+"Resume Encoding" = "Återuppta enkodning";
+
+/* HBQueueItemView -> Reveal button accessibility label */
+"Reveal destination in Finder" = "Visa målet i Finder";
+
+/* Job statistics */
+"Run time:" = "Speltid:";
+
+/* Export presets panel prompt */
+"Save" = "Spara";
+
+/* Picture HUD -> scale button
+Touch bar */
+"Scale To Screen" = "Skala till skärm";
+
+/* HBRange -> display name */
+"Seconds" = "Sekunder";
+
+/* Preferences -> send to app destination open panel */
+"Select the desired external application" = "Välj önskat externt program";
+
+/* Notification -> Show in Finder */
+"Show" = "Visa";
+
+/* Main Window Activity Toolbar Item
+Touch bar */
+"Show Activity Window" = "Visa aktivitetsfönster";
+
+/* Main Window Presets Toolbar Item */
+"Show Presets List" = "Visa förvalslista";
+
+/* Main Window Preview Toolbar Item
+Touch bar */
+"Show Preview Window" = "Visa förhandsvisningsfönstret";
+
+/* Main Window Presets Toolbar Item */
+"Show Queue Window" = "Visa köfönstret";
+
+/* Queue Window When Done Toolbar Item */
+"Shut Down Computer" = "Stäng av datorn";
+
+/* Job statistics */
+"Size:" = "Storlek:";
+
+/* Queue Alert -> cancel rip second button */
+"Skip Current Job" = "Hoppa över aktuellt jobb";
+
+/* Touch bar */
+"Slider" = "Draglist";
+
+/* Preferences -> Output Name Token */
+"Source" = "Källa";
+
+/* Main Window Start Toolbar Item
+Toolbar Start/Stop Item */
+"Start" = "Starta";
+
+/* Menu Start/Stop Item
+Queue -> start/stop menu
+Toolbar Start/Stop Item */
+"Start Encoding" = "Starta enkodning";
+
+/* Toolbar Start/Stop Item */
+"Start Queue" = "Starta kö";
+
+/* Main Window Start Toolbar Item
+Touch bar */
+"Start/Stop Encoding" = "Starta/Stoppa enkodning";
+
+/* Queue -> Stop action
+Toolbar Start/Stop Item */
+"Stop" = "Stoppa";
+
+/* Queue -> Stop action */
+"Stop action." = "Stoppa åtgärd.";
+
+/* Queue Alert -> cancel rip third button */
+"Stop After Current Job" = "Stoppa efter aktuellt jobb";
+
+/* Queue Alert -> cancel rip fourth button */
+"Stop All" = "Stoppa alla";
+
+/* Queue -> start/stop menu
+Toolbar Start/Stop Item */
+"Stop Encoding" = "Stoppa enkodning";
+
+/* Queue Stop Alert -> stop and remove second button */
+"Stop Encoding and Delete" = "Stoppa enkodning och ta bort";
+
+/* Queue Edit Alert -> stop and edit second button */
+"Stop Encoding and Edit" = "Stoppa enkodning och redigera";
+
+/* Queue Edit Alert -> stop and edit message */
+"Stop This Encode and Edit It?" = "Stoppa denna enkodning och redigera den?";
+
+/* Queue Stop Alert -> stop and remove message */
+"Stop This Encode and Remove It?" = "Stoppa denna enkodning och ta bort den?";
+
+/* Player HUD -> subtitles menu */
+"Subtitles" = "Undertexter";
+
+/* Queue Done Alert -> shut down message */
+"The computer will shut down after encoding is done." = "Datorn kommer att stängas av efter att enkodningen är färdig.";
+
+/* Queue Done Alert -> sleep message */
+"The computer will sleep after encoding is done." = "Denna datorn kommer att försättas i sömnläge efter enkodningen är färdig.";
+
+/* Destination same as source alert -> informative text */
+"The destination is the same as the source, you can not overwrite your source file!" = "Målet är samma som källan. Du kan inte skriva över din källfil!";
+
+/* Add preset window -> name alert message
+Rename preset window -> name alert message */
+"The preset name cannot be empty." = "Förvalsnamnet får inte vara tomt.";
+
+/* File already exists in queue alert -> message */
+"There is already a queue item for this destination." = "Det finns redan ett köobjekt för detta mål.";
+
+/* Invalid destination alert -> informative text */
+"This is not a valid destination directory!" = "Detta är inte en giltig målkatalog!";
+
+/* Preferences -> Output Name Token */
+"Time" = "Tid";
+
+/* Preferences -> Output Name Token */
+"Title" = "Titel";
+
+/* HBLanguage -> Unknown language */
+"Unknown" = "Okänt";
+
+/* Video -> Framerate */
+"Variable Framerate" = "Variabel bildfrekvens";
+
+/* Invalid destination alert -> message */
+"Warning!" = "Varning!";
+
+/* Queue Window When Done Toolbar Item */
+"When Done" = "När färdig";
+
+/* Preferences -> Output Name Token */
+"Width" = "Bredd";
+
+/* No comment provided by engineer. */
+"Working" = "Arbetar";
+
+/* Queue Alert -> cancel rip message */
+"You are currently encoding. What would you like to do?" = "Du enkodar för tillfället. Vad vill du göra?";
+
+/* Delete preset alert -> informative text */
+"You can't undo this action." = "Du kan inte ångra denna åtgärd.";
+
+/* Queue -> disk almost full alert informative text */
+"You need to make more space available on your destination disk." = "Du behöver frigöra mer plats på din måldisk.";
+
+/* Queue -> disk almost full alert message */
+"Your destination disk is almost full." = "Din måldisk är nästan full.";
+
+/* Queue done notification message */
+"Your encode %@ couldn't be completed." = "Din enkodning %@ kunde inte färdigställas.";
+
+/* Queue done notification message */
+"Your encode %@ is done!" = "Din enkodning %@ är färdig!";
+
+/* Queue Edit Alert -> stop and edit informative text
+Queue Stop Alert -> stop and remove informative text */
+"Your movie will be lost if you don't continue encoding." = "Din film kommer att gå förlorad om du inte fortsätter enkodningen.";
+
+/* Queue done notification message */
+"Your queue is done!" = "Din kö är färdig!";
+

--- a/macosx/sv.lproj/MainMenu.strings
+++ b/macosx/sv.lproj/MainMenu.strings
@@ -1,0 +1,267 @@
+/* Class = "NSMenu"; title = "Services"; ObjectID = "0te-ai-fgD"; */
+"0te-ai-fgD.title" = "Tjänster";
+
+/* Class = "NSMenuItem"; title = "Rename…"; ObjectID = "1GQ-n3-jfY"; */
+"1GQ-n3-jfY.title" = "Byt namn...";
+
+/* Class = "NSMenuItem"; title = "Filters"; ObjectID = "6rE-SM-AGi"; */
+"6rE-SM-AGi.title" = "Filter";
+
+/* Class = "NSMenuItem"; title = "Summary"; ObjectID = "9ie-b7-RaS"; */
+"9ie-b7-RaS.title" = "Sammandrag";
+
+/* Class = "NSMenu"; title = "MainMenu"; ObjectID = "29"; */
+"29.title" = "Huvudmeny";
+
+/* Class = "NSMenuItem"; title = "HandBrake"; ObjectID = "56"; */
+"56.title" = "HandBrake";
+
+/* Class = "NSMenu"; title = "HandBrake"; ObjectID = "57"; */
+"57.title" = "HandBrake";
+
+/* Class = "NSMenuItem"; title = "About HandBrake"; ObjectID = "58"; */
+"58.title" = "Om HandBrake";
+
+/* Class = "NSMenuItem"; title = "Quit HandBrake"; ObjectID = "136"; */
+"136.title" = "Avsluta HandBrake";
+
+/* Class = "NSMenuItem"; title = "Hide HandBrake"; ObjectID = "971"; */
+"971.title" = "Dölj HandBrake";
+
+/* Class = "NSMenuItem"; title = "Hide Others"; ObjectID = "973"; */
+"973.title" = "Dölj andra";
+
+/* Class = "NSMenuItem"; title = "Window"; ObjectID = "1189"; */
+"1189.title" = "Fönster";
+
+/* Class = "NSMenuItem"; title = "Bring All to Front"; ObjectID = "1190"; */
+"1190.title" = "Ta fram alla";
+
+/* Class = "NSMenuItem"; title = "Minimize"; ObjectID = "1191"; */
+"1191.title" = "Minimera";
+
+/* Class = "NSMenu"; title = "Window"; ObjectID = "1192"; */
+"1192.title" = "Fönster";
+
+/* Class = "NSMenuItem"; title = "Open Source…"; ObjectID = "1198"; */
+"1198.title" = "Öppna källa...";
+
+/* Class = "NSMenuItem"; title = "File"; ObjectID = "1200"; */
+"1200.title" = "Arkiv";
+
+/* Class = "NSMenu"; title = "File"; ObjectID = "1209"; */
+"1209.title" = "Arkiv";
+
+/* Class = "NSMenu"; title = "Help"; ObjectID = "1429"; */
+"1429.title" = "Hjälp";
+
+/* Class = "NSMenuItem"; title = "Help"; ObjectID = "1431"; */
+"1431.title" = "Hjälp";
+
+/* Class = "NSMenuItem"; title = "HandBrake Website"; ObjectID = "1432"; */
+"1432.title" = "HandBrakes webbsida";
+
+/* Class = "NSMenuItem"; title = "Preferences…"; ObjectID = "1445"; */
+"1445.title" = "Inställningar...";
+
+/* Class = "NSMenuItem"; title = "Edit"; ObjectID = "1795"; */
+"1795.title" = "Redigera";
+
+/* Class = "NSMenu"; title = "Edit"; ObjectID = "1796"; */
+"1796.title" = "Redigera";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "1797"; */
+"1797.title" = "Ta bort";
+
+/* Class = "NSMenuItem"; title = "Select All"; ObjectID = "1798"; */
+"1798.title" = "Markera allt";
+
+/* Class = "NSMenuItem"; title = "Undo"; ObjectID = "1799"; */
+"1799.title" = "Ångra";
+
+/* Class = "NSMenuItem"; title = "Redo"; ObjectID = "1801"; */
+"1801.title" = "Gör om";
+
+/* Class = "NSMenuItem"; title = "Find"; ObjectID = "1802"; */
+"1802.title" = "Sök";
+
+/* Class = "NSMenu"; title = "Find"; ObjectID = "1803"; */
+"1803.title" = "Sök";
+
+/* Class = "NSMenuItem"; title = "Jump to Selection"; ObjectID = "1804"; */
+"1804.title" = "Hoppa till markering";
+
+/* Class = "NSMenuItem"; title = "Find…"; ObjectID = "1805"; */
+"1805.title" = "Sök...";
+
+/* Class = "NSMenuItem"; title = "Find Next"; ObjectID = "1806"; */
+"1806.title" = "Hitta nästa";
+
+/* Class = "NSMenuItem"; title = "Find Previous"; ObjectID = "1807"; */
+"1807.title" = "Hitta föregående";
+
+/* Class = "NSMenuItem"; title = "Use Selection for Find"; ObjectID = "1808"; */
+"1808.title" = "Använd val för att hitta";
+
+/* Class = "NSMenuItem"; title = "Spelling"; ObjectID = "1810"; */
+"1810.title" = "Stavningskontroll";
+
+/* Class = "NSMenu"; title = "Spelling"; ObjectID = "1811"; */
+"1811.title" = "Stavningskontroll";
+
+/* Class = "NSMenuItem"; title = "Spelling…"; ObjectID = "1812"; */
+"1812.title" = "Stavningskontroll...";
+
+/* Class = "NSMenuItem"; title = "Check Spelling"; ObjectID = "1813"; */
+"1813.title" = "Kontrollera stavning";
+
+/* Class = "NSMenuItem"; title = "Check Spelling as You Type"; ObjectID = "1814"; */
+"1814.title" = "Kontrollera stavning när du skriver";
+
+/* Class = "NSMenuItem"; title = "Cut"; ObjectID = "1815"; */
+"1815.title" = "Klipp ut";
+
+/* Class = "NSMenuItem"; title = "Copy"; ObjectID = "1816"; */
+"1816.title" = "Kopiera";
+
+/* Class = "NSMenuItem"; title = "Speech"; ObjectID = "1817"; */
+"1817.title" = "Tal";
+
+/* Class = "NSMenu"; title = "Speech"; ObjectID = "1818"; */
+"1818.title" = "Tal";
+
+/* Class = "NSMenuItem"; title = "Stop Speaking"; ObjectID = "1819"; */
+"1819.title" = "Sluta prata";
+
+/* Class = "NSMenuItem"; title = "Start Speaking"; ObjectID = "1820"; */
+"1820.title" = "Börja prata";
+
+/* Class = "NSMenuItem"; title = "Paste"; ObjectID = "1821"; */
+"1821.title" = "Klistra in";
+
+/* Class = "NSMenuItem"; title = "Paste and Match Style"; ObjectID = "1822"; */
+"1822.title" = "Klistra in och matcha stil";
+
+/* Class = "NSMenuItem"; title = "Presets View"; ObjectID = "1884"; */
+"1884.title" = "Förvalsvy";
+
+/* Class = "NSMenuItem"; title = "Presets"; ObjectID = "1948"; */
+"1948.title" = "Förval";
+
+/* Class = "NSMenu"; title = "Presets"; ObjectID = "1949"; */
+"1949.title" = "Förval";
+
+/* Class = "NSMenuItem"; title = "Reset Official Presets"; ObjectID = "1950"; */
+"1950.title" = "Nollställ officiella förval";
+
+/* Class = "NSMenuItem"; title = "New Preset…"; ObjectID = "1955"; */
+"1955.title" = "Nytt förval...";
+
+/* Class = "NSMenuItem"; title = "Online Documentation"; ObjectID = "1985"; */
+"1985.title" = "Nätdokumentation";
+
+/* Class = "NSMenuItem"; title = "Activity Window"; ObjectID = "2295"; */
+"2295.title" = "Aktivitetsfönster";
+
+/* Class = "NSMenuItem"; title = "HandBrake"; ObjectID = "2368"; */
+"2368.title" = "HandBrake";
+
+/* Class = "NSMenuItem"; title = "Select Default"; ObjectID = "2421"; */
+"2421.title" = "Ange standard";
+
+/* Class = "NSMenuItem"; title = "Add To Queue"; ObjectID = "2443"; */
+"2443.title" = "Lägg till i kö";
+
+/* Class = "NSMenuItem"; title = "Start Encoding"; ObjectID = "2444"; */
+"2444.title" = "Starta enkodning";
+
+/* Class = "NSMenuItem"; title = "Queue"; ObjectID = "2445"; */
+"2445.title" = "Kö";
+
+/* Class = "NSMenuItem"; title = "Pause Encoding"; ObjectID = "2494"; */
+"2494.title" = "Pausa enkodning";
+
+/* Class = "NSMenuItem"; title = "Close Window"; ObjectID = "2508"; */
+"2508.title" = "Stäng fönster";
+
+/* Class = "NSMenuItem"; title = "Check for Updates…"; ObjectID = "4964"; */
+"4964.title" = "Leta efter uppdateringar...";
+
+/* Class = "NSMenuItem"; title = "Preview Window"; ObjectID = "5157"; */
+"5157.title" = "Förhandsvisningsfönster";
+
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "5188"; */
+"5188.title" = "Exportera…";
+
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "5192"; */
+"5192.title" = "Importera…";
+
+/* Class = "NSMenuItem"; title = "Show All"; ObjectID = "5280"; */
+"5280.title" = "Visa allt";
+
+/* Class = "NSMenuItem"; title = "Add Titles To Queue…"; ObjectID = "5897"; */
+"5897.title" = "Lägg till titlar i kö...";
+
+/* Class = "NSMenuItem"; title = "Audio"; ObjectID = "brQ-mu-8JM"; */
+"brQ-mu-8JM.title" = "Ljud";
+
+/* Class = "NSMenuItem"; title = "Delete"; ObjectID = "CN3-Rh-gVf"; */
+"CN3-Rh-gVf.title" = "Ta bort";
+
+/* Class = "NSMenuItem"; title = "Subtitles"; ObjectID = "Csx-2S-iUe"; */
+"Csx-2S-iUe.title" = "Undertexter";
+
+/* Class = "NSMenuItem"; title = "Open Recent"; ObjectID = "fNa-z2-K1i"; */
+"fNa-z2-K1i.title" = "Öppna senaste";
+
+/* Class = "NSMenuItem"; title = "Make Default"; ObjectID = "frQ-v5-pRa"; */
+"frQ-v5-pRa.title" = "Gör till standard";
+
+/* Class = "NSMenuItem"; title = "View"; ObjectID = "Hzp-jb-hme"; */
+"Hzp-jb-hme.title" = "Visa";
+
+/* Class = "NSMenuItem"; title = "Show Toolbar"; ObjectID = "IsV-5A-bqx"; */
+"IsV-5A-bqx.title" = "Visa verktygsrad";
+
+/* Class = "NSMenuItem"; title = "Video"; ObjectID = "Jef-U4-eQT"; */
+"Jef-U4-eQT.title" = "Video";
+
+/* Class = "NSMenuItem"; title = "Customize Toolbar…"; ObjectID = "KKV-n0-Fmr"; */
+"KKV-n0-Fmr.title" = "Anpassa verktygsrad...";
+
+/* Class = "NSMenuItem"; title = "Save"; ObjectID = "lab-Ly-3p3"; */
+"lab-Ly-3p3.title" = "Spara";
+
+/* Class = "NSMenuItem"; title = "Chapters"; ObjectID = "lCU-PH-gal"; */
+"lCU-PH-gal.title" = "Kapitel";
+
+/* Class = "NSMenuItem"; title = "Enter Full Screen"; ObjectID = "mGX-7Z-siB"; */
+"mGX-7Z-siB.title" = "Helskärmsläge";
+
+/* Class = "NSMenu"; title = "View"; ObjectID = "ndG-Ig-Yol"; */
+"ndG-Ig-Yol.title" = "Visa";
+
+/* Class = "NSMenuItem"; title = "Add All Titles To Queue"; ObjectID = "oYh-V7-kbx"; */
+"oYh-V7-kbx.title" = "Lägg till alla titlar i kön";
+
+/* Class = "NSMenuItem"; title = "Dimension"; ObjectID = "shS-hb-XSI"; */
+"shS-hb-XSI.title" = "Dimension";
+
+/* Class = "NSMenu"; title = "Open Recent"; ObjectID = "ukX-HN-SXk"; */
+"ukX-HN-SXk.title" = "Öppna senaste";
+
+/* Class = "NSMenuItem"; title = "Switch to Next Title"; ObjectID = "viv-aA-SoB"; */
+"viv-aA-SoB.title" = "Växla till nästa titel";
+
+/* Class = "NSMenuItem"; title = "Clear Menu"; ObjectID = "wPw-Uj-Gxi"; */
+"wPw-Uj-Gxi.title" = "Töm meny";
+
+/* Class = "NSMenuItem"; title = "New Category…"; ObjectID = "wvb-60-cWL"; */
+"wvb-60-cWL.title" = "Ny kategori...";
+
+/* Class = "NSMenuItem"; title = "Services"; ObjectID = "XcG-Aw-Gdb"; */
+"XcG-Aw-Gdb.title" = "Tjänster";
+
+/* Class = "NSMenuItem"; title = "Switch to Previous Title"; ObjectID = "zgj-Iv-4xJ"; */
+"zgj-Iv-4xJ.title" = "Växla till föregående titel";
+

--- a/macosx/sv.lproj/MainWindow.strings
+++ b/macosx/sv.lproj/MainWindow.strings
@@ -1,0 +1,162 @@
+/* Class = "NSTabViewItem"; label = "Filters"; ObjectID = "0UB-bG-kwS"; */
+"0UB-bG-kwS.label" = "Filter";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Save New Preset…"; ObjectID = "2vD-zN-YMe"; */
+"2vD-zN-YMe.ibShadowedToolTip" = "Spara nytt förval...";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Title to scan."; ObjectID = "3w9-Iu-3u2"; */
+"3w9-Iu-3u2.ibShadowedToolTip" = "Titel att läsa in.";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Recursively scan and open the content of every sub-folder."; ObjectID = "5hE-Ri-tcZ"; */
+"5hE-Ri-tcZ.ibShadowedToolTip" = "Sök rekursivt igenom och öppna innehållet för varje undermapp.";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "6E4-AG-PEh"; */
+"6E4-AG-PEh.title" = "0";
+
+/* Class = "NSWindow"; title = "HandBrake"; ObjectID = "21"; */
+"21.title" = "HandBrake";
+
+/* Class = "NSTabViewItem"; label = "Audio"; ObjectID = "1475"; */
+"1475.label" = "Ljud";
+
+/* Class = "NSTabViewItem"; label = "Video"; ObjectID = "1477"; */
+"1477.label" = "Video";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Source file"; ObjectID = "1538"; */
+"1538.ibExternalAccessibilityDescription" = "Källfil";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Source file name."; ObjectID = "1539"; */
+"1539.ibShadowedToolTip" = "Källans filnamn.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Start Chapter"; ObjectID = "1545"; */
+"1545.ibExternalAccessibilityDescription" = "Första kapitlet";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "First chapter to encode."; ObjectID = "1545"; */
+"1545.ibShadowedToolTip" = "Första kapitlet att enkoda.";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "End Chapter"; ObjectID = "1548"; */
+"1548.ibExternalAccessibilityDescription" = "Sista kapitlet";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Last chapter to encode."; ObjectID = "1548"; */
+"1548.ibShadowedToolTip" = "Sista kapitlet att enkoda.";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Duration"; ObjectID = "1554"; */
+"1554.ibExternalAccessibilityDescription" = "Speltid";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Output filename"; ObjectID = "1561"; */
+"1561.ibExternalAccessibilityDescription" = "Filnamn för utdata";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "File name. This is what your new video will be named."; ObjectID = "1561"; */
+"1561.ibShadowedToolTip" = "Filnamn. Detta är vad din nya video kommer att ha för namn.";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Browse Destination"; ObjectID = "1562"; */
+"1562.ibExternalAccessibilityDescription" = "Bläddra målet";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Browse to select a new destination path for your encode."; ObjectID = "1562"; */
+"1562.ibShadowedToolTip" = "Bläddra för att välja en ny målsökväg för din enkodning.";
+
+/* Class = "NSTabViewItem"; label = "Chapters"; ObjectID = "1989"; */
+"1989.label" = "Kapitel";
+
+/* Class = "NSTextFieldCell"; title = "Encoding Job 1: Test.mp4"; ObjectID = "4846"; */
+"4846.title" = "Enkodar jobb 1: Test.mp4";
+
+/* Class = "NSTextFieldCell"; title = "Source:"; ObjectID = "4905"; */
+"4905.title" = "Källa:";
+
+/* Class = "NSTextFieldCell"; title = "Title:"; ObjectID = "4907"; */
+"4907.title" = "Titel:";
+
+/* Class = "NSTextFieldCell"; title = "Save As:"; ObjectID = "4913"; */
+"4913.title" = "Spara som:";
+
+/* Class = "NSTextFieldCell"; title = "Duration:"; ObjectID = "4914"; */
+"4914.title" = "Speltid:";
+
+/* Class = "NSTextFieldCell"; title = "00:00:00"; ObjectID = "4915"; */
+"4915.title" = "00:00:00";
+
+/* Class = "NSButtonCell"; title = "Browse…"; ObjectID = "4920"; */
+"4920.title" = "Bläddra...";
+
+/* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "4923"; */
+"4923.title" = "Förval:";
+
+/* Class = "NSTextFieldCell"; title = "Angle:"; ObjectID = "5185"; */
+"5185.title" = "Vinkel:";
+
+/* Class = "NSTabViewItem"; label = "Subtitles"; ObjectID = "5194"; */
+"5194.label" = "Undertexter";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "Start time in seconds"; ObjectID = "5491"; */
+"5491.ibExternalAccessibilityDescription" = "Starttid i sekunder";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "First second to encode."; ObjectID = "5491"; */
+"5491.ibShadowedToolTip" = "Första sekunden att enkoda.";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "End time in seconds"; ObjectID = "5493"; */
+"5493.ibExternalAccessibilityDescription" = "Sluttid i sekunder";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Last second to encode."; ObjectID = "5493"; */
+"5493.ibShadowedToolTip" = "Sista sekunden att enkoda.";
+
+/* Class = "NSTextFieldCell"; title = "–"; ObjectID = "5506"; */
+"5506.title" = "–";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Range Selection"; ObjectID = "5513"; */
+"5513.ibExternalAccessibilityDescription" = "Omfångsval";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "First frame to encode."; ObjectID = "5521"; */
+"5521.ibShadowedToolTip" = "Första bildrutan att enkoda.";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Last frame to encode."; ObjectID = "5523"; */
+"5523.ibShadowedToolTip" = "Sista bildrutan att enkoda.";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = " "; ObjectID = "aID-g7-zTF"; */
+"aID-g7-zTF.ibShadowedIsNilPlaceholder" = "aaeffbdebc703c50e2574782f0579842_tr";
+
+/* Class = "NSTabViewItem"; label = "Summary"; ObjectID = "BA0-eg-2Ka"; */
+"BA0-eg-2Ka.label" = "Sammandrag";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Preset selection"; ObjectID = "bWH-Lp-mKY"; */
+"bWH-Lp-mKY.ibExternalAccessibilityDescription" = "Förvalsväljare";
+
+/* Class = "NSButtonCell"; title = "Reload"; ObjectID = "cgS-BU-Nfd"; */
+"cgS-BU-Nfd.title" = "Läs om";
+
+/* Class = "NSButton"; ibShadowedToolTip = "Scan only the specified title instead of all titles."; ObjectID = "DN4-48-aOI"; */
+"DN4-48-aOI.ibShadowedToolTip" = "Läs endast in angiven titel istället för alla titlar.";
+
+/* Class = "NSTabViewItem"; label = "Dimensions"; ObjectID = "eij-Sn-QmJ"; */
+"eij-Sn-QmJ.label" = "Dimensioner";
+
+/* Class = "NSButtonCell"; title = "Scan only title:"; ObjectID = "eQA-t2-FcV"; */
+"eQA-t2-FcV.title" = "Läs endast in titel:";
+
+/* Class = "NSButtonCell"; title = "Recursively scan folders"; ObjectID = "Hwu-gp-tRZ"; */
+"Hwu-gp-tRZ.title" = "Sök igenom mappar rekursivt";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = " "; ObjectID = "Iat-pL-ttI"; */
+"Iat-pL-ttI.ibShadowedIsNilPlaceholder" = "3bb4134d1db8d768bda54fd480079421_tr";
+
+/* Class = "NSButtonCell"; title = "Save New Preset…"; ObjectID = "IOU-3L-nvB"; */
+"IOU-3L-nvB.title" = "Spara nytt förval...";
+
+/* Class = "NSTextFieldCell"; title = "Range:"; ObjectID = "IxV-PW-oYh"; */
+"IxV-PW-oYh.title" = "Omfång:";
+
+/* Class = "NSTextFieldCell"; title = "Progress"; ObjectID = "KUR-YZ-Da8"; */
+"KUR-YZ-Da8.title" = "Förlopp";
+
+/* Class = "NSMenuItem"; title = "Selected Preset"; ObjectID = "OYP-3T-FnA"; */
+"OYP-3T-FnA.title" = "Valt förval";
+
+/* Class = "NSPathControl"; ibExternalAccessibilityDescription = "Destination folder path"; ObjectID = "PJi-21-hie"; */
+"PJi-21-hie.ibExternalAccessibilityDescription" = "Sökväg till målmapp";
+
+/* Class = "NSTextFieldCell"; title = "To:"; ObjectID = "rfK-nQ-Aq2"; */
+"rfK-nQ-Aq2.title" = "Till:";
+
+/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "rK6-EB-N9Z"; */
+"rK6-EB-N9Z.title" = "Visa i Finder";
+

--- a/macosx/sv.lproj/OutputPanel.strings
+++ b/macosx/sv.lproj/OutputPanel.strings
@@ -1,0 +1,18 @@
+/* Class = "NSWindow"; title = "Activity"; ObjectID = "5"; */
+"5.title" = "Aktivitet";
+
+/* Class = "NSMenu"; title = "Menu"; ObjectID = "11"; */
+"11.title" = "Meny";
+
+/* Class = "NSMenuItem"; title = "Clear Window Contents"; ObjectID = "12"; */
+"12.title" = "Töm fönsterinnehåll";
+
+/* Class = "NSMenuItem"; title = "Copy Window Contents"; ObjectID = "24"; */
+"24.title" = "Kopiera fönsterinnehåll";
+
+/* Class = "NSMenuItem"; title = "Clear Activity Log For This Session"; ObjectID = "35"; */
+"35.title" = "Töm aktivitetsloggen för denna session";
+
+/* Class = "NSMenuItem"; title = "Open Activity Logs Directory In Finder"; ObjectID = "43"; */
+"43.title" = "Öppna katalog för aktivitetsloggar i Finder";
+

--- a/macosx/sv.lproj/PicturePreview.strings
+++ b/macosx/sv.lproj/PicturePreview.strings
@@ -1,0 +1,3 @@
+/* Class = "NSWindow"; title = "Preview"; ObjectID = "5"; */
+"5.title" = "Förhandsvisning";
+

--- a/macosx/sv.lproj/Preferences.strings
+++ b/macosx/sv.lproj/Preferences.strings
@@ -1,0 +1,231 @@
+/* Class = "NSMenuItem"; title = "Shut Down Computer"; ObjectID = "2Js-R4-g0K"; */
+"2Js-R4-g0K.title" = "Stäng av datorn";
+
+/* Class = "NSWindow"; title = "Preferences"; ObjectID = "5"; */
+"5.title" = "Inställningar";
+
+/* Class = "NSButtonCell"; title = "Show preview images on summary tab"; ObjectID = "7CY-9s-SGl"; */
+"7CY-9s-SGl.title" = "Visa förhandsbilder i sammandragsfliken";
+
+/* Class = "NSTextFieldCell"; title = "None"; ObjectID = "7hX-9H-spK"; */
+"7hX-9H-spK.title" = "Ingen";
+
+/* Class = "NSMenuItem"; title = "Quit HandBrake"; ObjectID = "7JH-3c-gwW"; */
+"7JH-3c-gwW.title" = "Avsluta HandBrake";
+
+/* Class = "NSMenuItem"; title = "Do Nothing"; ObjectID = "7Qh-m6-OUo"; */
+"7Qh-m6-OUo.title" = "Gör ingenting";
+
+/* Class = "NSTextFieldCell"; title = "When Done:"; ObjectID = "9yk-Cr-cB6"; */
+"9yk-Cr-cB6.title" = "När färdig:";
+
+/* Class = "NSButtonCell"; title = "Automatically check for updates weekly"; ObjectID = "305"; */
+"305.title" = "Leta automatiskt efter uppdateringar veckovis";
+
+/* Class = "NSTextFieldCell"; title = "At Launch:"; ObjectID = "307"; */
+"307.title" = "Vid uppstart:";
+
+/* Class = "NSButtonCell"; title = "Store Activity Logs in same location as video"; ObjectID = "348"; */
+"348.title" = "Lagra aktivitetsloggar i samma plats som videon";
+
+/* Class = "NSTextFieldCell"; title = "Activity Logs:"; ObjectID = "351"; */
+"351.title" = "Aktivitetsloggar:";
+
+/* Class = "NSMenuItem"; title = "10"; ObjectID = "355"; */
+"355.title" = "10";
+
+/* Class = "NSMenuItem"; title = "15"; ObjectID = "356"; */
+"356.title" = "15";
+
+/* Class = "NSMenuItem"; title = "20"; ObjectID = "357"; */
+"357.title" = "20";
+
+/* Class = "NSMenuItem"; title = "25"; ObjectID = "361"; */
+"361.title" = "25";
+
+/* Class = "NSMenuItem"; title = "30"; ObjectID = "362"; */
+"362.title" = "30";
+
+/* Class = "NSMenuItem"; title = "Extended"; ObjectID = "368"; */
+"368.title" = "Utökad";
+
+/* Class = "NSMenuItem"; title = "Standard"; ObjectID = "369"; */
+"369.title" = "Standard";
+
+/* Class = "NSMenuItem"; title = "Minimised"; ObjectID = "370"; */
+"370.title" = "Minimerad";
+
+/* Class = "NSMenuItem"; title = "0.20"; ObjectID = "390"; */
+"390.title" = "0.20";
+
+/* Class = "NSMenuItem"; title = "0.25"; ObjectID = "391"; */
+"391.title" = "0.25";
+
+/* Class = "NSMenuItem"; title = "0.50"; ObjectID = "393"; */
+"393.title" = "0.50";
+
+/* Class = "NSMenuItem"; title = "1.0"; ObjectID = "394"; */
+"394.title" = "1.0";
+
+/* Class = "NSButtonCell"; title = "Use libdvdnav (instead of libdvdread)"; ObjectID = "399"; */
+"399.title" = "Använd libdvdnav (istället för libdvdread)";
+
+/* Class = "NSMenuItem"; title = "35"; ObjectID = "514"; */
+"514.title" = "35";
+
+/* Class = "NSMenuItem"; title = "40"; ObjectID = "515"; */
+"515.title" = "40";
+
+/* Class = "NSMenuItem"; title = "45"; ObjectID = "516"; */
+"516.title" = "45";
+
+/* Class = "NSMenuItem"; title = "50"; ObjectID = "517"; */
+"517.title" = "50";
+
+/* Class = "NSMenuItem"; title = "55"; ObjectID = "518"; */
+"518.title" = "55";
+
+/* Class = "NSMenuItem"; title = "60"; ObjectID = "519"; */
+"519.title" = "60";
+
+/* Class = "NSTextFieldCell"; title = "DVD and Blu-ray:"; ObjectID = "bG9-Tu-YsZ"; */
+"bG9-Tu-YsZ.title" = "Dvd och Bluray:";
+
+/* Class = "NSTextFieldCell"; title = "GB"; ObjectID = "BKV-oH-uht"; */
+"BKV-oH-uht.title" = "GB";
+
+/* Class = "NSTextFieldCell"; title = "Scan:"; ObjectID = "c0L-TU-WML"; */
+"c0L-TU-WML.title" = "Läs in:";
+
+/* Class = "NSMenuItem"; title = "2"; ObjectID = "Cge-hb-Nh8"; */
+"Cge-hb-Nh8.title" = "2";
+
+/* Class = "NSTextFieldCell"; title = "Encode up to"; ObjectID = "cI9-ML-lqx"; */
+"cI9-ML-lqx.title" = "Enkoda upp till";
+
+/* Class = "NSTextFieldCell"; title = "Encoder:"; ObjectID = "cqp-xU-GOe"; */
+"cqp-xU-GOe.title" = "Enkodare:";
+
+/* Class = "NSMenuItem"; title = "Auto"; ObjectID = "cZP-RL-fcB"; */
+"cZP-RL-fcB.title" = "Auto";
+
+/* Class = "NSButtonCell"; title = "Reset to \"Do nothing\" on launch"; ObjectID = "f47-PN-ctH"; */
+"f47-PN-ctH.title" = "Nollställ till 'Gör ingenting' vid uppstart";
+
+/* Class = "NSMenuItem"; title = "4"; ObjectID = "FB2-Vr-VKP"; */
+"FB2-Vr-VKP.title" = "4";
+
+/* Class = "NSButtonCell"; title = "Show notification when each job is completed"; ObjectID = "fdI-zP-r7j"; */
+"fdI-zP-r7j.title" = "Visa avisering när varje jobb är färdigställt";
+
+/* Class = "NSButtonCell"; title = "Keep duplicate titles"; ObjectID = "FOr-iY-GVl"; */
+"FOr-iY-GVl.title" = "Behåll dubbletta titlar";
+
+/* Class = "NSButtonCell"; title = "Play notification sound"; ObjectID = "GFD-Ju-1n9"; */
+"GFD-Ju-1n9.title" = "Spela upp aviseringsljud";
+
+/* Class = "NSTextFieldCell"; title = "Options:"; ObjectID = "ImU-Vn-SGr"; */
+"ImU-Vn-SGr.title" = "Alternativ:";
+
+/* Class = "NSMenuItem"; title = "3"; ObjectID = "IWj-tu-UhC"; */
+"IWj-tu-UhC.title" = "3";
+
+/* Class = "NSTextFieldCell"; title = "Decoder:"; ObjectID = "j6w-xf-tC0"; */
+"j6w-xf-tC0.title" = "Avkodare:";
+
+/* Class = "NSButtonCell"; title = "Ignore titles shorter than:"; ObjectID = "jNT-vQ-h0c"; */
+"jNT-vQ-h0c.title" = "Ignorera titlar kortare än:";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "None"; ObjectID = "JZb-Vz-cY4"; */
+"JZb-Vz-cY4.ibShadowedIsNilPlaceholder" = "Ingen";
+
+/* Class = "NSTextFieldCell"; title = "jobs simultaneously"; ObjectID = "kBl-mO-erf"; */
+"kBl-mO-erf.title" = "jobb samtidigt";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "kCF-8e-gXS"; */
+"kCF-8e-gXS.title" = "Tabellvycell";
+
+/* Class = "NSTextFieldCell"; title = "seconds"; ObjectID = "klQ-DW-Kc6"; */
+"klQ-DW-Kc6.title" = "sekunder";
+
+/* Class = "NSTextFieldCell"; title = "Format:"; ObjectID = "Ktg-Bh-1Pt"; */
+"Ktg-Bh-1Pt.title" = "Format:";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "l9y-MS-HnS"; */
+"l9y-MS-HnS.title" = "Textcell";
+
+/* Class = "NSButtonCell"; title = "Pause queue if disk space is lower than:"; ObjectID = "ODf-uW-BrD"; */
+"ODf-uW-BrD.title" = "Pausa kön om ledigt diskutrymme är mindre än:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Extensions"; ObjectID = "p5b-EU-Y2V"; */
+"p5b-EU-Y2V.headerCell.title" = "Filändelser";
+
+/* Class = "NSButtonCell"; title = "Send file to:"; ObjectID = "P5f-Vq-TeL"; */
+"P5f-Vq-TeL.title" = "Skicka fil till:";
+
+/* Class = "NSMenuItem"; title = ".m4v"; ObjectID = "phv-oU-WnC"; */
+"phv-oU-WnC.title" = ".m4v";
+
+/* Class = "NSButtonCell"; title = "Ignore titles longer than:"; ObjectID = "PoY-PD-tSq"; */
+"PoY-PD-tSq.title" = "Ignorera titlar längre än:";
+
+/* Class = "NSButtonCell"; title = "Show notification when queue is completed"; ObjectID = "Qdg-Tw-rlf"; */
+"Qdg-Tw-rlf.title" = "Visa avisering när kön är färdigställd";
+
+/* Class = "NSTextFieldCell"; title = "Options:"; ObjectID = "saX-n7-YV0"; */
+"saX-n7-YV0.title" = "Alternativ:";
+
+/* Class = "NSButtonCell"; title = "Clear completed jobs after an encode completes"; ObjectID = "szf-YE-Wml"; */
+"szf-YE-Wml.title" = "Töm färdiga jobb efter en enkodning är färdig";
+
+/* Class = "NSButtonCell"; title = "Use ISO Date Format (YYYY-MM-DD)"; ObjectID = "t9b-CO-ShI"; */
+"t9b-CO-ShI.title" = "Använd ISO-datumformat (YYYY-MM-DD)";
+
+/* Class = "NSButtonCell"; title = "Replace underscores with spaces"; ObjectID = "tAb-w4-Xwt"; */
+"tAb-w4-Xwt.title" = "Ersätt understreck med blanksteg";
+
+/* Class = "NSButtonCell"; title = "Clear completed jobs at launch"; ObjectID = "uIJ-tX-PEA"; */
+"uIJ-tX-PEA.title" = "Töm färdiga jobb vid uppstart";
+
+/* Class = "NSTextFieldCell"; title = "Default MP4 Extension:"; ObjectID = "v6r-mL-XmA"; */
+"v6r-mL-XmA.title" = "Standardfiländelse för MP4:";
+
+/* Class = "NSButtonCell"; title = "Remove common punctuation"; ObjectID = "vGu-jb-kdW"; */
+"vGu-jb-kdW.title" = "Ta bort vanliga skiljetecken";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Minimum free space on destination disk."; ObjectID = "VSi-rk-Vk2"; */
+"VSi-rk-Vk2.ibShadowedToolTip" = "Minimum ledigt utrymme på måldisken.";
+
+/* Class = "NSMenuItem"; title = "1"; ObjectID = "WAI-Bu-jIu"; */
+"WAI-Bu-jIu.title" = "1";
+
+/* Class = "NSSegmentedCell"; wbU-4j-344.ibShadowedToolTips[0] = "Add Extension"; ObjectID = "wbU-4j-344"; */
+"wbU-4j-344.ibShadowedToolTips[0]" = "Lägg till filändelse";
+
+/* Class = "NSSegmentedCell"; wbU-4j-344.ibShadowedToolTips[1] = "Remove Selected Extension"; ObjectID = "wbU-4j-344"; */
+"wbU-4j-344.ibShadowedToolTips[1]" = "Ta bort vald filändelse";
+
+/* Class = "NSTextFieldCell"; title = "Excluded file extensions:"; ObjectID = "wFM-UD-vzS"; */
+"wFM-UD-vzS.title" = "Exkluderade filändelser:";
+
+/* Class = "NSMenuItem"; title = ".mp4"; ObjectID = "wgg-7I-LBB"; */
+"wgg-7I-LBB.title" = ".mp4";
+
+/* Class = "NSButtonCell"; title = "Use same destination folder as source when possible"; ObjectID = "wXE-Fz-Dru"; */
+"wXE-Fz-Dru.title" = "Använd samma målmapp som källan om möjligt";
+
+/* Class = "NSMenuItem"; title = "Put Computer To Sleep"; ObjectID = "x7i-WX-w6l"; */
+"x7i-WX-w6l.title" = "Försätt datorn i sömnläge";
+
+/* Class = "NSButtonCell"; title = "Change case to Title Case"; ObjectID = "Y9B-ue-3sE"; */
+"Y9B-ue-3sE.title" = "Ändra skiftläge till titelns skiftläge";
+
+/* Class = "NSTextFieldCell"; title = "seconds"; ObjectID = "zOc-PA-WQr"; */
+"zOc-PA-WQr.title" = "sekunder";
+
+/* Class = "NSButtonCell"; title = "Browse…"; ObjectID = "zot-Bx-Ch3"; */
+"zot-Bx-Ch3.title" = "Bläddra...";
+
+/* Class = "NSButtonCell"; title = "Show Open Source panel"; ObjectID = "Zqz-Kn-xOS"; */
+"Zqz-Kn-xOS.title" = "Visa Öppna källa-panelen";
+

--- a/macosx/sv.lproj/Presets.strings
+++ b/macosx/sv.lproj/Presets.strings
@@ -1,0 +1,39 @@
+/* Class = "NSSegmentedCell"; 0di-xq-jgi.ibShadowedToolTips[0] = "Create a new custom preset based on the currently selected settings."; ObjectID = "0di-xq-jgi"; */
+"0di-xq-jgi.ibShadowedToolTips[0]" = "Skapa ett nytt anpassat förval baserat på de aktuellt valda inställningarna.";
+
+/* Class = "NSSegmentedCell"; 0di-xq-jgi.ibShadowedToolTips[1] = "Delete the selected preset."; ObjectID = "0di-xq-jgi"; */
+"0di-xq-jgi.ibShadowedToolTips[1]" = "Ta bort det valda förvalet.";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "4tC-UE-40G"; */
+"4tC-UE-40G.title" = "Textcell";
+
+/* Class = "NSMenuItem"; title = "Reset Official Presets"; ObjectID = "cm5-Kl-dB3"; */
+"cm5-Kl-dB3.title" = "Nollställ officiella förval";
+
+/* Class = "NSMenuItem"; title = "Make Default"; ObjectID = "D2t-YG-Frn"; */
+"D2t-YG-Frn.title" = "Gör till standard";
+
+/* Class = "NSMenuItem"; title = "New Category"; ObjectID = "Io0-Vm-Qez"; */
+"Io0-Vm-Qez.title" = "Ny kategori";
+
+/* Class = "NSMenuItem"; title = "Import…"; ObjectID = "LUl-ag-Iu6"; */
+"LUl-ag-Iu6.title" = "Importera…";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "oBC-Nh-TwB"; */
+"oBC-Nh-TwB.title" = "Tabellvycell";
+
+/* Class = "NSTextFieldCell"; title = "Presets"; ObjectID = "r4V-6L-SO8"; */
+"r4V-6L-SO8.title" = "Förval";
+
+/* Class = "NSScrollView"; ibExternalAccessibilityDescription = "Presets"; ObjectID = "uad-bt-uKD"; */
+"uad-bt-uKD.ibExternalAccessibilityDescription" = "Förval";
+
+/* Class = "NSMenuItem"; title = "Export…"; ObjectID = "xEQ-Un-J0n"; */
+"xEQ-Un-J0n.title" = "Exportera…";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Additional Options"; ObjectID = "Ybq-Zt-sta"; */
+"Ybq-Zt-sta.ibExternalAccessibilityDescription" = "Ytterligare alternativ";
+
+/* Class = "NSPopUpButton"; ibShadowedToolTip = "Show additional options."; ObjectID = "Ybq-Zt-sta"; */
+"Ybq-Zt-sta.ibShadowedToolTip" = "Visa ytterligare alternativ.";
+

--- a/macosx/sv.lproj/Queue.strings
+++ b/macosx/sv.lproj/Queue.strings
@@ -1,0 +1,3 @@
+/* Class = "NSWindow"; title = "Queue"; ObjectID = "2576"; */
+"2576.title" = "Kö";
+

--- a/macosx/sv.lproj/Subtitles.strings
+++ b/macosx/sv.lproj/Subtitles.strings
@@ -1,0 +1,114 @@
+/* Class = "NSTableView"; ibExternalAccessibilityDescription = "Subtitles tracks"; ObjectID = "0yM-wE-D2x"; */
+"0yM-wE-D2x.ibExternalAccessibilityDescription" = "Undertextspår";
+
+/* Class = "NSTableColumn"; headerCell.title = "Encoding"; ObjectID = "1Qg-We-ltR"; */
+"1Qg-We-ltR.headerCell.title" = "Enkodning";
+
+/* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "4PX-In-DpF"; */
+"4PX-In-DpF.title" = "Lägg till alla spår";
+
+/* Class = "NSTableColumn"; headerCell.title = "Language"; ObjectID = "9ka-9O-WDj"; */
+"9ka-9O-WDj.headerCell.title" = "Språk";
+
+/* Class = "NSTextField"; ibExternalAccessibilityDescription = "SRT/SSA Offset"; ObjectID = "aJi-zQ-0cg"; */
+"aJi-zQ-0cg.ibExternalAccessibilityDescription" = "SRT/SSA-justering";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "dap-ee-kor"; */
+"dap-ee-kor.title" = "Objekt 1";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "fAW-To-EeP"; */
+"fAW-To-EeP.title" = "Objekt 3";
+
+/* Class = "NSTableColumn"; headerCell.title = "Burned In"; ObjectID = "fIe-Fg-ufj"; */
+"fIe-Fg-ufj.headerCell.title" = "Inbränd";
+
+/* Class = "NSTableColumn"; headerCell.title = "Default"; ObjectID = "fvq-pE-sOC"; */
+"fvq-pE-sOC.headerCell.title" = "Standard";
+
+/* Class = "NSMenuItem"; title = "Add External Subtitles Track…"; ObjectID = "fXD-7h-jMl"; */
+"fXD-7h-jMl.title" = "Lägg till externt undertextspår...";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "g4b-FM-qX4"; */
+"g4b-FM-qX4.title" = "Objekt 2";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "gHY-6m-ASb"; */
+"gHY-6m-ASb.title" = "Objekt 2";
+
+/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "gYk-0C-2tR"; */
+"gYk-0C-2tR.title" = "Textcell";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Forced subtitles only"; ObjectID = "HC5-ql-Vcr"; */
+"HC5-ql-Vcr.ibExternalAccessibilityDescription" = "Tvingade undertexter endast";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "hhH-c3-gD0"; */
+"hhH-c3-gD0.title" = "0";
+
+/* Class = "NSMenuItem"; title = "Item 2"; ObjectID = "HQq-Mp-4sI"; */
+"HQq-Mp-4sI.title" = "Objekt 2";
+
+/* Class = "NSMenuItem"; ibShadowedToolTip = "Add new SRT/SSA subtitle to the list."; ObjectID = "HW0-PS-t0U"; */
+"HW0-PS-t0U.ibShadowedToolTip" = "Lägg till ny SRT/SSA-undertext till listan.";
+
+/* Class = "NSMenuItem"; title = "Add External Subtitles Track…"; ObjectID = "HW0-PS-t0U"; */
+"HW0-PS-t0U.title" = "Lägg till externt undertextspår...";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT/SSA Language"; ObjectID = "Inz-O5-B8g"; */
+"Inz-O5-B8g.ibExternalAccessibilityDescription" = "SRT/SSA-språk";
+
+/* Class = "NSMenuItem"; title = "Reload"; ObjectID = "jcM-HL-QJ6"; */
+"jcM-HL-QJ6.title" = "Läs om";
+
+/* Class = "NSButtonCell"; title = "Reload"; ObjectID = "jG8-uo-1tv"; */
+"jG8-uo-1tv.title" = "Läs om";
+
+/* Class = "NSTableColumn"; headerCell.title = "Forced Only"; ObjectID = "klV-Gy-igk"; */
+"klV-Gy-igk.headerCell.title" = "Endast tvingad";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Default"; ObjectID = "mdO-Qu-3Pb"; */
+"mdO-Qu-3Pb.ibExternalAccessibilityDescription" = "Standard";
+
+/* Class = "NSMenuItem"; title = "Remove All Tracks"; ObjectID = "mVi-zH-KUq"; */
+"mVi-zH-KUq.title" = "Ta bort alla spår";
+
+/* Class = "NSTableColumn"; headerCell.title = "Track"; ObjectID = "N3S-st-yGv"; */
+"N3S-st-yGv.headerCell.title" = "Spår";
+
+/* Class = "NSButtonCell"; title = "Selection Behavior…"; ObjectID = "oxg-bs-1si"; */
+"oxg-bs-1si.title" = "Valbeteende...";
+
+/* Class = "NSMenuItem"; title = "Selection Behavior…"; ObjectID = "pwm-PV-1x4"; */
+"pwm-PV-1x4.title" = "Valbeteende...";
+
+/* Class = "NSTextFieldCell"; title = "Text"; ObjectID = "QRj-KI-a03"; */
+"QRj-KI-a03.title" = "Text";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "SRT/SSA Character Encoding"; ObjectID = "QV0-kE-4yR"; */
+"QV0-kE-4yR.ibExternalAccessibilityDescription" = "Teckenkodning för SRT/SSA";
+
+/* Class = "NSMenuItem"; title = "Remove All Tracks"; ObjectID = "R8a-qg-ASg"; */
+"R8a-qg-ASg.title" = "Ta bort alla spår";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "Rj8-KI-k4L"; */
+"Rj8-KI-k4L.title" = "Objekt 1";
+
+/* Class = "NSMenuItem"; title = "Add All Tracks"; ObjectID = "S2I-Jd-Lyg"; */
+"S2I-Jd-Lyg.title" = "Lägg till alla spår";
+
+/* Class = "NSPopUpButton"; ibExternalAccessibilityDescription = "Selected track"; ObjectID = "Tf3-cP-TGw"; */
+"Tf3-cP-TGw.ibExternalAccessibilityDescription" = "Valt spår";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "ThR-Cn-Vfr"; */
+"ThR-Cn-Vfr.title" = "Objekt 3";
+
+/* Class = "NSMenuItem"; title = "Tracks"; ObjectID = "TJO-RZ-jgb"; */
+"TJO-RZ-jgb.title" = "Spår";
+
+/* Class = "NSMenuItem"; title = "Item 1"; ObjectID = "yDg-DK-z5D"; */
+"yDg-DK-z5D.title" = "Objekt 1";
+
+/* Class = "NSMenuItem"; title = "Item 3"; ObjectID = "yEC-jb-q8b"; */
+"yEC-jb-q8b.title" = "Objekt 3";
+
+/* Class = "NSButton"; ibExternalAccessibilityDescription = "Burned In"; ObjectID = "zpm-9Z-Hsq"; */
+"zpm-9Z-Hsq.ibExternalAccessibilityDescription" = "Inbränd";
+

--- a/macosx/sv.lproj/SubtitlesDefaults.strings
+++ b/macosx/sv.lproj/SubtitlesDefaults.strings
@@ -1,0 +1,60 @@
+/* Class = "NSButtonCell"; title = "Add Closed Captions when available"; ObjectID = "66v-2g-DHn"; */
+"66v-2g-DHn.title" = "Lägg till dold bildtext när möjligt";
+
+/* Class = "NSButtonCell"; title = "DVD Subtitles"; ObjectID = "69Q-xB-Vyq"; */
+"69Q-xB-Vyq.title" = "Dvd-undertexter";
+
+/* Class = "NSTextFieldCell"; title = "Burn-In Behavior:"; ObjectID = "640-NB-Uby"; */
+"640-NB-Uby.title" = "Beteende för inbränning:";
+
+/* Class = "NSScrollView"; ibExternalAccessibilityDescription = "Subtitles Track Languages"; ObjectID = "aTC-39-h6S"; */
+"aTC-39-h6S.ibExternalAccessibilityDescription" = "Språk för undertextspår";
+
+/* Class = "NSButtonCell"; title = "Blu-ray Subtitles"; ObjectID = "bfV-9D-6dh"; */
+"bfV-9D-6dh.title" = "Bluray-undertexter";
+
+/* Class = "NSMenuItem"; title = "Foreign Audio, then First Selected Track"; ObjectID = "d79-2j-fhc"; */
+"d79-2j-fhc.title" = "Utländskt ljud, sedan första valda spåret";
+
+/* Class = "NSButtonCell"; title = "Cancel"; ObjectID = "ego-rt-a64"; */
+"ego-rt-a64.title" = "Avbryt";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "ej8-4k-1vd"; */
+"ej8-4k-1vd.title" = "Ingen";
+
+/* Class = "NSTextFieldCell"; title = "Track Selection Behavior:"; ObjectID = "GbM-vm-RC2"; */
+"GbM-vm-RC2.title" = "Beteende för spårval:";
+
+/* Class = "NSMenuItem"; title = "All Matching Selected Languages"; ObjectID = "GZP-q7-SYy"; */
+"GZP-q7-SYy.title" = "Alla matchande valda språk";
+
+/* Class = "NSButtonCell"; title = "OK"; ObjectID = "iLI-Nb-D7t"; */
+"iLI-Nb-D7t.title" = "Ok";
+
+/* Class = "NSMenuItem"; title = "First Matching Selected Languages"; ObjectID = "jDd-Ji-7Sm"; */
+"jDd-Ji-7Sm.title" = "Första matchande valda språken";
+
+/* Class = "NSWindow"; title = "Subtitles Selection Behaviour"; ObjectID = "kwM-lz-5lG"; */
+"kwM-lz-5lG.title" = "Beteende för undertextval";
+
+/* Class = "NSTextFieldCell"; title = "Languages:"; ObjectID = "mAT-Jp-SG1"; */
+"mAT-Jp-SG1.title" = "Språk:";
+
+/* Class = "NSMenuItem"; title = "First Selected Track"; ObjectID = "mnl-P8-dtK"; */
+"mnl-P8-dtK.title" = "Första valda spåret";
+
+/* Class = "NSMenuItem"; title = "None"; ObjectID = "mvw-Hg-JFM"; */
+"mvw-Hg-JFM.title" = "Ingen";
+
+/* Class = "NSTextFieldCell"; title = "Options:"; ObjectID = "NJl-q3-zXL"; */
+"NJl-q3-zXL.title" = "Alternativ:";
+
+/* Class = "NSMenuItem"; title = "Foreign Audio Subtitles Track"; ObjectID = "QRd-XH-6TH"; */
+"QRd-XH-6TH.title" = "Undertextspår med utländskt ljud";
+
+/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "qVQ-fS-w1S"; */
+"qVQ-fS-w1S.title" = "Tabellvycell";
+
+/* Class = "NSButtonCell"; title = "Add Foreign Audio Search"; ObjectID = "vNY-OC-hTJ"; */
+"vNY-OC-hTJ.title" = "Lägg till sökning av utländskt ljud";
+

--- a/macosx/sv.lproj/Video.strings
+++ b/macosx/sv.lproj/Video.strings
@@ -1,0 +1,57 @@
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "auto"; ObjectID = "4Hq-BG-Ulb"; */
+"4Hq-BG-Ulb.ibShadowedIsNilPlaceholder" = "auto";
+
+/* Class = "NSButtonCell"; title = "Constant Framerate"; ObjectID = "6Dd-IP-Pwt"; */
+"6Dd-IP-Pwt.title" = "Konstant bildfrekvens";
+
+/* Class = "NSTextFieldCell"; title = "0"; ObjectID = "bvD-W7-O0N"; */
+"bvD-W7-O0N.title" = "0";
+
+/* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "cRF-pz-1jt"; */
+"cRF-pz-1jt.title" = "Alternativ för enkodare:";
+
+/* Class = "CocoaBindingsConnection"; ibShadowedIsNilPlaceholder = "auto"; ObjectID = "CRz-On-Jen"; */
+"CRz-On-Jen.ibShadowedIsNilPlaceholder" = "auto";
+
+/* Class = "NSTextField"; ibShadowedToolTip = "Displays all internal video encoder options."; ObjectID = "dwn-bf-Ua0"; */
+"dwn-bf-Ua0.ibShadowedToolTip" = "Visar alla interna alternativ för videoenkodaren.";
+
+/* Class = "NSButtonCell"; title = "Fast Decode"; ObjectID = "EcY-w1-bc8"; */
+"EcY-w1-bc8.title" = "Snabb dekodning";
+
+/* Class = "NSTextFieldCell"; title = "Quality:"; ObjectID = "F3s-qR-qeE"; */
+"F3s-qR-qeE.title" = "Kvalitet:";
+
+/* Class = "NSTextFieldCell"; title = "Tune:"; ObjectID = "fzT-im-zKN"; */
+"fzT-im-zKN.title" = "Justera:";
+
+/* Class = "NSTextFieldCell"; title = "Profile:"; ObjectID = "Hho-GY-qOR"; */
+"Hho-GY-qOR.title" = "Profil:";
+
+/* Class = "NSTextFieldCell"; title = "Additional Options:"; ObjectID = "ja7-Zr-y1P"; */
+"ja7-Zr-y1P.title" = "Ytterligare alternativ:";
+
+/* Class = "NSTextFieldCell"; title = "Encoder Options:"; ObjectID = "kPs-u2-fDn"; */
+"kPs-u2-fDn.title" = "Alternativ för enkodare:";
+
+/* Class = "NSTextFieldCell"; title = "Video Encoder:"; ObjectID = "Mrb-6Q-0YM"; */
+"Mrb-6Q-0YM.title" = "Videoenkodare:";
+
+/* Class = "NSTextFieldCell"; title = "Preset:"; ObjectID = "QWu-rv-zfM"; */
+"QWu-rv-zfM.title" = "Förval:";
+
+/* Class = "NSTextFieldCell"; title = "Framerate (FPS):"; ObjectID = "SJc-tv-AMH"; */
+"SJc-tv-AMH.title" = "Bildfrekvens (bilder/s):";
+
+/* Class = "NSTextFieldCell"; title = "Level:"; ObjectID = "sTM-lk-DBC"; */
+"sTM-lk-DBC.title" = "Nivå:";
+
+/* Class = "NSButtonCell"; title = "Average Bitrate (kbps):"; ObjectID = "VQe-CK-YDR"; */
+"VQe-CK-YDR.title" = "Genomsnittlig bitfrekvens (kbps):";
+
+/* Class = "NSButtonCell"; title = "Constant Quality"; ObjectID = "ZjL-cY-O5f"; */
+"ZjL-cY-O5f.title" = "Konstant kvalitet";
+
+/* Class = "NSButtonCell"; title = "Variable Framerate"; ObjectID = "zZo-75-1WG"; */
+"zZo-75-1WG.title" = "Variabel bildfrekvens";
+


### PR DESCRIPTION
This adds the Swedish language to macOS. It's not quite 100% yet, but I have to update all locales for 1.9.0 in 1-2 weeks anyway. 
I have also taken the opportunity to fix a small issue with the HandBrakeXPCService Localizable.strings file for some locales.