### PR TITLE
contrib: update sse2neon to 1.8.0

### DIFF
--- a/contrib/sse2neon/module.defs
+++ b/contrib/sse2neon/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,SSE2NEON,sse2neon))
 $(eval $(call import.CONTRIB.defs,SSE2NEON))
 
-SSE2NEON.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/sse2neon-1.7.0.tar.gz
-SSE2NEON.FETCH.url      += https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.7.0.tar.gz
-SSE2NEON.FETCH.sha256    = cee6d54922dbc9d4fa57749e3e4b46161b7f435a22e592db9da008051806812a
-SSE2NEON.FETCH.basename  = sse2neon-1.7.0.tar.gz
-SSE2NEON.EXTRACT.tarbase = sse2neon-1.7.0
+SSE2NEON.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/sse2neon-1.8.0.tar.gz
+SSE2NEON.FETCH.url      += https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.8.0.tar.gz
+SSE2NEON.FETCH.sha256    = e251746e3b761f3f0de1ad462b1efe53532341b6b0498d394765fceb85ce8a46
+SSE2NEON.FETCH.basename  = sse2neon-1.8.0.tar.gz
+SSE2NEON.EXTRACT.tarbase = sse2neon-1.8.0
 
 SSE2NEON.CONFIGURE = $(TOUCH.exe) $@
 SSE2NEON.BUILD     = $(TOUCH.exe) $@


### PR DESCRIPTION
**sse2neon 1.8.0:**

**What's Changed:**
- Fix Clang showing incorrect GCC version warning
- Restore options for precision of div/rcp/sqrt/rsqrt
- Optimize CRC intrinisics for targets lacking of CRC extension
- test: Avoid errors when cross compile by gcc-8.3/9.2
- Improve unsupported target message
- Fix with _mm_div_ps when SSE2NEON_PRECISE_DIV=1
- Use unaligned data types for unaligned intrinsics
- fix: Fix uninitialized parameters
- fix: Disable optimization to avoid pontential errors
- Fix minor typos in the sse2neon header
- fix: Fix strict-aliasing errors
- fix test_mm_dp_pd test
- Add support for clang-cl on Windows
- Fix performance regression after OPTNONE changes
- Allow optimization and use fesetround(), fegetround()
- CI: Bump dependency
- Allow to specify -DSSE2NEON_SUPPRESS_WARNINGS to avoid the #warning about optimization issues
- Add _MM_SHUFFLE2() macro for shuffle parameter for _mm_shuffle_pd()
- README.md: mention GDAL
- CI: Update Arm GNU Toolchain and use Ubuntu 24.04
- Fix undefined mm{malloc,free} with LLVM/MinGW

**Tested on:**
I've unfortunately could not test this PR on ARM because of no ARM hardware.