### PR TITLE
ui: title background on file conflict

### DIFF
--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -290,26 +290,32 @@ static PangoAttrList *default_title_attrs;
 static void
 title_add_set_sensitive (GtkWidget *row, gboolean sensitive)
 {
+    PangoAttrList *pal;
+    PangoAttribute *bg, *alpha;
     GtkWidget *widget;
     widget = find_widget(row, "title_selected");
     gtk_widget_set_sensitive(widget, sensitive);
 
     widget = find_widget(row, "title_label");
+
     if (!sensitive)
     {
-        PangoAttrList *pal;
-        PangoAttribute *bg;
-        bg = pango_attr_background_new(0xFFFF, 0xFFFF, 0xA000);
-        pal = pango_attr_list_new();
-        pango_attr_list_insert(pal, bg);
-        gtk_label_set_attributes(GTK_LABEL(widget), pal);
+        alpha = pango_attr_background_alpha_new(0);
         gtk_widget_set_has_tooltip(widget, TRUE);
     }
     else
     {
+        alpha = pango_attr_background_alpha_new(1);
         gtk_label_set_attributes(GTK_LABEL(widget), default_title_attrs);
         gtk_widget_set_has_tooltip(widget, FALSE);
     }
+
+    pal = pango_attr_list_new();
+    bg = pango_attr_background_new(0xFFFF, 0xFFFF, 0xA000);
+    pango_attr_list_insert(pal, bg);
+    pango_attr_list_insert(pal, alpha);
+
+    gtk_label_set_attributes(GTK_LABEL(widget), pal);
 }
 
 static gboolean


### PR DESCRIPTION
**Description of Change:**

Title background when adding multiple titles is set to yellow when there is a file conflict. This is not removed when the conflict is resolved. Set the background alpha to 1 to remove the background when the conflict is resolved.

**Tested on:**

- Arch Linux
