### PR TITLE
Fix setting nvenc profiles

### DIFF
--- a/contrib/ffmpeg/A29-Revert-lavc-Check-codec_whitelist-early-in-avcodec_o.patch
+++ b/contrib/ffmpeg/A29-Revert-lavc-Check-codec_whitelist-early-in-avcodec_o.patch
@@ -1,0 +1,47 @@
+From 1266d5d35e90619350372b5656fce35114b798cb Mon Sep 17 00:00:00 2001
+From: Sam H <samhutchins@users.noreply.github.com>
+Date: Tue, 12 Nov 2024 19:03:02 +0000
+Subject: [PATCH] Revert "lavc: Check codec_whitelist early in avcodec_open2()"
+
+This reverts commit 7753a9d62725d5bd8313e2d249acbe1c8af79ab1.
+---
+ libavcodec/avcodec.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/libavcodec/avcodec.c b/libavcodec/avcodec.c
+index d1daf47611..d9b0e1246f 100644
+--- a/libavcodec/avcodec.c
++++ b/libavcodec/avcodec.c
+@@ -175,14 +175,6 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     if (avctx->extradata_size < 0 || avctx->extradata_size >= FF_MAX_EXTRADATA_SIZE)
+         return AVERROR(EINVAL);
+ 
+-    if ((ret = av_opt_set_dict(avctx, options)) < 0)
+-        return ret;
+-
+-    if (avctx->codec_whitelist && av_match_list(codec->name, avctx->codec_whitelist, ',') <= 0) {
+-        av_log(avctx, AV_LOG_ERROR, "Codec (%s) not on whitelist \'%s\'\n", codec->name, avctx->codec_whitelist);
+-        return AVERROR(EINVAL);
+-    }
+-
+     avci = av_codec_is_decoder(codec) ?
+         ff_decode_internal_alloc()    :
+         ff_encode_internal_alloc();
+@@ -216,6 +208,14 @@ int attribute_align_arg avcodec_open2(AVCodecContext *avctx, const AVCodec *code
+     } else {
+         avctx->priv_data = NULL;
+     }
++    if ((ret = av_opt_set_dict(avctx, options)) < 0)
++        goto free_and_end;
++
++    if (avctx->codec_whitelist && av_match_list(codec->name, avctx->codec_whitelist, ',') <= 0) {
++        av_log(avctx, AV_LOG_ERROR, "Codec (%s) not on whitelist \'%s\'\n", codec->name, avctx->codec_whitelist);
++        ret = AVERROR(EINVAL);
++        goto free_and_end;
++    }
+ 
+     // only call ff_set_dimensions() for non H.264/VP6F/DXV codecs so as not to overwrite previously setup dimensions
+     if (!(avctx->coded_width && avctx->coded_height && avctx->width && avctx->height &&
+-- 
+2.47.0
+

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -718,6 +718,8 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
                 av_dict_set(&av_opts, "profile", "baseline", 0);
             else if (!strcasecmp(job->encoder_profile, "main"))
                 av_dict_set(&av_opts, "profile", "main", 0);
+            else if (!strcasecmp(job->encoder_profile, "main10"))
+                av_dict_set(&av_opts, "profile", "main10", 0);
             else if (!strcasecmp(job->encoder_profile, "high"))
                 av_dict_set(&av_opts, "profile", "high", 0);
         }


### PR DESCRIPTION
**Description of Change:**

Another attempt at fixing #6340 

 - Revert the change in ffmpeg that intorduces this regression
 - Ensure `main10` is passed through properly

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Fedora Linux
