### PR TITLE
build: generate pdb for llvm-mingw aarch64 builds

### DIFF
--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -187,7 +187,11 @@ ifeq ($(HAS.dlfcn),1)
     LIBHB.GCC.l += dl
 endif
 LIBHB.out += $(LIBHB.dll) $(LIBHB.lib)
-
+ifeq ($(HOST.machine),$(filter $(HOST.machine),aarch64))
+    ifneq (none,$(GCC.g))
+        LIBHB.out += $(LIBHB.pdb)
+    endif
+endif
 endif
 
 ###############################################################################

--- a/make/variant/mingw.defs
+++ b/make/variant/mingw.defs
@@ -10,3 +10,13 @@ GCC.args.g.std  = -g2
 GCC.args.g.max  = -g3
 
 GCC.args.extra += -mno-ms-bitfields
+
+ifeq ($(HOST.machine),$(filter $(HOST.machine),aarch64))
+    ifneq (none,$(GCC.g))
+        GCC.args.g.max        += -gcodeview
+        GCC.args.g.min        += -gcodeview
+        GCC.args.g.std        += -gcodeview
+        GCC.args.extra.exe++  += -Wl-debug -Wl,--pdb=
+        GCC.args.extra.exe    += -Wl-debug -Wl,--pdb=
+    endif
+endif


### PR DESCRIPTION
Adds feature to generate PDB with Windows ARM64 Debug builds

Requires [A02-Fix-i8mm-architecture-build-errors-for-mingw-cross-c.patch#L20](https://github.com/HandBrake/HandBrake/blob/266ca65274ed4de9e270101f8655e5d9fcb9bc43/contrib/svt-av1/A02-Fix-i8mm-architecture-build-errors-for-mingw-cross-c.patch#L20) from #6487, without which debug builds fail with inlining errors

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
