### PR TITLE
build: fix gcc14 aarch64 build failure

### DIFF
--- a/libhb/templates/comb_detect_template.c
+++ b/libhb/templates/comb_detect_template.c
@@ -270,7 +270,7 @@ static void FUNC(detect_gamma_combed_segment)(hb_filter_private_t *pv,
                 mask_vec = vandq_u32(mask_vec, condition);
                 mask_vec = vandq_u32(mask_vec, v_one);
 
-                vst1q_u32(&mask32, mask_vec);
+                vst1q_u32(mask32, mask_vec);
 
                 mask[0] = mask32[0];
                 mask[1] = mask32[1];
@@ -550,7 +550,7 @@ static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
                         mask_vec = vandq_u32(mask_vec, condition);
                         mask_vec = vandq_u32(mask_vec, v_one);
 
-                        vst1q_u32(&mask32, mask_vec);
+                        vst1q_u32(mask32, mask_vec);
 
                         mask[0] = mask32[0];
                         mask[1] = mask32[1];
@@ -568,7 +568,7 @@ static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
                         mask_vec = vandq_u32(mask_vec, condition);
                         mask_vec = vandq_u32(mask_vec, v_one);
 
-                        vst1q_u32(&mask32, mask_vec);
+                        vst1q_u32(mask32, mask_vec);
 
                         mask[0] = mask32[0];
                         mask[1] = mask32[1];
@@ -585,7 +585,7 @@ static void FUNC(detect_combed_segment)(hb_filter_private_t *pv,
                         mask_vec = vandq_u32(mask_vec, condition);
                         mask_vec = vandq_u32(mask_vec, v_one);
 
-                        vst1q_u32(&mask32, mask_vec);
+                        vst1q_u32(mask32, mask_vec);
 
                         mask[0] = mask32[0];
                         mask[1] = mask32[1];

--- a/libhb/templates/decomb_template.c
+++ b/libhb/templates/decomb_template.c
@@ -181,7 +181,7 @@ static void FUNC(blend_filter_line)(const filter_param_t *filter,
         result = vshrq_n_s32(result, 3);
 
         uint32x4_t result_u32 = vreinterpretq_u32_s32(vaddq_s32(result, offset));
-        vst1q_u32(&cr_table_vec, result_u32);
+        vst1q_u32(cr_table_vec, result_u32);
         dst[x+0] = crop_table[cr_table_vec[0]];
         dst[x+1] = crop_table[cr_table_vec[1]];
         dst[x+2] = crop_table[cr_table_vec[2]];
@@ -263,7 +263,7 @@ static void FUNC(blend_filter_line)(const filter_param_t *filter,
         result = vshrq_n_s16(result, 3);
 
         uint16x8_t result_u16 = vreinterpretq_u16_s16(vaddq_s16(result, offset));
-        vst1q_u16(&cr_table_vec, result_u16);
+        vst1q_u16(cr_table_vec, result_u16);
         dst[x+0] = crop_table[cr_table_vec[0]];
         dst[x+1] = crop_table[cr_table_vec[1]];
         dst[x+2] = crop_table[cr_table_vec[2]];


### PR DESCRIPTION
Fixes #6454 



**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux