### PR TITLE
rendersub: use ASS track YCbCrMatrix field.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -6236,6 +6236,23 @@ int hb_rgb2yuv_bt2020(int rgb)
     return (y << 16) | (Cr << 8) | Cb;
 }
 
+hb_csp_convert_f hb_get_rgb2yuv_function(int color_matrix)
+{
+    switch (color_matrix)
+    {
+    case HB_COLR_MAT_BT470BG:
+    case HB_COLR_MAT_SMPTE170M:
+    case HB_COLR_MAT_FCC:
+        return hb_rgb2yuv;
+    case HB_COLR_MAT_BT2020_NCL:
+    case HB_COLR_MAT_BT2020_CL: //wrong
+        return hb_rgb2yuv_bt2020;
+    default: //assume 709 for the rest
+        break;
+    }
+    return hb_rgb2yuv_bt709;
+}
+
 void hb_compute_chroma_smoothing_coefficient(unsigned chroma_coeffs[2][4], int pix_fmt, int chroma_location)
 {
     const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);

--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -619,23 +619,7 @@ int decavsubWork( hb_avsub_context_t * ctx,
                     int xx, yy;
                     uint32_t argb, ayuv;
 
-                    typedef int (*csp_f)(int);
-                    csp_f rgb2yuv_fn;
-
-                    switch (ctx->job->color_matrix)
-                    {
-                        case HB_COLR_MAT_BT470BG:
-                        case HB_COLR_MAT_SMPTE170M:
-                        case HB_COLR_MAT_FCC:
-                            rgb2yuv_fn = hb_rgb2yuv;
-                            break;
-                        case HB_COLR_MAT_BT2020_NCL:
-                        case HB_COLR_MAT_BT2020_CL: //wrong
-                            rgb2yuv_fn = hb_rgb2yuv_bt2020;
-                            break;
-                        default: //assume 709 for the rest
-                            rgb2yuv_fn = hb_rgb2yuv_bt709;
-                    }
+                    hb_csp_convert_f rgb2yuv_fn = hb_get_rgb2yuv_function(ctx->job->color_matrix);
 
                     //Convert the palette at once to YUV
                     for (xx = 0; xx < rect->nb_colors; xx++)

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1628,6 +1628,9 @@ int hb_rgb2yuv(int rgb);
 int hb_rgb2yuv_bt709(int rgb);
 int hb_rgb2yuv_bt2020(int rgb);
 
+typedef int (*hb_csp_convert_f)(int);
+hb_csp_convert_f hb_get_rgb2yuv_function(int color_matrix);
+
 void hb_compute_chroma_smoothing_coefficient(unsigned chroma_coeffs[2][4],
                                              int pix_fmt, int chroma_location);
 


### PR DESCRIPTION
Pick the YCbCr conversion function according to the YCbCrMatrix header of the ASS script.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux