### PR TITLE
nv-codec-headers: Harden DLL loading

### DIFF
--- a/contrib/nvenc/A01-dll-harden.patch
+++ b/contrib/nvenc/A01-dll-harden.patch
@@ -1,0 +1,11 @@
+--- nv-codec-headers-12.2.72.0/include/ffnvcodec/dynlink_loader.h
++++ nv-codec-headers-12.2.72.0/include/ffnvcodec/dynlink_loader.h
+@@ -62,7 +62,7 @@
+
+ #if !defined(FFNV_LOAD_FUNC) || !defined(FFNV_SYM_FUNC)
+ # ifdef _WIN32
+-#  define FFNV_LOAD_FUNC(path) LoadLibrary(TEXT(path))
++#  define FFNV_LOAD_FUNC(path) LoadLibraryExA(TEXT(path), NULL, LOAD_LIBRARY_SEARCH_SYSTEM32)
+ #  define FFNV_SYM_FUNC(lib, sym) GetProcAddress((lib), (sym))
+ #  define FFNV_FREE_FUNC(lib) FreeLibrary(lib)
+ # else


### PR DESCRIPTION
**Description of Change:**

On non-Nvidia systems, it will search the users various path folders for the dll file which is not ideal where they are user-writable.  

In the context of HandBrake this is considered a low risk. Between in-app functionality and the fact we run as user-space it's somewhat moot.  Either way, it's good to clean this up so that it doesn't flag.


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

ProcMon confirms it's only loading from System32 now.