### PR TITLE
contrib: update HarfBuzz to 10.2.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.1.0.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.1.0/harfbuzz-10.1.0.tar.xz
-HARFBUZZ.FETCH.sha256  = 6ce3520f2d089a33cef0fc48321334b8e0b72141f6a763719aaaecd2779ecb82
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.2.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.2.0/harfbuzz-10.2.0.tar.xz
+HARFBUZZ.FETCH.sha256  = 620e3468faec2ea8685d32c46a58469b850ef63040b3565cde05959825b48227
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 10.2.0:**

What's Changed
- Consider Unicode Variation Selectors when subsetting “cmap” table.
- Guard hb_cairo_glyphs_from_buffer() against malformed UTF-8 strings.
- Fix incorrect “COLR” v1 glyph scaling in hb-cairo.
- Use locale-independent parsing of double numbers is “hb-subset” command line tool.
- Fix incorrect zeroing of advance width of base glyphs in various “Courier New” font versions due to incorrect “GDEF” glyph classes.
- Fix handling of long language codes with “HB_LEAN” configuration.
- Update OpenType language system registry.
- Allow all Myanmar tone marks (including visarga) in any order
- Don’t insert U+25CC DOTTED CIRCLE before superscript/subscript digits
- Handle Garay script as right to left script.
- New API for serializing font tables and potentially repacking them in optimal way. This was a previously experimental-only API.
- New API for converting font variation setting from and to strings.
- Various build fixes
- Various subsetter and instancer fixes.
- New API: +hb_subset_serialize_link_t +hb_subset_serialize_object_t +hb_subset_serialize_or_fail() +hb_subset_axis_range_from_string() +hb_subset_axis_range_to_string()

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux