### PR TITLE
Use "vq" instead of "None" for default SVT-AV1 tune label

### DIFF
--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -184,17 +184,21 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
         }
     }
 
-    if (job->encoder_tune != NULL && strstr("ssim", job->encoder_tune) != NULL)
+    if (job->encoder_tune != NULL && strstr("vq", job->encoder_tune) != NULL)
     {
-        param->tune = 2;
+        param->tune = 0; // "vq" corresponds to tune = 0
     }
     else if (job->encoder_tune != NULL && strstr("psnr", job->encoder_tune) != NULL)
     {
-        param->tune = 1;
+        param->tune = 1; // "psnr" corresponds to tune = 1
+    }
+    else if (job->encoder_tune != NULL && strstr("ssim", job->encoder_tune) != NULL)
+    {
+        param->tune = 2; // "ssim" corresponds to tune = 2
     }
     else
     {
-        param->tune = 0;
+        param->tune = 0; // Default to "vq" if no specific tune is found
     }
 
     if (job->encoder_tune != NULL && strstr("fastdecode", job->encoder_tune) != NULL)

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -22,21 +22,21 @@ static const char * const hb_av1_level_names[] = {
 
 static const int          hb_av1_level_values[] = {
      -1,  20,  21,  22,  23,  30,  31,  32,  33,  40,  41,  42,
-     43,  50,  51,  52,  53,  60,  61,  62,  63,  0 };
+     43,  50,  51,  52,  53,  60,  61,  62,  63,  0, };
 
 static const char * const av1_svt_preset_names[] =
 {
-    "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL
+    "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL,
 };
 
 static const char * const av1_svt_tune_names[] =
 {
-    "psnr", "ssim", "fastdecode", NULL
+    "vq", "psnr", "ssim", "fastdecode", NULL,
 };
 
 static const char * const av1_svt_profile_names[] =
 {
-    "auto", "main", NULL // "high", "profesional"
+    "auto", "main", NULL, // "high", "profesional"
 };
 
 #endif // HANDBRAKE_AV1_COMMON_H


### PR DESCRIPTION
Fixes #6012.

This change should replace "None" (which selects tune VQ) with a dropdown option "vq" for SVT-AV1 tune.
Tested on macOS. At the moment it just adds a new option "vq". Could somebody give me a hint on how to remove the "None" from the dropdown? (removing the NULL does not work)