### PR TITLE
Set AMD VCE encoders default profile to auto

### DIFF
--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -15,9 +15,9 @@ int            hb_vce_h265_available();
 int            hb_vce_av1_available();
 
 static const char * const hb_vce_h264_profile_names[] = { "auto", "baseline", "main", "high",  NULL, };
-static const char * const hb_vce_h265_profile_names[] = { "main", NULL, };
-static const char * const hb_vce_h265_10bit_profile_names[] = { "main10", NULL, };
-static const char * const hb_vce_av1_profile_names[]  = { "main", NULL, };
+static const char * const hb_vce_h265_profile_names[] = { "auto", "main", NULL, };
+static const char * const hb_vce_h265_10bit_profile_names[] = { "auto", "main10", NULL, };
+static const char * const hb_vce_av1_profile_names[]  = { "auto", "main", NULL, };
 
 static const char * const hb_vce_h264_level_names[] =
 {


### PR DESCRIPTION
Description of Change:
This is a optimization for HEVC and AV1 AMD VCE encoders quality.
This PR will change the HEVC and AV1 AMD VCE encoders profile to "auto" by default.
Therefore, the HEVC and AV1 encoder profile will follow AMD VCE default setting.

Tested on:
- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux