### PR TITLE
build: Prefer Flatpak-installed flatpak-builder

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -30,9 +30,9 @@ jobs:
         sudo apt-get install -y libtheora-dev libtool libtool-bin libturbojpeg0-dev libvorbis-dev libx264-dev libxml2-dev libvpx-dev m4 make meson nasm ninja-build patch pkg-config tar zlib1g-dev
         sudo apt-get install -y libva-dev libdrm-dev intltool libglib2.0-dev libunwind-dev libgtk-4-dev libgudev-1.0-dev libssl-dev
         sudo python -m pip install meson
-        sudo apt-get install flatpak flatpak-builder
+        sudo apt-get install flatpak
         sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y flathub org.freedesktop.Sdk//24.08 org.freedesktop.Platform//24.08 org.gnome.Platform//47 org.gnome.Sdk//47
+        sudo flatpak install -y flathub org.freedesktop.Sdk//24.08 org.freedesktop.Platform//24.08 org.gnome.Platform//47 org.gnome.Sdk//47 org.flatpak.Builder
         sudo flatpak install -y org.freedesktop.Sdk.Extension.llvm18//24.08
         sudo flatpak install -y org.freedesktop.Sdk.Extension.rust-stable//24.08
         sudo apt-get upgrade -y

--- a/pkg/linux/module.defs
+++ b/pkg/linux/module.defs
@@ -131,6 +131,11 @@ ifeq (1,$(FEATURE.qsv))
 endif
 
 PKG.plugins.flatpak = $(PKG.mediasdk.flatpak)
+ifneq (,$(shell flatpak run org.flatpak.Builder --version))
+	FLATPAK_BUILDER.exe = flatpak run org.flatpak.Builder
+else
+	FLATPAK_BUILDER.exe = flatpak-builder
+endif
 
 ifneq ($(HB_URL),)
 ifneq ($(HB_SHA256),)

--- a/pkg/linux/module.rules
+++ b/pkg/linux/module.rules
@@ -81,7 +81,7 @@ $(PKG.gui.flatpak): GNUmakefile $(PKG.gui.template.flatpak) $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
 	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.gui.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.gui.manifest.flatpak)
-	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(PKG.gui.manifest.flatpak)
+	$(FLATPAK_BUILDER.exe) --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.gui.build.flatpak) $(PKG.gui.manifest.flatpak)
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.gui.flatpak) $(PKG.gui.name.flatpak) $(PKG.branch.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
 $(PKG.gui.debug.flatpak): $(PKG.gui.flatpak)
@@ -92,7 +92,7 @@ $(PKG.cli.flatpak): GNUmakefile $(PKG.cli.template.flatpak) $(PKG.src.tar.bz2)
 	$(MKDIR.exe) -p $(STAGE.out.flatpak/)
 	$(MKDIR.exe) -p $(PKG.out.flatpak/)
 	$(SRC/)scripts/create_flatpak_manifest.py $(FPFLAGS) -a "$(abspath $(PKG.src.tar.bz2))" -t $(PKG.cli.template.flatpak) $(foreach m,$(CONTRIBS),-c "$(abspath $(CONTRIB.download/)$($m.FETCH.basename))") $(PKG.cli.manifest.flatpak)
-	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(PKG.cli.manifest.flatpak)
+	$(FLATPAK_BUILDER.exe) --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.cli.build.flatpak) $(PKG.cli.manifest.flatpak)
 	flatpak build-bundle $(PKG.repo.flatpak) $(PKG.cli.flatpak) $(PKG.cli.name.flatpak) $(PKG.branch.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 
 $(PKG.cli.debug.flatpak): $(PKG.cli.flatpak)
@@ -106,7 +106,7 @@ $(PKG.mediasdk.flatpak): GNUmakefile $(PKG.mediasdk.template.flatpak) $(PKG.gui.
 	flatpak --user install --noninteractive $(PKG.gui.flatpak)
 	$(CP.exe) $(PKG.mediasdk.metainfo.flatpak) $(STAGE.out.flatpak/)
 	$(CP.exe) $(PKG.mediasdk.patch.flatpak) $(STAGE.out.flatpak/)
-	flatpak-builder --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.mediasdk.build.flatpak) $(PKG.mediasdk.manifest.flatpak)
+	$(FLATPAK_BUILDER.exe) --default-branch=$(PKG.branch.flatpak) --disable-cache --force-clean $(PGPSIGN) --repo=$(PKG.repo.flatpak) $(PKG.mediasdk.build.flatpak) $(PKG.mediasdk.manifest.flatpak)
 	flatpak build-bundle --runtime $(PKG.repo.flatpak) $(PKG.mediasdk.flatpak) $(PKG.mediasdk.name.flatpak) $(PKG.plugin.version.flatpak) --runtime-repo=https://flathub.org/repo/flathub.flatpakrepo
 	-flatpak --user remove --noninteractive $(PKG.gui.name.flatpak)//$(PKG.branch.flatpak)
 


### PR DESCRIPTION
Installs flatpak-builder from Flathub, and uses that if installed. Hopefully fixes the build failures in IntelMediaSDK.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux