### PR TITLE
gtk: Improve preset handling

### DIFF
--- a/gtk/po/ghb.pot
+++ b/gtk/po/ghb.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: ghb 20240416-git-d9791800c\n"
+"Project-Id-Version: ghb 20241116-git-41d7e1d69\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-04-16 19:10+0100\n"
+"POT-Creation-Date: 2024-11-16 19:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -22,11 +22,11 @@ msgstr ""
 msgid "_File"
 msgstr ""
 
-#: src/ui/menu.ui:10 src/ui/menu.ui:462
+#: src/ui/menu.ui:10 src/ui/menu.ui:456
 msgid "_Open Source…"
 msgstr ""
 
-#: src/ui/menu.ui:14 src/ui/menu.ui:466
+#: src/ui/menu.ui:14 src/ui/menu.ui:460
 msgid "Open _Directory…"
 msgstr ""
 
@@ -39,7 +39,7 @@ msgid "_Preferences"
 msgstr ""
 
 #. Toss up a warning dialog
-#: src/ui/menu.ui:30 src/ui/menu.ui:210 src/callbacks.c:3814
+#: src/ui/menu.ui:30 src/ui/menu.ui:210 src/callbacks.c:3820
 msgid "_Quit"
 msgstr ""
 
@@ -51,19 +51,19 @@ msgstr ""
 msgid "_Add"
 msgstr ""
 
-#: src/ui/menu.ui:43 src/ui/menu.ui:449
+#: src/ui/menu.ui:43 src/ui/menu.ui:443
 msgid "Add _Multiple…"
 msgstr ""
 
-#: src/ui/menu.ui:47 src/ui/menu.ui:453
+#: src/ui/menu.ui:47 src/ui/menu.ui:447
 msgid "Add A_ll"
 msgstr ""
 
-#: src/ui/menu.ui:53 src/queuehandler.c:1877
+#: src/ui/menu.ui:53 src/queuehandler.c:1870
 msgid "_Start Encoding"
 msgstr ""
 
-#: src/ui/menu.ui:57 src/queuehandler.c:1920
+#: src/ui/menu.ui:57 src/queuehandler.c:1913
 msgid "_Pause Encoding"
 msgstr ""
 
@@ -103,9 +103,9 @@ msgstr ""
 msgid "_New Preset…"
 msgstr ""
 
-#: src/ui/menu.ui:107 src/ui/menu.ui:229 src/ui/menu.ui:268 src/ui/ghb.ui:5975
-#: src/ui/ghb.ui:6065 src/callbacks.c:2135 src/chapters.c:455
-#: src/ghb-file-button.c:219 src/presets.c:2229 src/queuehandler.c:1391
+#: src/ui/menu.ui:107 src/ui/menu.ui:229 src/ui/menu.ui:268 src/ui/ghb.ui:6038
+#: src/ui/ghb.ui:6128 src/callbacks.c:2141 src/chapters.c:455
+#: src/ghb-file-button.c:219 src/presets.c:2331 src/queuehandler.c:1386
 msgid "_Save"
 msgstr ""
 
@@ -189,11 +189,11 @@ msgstr ""
 msgid "_Add Track"
 msgstr ""
 
-#: src/ui/menu.ui:350 src/ui/menu.ui:425 src/ui/menu.ui:437
+#: src/ui/menu.ui:350 src/ui/menu.ui:419 src/ui/menu.ui:431
 msgid "Add A_ll Tracks"
 msgstr ""
 
-#: src/ui/menu.ui:354 src/ui/menu.ui:441
+#: src/ui/menu.ui:354 src/ui/menu.ui:435
 msgid "Add _Foreign Audio Scan"
 msgstr ""
 
@@ -217,11 +217,7 @@ msgstr ""
 msgid "_Reset"
 msgstr ""
 
-#: src/ui/menu.ui:413
-msgid "Re_move"
-msgstr ""
-
-#: src/ui/menu.ui:421 src/ui/menu.ui:433
+#: src/ui/menu.ui:415 src/ui/menu.ui:427
 msgid "_Add New Track"
 msgstr ""
 
@@ -314,23 +310,23 @@ msgstr ""
 msgid "HandBrake Queue"
 msgstr ""
 
-#: src/ui/ghb.ui:212 src/ui/ghb.ui:1416 src/queuehandler.c:1850
-#: src/queuehandler.c:1863
+#: src/ui/ghb.ui:212 src/ui/ghb.ui:1416 src/queuehandler.c:1843
+#: src/queuehandler.c:1856
 msgid "Start Encoding"
 msgstr ""
 
-#: src/ui/ghb.ui:213 src/ui/ghb.ui:1417 src/ui/ghb.ui:4156
-#: src/queuehandler.c:1849 src/queuehandler.c:1862
+#: src/ui/ghb.ui:213 src/ui/ghb.ui:1417 src/ui/ghb.ui:4154
+#: src/queuehandler.c:1842 src/queuehandler.c:1855
 msgid "Start"
 msgstr ""
 
-#: src/ui/ghb.ui:221 src/ui/ghb.ui:1424 src/queuehandler.c:1894
-#: src/queuehandler.c:1907
+#: src/ui/ghb.ui:221 src/ui/ghb.ui:1424 src/queuehandler.c:1887
+#: src/queuehandler.c:1900
 msgid "Pause Encoding"
 msgstr ""
 
-#: src/ui/ghb.ui:222 src/ui/ghb.ui:1425 src/queuehandler.c:1893
-#: src/queuehandler.c:1906
+#: src/ui/ghb.ui:222 src/ui/ghb.ui:1425 src/queuehandler.c:1886
+#: src/queuehandler.c:1899
 msgid "Pause"
 msgstr ""
 
@@ -346,7 +342,7 @@ msgstr ""
 msgid "Options"
 msgstr ""
 
-#: src/ui/ghb.ui:322 src/ui/ghb.ui:4540
+#: src/ui/ghb.ui:322 src/ui/ghb.ui:4538
 msgid "When Done:"
 msgstr ""
 
@@ -372,10 +368,10 @@ msgstr ""
 msgid "Edit"
 msgstr ""
 
-#: src/ui/ghb.ui:456 src/ui/ghb.ui:2947 src/ui/ghb.ui:3071 src/ui/ghb.ui:3212
-#: src/ui/ghb.ui:3587 src/hb-backend.c:4308 src/hb-backend.c:4315
-#: src/hb-backend.c:4339 src/hb-backend.c:4347 src/hb-backend.c:4375
-#: src/hb-backend.c:4384 src/hb-backend.c:4411 src/hb-backend.c:4436
+#: src/ui/ghb.ui:456 src/ui/ghb.ui:2945 src/ui/ghb.ui:3069 src/ui/ghb.ui:3210
+#: src/ui/ghb.ui:3585 src/hb-backend.c:4305 src/hb-backend.c:4312
+#: src/hb-backend.c:4336 src/hb-backend.c:4344 src/hb-backend.c:4372
+#: src/hb-backend.c:4381 src/hb-backend.c:4408 src/hb-backend.c:4433
 msgid "Preset:"
 msgstr ""
 
@@ -383,7 +379,7 @@ msgstr ""
 msgid "Source:"
 msgstr ""
 
-#: src/ui/ghb.ui:515 src/ui/ghb.ui:4205
+#: src/ui/ghb.ui:515 src/ui/ghb.ui:4203
 msgid "Title:"
 msgstr ""
 
@@ -462,11 +458,11 @@ msgstr ""
 msgid "HandBrake"
 msgstr ""
 
-#: src/ui/ghb.ui:1363 src/callbacks.c:4521
+#: src/ui/ghb.ui:1363 src/callbacks.c:4556
 msgid "Choose Video Source"
 msgstr ""
 
-#: src/ui/ghb.ui:1364 src/callbacks.c:1866 src/callbacks.c:4520
+#: src/ui/ghb.ui:1364 src/callbacks.c:1873 src/callbacks.c:4555
 msgid "Open Source"
 msgstr ""
 
@@ -509,12 +505,12 @@ msgstr ""
 #: src/ui/ghb.ui:1498 src/hb-backend.c:54 src/hb-backend.c:66
 #: src/hb-backend.c:79 src/hb-backend.c:117 src/hb-backend.c:217
 #: src/hb-backend.c:250 src/hb-backend.c:261 src/hb-backend.c:288
-#: src/hb-backend.c:373 src/hb-backend.c:2537 src/hb-backend.c:2762
+#: src/hb-backend.c:373 src/hb-backend.c:2547 src/hb-backend.c:2772
 #: src/subtitlehandler.c:1434
 msgid "None"
 msgstr ""
 
-#: src/ui/ghb.ui:1526 src/callbacks.c:4493
+#: src/ui/ghb.ui:1526 src/callbacks.c:4528
 msgid "Scanning..."
 msgstr ""
 
@@ -569,7 +565,7 @@ msgstr ""
 msgid "<u><i>Modified</i></u>"
 msgstr ""
 
-#: src/ui/ghb.ui:1681 src/ui/ghb.ui:3859 src/ui/ghb.ui:4013
+#: src/ui/ghb.ui:1681 src/ui/ghb.ui:3857 src/ui/ghb.ui:4011
 msgid "Reload"
 msgstr ""
 
@@ -595,7 +591,7 @@ msgstr ""
 msgid "Format to mux encoded tracks to."
 msgstr ""
 
-#: src/ui/ghb.ui:1770 src/queuehandler.c:230
+#: src/ui/ghb.ui:1770 src/queuehandler.c:225
 msgid "Web Optimized"
 msgstr ""
 
@@ -652,7 +648,7 @@ msgstr ""
 msgid "Size:"
 msgstr ""
 
-#: src/ui/ghb.ui:1987 src/ui/ghb.ui:2006 src/ui/ghb.ui:6229
+#: src/ui/ghb.ui:1987 src/ui/ghb.ui:2006 src/ui/ghb.ui:6292
 msgid "Video Preview"
 msgstr ""
 
@@ -664,15 +660,15 @@ msgstr ""
 msgid "<b>Source Dimensions</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:2051 src/ui/ghb.ui:2699
+#: src/ui/ghb.ui:2051 src/ui/ghb.ui:2697
 msgid "Storage Size:"
 msgstr ""
 
-#: src/ui/ghb.ui:2074 src/ui/ghb.ui:2726
+#: src/ui/ghb.ui:2074 src/ui/ghb.ui:2724
 msgid "Display Size:"
 msgstr ""
 
-#: src/ui/ghb.ui:2097 src/ui/ghb.ui:2793
+#: src/ui/ghb.ui:2097 src/ui/ghb.ui:2791
 msgid "Aspect Ratio:"
 msgstr ""
 
@@ -798,7 +794,7 @@ msgid ""
 "1:1."
 msgstr ""
 
-#: src/ui/ghb.ui:2485 src/ui/ghb.ui:2749
+#: src/ui/ghb.ui:2485 src/ui/ghb.ui:2747
 msgid "×"
 msgstr ""
 
@@ -829,60 +825,60 @@ msgstr ""
 msgid "<b>Borders</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:2568
+#: src/ui/ghb.ui:2567
 msgid "Fill:"
 msgstr ""
 
-#: src/ui/ghb.ui:2580
+#: src/ui/ghb.ui:2579
 msgid "Add a border around the video."
 msgstr ""
 
-#: src/ui/ghb.ui:2594
+#: src/ui/ghb.ui:2592
 msgid "Left Pad"
 msgstr ""
 
-#: src/ui/ghb.ui:2608
+#: src/ui/ghb.ui:2606
 msgid "Top Pad"
 msgstr ""
 
-#: src/ui/ghb.ui:2622
+#: src/ui/ghb.ui:2620
 msgid "Bottom Pad"
 msgstr ""
 
-#: src/ui/ghb.ui:2636
+#: src/ui/ghb.ui:2634
 msgid "Right Pad"
 msgstr ""
 
-#: src/ui/ghb.ui:2649
+#: src/ui/ghb.ui:2647
 msgid "Color:"
 msgstr ""
 
-#: src/ui/ghb.ui:2661
+#: src/ui/ghb.ui:2659
 msgid "Color of border added around video."
 msgstr ""
 
-#: src/ui/ghb.ui:2685
+#: src/ui/ghb.ui:2683
 msgid "<b>Final Dimensions</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:2737 src/ui/ghb.ui:2760 src/ui/ghb.ui:2773
+#: src/ui/ghb.ui:2735 src/ui/ghb.ui:2758 src/ui/ghb.ui:2771
 msgid "Changing the display size will stretch the video."
 msgstr ""
 
-#: src/ui/ghb.ui:2771 src/hb-backend.c:116 src/hb-backend.c:219
+#: src/ui/ghb.ui:2769 src/hb-backend.c:116 src/hb-backend.c:219
 #: src/hb-backend.c:291
 msgid "Automatic"
 msgstr ""
 
-#: src/ui/ghb.ui:2822
+#: src/ui/ghb.ui:2820
 msgid "Filters"
 msgstr ""
 
-#: src/ui/ghb.ui:2832
+#: src/ui/ghb.ui:2830
 msgid "Detelecine:"
 msgstr ""
 
-#: src/ui/ghb.ui:2843
+#: src/ui/ghb.ui:2841
 msgid ""
 "This filter removes 'combing' artifacts that are the result of telecining.\n"
 "\n"
@@ -890,18 +886,18 @@ msgid ""
 "video frame rates which are 30fps."
 msgstr ""
 
-#: src/ui/ghb.ui:2859 src/ui/ghb.ui:3285
+#: src/ui/ghb.ui:2857 src/ui/ghb.ui:3283
 msgid ""
 "Custom detelecine filter string format\n"
 "\n"
 "JunkLeft:JunkRight:JunkTop:JunkBottom:StrictBreaks:MetricPlane:Parity"
 msgstr ""
 
-#: src/ui/ghb.ui:2874
+#: src/ui/ghb.ui:2872
 msgid "Interlace Detection:"
 msgstr ""
 
-#: src/ui/ghb.ui:2885
+#: src/ui/ghb.ui:2883
 msgid ""
 "This filter detects interlaced frames.\n"
 "\n"
@@ -909,7 +905,7 @@ msgid ""
 "to be interlaced will be deinterlaced."
 msgstr ""
 
-#: src/ui/ghb.ui:2900
+#: src/ui/ghb.ui:2898
 msgid ""
 "Custom interlace detection filter string format\n"
 "\n"
@@ -917,11 +913,11 @@ msgid ""
 "Block Thresh: Block Width: Block Height"
 msgstr ""
 
-#: src/ui/ghb.ui:2916
+#: src/ui/ghb.ui:2914
 msgid "Deinterlace:"
 msgstr ""
 
-#: src/ui/ghb.ui:2927
+#: src/ui/ghb.ui:2925
 msgid ""
 "Choose decomb or deinterlace filter.\n"
 "\n"
@@ -929,7 +925,7 @@ msgid ""
 "The deinterlace filter is a classic YADIF deinterlacer.\n"
 msgstr ""
 
-#: src/ui/ghb.ui:2954
+#: src/ui/ghb.ui:2952
 msgid ""
 "Choose decomb or deinterlace filter options.\n"
 "\n"
@@ -938,39 +934,39 @@ msgid ""
 "    "
 msgstr ""
 
-#: src/ui/ghb.ui:2981
+#: src/ui/ghb.ui:2979
 msgid "Deblock Filter:"
 msgstr ""
 
-#: src/ui/ghb.ui:2992
+#: src/ui/ghb.ui:2990
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ui/ghb.ui:3009 src/ui/ghb.ui:3089 src/ui/ghb.ui:3151 src/ui/ghb.ui:3229
-#: src/ui/ghb.ui:3643 src/hb-backend.c:4412 src/hb-backend.c:4437
+#: src/ui/ghb.ui:3007 src/ui/ghb.ui:3087 src/ui/ghb.ui:3149 src/ui/ghb.ui:3227
+#: src/ui/ghb.ui:3641 src/hb-backend.c:4409 src/hb-backend.c:4434
 msgid "Tune:"
 msgstr ""
 
-#: src/ui/ghb.ui:3016
+#: src/ui/ghb.ui:3014
 msgid ""
 "The deblocking filter removes a common type of compression artifact.\n"
 "    If your source exhibits 'blockiness', this filter may help clean it up."
 msgstr ""
 
-#: src/ui/ghb.ui:3025 src/ui/ghb.ui:3167
+#: src/ui/ghb.ui:3023 src/ui/ghb.ui:3165
 msgid ""
 "Custom deblock filter string format\n"
 "\n"
 "    strength=weak|strong:thresh=0-100:blocksize=4-512"
 msgstr ""
 
-#: src/ui/ghb.ui:3042
+#: src/ui/ghb.ui:3040
 msgid "Denoise Filter:"
 msgstr ""
 
-#: src/ui/ghb.ui:3053
+#: src/ui/ghb.ui:3051
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "Film grain and other types of high frequency noise are difficult to "
@@ -978,7 +974,7 @@ msgid ""
 "Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ui/ghb.ui:3078 src/ui/ghb.ui:3096
+#: src/ui/ghb.ui:3076 src/ui/ghb.ui:3094
 msgid ""
 "Denoise filtering reduces or removes the appearance of noise and grain.\n"
 "    Film grain and other types of high frequency noise are difficult to "
@@ -986,78 +982,78 @@ msgid ""
 "    Using this filter on such sources can result in smaller file sizes."
 msgstr ""
 
-#: src/ui/ghb.ui:3106 src/ui/ghb.ui:3245
+#: src/ui/ghb.ui:3104 src/ui/ghb.ui:3243
 msgid ""
 "Custom denoise filter string format\n"
 "\n"
 "    SpatialLuma:SpatialChroma:TemporalLuma:TemporalChroma"
 msgstr ""
 
-#: src/ui/ghb.ui:3123
+#: src/ui/ghb.ui:3121
 msgid "Chroma Smooth Filter:"
 msgstr ""
 
-#: src/ui/ghb.ui:3134
+#: src/ui/ghb.ui:3132
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ui/ghb.ui:3158
+#: src/ui/ghb.ui:3156
 msgid ""
 "The chroma smooth filter removes common color artifacts.\n"
 "    Lower resolution analog source content may benefit from this filter."
 msgstr ""
 
-#: src/ui/ghb.ui:3184
+#: src/ui/ghb.ui:3182
 msgid "Sharpen Filter:"
 msgstr ""
 
-#: src/ui/ghb.ui:3195
+#: src/ui/ghb.ui:3193
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "high frequency components in the video."
 msgstr ""
 
-#: src/ui/ghb.ui:3219 src/ui/ghb.ui:3236
+#: src/ui/ghb.ui:3217 src/ui/ghb.ui:3234
 msgid ""
 "Sharpen filtering enhances edges and other\n"
 "    high frequency components in the video."
 msgstr ""
 
-#: src/ui/ghb.ui:3262
+#: src/ui/ghb.ui:3260
 msgid "Colorspace:"
 msgstr ""
 
-#: src/ui/ghb.ui:3273
+#: src/ui/ghb.ui:3271
 msgid "Translate the colorspace of the source."
 msgstr ""
 
-#: src/ui/ghb.ui:3299 src/hb-backend.c:4880
+#: src/ui/ghb.ui:3297 src/hb-backend.c:4877
 msgid "Grayscale"
 msgstr ""
 
-#: src/ui/ghb.ui:3301
+#: src/ui/ghb.ui:3299
 msgid "If enabled, filter colour components out of video."
 msgstr ""
 
-#: src/ui/ghb.ui:3318 src/callbacks.c:5609
+#: src/ui/ghb.ui:3316 src/callbacks.c:5644
 msgid "Video"
 msgstr ""
 
-#: src/ui/ghb.ui:3333
+#: src/ui/ghb.ui:3331
 msgid "Video Encoder:"
 msgstr ""
 
-#: src/ui/ghb.ui:3343
+#: src/ui/ghb.ui:3341
 msgid "Available video encoders."
 msgstr ""
 
-#: src/ui/ghb.ui:3354
+#: src/ui/ghb.ui:3352
 msgid "Framerate:"
 msgstr ""
 
-#: src/ui/ghb.ui:3364
+#: src/ui/ghb.ui:3362
 msgid ""
 "Output framerate.\n"
 "\n"
@@ -1065,19 +1061,19 @@ msgid ""
 "a variable framerate, 'Same as source' will preserve it."
 msgstr ""
 
-#: src/ui/ghb.ui:3380
+#: src/ui/ghb.ui:3378
 msgid "Constant Framerate"
 msgstr ""
 
-#: src/ui/ghb.ui:3381
+#: src/ui/ghb.ui:3379
 msgid "Enables constant framerate output."
 msgstr ""
 
-#: src/ui/ghb.ui:3388
+#: src/ui/ghb.ui:3386
 msgid "Peak Framerate (VFR)"
 msgstr ""
 
-#: src/ui/ghb.ui:3389
+#: src/ui/ghb.ui:3387
 msgid ""
 "Enables variable framerate output with a peak\n"
 "    rate determined by the framerate setting.\n"
@@ -1085,22 +1081,22 @@ msgid ""
 "    VFR is not compatible with some players."
 msgstr ""
 
-#: src/ui/ghb.ui:3400
+#: src/ui/ghb.ui:3398
 msgid "Variable Framerate"
 msgstr ""
 
-#: src/ui/ghb.ui:3401
+#: src/ui/ghb.ui:3399
 msgid ""
 "Enables variable framerate output.\n"
 "\n"
 "    VFR is not compatible with some players."
 msgstr ""
 
-#: src/ui/ghb.ui:3427
+#: src/ui/ghb.ui:3425
 msgid "Constant Quality:"
 msgstr ""
 
-#: src/ui/ghb.ui:3428
+#: src/ui/ghb.ui:3426
 msgid ""
 "Set the desired quality factor.\n"
 "  The encoder targets a certain quality.\n"
@@ -1117,7 +1113,7 @@ msgid ""
 "  These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ui/ghb.ui:3467
+#: src/ui/ghb.ui:3465
 msgid ""
 "Set the desired quality factor.\n"
 "The encoder targets a certain quality.\n"
@@ -1133,15 +1129,15 @@ msgid ""
 "These encoders do not have a lossless mode."
 msgstr ""
 
-#: src/ui/ghb.ui:3483 src/audiohandler.c:1783
+#: src/ui/ghb.ui:3481 src/audiohandler.c:1791
 msgid "Quality"
 msgstr ""
 
-#: src/ui/ghb.ui:3494
+#: src/ui/ghb.ui:3492
 msgid "Bitrate (kbps):    "
 msgstr ""
 
-#: src/ui/ghb.ui:3495 src/ui/ghb.ui:3512
+#: src/ui/ghb.ui:3493 src/ui/ghb.ui:3510
 msgid ""
 "Set the average bitrate.\n"
 "\n"
@@ -1152,11 +1148,11 @@ msgid ""
 "settings."
 msgstr ""
 
-#: src/ui/ghb.ui:3541
+#: src/ui/ghb.ui:3539
 msgid "Multi-Pass Encoding"
 msgstr ""
 
-#: src/ui/ghb.ui:3543
+#: src/ui/ghb.ui:3541
 msgid ""
 "Perform Multi Pass Encoding.\n"
 "\n"
@@ -1166,17 +1162,17 @@ msgid ""
 "to make bitrate allocation decisions."
 msgstr ""
 
-#: src/ui/ghb.ui:3554
+#: src/ui/ghb.ui:3552
 msgid "Turbo Analysis Pass"
 msgstr ""
 
-#: src/ui/ghb.ui:3556
+#: src/ui/ghb.ui:3554
 msgid ""
 "During the analysis pass of a multi pass encode, use settings that speed "
 "things along."
 msgstr ""
 
-#: src/ui/ghb.ui:3601
+#: src/ui/ghb.ui:3599
 msgid ""
 "Adjusts encoder settings to trade off compression efficiency against "
 "encoding speed.\n"
@@ -1188,11 +1184,11 @@ msgid ""
 "settings will result in better quality or smaller files."
 msgstr ""
 
-#: src/ui/ghb.ui:3616
+#: src/ui/ghb.ui:3614
 msgid "Encoder Preset"
 msgstr ""
 
-#: src/ui/ghb.ui:3653
+#: src/ui/ghb.ui:3651
 msgid ""
 "Tune settings to optimize for common scenarios.\n"
 "\n"
@@ -1201,22 +1197,22 @@ msgid ""
 "preset but before all other parameters."
 msgstr ""
 
-#: src/ui/ghb.ui:3667
+#: src/ui/ghb.ui:3665
 msgid "Fast Decode"
 msgstr ""
 
-#: src/ui/ghb.ui:3669
+#: src/ui/ghb.ui:3667
 msgid ""
 "Reduce decoder CPU usage.\n"
 "\n"
 "Set this if your device is struggling to play the output (dropped frames)."
 msgstr ""
 
-#: src/ui/ghb.ui:3684
+#: src/ui/ghb.ui:3682
 msgid "Zero Latency"
 msgstr ""
 
-#: src/ui/ghb.ui:3686
+#: src/ui/ghb.ui:3684
 msgid ""
 "Minimize latency between input to encoder and output of decoder.\n"
 "\n"
@@ -1226,451 +1222,482 @@ msgid ""
 "this setting is of little value here."
 msgstr ""
 
-#: src/ui/ghb.ui:3704
+#: src/ui/ghb.ui:3702
 msgid "Profile:"
 msgstr ""
 
-#: src/ui/ghb.ui:3714
+#: src/ui/ghb.ui:3712
 msgid ""
 "Sets and ensures compliance with the specified profile.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ui/ghb.ui:3727
+#: src/ui/ghb.ui:3725
 msgid "Level:"
 msgstr ""
 
-#: src/ui/ghb.ui:3737
+#: src/ui/ghb.ui:3735
 msgid ""
 "Sets and ensures compliance with the specified level.\n"
 "\n"
 "Overrides all other settings."
 msgstr ""
 
-#: src/ui/ghb.ui:3753
+#: src/ui/ghb.ui:3751
 msgid "Additional Options:"
 msgstr ""
 
-#: src/ui/ghb.ui:3793
+#: src/ui/ghb.ui:3791
 msgid "Audio"
 msgstr ""
 
-#: src/ui/ghb.ui:3822
+#: src/ui/ghb.ui:3820
 msgid "Show audio default selection options"
 msgstr ""
 
-#: src/ui/ghb.ui:3836 src/ui/ghb.ui:3990
+#: src/ui/ghb.ui:3834 src/ui/ghb.ui:3988
 msgid "Selection Behavior…"
 msgstr ""
 
-#: src/ui/ghb.ui:3845
+#: src/ui/ghb.ui:3843
 msgid "Reload all audio settings from defaults"
 msgstr ""
 
-#: src/ui/ghb.ui:3888 src/ui/ghb.ui:4042 src/ui/ghb.ui:4949
+#: src/ui/ghb.ui:3886 src/ui/ghb.ui:4040 src/ui/ghb.ui:4953
 msgid "Remove"
 msgstr ""
 
-#: src/ui/ghb.ui:3911 src/ui/ghb.ui:4065
+#: src/ui/ghb.ui:3909 src/ui/ghb.ui:4063
 msgid "Clear"
 msgstr ""
 
-#: src/ui/ghb.ui:3947
+#: src/ui/ghb.ui:3945
 msgid "Subtitles"
 msgstr ""
 
-#: src/ui/ghb.ui:3963
+#: src/ui/ghb.ui:3961
 msgid "Tracks"
 msgstr ""
 
-#: src/ui/ghb.ui:3976
+#: src/ui/ghb.ui:3974
 msgid "Show subtitle default selection options"
 msgstr ""
 
-#: src/ui/ghb.ui:4101
+#: src/ui/ghb.ui:4099
 msgid "Chapters"
 msgstr ""
 
-#: src/ui/ghb.ui:4112 src/callbacks.c:2533 src/queuehandler.c:220
+#: src/ui/ghb.ui:4110 src/callbacks.c:2539 src/queuehandler.c:215
 msgid "Chapter Markers"
 msgstr ""
 
-#: src/ui/ghb.ui:4114
+#: src/ui/ghb.ui:4112
 msgid "Add chapter markers to output file."
 msgstr ""
 
-#: src/ui/ghb.ui:4121
+#: src/ui/ghb.ui:4119
 msgid "Import Chapters"
 msgstr ""
 
-#: src/ui/ghb.ui:4123
+#: src/ui/ghb.ui:4121
 msgid "Import chapter list from an XML file"
 msgstr ""
 
-#: src/ui/ghb.ui:4131
+#: src/ui/ghb.ui:4129
 msgid "Export Chapters"
 msgstr ""
 
-#: src/ui/ghb.ui:4133
+#: src/ui/ghb.ui:4131
 msgid "Export chapter list as an XML file"
 msgstr ""
 
-#: src/ui/ghb.ui:4149
+#: src/ui/ghb.ui:4147
 msgid "Index"
 msgstr ""
 
-#: src/ui/ghb.ui:4163
+#: src/ui/ghb.ui:4161
 msgid "Duration"
 msgstr ""
 
-#: src/ui/ghb.ui:4169
+#: src/ui/ghb.ui:4167
 msgid "Title"
 msgstr ""
 
-#: src/ui/ghb.ui:4195
+#: src/ui/ghb.ui:4193
 msgid "Tags"
 msgstr ""
 
-#: src/ui/ghb.ui:4233
+#: src/ui/ghb.ui:4231
 msgid "Actors:"
 msgstr ""
 
-#: src/ui/ghb.ui:4261
+#: src/ui/ghb.ui:4259
 msgid "Director:"
 msgstr ""
 
-#: src/ui/ghb.ui:4289
+#: src/ui/ghb.ui:4287
 msgid "Release Date:"
 msgstr ""
 
-#: src/ui/ghb.ui:4317
+#: src/ui/ghb.ui:4315
 msgid "Comment:"
 msgstr ""
 
-#: src/ui/ghb.ui:4345
+#: src/ui/ghb.ui:4343
 msgid "Genre:"
 msgstr ""
 
-#: src/ui/ghb.ui:4373 src/ui/ghb.ui:6026 src/ui/ghb.ui:6178
+#: src/ui/ghb.ui:4371 src/ui/ghb.ui:6089 src/ui/ghb.ui:6241
 msgid "Description:"
 msgstr ""
 
-#: src/ui/ghb.ui:4401
+#: src/ui/ghb.ui:4399
 msgid "Plot:"
 msgstr ""
 
-#: src/ui/ghb.ui:4452
+#: src/ui/ghb.ui:4450
 msgid "<b>Save As:</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:4464
+#: src/ui/ghb.ui:4462
 msgid "Destination filename for your encode."
 msgstr ""
 
-#: src/ui/ghb.ui:4478
+#: src/ui/ghb.ui:4476
 msgid "<b>To:</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:4489
+#: src/ui/ghb.ui:4487
 msgid "Destination directory for your encode."
 msgstr ""
 
-#: src/ui/ghb.ui:4491 src/title-add.c:474
+#: src/ui/ghb.ui:4489 src/title-add.c:474
 msgid "Destination Directory"
 msgstr ""
 
-#: src/ui/ghb.ui:4564
+#: src/ui/ghb.ui:4568
 msgid "Subtitle Selection Behavior"
 msgstr ""
 
-#: src/ui/ghb.ui:4833
+#: src/ui/ghb.ui:4837
 msgid "Audio Selection Behavior"
 msgstr ""
 
-#: src/ui/ghb.ui:4863
+#: src/ui/ghb.ui:4867
 msgid "Track Selection Behavior:"
 msgstr ""
 
-#: src/ui/ghb.ui:4874
+#: src/ui/ghb.ui:4878
 msgid "Choose which audio tracks of the source media are used."
 msgstr ""
 
-#: src/ui/ghb.ui:4922
+#: src/ui/ghb.ui:4926
 msgid ""
 "Create a list of languages you would like to select audio for.\n"
 "Tracks matching these languages will be selected using the chosen Selection "
 "Behavior."
 msgstr ""
 
-#: src/ui/ghb.ui:4936 src/ui/ghb.ui:5288
+#: src/ui/ghb.ui:4940 src/ui/ghb.ui:5322
 msgid "Add"
 msgstr ""
 
-#: src/ui/ghb.ui:4962
+#: src/ui/ghb.ui:4966
 msgid "Available Languages"
 msgstr ""
 
-#: src/ui/ghb.ui:4971
+#: src/ui/ghb.ui:4975
 msgid "Selected Languages"
 msgstr ""
 
-#: src/ui/ghb.ui:4995
+#: src/ui/ghb.ui:4999
 msgid "Auto Passthru:"
 msgstr ""
 
-#: src/ui/ghb.ui:5004
+#: src/ui/ghb.ui:5008
 msgid "MP2"
 msgstr ""
 
-#: src/ui/ghb.ui:5006
+#: src/ui/ghb.ui:5010
 msgid ""
 "Enable this if your playback device supports MP2.\n"
 "This permits MP2 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5019
+#: src/ui/ghb.ui:5023
 msgid "MP3"
 msgstr ""
 
-#: src/ui/ghb.ui:5021
+#: src/ui/ghb.ui:5025
 msgid ""
 "Enable this if your playback device supports MP3.\n"
 "This permits MP3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5034
+#: src/ui/ghb.ui:5038
 msgid "AC-3"
 msgstr ""
 
-#: src/ui/ghb.ui:5036
+#: src/ui/ghb.ui:5040
 msgid ""
 "Enable this if your playback device supports AC-3.\n"
 "This permits AC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5049
+#: src/ui/ghb.ui:5053
 msgid "EAC-3"
 msgstr ""
 
-#: src/ui/ghb.ui:5051
+#: src/ui/ghb.ui:5055
 msgid ""
 "Enable this if your playback device supports EAC-3.\n"
 "This permits EAC-3 passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5064
+#: src/ui/ghb.ui:5068
 msgid "DTS"
 msgstr ""
 
-#: src/ui/ghb.ui:5066
+#: src/ui/ghb.ui:5070
 msgid ""
 "Enable this if your playback device supports DTS.\n"
 "This permits DTS passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5079
+#: src/ui/ghb.ui:5083
 msgid "DTS-HD"
 msgstr ""
 
-#: src/ui/ghb.ui:5081
+#: src/ui/ghb.ui:5085
 msgid ""
 "Enable this if your playback device supports DTS-HD.\n"
 "This permits DTS-HD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5094
+#: src/ui/ghb.ui:5098
 msgid "TrueHD"
 msgstr ""
 
-#: src/ui/ghb.ui:5096
+#: src/ui/ghb.ui:5100
 msgid ""
 "Enable this if your playback device supports TrueHD.\n"
 "This permits TrueHD passthru to be selected when automatic passthru "
 "selection is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5109
+#: src/ui/ghb.ui:5113
+msgid "ALAC"
+msgstr ""
+
+#: src/ui/ghb.ui:5115
+msgid ""
+"Enable this if your playback device supports ALAC.\n"
+"This permits ALAC passthru to be selected when automatic passthru selection "
+"is enabled."
+msgstr ""
+
+#: src/ui/ghb.ui:5128
 msgid "FLAC"
 msgstr ""
 
-#: src/ui/ghb.ui:5111
+#: src/ui/ghb.ui:5130
 msgid ""
 "Enable this if your playback device supports FLAC.\n"
 "This permits FLAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5124
+#: src/ui/ghb.ui:5143
 msgid "AAC"
 msgstr ""
 
-#: src/ui/ghb.ui:5126
+#: src/ui/ghb.ui:5145
 msgid ""
 "Enable this if your playback device supports AAC.\n"
 "This permits AAC passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5139
+#: src/ui/ghb.ui:5158
+msgid "Vorbis"
+msgstr ""
+
+#: src/ui/ghb.ui:5160
+msgid ""
+"Enable this if your playback device supports Vorbis.\n"
+"This permits Vorbis passthru to be selected when automatic passthru "
+"selection is enabled."
+msgstr ""
+
+#: src/ui/ghb.ui:5173
 msgid "Opus"
 msgstr ""
 
-#: src/ui/ghb.ui:5141
+#: src/ui/ghb.ui:5175
 msgid ""
 "Enable this if your playback device supports Opus.\n"
 "This permits Opus passthru to be selected when automatic passthru selection "
 "is enabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5162
+#: src/ui/ghb.ui:5196
 msgid "Passthru Fallback:"
 msgstr ""
 
-#: src/ui/ghb.ui:5168
+#: src/ui/ghb.ui:5202
 msgid ""
 "Set the audio codec to encode with when a suitable track can not be found "
 "for audio passthru."
 msgstr ""
 
-#: src/ui/ghb.ui:5184
+#: src/ui/ghb.ui:5218
 msgid "Audio encoder settings for each selected track:"
 msgstr ""
 
-#: src/ui/ghb.ui:5185
+#: src/ui/ghb.ui:5219
 msgid "Each selected source track will be encoded with all selected encoders"
 msgstr ""
 
-#: src/ui/ghb.ui:5195
+#: src/ui/ghb.ui:5229
 msgid "Encoder"
 msgstr ""
 
-#: src/ui/ghb.ui:5201
+#: src/ui/ghb.ui:5235
 msgid "Bitrate/Quality"
 msgstr ""
 
-#: src/ui/ghb.ui:5207
+#: src/ui/ghb.ui:5241
 msgid "Mixdown"
 msgstr ""
 
-#: src/ui/ghb.ui:5213
+#: src/ui/ghb.ui:5247
 msgid "Samplerate"
 msgstr ""
 
-#: src/ui/ghb.ui:5219 src/queuehandler.c:555
+#: src/ui/ghb.ui:5253 src/queuehandler.c:550
 msgid "Gain"
 msgstr ""
 
-#: src/ui/ghb.ui:5225
+#: src/ui/ghb.ui:5259
 msgid "DRC"
 msgstr ""
 
-#: src/ui/ghb.ui:5253
+#: src/ui/ghb.ui:5287
 msgid "Add Track"
 msgstr ""
 
-#: src/ui/ghb.ui:5254
+#: src/ui/ghb.ui:5288
 msgid ""
 "Add an audio encoder.\n"
 "Each selected source track will be encoded with all selected encoders."
 msgstr ""
 
-#: src/ui/ghb.ui:5261
+#: src/ui/ghb.ui:5295
 msgid "Use only first encoder for secondary audio"
 msgstr ""
 
-#: src/ui/ghb.ui:5263
+#: src/ui/ghb.ui:5297
 msgid ""
 "Only the primary audio track will be encoded with the full encoder list.\n"
 "  All other secondary audio output tracks will be encoded with first encoder "
 "only."
 msgstr ""
 
-#: src/ui/ghb.ui:5276
+#: src/ui/ghb.ui:5310
 msgid "Add Multiple Titles"
 msgstr ""
 
-#: src/ui/ghb.ui:5282 src/ui/ghb.ui:5969 src/ui/ghb.ui:6059
-#: src/hb-backend.c:4480 src/hb-backend.c:4530 src/hb-backend.c:4547
-#: src/hb-backend.c:4564 src/hb-backend.c:4621 src/hb-backend.c:4673
-#: src/presets.c:2583 src/title-add.c:124 src/title-add.c:134
+#: src/ui/ghb.ui:5316 src/ui/ghb.ui:6032 src/ui/ghb.ui:6122
+#: src/hb-backend.c:4477 src/hb-backend.c:4527 src/hb-backend.c:4544
+#: src/hb-backend.c:4561 src/hb-backend.c:4618 src/hb-backend.c:4670
+#: src/presets.c:2123 src/presets.c:2505 src/presets.c:2730 src/title-add.c:124
+#: src/title-add.c:134
 msgid "Cancel"
 msgstr ""
 
-#: src/ui/ghb.ui:5306
+#: src/ui/ghb.ui:5340
 msgid "Select All"
 msgstr ""
 
-#: src/ui/ghb.ui:5308
+#: src/ui/ghb.ui:5342
 msgid "Mark all titles for adding to the queue"
 msgstr ""
 
-#: src/ui/ghb.ui:5317
+#: src/ui/ghb.ui:5351
 msgid "Clear All"
 msgstr ""
 
-#: src/ui/ghb.ui:5319
+#: src/ui/ghb.ui:5353
 msgid "Unmark all titles"
 msgstr ""
 
-#: src/ui/ghb.ui:5328
+#: src/ui/ghb.ui:5362
 msgid "Invert Selection"
 msgstr ""
 
-#: src/ui/ghb.ui:5361 src/title-add.c:351
+#: src/ui/ghb.ui:5395 src/title-add.c:351
 msgid "Destination files OK.  No duplicates detected."
 msgstr ""
 
-#: src/ui/ghb.ui:5373
+#: src/ui/ghb.ui:5407
 msgid "Preferences"
 msgstr ""
 
-#: src/ui/ghb.ui:5418
+#: src/ui/ghb.ui:5452
 msgid "General"
 msgstr ""
 
-#: src/ui/ghb.ui:5425
+#: src/ui/ghb.ui:5459
 msgid "Use automatic naming (uses modified source name)"
 msgstr ""
 
-#: src/ui/ghb.ui:5427
+#: src/ui/ghb.ui:5461
 msgid "Create destination filename from source filename or volume label"
 msgstr ""
 
-#: src/ui/ghb.ui:5442
+#: src/ui/ghb.ui:5476
 msgid "Auto-Name Template"
 msgstr ""
 
-#: src/ui/ghb.ui:5450
+#: src/ui/ghb.ui:5484
 msgid ""
 "Available Options: {source-path} {source} {title} {preset} {chapters} {date} "
 "{time} {creation-date} {creation-time} {modification-date} {modification-"
 "time} {codec} {bit-depth} {quality} {bitrate} {width} {height}"
 msgstr ""
 
-#: src/ui/ghb.ui:5464
+#: src/ui/ghb.ui:5498
 msgid "Use iPod/iTunes friendly (.m4v) file extension for MP4"
 msgstr ""
 
-#: src/ui/ghb.ui:5487
+#: src/ui/ghb.ui:5509
 msgid "Number of previews"
 msgstr ""
 
-#: src/ui/ghb.ui:5510
+#: src/ui/ghb.ui:5532
 msgid "Minimum DVD/Blu-ray title duration (seconds)"
 msgstr ""
 
-#: src/ui/ghb.ui:5518
+#: src/ui/ghb.ui:5555
+msgid "Maximum DVD/Blu-ray title duration (seconds)"
+msgstr ""
+
+#: src/ui/ghb.ui:5575
+msgid "Keep duplicate titles"
+msgstr ""
+
+#: src/ui/ghb.ui:5581
 msgid "Use the same settings for all titles in a batch"
 msgstr ""
 
-#: src/ui/ghb.ui:5520
+#: src/ui/ghb.ui:5583
 msgid ""
 "When checked, every title will use the same settings when adding a\n"
 "batch of titles to the queue.\n"
@@ -1679,116 +1706,116 @@ msgid ""
 "independently."
 msgstr ""
 
-#: src/ui/ghb.ui:5530
+#: src/ui/ghb.ui:5593
 msgid "Show preview image in Summary tab"
 msgstr ""
 
-#: src/ui/ghb.ui:5533
+#: src/ui/ghb.ui:5596
 msgid ""
 "Uncheck this if you want to hide the video preview image on the Summary tab "
 "for privacy reasons."
 msgstr ""
 
-#: src/ui/ghb.ui:5542
+#: src/ui/ghb.ui:5605
 msgid "Excluded File Extensions:"
 msgstr ""
 
-#: src/ui/ghb.ui:5551
+#: src/ui/ghb.ui:5614
 msgid ""
 "The following file extensions will be ignored when scanning a folder. The "
 "list is case insensitive."
 msgstr ""
 
-#: src/ui/ghb.ui:5561
+#: src/ui/ghb.ui:5624
 msgctxt "Queue tab in Preferences window"
 msgid "Queue"
 msgstr ""
 
-#: src/ui/ghb.ui:5574
+#: src/ui/ghb.ui:5637
 msgid "Pause queue if disk space is lower than:"
 msgstr ""
 
-#: src/ui/ghb.ui:5590
+#: src/ui/ghb.ui:5653
 msgid "Disk Free Space Limit"
 msgstr ""
 
-#: src/ui/ghb.ui:5598 src/queuehandler.c:803 src/queuehandler.c:1293
+#: src/ui/ghb.ui:5661 src/queuehandler.c:798 src/queuehandler.c:1288
 msgid "GB"
 msgstr ""
 
-#: src/ui/ghb.ui:5608
+#: src/ui/ghb.ui:5671
 msgid "Clear completed jobs after an encode completes"
 msgstr ""
 
-#: src/ui/ghb.ui:5610
+#: src/ui/ghb.ui:5673
 msgid ""
 "By default, completed jobs remain in the queue and are marked as complete.\n"
 "  Check this if you want the queue to clean itself up by deleting completed "
 "jobs."
 msgstr ""
 
-#: src/ui/ghb.ui:5618
+#: src/ui/ghb.ui:5681
 msgid "Power Saving"
 msgstr ""
 
-#: src/ui/ghb.ui:5632
+#: src/ui/ghb.ui:5695
 msgid "Pause encoding when in Power Saver mode"
 msgstr ""
 
-#: src/ui/ghb.ui:5636
+#: src/ui/ghb.ui:5699
 msgid ""
 "If checked, encoding will be paused when the device\n"
 "enters Power Saver mode. Encoding will resume when\n"
 "Power Saver mode is disabled."
 msgstr ""
 
-#: src/ui/ghb.ui:5644
+#: src/ui/ghb.ui:5707
 msgid "Pause encoding when on battery power"
 msgstr ""
 
-#: src/ui/ghb.ui:5648
+#: src/ui/ghb.ui:5711
 msgid ""
 "If checked, encoding will be paused when charger is\n"
 "unplugged. Encoding will resume when reconnected to\n"
 "a mains power source."
 msgstr ""
 
-#: src/ui/ghb.ui:5656
+#: src/ui/ghb.ui:5719
 msgid "Pause encoding when battery is low"
 msgstr ""
 
-#: src/ui/ghb.ui:5660
+#: src/ui/ghb.ui:5723
 msgid ""
 "If checked, encoding will be paused when the battery\n"
 "level is low. Encoding will resume when the\n"
 "battery is charged."
 msgstr ""
 
-#: src/ui/ghb.ui:5672
+#: src/ui/ghb.ui:5735
 msgid "When Done"
 msgstr ""
 
-#: src/ui/ghb.ui:5684
+#: src/ui/ghb.ui:5747
 msgid "Default action when queue is completed:"
 msgstr ""
 
-#: src/ui/ghb.ui:5697
+#: src/ui/ghb.ui:5760
 msgid "Show notification when queue is completed"
 msgstr ""
 
-#: src/ui/ghb.ui:5705
+#: src/ui/ghb.ui:5768
 msgid "Show notification when each item is completed"
 msgstr ""
 
-#: src/ui/ghb.ui:5717
+#: src/ui/ghb.ui:5780
 msgid "Advanced"
 msgstr ""
 
-#: src/ui/ghb.ui:5733
+#: src/ui/ghb.ui:5796
 msgid "Set a custom directory for Handbrake temporary files"
 msgstr ""
 
-#: src/ui/ghb.ui:5735 src/ui/ghb.ui:5751
+#: src/ui/ghb.ui:5798 src/ui/ghb.ui:5814
 msgid ""
 "Temporary files that HandBrake creates will be placed under this directory.\n"
 "\n"
@@ -1802,125 +1829,125 @@ msgid ""
 "memory size and may be too small for things like the 2-pass stats file."
 msgstr ""
 
-#: src/ui/ghb.ui:5760
+#: src/ui/ghb.ui:5823
 msgid "Temp Directory"
 msgstr ""
 
-#: src/ui/ghb.ui:5783
+#: src/ui/ghb.ui:5846
 msgid "Constant Quality fractional granularity"
 msgstr ""
 
-#: src/ui/ghb.ui:5795
+#: src/ui/ghb.ui:5858
 msgid "Use dvdnav (instead of libdvdread)"
 msgstr ""
 
-#: src/ui/ghb.ui:5813
+#: src/ui/ghb.ui:5876
 msgid "Put individual encode logs in same location as movie"
 msgstr ""
 
-#: src/ui/ghb.ui:5833
+#: src/ui/ghb.ui:5896
 msgid "Activity Log Verbosity Level"
 msgstr ""
 
-#: src/ui/ghb.ui:5852
+#: src/ui/ghb.ui:5915
 msgid "Activity Log Longevity"
 msgstr ""
 
-#: src/ui/ghb.ui:5865
+#: src/ui/ghb.ui:5928
 msgid "Scale down High Definition previews"
 msgstr ""
 
-#: src/ui/ghb.ui:5877
+#: src/ui/ghb.ui:5940
 msgid "Automatically Scan DVD when loaded"
 msgstr ""
 
-#: src/ui/ghb.ui:5879
+#: src/ui/ghb.ui:5942
 msgid "Scans the DVD whenever a new disc is loaded"
 msgstr ""
 
-#: src/ui/ghb.ui:5906
+#: src/ui/ghb.ui:5969
 msgid "Activity Window Font Size"
 msgstr ""
 
-#: src/ui/ghb.ui:5924
+#: src/ui/ghb.ui:5987
 msgid "Allow Tweaks"
 msgstr ""
 
-#: src/ui/ghb.ui:5937
+#: src/ui/ghb.ui:6000
 msgid "Allow HandBrake For Dummies"
 msgstr ""
 
-#: src/ui/ghb.ui:5961
+#: src/ui/ghb.ui:6024
 msgid "Rename Preset"
 msgstr ""
 
-#: src/ui/ghb.ui:6005 src/ui/ghb.ui:6139
+#: src/ui/ghb.ui:6068 src/ui/ghb.ui:6202
 msgid "Preset Name:"
 msgstr ""
 
-#: src/ui/ghb.ui:6051
+#: src/ui/ghb.ui:6114
 msgid "New Preset"
 msgstr ""
 
-#: src/ui/ghb.ui:6094
+#: src/ui/ghb.ui:6157
 msgid "Category:"
 msgstr ""
 
-#: src/ui/ghb.ui:6104
+#: src/ui/ghb.ui:6167
 msgid "Set the category that this preset will be shown under."
 msgstr ""
 
-#: src/ui/ghb.ui:6115
+#: src/ui/ghb.ui:6178
 msgid "Category Name:"
 msgstr ""
 
-#: src/ui/ghb.ui:6164
+#: src/ui/ghb.ui:6227
 msgid "Default Preset"
 msgstr ""
 
-#: src/ui/ghb.ui:6166
+#: src/ui/ghb.ui:6229
 msgid "Make this the default Preset when HandBrake starts"
 msgstr ""
 
-#: src/ui/ghb.ui:6205
+#: src/ui/ghb.ui:6268
 msgid "HandBrake Preview"
 msgstr ""
 
-#: src/ui/ghb.ui:6273
+#: src/ui/ghb.ui:6336
 msgid "Select preview frames."
 msgstr ""
 
-#: src/ui/ghb.ui:6288 src/preview.c:167
+#: src/ui/ghb.ui:6351 src/preview.c:167
 msgid ""
 "Encode and play a short sequence of video starting from the current preview "
 "position."
 msgstr ""
 
-#: src/ui/ghb.ui:6301
+#: src/ui/ghb.ui:6364
 msgid "Preview Video Position"
 msgstr ""
 
-#: src/ui/ghb.ui:6314
+#: src/ui/ghb.ui:6377
 msgid "Preview Encode Progress"
 msgstr ""
 
-#: src/ui/ghb.ui:6323
+#: src/ui/ghb.ui:6386
 msgid "Click to toggle full screen mode"
 msgstr ""
 
-#: src/ui/ghb.ui:6338
+#: src/ui/ghb.ui:6401
 msgid "<b>Duration:</b>"
 msgstr ""
 
-#: src/ui/ghb.ui:6346
+#: src/ui/ghb.ui:6409
 msgid "Set the duration of the live preview in seconds."
 msgstr ""
 
-#: src/ui/ghb.ui:6356
+#: src/ui/ghb.ui:6419
 msgid "Source Resolution"
 msgstr ""
 
-#: src/ui/ghb.ui:6359
+#: src/ui/ghb.ui:6422
 msgid "Reset preview window to the source video's resolution"
 msgstr ""
 
@@ -1932,7 +1959,7 @@ msgstr ""
 msgid "(None)"
 msgstr ""
 
-#: src/ui/ghb-queue-row.ui:17 src/ghb-queue-row.c:265 src/ghb-queue-row.c:281
+#: src/ui/ghb-queue-row.ui:17 src/ghb-queue-row.c:272 src/ghb-queue-row.c:288
 msgid "Pending Queue Item"
 msgstr ""
 
@@ -1945,8 +1972,8 @@ msgid "Encode Progress"
 msgstr ""
 
 #. Audio DRC Label
-#: src/audiohandler.c:419 src/audiohandler.c:764 src/audiohandler.c:1175
-#: src/audiohandler.c:1929 src/callbacks.c:5465 src/hb-backend.c:180
+#: src/audiohandler.c:427 src/audiohandler.c:772 src/audiohandler.c:1183
+#: src/audiohandler.c:1937 src/callbacks.c:5500 src/hb-backend.c:180
 #: src/hb-backend.c:193 src/hb-backend.c:205 src/hb-backend.c:230
 #: src/hb-backend.c:301 src/hb-backend.c:313 src/hb-backend.c:325
 #: src/hb-backend.c:386
@@ -1954,41 +1981,41 @@ msgstr ""
 msgid "Off"
 msgstr ""
 
-#: src/audiohandler.c:431 src/audiohandler.c:760 src/audiohandler.c:1245
+#: src/audiohandler.c:439 src/audiohandler.c:768 src/audiohandler.c:1253
 #, c-format
 msgid "%ddB"
 msgstr ""
 
-#: src/audiohandler.c:736
+#: src/audiohandler.c:744
 msgid "Quality: "
 msgstr ""
 
-#: src/audiohandler.c:743
+#: src/audiohandler.c:751
 #, c-format
 msgid "Bitrate: %dkbps\n"
 msgstr ""
 
-#: src/audiohandler.c:755
+#: src/audiohandler.c:763
 #, c-format
 msgid "%.4gkHz"
 msgstr ""
 
-#: src/audiohandler.c:770
+#: src/audiohandler.c:778
 #, c-format
 msgid "<small>%d - %s (%.4gkHz)</small>"
 msgstr ""
 
-#: src/audiohandler.c:775
+#: src/audiohandler.c:783
 #, c-format
 msgid "Bitrate: %.4gkbps"
 msgstr ""
 
-#: src/audiohandler.c:781
+#: src/audiohandler.c:789
 #, c-format
 msgid "<small>Passthru</small>"
 msgstr ""
 
-#: src/audiohandler.c:790
+#: src/audiohandler.c:798
 #, c-format
 msgid ""
 "%sGain: %s\n"
@@ -1996,59 +2023,59 @@ msgid ""
 "Track Name: %s"
 msgstr ""
 
-#: src/audiohandler.c:795
+#: src/audiohandler.c:803
 #, c-format
 msgid ""
 "%sGain: %s\n"
 "DRC: %s"
 msgstr ""
 
-#: src/audiohandler.c:1401
+#: src/audiohandler.c:1409
 msgid "Add Audio Track"
 msgstr ""
 
-#: src/audiohandler.c:1493
+#: src/audiohandler.c:1501
 msgid "Edit Audio Track"
 msgstr ""
 
-#: src/audiohandler.c:1766
+#: src/audiohandler.c:1774
 msgid "Set the audio codec to encode this track with."
 msgstr ""
 
-#: src/audiohandler.c:1780
+#: src/audiohandler.c:1788
 msgid "Bitrate"
 msgstr ""
 
-#: src/audiohandler.c:1798
+#: src/audiohandler.c:1806
 msgid "Set the bitrate to encode this track with."
 msgstr ""
 
-#: src/audiohandler.c:1823
+#: src/audiohandler.c:1831
 msgid ""
 "<b>Audio Quality:</b>\n"
 "For encoders that support it, adjust the quality of the output."
 msgstr ""
 
-#: src/audiohandler.c:1850
+#: src/audiohandler.c:1858
 msgid "Set the mixdown of the output audio track."
 msgstr ""
 
-#: src/audiohandler.c:1863
+#: src/audiohandler.c:1871
 msgid "Set the sample rate of the output audio track."
 msgstr ""
 
-#: src/audiohandler.c:1884
+#: src/audiohandler.c:1892
 msgid ""
 "<b>Audio Gain:</b> Adjust the amplification or attenuation of the output "
 "audio track."
 msgstr ""
 
 #. Audio Gain Label
-#: src/audiohandler.c:1895
+#: src/audiohandler.c:1903
 msgid "0dB"
 msgstr ""
 
-#: src/audiohandler.c:1915
+#: src/audiohandler.c:1923
 msgid ""
 "<b>Dynamic Range Compression:</b> Adjust the dynamic range of the output "
 "audio track.\n"
@@ -2059,7 +2086,7 @@ msgid ""
 "sounds louder."
 msgstr ""
 
-#: src/audiohandler.c:1946
+#: src/audiohandler.c:1954
 msgid "Remove this audio encoder"
 msgstr ""
 
@@ -2067,306 +2094,306 @@ msgstr ""
 msgid "An encode is in progress."
 msgstr ""
 
-#: src/callbacks.c:1124 src/callbacks.c:1135 src/callbacks.c:1785
+#: src/callbacks.c:1125 src/callbacks.c:1136 src/callbacks.c:1792
 msgid "Not Selected"
 msgstr ""
 
-#: src/callbacks.c:1133
+#: src/callbacks.c:1134
 msgid "Detected DVD devices:"
 msgstr ""
 
 #. This needs to be in scanning and working since scanning
 #. happens fast enough that it can be missed
-#: src/callbacks.c:1460 src/callbacks.c:4578
+#: src/callbacks.c:1461 src/callbacks.c:4613
 msgid "Scanning ..."
 msgstr ""
 
-#: src/callbacks.c:1492 src/callbacks.c:1493 src/callbacks.c:1512
-#: src/callbacks.c:1513
+#: src/callbacks.c:1493 src/callbacks.c:1494 src/callbacks.c:1516
+#: src/callbacks.c:1517
 msgid "Stop Scan"
 msgstr ""
 
-#: src/callbacks.c:1866
+#: src/callbacks.c:1873
 msgid "Open Source Directory"
 msgstr ""
 
-#: src/callbacks.c:1869 src/chapters.c:484 src/ghb-file-button.c:222
-#: src/presets.c:2113 src/queuehandler.c:1479
+#: src/callbacks.c:1876 src/chapters.c:483 src/ghb-file-button.c:222
+#: src/presets.c:2216 src/queuehandler.c:1469
 msgid "_Open"
 msgstr ""
 
-#: src/callbacks.c:1870 src/callbacks.c:2136 src/chapters.c:456
-#: src/chapters.c:485 src/presets.c:2114 src/presets.c:2230
-#: src/queuehandler.c:1392 src/queuehandler.c:1480
+#: src/callbacks.c:1877 src/callbacks.c:2142 src/chapters.c:456
+#: src/chapters.c:484 src/ghb-file-button.c:355 src/presets.c:2217
+#: src/presets.c:2332 src/queuehandler.c:1387 src/queuehandler.c:1470
 msgid "_Cancel"
 msgstr ""
 
-#: src/callbacks.c:1877
+#: src/callbacks.c:1884
 msgid "Recursively scan directories"
 msgstr ""
 
-#: src/callbacks.c:1889
+#: src/callbacks.c:1896
 msgid "Single Title"
 msgstr ""
 
-#: src/callbacks.c:2247 src/callbacks.c:2391
+#: src/callbacks.c:2253 src/callbacks.c:2397
 msgid "FPS"
 msgstr ""
 
-#: src/callbacks.c:2251
+#: src/callbacks.c:2257
 #, c-format
 msgid "Dolby Vision %d.%d"
 msgstr ""
 
-#: src/callbacks.c:2255 src/callbacks.c:2258
+#: src/callbacks.c:2261 src/callbacks.c:2264
 msgid "HDR10+"
 msgstr ""
 
-#: src/callbacks.c:2260
+#: src/callbacks.c:2266
 msgid "HDR10"
 msgstr ""
 
-#: src/callbacks.c:2262
+#: src/callbacks.c:2268
 msgid "HDR"
 msgstr ""
 
-#: src/callbacks.c:2264
+#: src/callbacks.c:2270
 msgid "SDR"
 msgstr ""
 
 #. TRANSLATORS: This is the bit depth of the video
-#: src/callbacks.c:2272
+#: src/callbacks.c:2278
 #, c-format
 msgid "%d-bit"
 msgstr ""
 
-#: src/callbacks.c:2294
+#: src/callbacks.c:2300
 msgid "Audio Track"
 msgid_plural "Audio Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2297
+#: src/callbacks.c:2303
 msgid "Subtitle Track"
 msgid_plural "Subtitle Tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2395
+#: src/callbacks.c:2401
 msgid "CFR"
 msgstr ""
 
-#: src/callbacks.c:2399
+#: src/callbacks.c:2405
 msgid "PFR"
 msgstr ""
 
-#: src/callbacks.c:2403
+#: src/callbacks.c:2409
 msgid "VFR"
 msgstr ""
 
-#: src/callbacks.c:2445
+#: src/callbacks.c:2451
 #, c-format
 msgid "+ %d more audio track"
 msgid_plural "+ %d more audio tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2476 src/queuehandler.c:592 src/queuehandler.c:1027
+#: src/callbacks.c:2482 src/queuehandler.c:587 src/queuehandler.c:1022
 #: src/subtitlehandler.c:415 src/subtitlehandler.c:1292
 msgid "Foreign Audio Scan"
 msgstr ""
 
-#: src/callbacks.c:2479 src/callbacks.c:2511 src/queuehandler.c:595
-#: src/queuehandler.c:632
+#: src/callbacks.c:2485 src/callbacks.c:2517 src/queuehandler.c:590
+#: src/queuehandler.c:627
 #, c-format
 msgid ", Forced Only"
 msgstr ""
 
-#: src/callbacks.c:2483 src/callbacks.c:2515 src/queuehandler.c:599
-#: src/queuehandler.c:636
+#: src/callbacks.c:2489 src/callbacks.c:2521 src/queuehandler.c:594
+#: src/queuehandler.c:631
 #, c-format
 msgid ", Burned"
 msgstr ""
 
-#: src/callbacks.c:2487 src/callbacks.c:2519 src/queuehandler.c:603
-#: src/queuehandler.c:640
+#: src/callbacks.c:2493 src/callbacks.c:2525 src/queuehandler.c:598
+#: src/queuehandler.c:635
 #, c-format
 msgid ", Default"
 msgstr ""
 
-#: src/callbacks.c:2525
+#: src/callbacks.c:2531
 #, c-format
 msgid "+ %d more subtitle track"
 msgid_plural "+ %d more subtitle tracks"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:2680
+#: src/callbacks.c:2686
 msgid "storage"
 msgstr ""
 
-#: src/callbacks.c:2681
+#: src/callbacks.c:2687
 msgid "display"
 msgstr ""
 
-#: src/callbacks.c:2682
+#: src/callbacks.c:2688
 msgid "Pixel Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2683
+#: src/callbacks.c:2689
 msgid "Display Aspect Ratio"
 msgstr ""
 
-#: src/callbacks.c:2818 src/hb-backend.c:2206 src/hb-backend.c:2327
-#: src/hb-backend.c:2339
+#: src/callbacks.c:2824 src/hb-backend.c:2216 src/hb-backend.c:2337
+#: src/hb-backend.c:2349
 msgid "No Title Found"
 msgstr ""
 
-#: src/callbacks.c:2819
+#: src/callbacks.c:2825
 msgid "New Video"
 msgstr ""
 
-#: src/callbacks.c:3815
+#: src/callbacks.c:3821
 msgid "Temp Directory Changed"
 msgstr ""
 
-#: src/callbacks.c:3816
+#: src/callbacks.c:3822
 msgid "You must restart HandBrake now."
 msgstr ""
 
-#: src/callbacks.c:3843 src/callbacks.c:3853 src/callbacks.c:3871
-#: src/callbacks.c:3920
+#: src/callbacks.c:3849 src/callbacks.c:3859 src/callbacks.c:3877
+#: src/callbacks.c:3926
 #, c-format
 msgid "%s in %d seconds…"
 msgstr ""
 
-#: src/callbacks.c:4097
+#: src/callbacks.c:4132
 msgid "Stop Encoding?"
 msgstr ""
 
-#: src/callbacks.c:4098 src/callbacks.c:4123 src/queuehandler.c:1702
+#: src/callbacks.c:4133 src/callbacks.c:4158 src/queuehandler.c:1695
 msgid "Your movie will be lost if you don't continue encoding."
 msgstr ""
 
-#: src/callbacks.c:4099 src/queuehandler.c:1636
+#: src/callbacks.c:4134 src/queuehandler.c:1626
 msgid "Cancel Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:4099
+#: src/callbacks.c:4134
 msgid "Cancel Current, Start Next"
 msgstr ""
 
-#: src/callbacks.c:4100
+#: src/callbacks.c:4135
 msgid "Finish Current and Stop"
 msgstr ""
 
-#: src/callbacks.c:4100 src/callbacks.c:4124 src/queuehandler.c:1703
+#: src/callbacks.c:4135 src/callbacks.c:4159 src/queuehandler.c:1696
 msgid "Continue Encoding"
 msgstr ""
 
-#: src/callbacks.c:4122
+#: src/callbacks.c:4157
 msgid "Quit HandBrake?"
 msgstr ""
 
-#: src/callbacks.c:4124
+#: src/callbacks.c:4159
 msgid "Cancel All and Quit"
 msgstr ""
 
-#: src/callbacks.c:4290
+#: src/callbacks.c:4325
 #, c-format
 msgid "%d encode pending"
 msgid_plural "%d encodes pending"
 msgstr[0] ""
 msgstr[1] ""
 
-#: src/callbacks.c:4349 src/callbacks.c:4417
+#: src/callbacks.c:4384 src/callbacks.c:4452
 #, c-format
 msgid "job %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4359
+#: src/callbacks.c:4394
 #, c-format
 msgid "pass %d (subtitle scan) of %d, "
 msgstr ""
 
-#: src/callbacks.c:4364
+#: src/callbacks.c:4399
 #, c-format
 msgid "pass %d of %d, "
 msgstr ""
 
-#: src/callbacks.c:4377
+#: src/callbacks.c:4412
 #, c-format
 msgid "Encoding: %s%s%.2f %% (%.2f fps, avg %.2f fps, ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4387 src/callbacks.c:4427
+#: src/callbacks.c:4422 src/callbacks.c:4462
 #, c-format
 msgid "Encoding: %s%s%.2f %% (ETA %02dh%02dm%02ds)"
 msgstr ""
 
-#: src/callbacks.c:4397 src/callbacks.c:4436
+#: src/callbacks.c:4432 src/callbacks.c:4471
 #, c-format
 msgid "Encoding: %s%s%.2f %%"
 msgstr ""
 
-#: src/callbacks.c:4423
+#: src/callbacks.c:4458
 #, c-format
 msgid "Searching for start time, "
 msgstr ""
 
-#: src/callbacks.c:4498
+#: src/callbacks.c:4533
 #, c-format
 msgid "Scanning title %d of %d..."
 msgstr ""
 
-#: src/callbacks.c:4502
+#: src/callbacks.c:4537
 #, c-format
 msgid "Scanning title %d of %d preview %d..."
 msgstr ""
 
-#: src/callbacks.c:4589
+#: src/callbacks.c:4624
 msgid "Paused"
 msgstr ""
 
-#: src/callbacks.c:4616
+#: src/callbacks.c:4651
 msgid "Encode Done!"
 msgstr ""
 
-#: src/callbacks.c:4621
+#: src/callbacks.c:4656
 msgid "Encode Canceled."
 msgstr ""
 
-#: src/callbacks.c:4626
+#: src/callbacks.c:4661
 msgid "Encode Failed."
 msgstr ""
 
-#: src/callbacks.c:4668
+#: src/callbacks.c:4703
 msgid "Muxing: This may take a while..."
 msgstr ""
 
-#: src/callbacks.c:5478 src/callbacks.c:5485 src/callbacks.c:5493
+#: src/callbacks.c:5513 src/callbacks.c:5520 src/callbacks.c:5528
 msgid "Your encode is complete."
 msgstr ""
 
-#: src/callbacks.c:5479
+#: src/callbacks.c:5514
 msgid "Quitting HandBrake"
 msgstr ""
 
-#: src/callbacks.c:5486
+#: src/callbacks.c:5521
 msgid "Putting computer to sleep"
 msgstr ""
 
-#: src/callbacks.c:5494
+#: src/callbacks.c:5529
 msgid "Shutting down the computer"
 msgstr ""
 
 #. Add filters
-#: src/callbacks.c:5608 src/chapters.c:458 src/chapters.c:487
-#: src/presets.c:2116 src/queuehandler.c:1483
+#: src/callbacks.c:5643 src/chapters.c:458 src/chapters.c:486
+#: src/presets.c:2219 src/queuehandler.c:1473
 msgid "All Files"
 msgstr ""
 
-#: src/chapters.c:459 src/chapters.c:488
+#: src/chapters.c:459 src/chapters.c:487
 msgid "Chapters (*.xml)"
 msgstr ""
 
@@ -2378,19 +2405,19 @@ msgstr ""
 msgid "_Select"
 msgstr ""
 
-#: src/ghb-queue-row.c:260
+#: src/ghb-queue-row.c:267
 msgid "Running Queue Item"
 msgstr ""
 
-#: src/ghb-queue-row.c:269
+#: src/ghb-queue-row.c:276
 msgid "Failed Queue Item"
 msgstr ""
 
-#: src/ghb-queue-row.c:273
+#: src/ghb-queue-row.c:280
 msgid "Cancelled Queue Item"
 msgstr ""
 
-#: src/ghb-queue-row.c:277
+#: src/ghb-queue-row.c:284
 msgid "Completed Queue Item"
 msgstr ""
 
@@ -2414,7 +2441,7 @@ msgstr ""
 msgid "Foreign Audio, then First Selected Track"
 msgstr ""
 
-#: src/hb-backend.c:91 src/queuehandler.c:167
+#: src/hb-backend.c:91 src/queuehandler.c:162
 msgid "Chapters:"
 msgstr ""
 
@@ -2422,7 +2449,7 @@ msgstr ""
 msgid "Seconds:"
 msgstr ""
 
-#: src/hb-backend.c:93 src/queuehandler.c:188
+#: src/hb-backend.c:93 src/queuehandler.c:183
 msgid "Frames:"
 msgstr ""
 
@@ -2463,7 +2490,7 @@ msgstr ""
 msgid "Immortal"
 msgstr ""
 
-#: src/hb-backend.c:181 src/hb-backend.c:4864
+#: src/hb-backend.c:181 src/hb-backend.c:4861
 msgid "Decomb"
 msgstr ""
 
@@ -2699,72 +2726,72 @@ msgstr ""
 msgid "(NTSC Video)"
 msgstr ""
 
-#: src/hb-backend.c:2195
+#: src/hb-backend.c:2205
 #, c-format
 msgid "%s - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2346
+#: src/hb-backend.c:2356
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - %s"
 msgstr ""
 
-#: src/hb-backend.c:2365
+#: src/hb-backend.c:2375
 #, c-format
 msgid "%3d - %02dh%02dm%02ds - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2371
+#: src/hb-backend.c:2381
 #, c-format
 msgid "%3d - (%05d.MPLS)"
 msgstr ""
 
-#: src/hb-backend.c:2377
+#: src/hb-backend.c:2387
 #, c-format
 msgid "%3d - %02dh%02dm%02ds"
 msgstr ""
 
-#: src/hb-backend.c:2410
+#: src/hb-backend.c:2420
 msgid "No Titles"
 msgstr ""
 
 #. No audio. set some default
-#: src/hb-backend.c:2690
+#: src/hb-backend.c:2700
 msgid "No Audio"
 msgstr ""
 
-#: src/hb-backend.c:4306 src/hb-backend.c:4314
+#: src/hb-backend.c:4303 src/hb-backend.c:4311
 msgid "Invalid Detelecine Settings"
 msgstr ""
 
-#: src/hb-backend.c:4309 src/hb-backend.c:4340 src/hb-backend.c:4376
-#: src/hb-backend.c:4413 src/hb-backend.c:4438
+#: src/hb-backend.c:4306 src/hb-backend.c:4337 src/hb-backend.c:4373
+#: src/hb-backend.c:4410 src/hb-backend.c:4435
 msgid "Custom:"
 msgstr ""
 
-#: src/hb-backend.c:4337 src/hb-backend.c:4345
+#: src/hb-backend.c:4334 src/hb-backend.c:4342
 msgid "Invalid Comb Detect Settings"
 msgstr ""
 
-#: src/hb-backend.c:4372 src/hb-backend.c:4381
+#: src/hb-backend.c:4369 src/hb-backend.c:4378
 msgid "Invalid Deinterlace Settings"
 msgstr ""
 
-#: src/hb-backend.c:4374 src/hb-backend.c:4383 src/hb-backend.c:4410
-#: src/hb-backend.c:4435
+#: src/hb-backend.c:4371 src/hb-backend.c:4380 src/hb-backend.c:4407
+#: src/hb-backend.c:4432
 msgid "Filter:"
 msgstr ""
 
-#: src/hb-backend.c:4408
+#: src/hb-backend.c:4405
 msgid "Invalid Denoise Settings"
 msgstr ""
 
-#: src/hb-backend.c:4433
+#: src/hb-backend.c:4430
 msgid "Invalid Sharpen Settings"
 msgstr ""
 
 #. mp4/theora combination is not supported.
-#: src/hb-backend.c:4462
+#: src/hb-backend.c:4459
 msgid ""
 "Theora is not supported in the MP4 container.\n"
 "\n"
@@ -2773,7 +2800,7 @@ msgid ""
 msgstr ""
 
 #. webm only supports vp8, vp9 and av1.
-#: src/hb-backend.c:4471
+#: src/hb-backend.c:4468
 msgid ""
 "Only VP8, VP9 and AV1 is supported in the WebM container.\n"
 "\n"
@@ -2781,25 +2808,25 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4479 src/hb-backend.c:4530 src/hb-backend.c:4547
-#: src/hb-backend.c:4564 src/hb-backend.c:4621 src/hb-backend.c:4673
+#: src/hb-backend.c:4476 src/hb-backend.c:4527 src/hb-backend.c:4544
+#: src/hb-backend.c:4561 src/hb-backend.c:4618 src/hb-backend.c:4670
 msgid "Continue"
 msgstr ""
 
-#: src/hb-backend.c:4480
+#: src/hb-backend.c:4477
 msgid "Invalid Video Codec"
 msgstr ""
 
 #. No valid title, stop right there
-#: src/hb-backend.c:4503 src/hb-backend.c:4589
+#: src/hb-backend.c:4500 src/hb-backend.c:4586
 msgid "No title found.\n"
 msgstr ""
 
-#: src/hb-backend.c:4530 src/hb-backend.c:4547
+#: src/hb-backend.c:4527 src/hb-backend.c:4544
 msgid "Invalid Subtitle Selection"
 msgstr ""
 
-#: src/hb-backend.c:4531
+#: src/hb-backend.c:4528
 msgid ""
 "Only one subtitle may be burned into the video.\n"
 "\n"
@@ -2807,7 +2834,7 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4548
+#: src/hb-backend.c:4545
 msgid ""
 "WebM in HandBrake only supports burned subtitles.\n"
 "\n"
@@ -2815,11 +2842,11 @@ msgid ""
 "If you continue, some subtitles will be lost."
 msgstr ""
 
-#: src/hb-backend.c:4564
+#: src/hb-backend.c:4561
 msgid "Subtitle File Not Found"
 msgstr ""
 
-#: src/hb-backend.c:4565
+#: src/hb-backend.c:4562
 msgid ""
 "SRT file does not exist or not a regular file.\n"
 "\n"
@@ -2827,11 +2854,11 @@ msgid ""
 "If you continue, this subtitle will be ignored."
 msgstr ""
 
-#: src/hb-backend.c:4621 src/hb-backend.c:4673
+#: src/hb-backend.c:4618 src/hb-backend.c:4670
 msgid "Invalid Audio Selection"
 msgstr ""
 
-#: src/hb-backend.c:4622
+#: src/hb-backend.c:4619
 msgid ""
 "The source does not support Pass-Thru.\n"
 "\n"
@@ -2839,7 +2866,7 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4674
+#: src/hb-backend.c:4671
 #, c-format
 msgid ""
 "%s is not supported in the %s container.\n"
@@ -2848,51 +2875,51 @@ msgid ""
 "If you continue, one will be chosen for you."
 msgstr ""
 
-#: src/hb-backend.c:4856
+#: src/hb-backend.c:4853
 msgid "Comb Detect"
 msgstr ""
 
-#: src/hb-backend.c:4858
+#: src/hb-backend.c:4855
 msgid "Detelecine"
 msgstr ""
 
-#: src/hb-backend.c:4860
+#: src/hb-backend.c:4857
 msgid "Deinterlace (Yadif)"
 msgstr ""
 
-#: src/hb-backend.c:4862
+#: src/hb-backend.c:4859
 msgid "Deinterlace (Bwdif)"
 msgstr ""
 
-#: src/hb-backend.c:4866
+#: src/hb-backend.c:4863
 msgid "Deblock"
 msgstr ""
 
-#: src/hb-backend.c:4868
+#: src/hb-backend.c:4865
 msgid "Denoise (NLMeans)"
 msgstr ""
 
-#: src/hb-backend.c:4870
+#: src/hb-backend.c:4867
 msgid "Denoise (HQDN3D)"
 msgstr ""
 
-#: src/hb-backend.c:4872
+#: src/hb-backend.c:4869
 msgid "Chroma Smooth"
 msgstr ""
 
-#: src/hb-backend.c:4874
+#: src/hb-backend.c:4871
 msgid "Sharpen (Unsharp)"
 msgstr ""
 
-#: src/hb-backend.c:4876
+#: src/hb-backend.c:4873
 msgid "Rotate"
 msgstr ""
 
-#: src/hb-backend.c:4878
+#: src/hb-backend.c:4875
 msgid "Sharpen (lapsharp)"
 msgstr ""
 
-#: src/hb-backend.c:4882
+#: src/hb-backend.c:4879
 msgid "Colorspace"
 msgstr ""
 
@@ -2939,31 +2966,35 @@ msgstr ""
 msgid "%d.%d GB free space remaining."
 msgstr ""
 
-#: src/notifications.c:165 src/queuehandler.c:1176
+#: src/notifications.c:165 src/queuehandler.c:1171
 msgid "Encoding Paused"
 msgstr ""
 
-#: src/presets.c:78
+#: src/presets.c:52
+msgid "My Presets"
+msgstr ""
+
+#: src/presets.c:87
 msgid "Preset Name"
 msgstr ""
 
-#: src/presets.c:1281
+#: src/presets.c:1299
 msgid "ghb_presets_menu_init: Failed to find presets folder."
 msgstr ""
 
-#: src/presets.c:1443
+#: src/presets.c:1455
 msgid "Failed to find parent folder when adding child."
 msgstr ""
 
-#: src/presets.c:1927
+#: src/presets.c:1942
 msgid "Load backup presets"
 msgstr ""
 
-#: src/presets.c:1927
+#: src/presets.c:1942
 msgid "Get me out of here!"
 msgstr ""
 
-#: src/presets.c:1928
+#: src/presets.c:1943
 msgid ""
 "Presets found are newer than what is supported by this version of "
 "HandBrake!\n"
@@ -2971,27 +3002,45 @@ msgid ""
 "Would you like to continue?"
 msgstr ""
 
-#: src/presets.c:2117
+#: src/presets.c:2123 src/presets.c:2505 src/title-add.c:124
+#: src/title-add.c:134
+msgid "Overwrite"
+msgstr ""
+
+#: src/presets.c:2124 src/presets.c:2506
+msgid "Overwrite Preset?"
+msgstr ""
+
+#: src/presets.c:2125 src/presets.c:2507
+#, c-format
+msgid "The preset “%s” already exists. Do you want to overwrite it?"
+msgstr ""
+
+#: src/presets.c:2214
+msgid "Import Preset"
+msgstr ""
+
+#: src/presets.c:2220
 msgid "Presets (*.json)"
 msgstr ""
 
-#: src/presets.c:2227
+#: src/presets.c:2329
 msgid "Export Preset"
 msgstr ""
 
-#: src/presets.c:2583
+#: src/presets.c:2730
 msgid "_Delete"
 msgstr ""
 
-#: src/presets.c:2584
+#: src/presets.c:2731
 msgid "Delete Folder?"
 msgstr ""
 
-#: src/presets.c:2584
+#: src/presets.c:2731
 msgid "Delete Preset?"
 msgstr ""
 
-#: src/presets.c:2585
+#: src/presets.c:2732
 #, c-format
 msgid ""
 "Are you sure you want to delete “%s”?\n"
@@ -3018,24 +3067,24 @@ msgstr ""
 msgid "The video could not be played. For more details, see the Activity Log."
 msgstr ""
 
-#: src/queuehandler.c:133
+#: src/queuehandler.c:128
 #, c-format
 msgid "%s (Modified)"
 msgstr ""
 
-#: src/queuehandler.c:181
+#: src/queuehandler.c:176
 msgid "Time:"
 msgstr ""
 
-#: src/queuehandler.c:225
+#: src/queuehandler.c:220
 msgid "Align A/V"
 msgstr ""
 
-#: src/queuehandler.c:235
+#: src/queuehandler.c:230
 msgid "iPod 5G"
 msgstr ""
 
-#: src/queuehandler.c:267
+#: src/queuehandler.c:262
 #, c-format
 msgid ""
 "%d:%d:%d:%d Crop\n"
@@ -3044,164 +3093,164 @@ msgid ""
 "%s Display Aspect Ratio"
 msgstr ""
 
-#: src/queuehandler.c:296
+#: src/queuehandler.c:291
 #, c-format
 msgid "%s, Bitrate %dkbps"
 msgstr ""
 
-#: src/queuehandler.c:302
+#: src/queuehandler.c:297
 #, c-format
 msgid "%s, Constant Quality %.4g(%s)"
 msgstr ""
 
-#: src/queuehandler.c:309
+#: src/queuehandler.c:304
 #, c-format
 msgid " (Multi Pass)"
 msgstr ""
 
-#: src/queuehandler.c:341
+#: src/queuehandler.c:336
 #, c-format
 msgid "%sPreset %s"
 msgstr ""
 
-#: src/queuehandler.c:346
+#: src/queuehandler.c:341
 #, c-format
 msgid "%sTune %s"
 msgstr ""
 
-#: src/queuehandler.c:351
+#: src/queuehandler.c:346
 #, c-format
 msgid "%sProfile %s"
 msgstr ""
 
-#: src/queuehandler.c:356
+#: src/queuehandler.c:351
 #, c-format
 msgid "%sLevel %s"
 msgstr ""
 
-#: src/queuehandler.c:373
+#: src/queuehandler.c:368
 #, c-format
 msgid ""
 "\n"
 "Constant Framerate %s fps"
 msgstr ""
 
-#: src/queuehandler.c:377
+#: src/queuehandler.c:372
 #, c-format
 msgid ""
 "\n"
 "Peak Framerate %s fps (may be lower)"
 msgstr ""
 
-#: src/queuehandler.c:382
+#: src/queuehandler.c:377
 #, c-format
 msgid ""
 "\n"
 "Variable Framerate %s fps"
 msgstr ""
 
-#: src/queuehandler.c:550
+#: src/queuehandler.c:545
 msgid "kbps"
 msgstr ""
 
-#: src/queuehandler.c:684 src/queuehandler.c:709
+#: src/queuehandler.c:679 src/queuehandler.c:704
 msgid "Pending"
 msgstr ""
 
-#: src/queuehandler.c:696 src/queuehandler.c:1187
+#: src/queuehandler.c:691 src/queuehandler.c:1182
 msgid "Completed"
 msgstr ""
 
-#: src/queuehandler.c:700 src/queuehandler.c:1191
+#: src/queuehandler.c:695 src/queuehandler.c:1186
 msgid "Canceled"
 msgstr ""
 
-#: src/queuehandler.c:704 src/queuehandler.c:1195
+#: src/queuehandler.c:699 src/queuehandler.c:1190
 msgid "Failed"
 msgstr ""
 
-#: src/queuehandler.c:745 src/queuehandler.c:773 src/queuehandler.c:1235
-#: src/queuehandler.c:1263
+#: src/queuehandler.c:740 src/queuehandler.c:768 src/queuehandler.c:1230
+#: src/queuehandler.c:1258
 #, c-format
 msgid "%d Day %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:748 src/queuehandler.c:776 src/queuehandler.c:1238
-#: src/queuehandler.c:1266
+#: src/queuehandler.c:743 src/queuehandler.c:771 src/queuehandler.c:1233
+#: src/queuehandler.c:1261
 #, c-format
 msgid "%d Days %02d:%02d:%02d"
 msgstr ""
 
-#: src/queuehandler.c:789 src/queuehandler.c:1279
+#: src/queuehandler.c:784 src/queuehandler.c:1274
 msgid "B"
 msgstr ""
 
-#: src/queuehandler.c:793 src/queuehandler.c:1283
+#: src/queuehandler.c:788 src/queuehandler.c:1278
 msgid "KB"
 msgstr ""
 
-#: src/queuehandler.c:798 src/queuehandler.c:1288
+#: src/queuehandler.c:793 src/queuehandler.c:1283
 msgid "MB"
 msgstr ""
 
-#: src/queuehandler.c:814 src/queuehandler.c:1304
+#: src/queuehandler.c:809 src/queuehandler.c:1299
 msgid "Not Available"
 msgstr ""
 
-#: src/queuehandler.c:1139
+#: src/queuehandler.c:1134
 msgid "Foreign Audio Search"
 msgstr ""
 
-#: src/queuehandler.c:1143
+#: src/queuehandler.c:1138
 msgid "Encode"
 msgstr ""
 
-#: src/queuehandler.c:1147
+#: src/queuehandler.c:1142
 msgid "Encode Analysis Pass"
 msgstr ""
 
-#: src/queuehandler.c:1151
+#: src/queuehandler.c:1146
 msgid "Encode Final Pass"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1156
+#: src/queuehandler.c:1151
 msgid "Error"
 msgstr ""
 
-#: src/queuehandler.c:1160
+#: src/queuehandler.c:1155
 #, c-format
 msgid ""
 "pass %d of %d\n"
 "%s"
 msgstr ""
 
-#: src/queuehandler.c:1172
+#: src/queuehandler.c:1167
 msgid "Scanning Title"
 msgstr ""
 
-#: src/queuehandler.c:1180
+#: src/queuehandler.c:1175
 msgid "Encoding In Progress"
 msgstr ""
 
 #. Should never happen
-#: src/queuehandler.c:1200
+#: src/queuehandler.c:1195
 msgid "Unknown"
 msgstr ""
 
-#: src/queuehandler.c:1388
+#: src/queuehandler.c:1383
 msgid "Export Queue"
 msgstr ""
 
-#: src/queuehandler.c:1476
+#: src/queuehandler.c:1466
 msgid "Import Queue"
 msgstr ""
 
-#: src/queuehandler.c:1627
+#: src/queuehandler.c:1617
 msgid "Low Disk Space: Encoding Paused"
 msgstr ""
 
-#: src/queuehandler.c:1629
+#: src/queuehandler.c:1619
 #, c-format
 msgid ""
 "The destination filesystem is almost full: %<PRId64> MB free.\n"
@@ -3209,43 +3258,43 @@ msgid ""
 "Encode may be incomplete if you proceed."
 msgstr ""
 
-#: src/queuehandler.c:1634
+#: src/queuehandler.c:1624
 msgid "Resume, I've fixed the problem"
 msgstr ""
 
-#: src/queuehandler.c:1635
+#: src/queuehandler.c:1625
 msgid "Resume, Don't tell me again"
 msgstr ""
 
-#: src/queuehandler.c:1701
+#: src/queuehandler.c:1694
 msgid "Remove Item in Progress?"
 msgstr ""
 
-#: src/queuehandler.c:1703
+#: src/queuehandler.c:1696
 msgid "Cancel and Remove"
 msgstr ""
 
-#: src/queuehandler.c:1843 src/queuehandler.c:1856
+#: src/queuehandler.c:1836 src/queuehandler.c:1849
 msgid "Stop"
 msgstr ""
 
-#: src/queuehandler.c:1844 src/queuehandler.c:1857
+#: src/queuehandler.c:1837 src/queuehandler.c:1850
 msgid "Stop Encoding"
 msgstr ""
 
-#: src/queuehandler.c:1869
+#: src/queuehandler.c:1862
 msgid "S_top Encoding"
 msgstr ""
 
-#: src/queuehandler.c:1887 src/queuehandler.c:1900
+#: src/queuehandler.c:1880 src/queuehandler.c:1893
 msgid "Resume"
 msgstr ""
 
-#: src/queuehandler.c:1888 src/queuehandler.c:1901
+#: src/queuehandler.c:1881 src/queuehandler.c:1894
 msgid "Resume Encoding"
 msgstr ""
 
-#: src/queuehandler.c:1912
+#: src/queuehandler.c:1905
 msgid "_Resume Encoding"
 msgstr ""
 
@@ -3305,10 +3354,6 @@ msgstr ""
 #: src/title-add.c:113
 #, c-format
 msgid "“%s” is not a writable directory."
-msgstr ""
-
-#: src/title-add.c:124 src/title-add.c:134
-msgid "Overwrite"
 msgstr ""
 
 #: src/title-add.c:124 src/title-add.c:134

--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -392,7 +392,6 @@ GHB_DECLARE_ACTION_CB(queue_open_log_dir_action_cb);
 GHB_DECLARE_ACTION_CB(queue_open_log_action_cb);
 GHB_DECLARE_ACTION_CB(queue_delete_all_action_cb);
 GHB_DECLARE_ACTION_CB(queue_delete_complete_action_cb);
-GHB_DECLARE_ACTION_CB(queue_delete_action_cb);
 GHB_DECLARE_ACTION_CB(queue_reset_fail_action_cb);
 GHB_DECLARE_ACTION_CB(queue_reset_all_action_cb);
 GHB_DECLARE_ACTION_CB(queue_reset_action_cb);
@@ -469,7 +468,6 @@ map_actions (GtkApplication *app, signal_user_data_t *ud)
         { "queue-reset-fail",      queue_reset_fail_action_cb      },
         { "queue-reset-all",       queue_reset_all_action_cb       },
         { "queue-reset",           queue_reset_action_cb           },
-        { "queue-delete",          queue_delete_action_cb          },
         { "queue-delete-complete", queue_delete_complete_action_cb },
         { "queue-delete-all",      queue_delete_all_action_cb      },
         { "queue-export",          queue_export_action_cb          },

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -4653,7 +4653,7 @@ ghb_backend_events(signal_user_data_t *ud)
         if (ghb_dict_get_bool(ud->prefs, "RemoveFinishedJobs") &&
             status.queue.error == GHB_ERROR_NONE)
         {
-            ghb_queue_remove_row(ud, index);
+            ghb_queue_remove_row_at_index(index);
         }
         if (ghb_get_cancel_status() != GHB_CANCEL_ALL &&
             ghb_get_cancel_status() != GHB_CANCEL_FINISH)

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -3937,13 +3937,12 @@ ghb_countdown_dialog_show (const gchar *message, const gchar *action,
     gtk_widget_show(dialog);
 }
 
-gboolean
-ghb_question_dialog_run (GtkWindow *parent, GhbActionStyle accept_style,
-                         const char *accept_button, const char *cancel_button,
-                         const char *title, const char *format, ...)
+G_GNUC_PRINTF(6, 0) static GtkMessageDialog *
+question_dialog_va (GtkWindow *parent, GhbActionStyle accept_style,
+                    const char *accept_button, const char *cancel_button,
+                    const char *title, const char *format, va_list va_args)
 {
     GtkWidget *dialog, *button;
-    GtkResponseType response;
 
     if (parent == NULL)
     {
@@ -3957,12 +3956,9 @@ ghb_question_dialog_run (GtkWindow *parent, GhbActionStyle accept_style,
                                     "%s", title);
     if (format)
     {
-        va_list args;
         char *message;
 
-        va_start(args, format);
-        message = g_strdup_vprintf(format, args);
-        va_end(args);
+        message = g_strdup_vprintf(format, va_args);
         gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog), "%s", message);
         g_free(message);
     }
@@ -3989,6 +3985,39 @@ ghb_question_dialog_run (GtkWindow *parent, GhbActionStyle accept_style,
             break;
         }
     }
+    return GTK_MESSAGE_DIALOG(dialog);
+}
+
+GtkMessageDialog *
+ghb_question_dialog_new (GtkWindow *parent, GhbActionStyle accept_style,
+                         const char *accept_button, const char *cancel_button,
+                         const char *title, const char *format, ...)
+{
+    va_list args;
+    GtkMessageDialog *dialog;
+
+    va_start(args, format);
+    dialog = question_dialog_va(parent, accept_style, accept_button,
+                                cancel_button, title, format, args);
+    va_end(args);
+
+    return dialog;
+}
+
+gboolean
+ghb_question_dialog_run (GtkWindow *parent, GhbActionStyle accept_style,
+                         const char *accept_button, const char *cancel_button,
+                         const char *title, const char *format, ...)
+{
+    va_list args;
+    GtkMessageDialog *dialog;
+    GtkResponseType response;
+
+    va_start(args, format);
+    dialog = question_dialog_va(parent, accept_style, accept_button,
+                                cancel_button, title, format, args);
+    va_end(args);
+
     response = ghb_dialog_run(GTK_DIALOG(dialog));
     gtk_window_destroy(GTK_WINDOW(dialog));
     if (response == GTK_RESPONSE_ACCEPT)
@@ -5667,14 +5696,4 @@ log_directory_action_cb (GSimpleAction *action, GVariant *param, signal_user_dat
         return;
 
     ghb_browse_uri(uri);
-}
-
-G_MODULE_EXPORT void
-string_list_changed_cb (GtkStringList *self, guint position,
-                        guint removed, guint added, gpointer user_data)
-{
-    for (int i = 0; i < g_list_model_get_n_items(G_LIST_MODEL(self)); i++)
-    {
-         printf("String: %s\n", gtk_string_list_get_string(self, i));
-    }
 }

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -45,6 +45,9 @@ void ghb_countdown_dialog_show(const gchar *message, const char *action,
 gboolean ghb_question_dialog_run(GtkWindow *parent, GhbActionStyle accept_style,
      const char *accept_button, const char *cancel_button,
      const char *title, const char *format, ...) G_GNUC_PRINTF(6, 7);
+GtkMessageDialog *ghb_question_dialog_new(GtkWindow *parent, GhbActionStyle accept_style,
+     const char *accept_button, const char *cancel_button,
+     const char *title, const char *format, ...) G_GNUC_PRINTF(6, 7);
 void ghb_alert_dialog_show(GtkMessageType type, const char *title,
                            const char *format, ...) G_GNUC_PRINTF(3, 4);
 GtkWidget *ghb_cancel_dialog_new(GtkWindow *parent,

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -2030,9 +2030,10 @@ preset_category_opts_set(signal_user_data_t *ud, const char *opt_name,
         const char * name;
         hb_value_t * folder = hb_value_array_get(presets, ii);
 
-        if (!hb_value_get_bool(hb_dict_get(folder, "Folder")))
+        if (!hb_value_get_bool(hb_dict_get(folder, "Folder")) ||
+            hb_value_get_int(hb_dict_get(folder, "Type")) != 1)
         {
-            // Only list folders
+            // Only list custom folders
             continue;
         }
 

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1252,10 +1252,11 @@ G_MODULE_EXPORT void
 preset_select_action_cb(GSimpleAction *action, GVariant *param,
                         signal_user_data_t *ud)
 {
-    const char * preset_path = g_variant_get_string(param, NULL);
-    int          type        = preset_path[0] - '0';
+    char *preset_path = g_uri_unescape_string(g_variant_get_string(param, NULL), NULL);
+    int   type        = preset_path[0] - '0';
 
     ghb_select_preset(ud, &preset_path[1], type);
+    g_free(preset_path);
 }
 
 G_MODULE_EXPORT void
@@ -1360,17 +1361,18 @@ ghb_presets_menu_init(signal_user_data_t *ud)
                     {
                         continue;
                     }
-                    g_string_append_printf(preset_str, "/%s", name);
+                    g_string_append(preset_str, "/");
+                    g_string_append_uri_escaped(preset_str, name, NULL, TRUE);
 
                     char * preset_path;
                     char * detail_action;
 
                     preset_path = g_string_free(preset_str, FALSE);
-                    detail_action = g_strdup_printf("app.preset-select(\"%s\")",
+                    detail_action = g_strdup_printf("app.preset-select('%s')",
                                                     preset_path);
                     g_menu_append(submenu, name, detail_action);
-                    free(preset_path);
-                    free(detail_action);
+                    g_free(preset_path);
+                    g_free(detail_action);
                 }
                 if (type == HB_PRESET_TYPE_CUSTOM &&
                     g_strv_contains((const char**)official_names, folder_name))

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1340,16 +1340,17 @@ ghb_presets_menu_init(signal_user_data_t *ud)
                 submenu_count = ghb_array_len(folder);
                 for (jj = 0; jj < submenu_count; jj++)
                 {
+                    int           preset_type;
                     const gchar * name;
                     GString     * preset_str = g_string_new(folder_str->str);
 
                     dict        = ghb_array_get(folder, jj);
                     name        = ghb_dict_get_string(dict, "PresetName");
-                    type        = ghb_dict_get_int(dict, "Type");
+                    preset_type = ghb_dict_get_int(dict, "Type");
                     is_folder   = ghb_dict_get_bool(dict, "Folder");
 
                     // Sanity check, Preset types must match their folder
-                    if (type != folder_type)
+                    if (preset_type != folder_type)
                     {
                         continue;
                     }

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -2107,6 +2107,9 @@ preset_import_response_cb (GtkFileChooser *chooser, GtkResponseType response,
         GhbValue *imported = hb_presets_read_file(filename);
         GhbValue *list = hb_dict_get(imported, "PresetList");
         GhbValue *preset = ghb_value_dup(ghb_array_get(list, 0));
+        // Ensure imported presets have the right type and aren't set as default
+        ghb_dict_set_bool(preset, "Default", FALSE);
+        ghb_dict_set_int(preset, "Type", HB_PRESET_TYPE_CUSTOM);
         const char *preset_name = ghb_dict_get_string(preset, "PresetName");
 
         preset_write_data *data = g_malloc0(sizeof(preset_write_data));

--- a/gtk/src/queuehandler.h
+++ b/gtk/src/queuehandler.h
@@ -28,7 +28,8 @@ G_BEGIN_DECLS
 
 void     ghb_queue_buttons_grey(signal_user_data_t *ud);
 gboolean ghb_reload_queue(signal_user_data_t *ud);
-void     ghb_queue_remove_row(signal_user_data_t *ud, int row);
+void     ghb_queue_remove_row(GhbQueueRow *row);
+void     ghb_queue_remove_row_at_index(int row);
 gint     ghb_find_queue_job(GhbValue *queue, gint unique_id, GhbValue **job);
 void     ghb_low_disk_check(signal_user_data_t *ud);
 void     ghb_reset_disk_space_check(void);
@@ -43,6 +44,5 @@ void     ghb_queue_update_live_stats(signal_user_data_t * ud, int index,
 void     ghb_queue_drag_n_drop_init(signal_user_data_t * ud);
 void     ghb_add_to_queue_list(signal_user_data_t *ud, GhbValue *queueDict);
 void     ghb_queue_selection_init(signal_user_data_t * ud);
-void     ghb_queue_row_remove(GhbQueueRow *row);
 
 G_END_DECLS

--- a/gtk/src/ui/menu.ui
+++ b/gtk/src/ui/menu.ui
@@ -407,12 +407,6 @@
         <attribute name="label" translatable="yes">_Reset</attribute>
       </item>
     </section>
-    <section>
-      <item>
-        <attribute name="action">app.queue-delete</attribute>
-        <attribute name="label" translatable="yes">Re_move</attribute>
-      </item>
-    </section>
   </menu>
   <menu id="add-audio-menu">
     <section>


### PR DESCRIPTION
Fixes various issues around presets, such as preventing duplicate presets being added to the same folder, and fixing imported presets not showing up by adding them to a folder.

This introduces some new strings which will need translation. If it's too late for 1.9.0, I can remove the dialogs which use them and just keep the other fixes.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux