### PR TITLE
build: add compiler flags to optimize win arm64 builds

### DIFF
--- a/contrib/svt-av1/A02-Fix-i8mm-architecture-build-errors-for-mingw-cross-c.patch
+++ b/contrib/svt-av1/A02-Fix-i8mm-architecture-build-errors-for-mingw-cross-c.patch
@@ -1,0 +1,27 @@
+From 95d38b6cd541a10f0d7520f33b24ab32267e8315 Mon Sep 17 00:00:00 2001
+From: Harshitha Suresh <harshitha@multicorewareinc.com>
+Date: Fri, 13 Dec 2024 20:05:52 +0530
+Subject: [PATCH] Fix i8mm architecture build errors for mingw cross
+ compilation
+
+---
+ CMakeLists.txt | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 0666d76d..0d5bbf8c 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -174,6 +174,9 @@ svfloat32_t func(svfloat32_t a) {
+             add_compile_definitions(HAVE_${flavor}=0)
+         endif()
+     endforeach()
++	if(ENABLE_NEON_I8MM)
++		add_compile_options(-march=armv8.2-a+dotprod+i8mm)
++	endif()
+ 
+     add_definitions(-DARCH_AARCH64=1)
+     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-lax-vector-conversions")
+-- 
+2.36.0.windows.1
+

--- a/make/include/gcc.defs
+++ b/make/include/gcc.defs
@@ -95,6 +95,13 @@ ifeq ($(HOST.machine),$(filter $(HOST.machine),i686 x86_64))
     GCC.args.extra    += -mfpmath=sse -msse2
 endif
 GCC.args.extra        += $(CPPFLAGS) $(CFLAGS)
+ifeq (1,$(HOST.cross))
+    ifeq ($(HOST.machine),$(filter $(HOST.machine),aarch64))
+        ifeq (mingw,$(HOST.system))
+            GCC.args.extra  += -finline-functions -funroll-loops -mllvm -inline-threshold=1000 -ftree-vectorize -mllvm --instcombine-code-sinking -mllvm --hot-cold-split
+        endif
+    endif
+endif
 GCC.args.extra.h_o     =
 GCC.args.extra.c_o     =
 GCC.args.extra.dylib   = $(LDFLAGS)


### PR DESCRIPTION
**Description of Change:**
This adds the missing compiler flags/optimizations (as discussed in #6346) for Windows ARM64 builds.

BigBuckBunny 4K - Fast 1080p preset - SVT-AV1 encoder
- Before: 39 FPS
- After: 40.5 FPS

BigBuckBunny 4K - HQ 4K preset - SVT-AV1 encoder
- Before: 12.7 FPS
- After: 13.38 FPS


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux