### PR TITLE
flatpak: Override libdir in CMake-built modules

### DIFF
--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -19,7 +19,8 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
             ],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",
@@ -77,6 +78,7 @@
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DMEDIA_RUN_TEST_SUITE=OFF",
                 "-DENABLE_PRODUCTION_KMD=ON"
             ],
@@ -92,6 +94,7 @@
             "builddir": true,
             "config-opts": [
                 "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DBUILD_SAMPLES=OFF",
                 "-DBUILD_TESTS=OFF",
                 "-DBUILD_TOOLS=OFF",
@@ -127,7 +130,8 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
-                "-DCMAKE_BUILD_TYPE=Release"
+                "-DCMAKE_BUILD_TYPE=Release",
+                "-DCMAKE_INSTALL_LIBDIR=lib"
             ],
             "build-options": {
                 "prefix" : "/app/extensions/IntelMediaSDK",


### PR DESCRIPTION
This should fix the IntelMediaSDK build issue for real this time.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

