### PR TITLE
contrib: update libvpl to 2.14.0

### DIFF
--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
-LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.13.0.tar.gz
-LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpl-2.13.0.tar.gz
-LIBVPL.FETCH.sha256    = 1c740e2b58f7853f56b618bdb7d4a7e5d37f8c1a9b30105a0b79ba80873e1cbd
-LIBVPL.FETCH.basename  = libvpl-2.13.0.tar.gz
-LIBVPL.EXTRACT.tarbase = libvpl-2.13.0
+LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.14.0.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpl-2.14.0.tar.gz
+LIBVPL.FETCH.sha256    = 7c6bff1c1708d910032c2e6c44998ffff3f5fdbf06b00972bc48bf2dd9e5ac06
+LIBVPL.FETCH.basename  = libvpl-2.14.0.tar.gz
+LIBVPL.EXTRACT.tarbase = libvpl-2.14.0
 
 LIBVPL.build_dir             = build
 LIBVPL.CONFIGURE.exe         = cmake


### PR DESCRIPTION
Added

    Intel® VPL API 2.14 support, including new quality and speed settings for AI
    based video frame interpolation, new algorithm and mode selection options for
    AI based super resolution, and HEVC level 8.5 decode support.

    Improved support for Python 3.12 development environments.

Fixed

    Bootstrap to support Debian distributions that do not define ID_LIKE.

Known Issues

    vpl-infer example will fail to load model if built with CMake version higher than 3.25.3 on Windows

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux