### PR TITLE
Run log cleaning at Background QoS

### DIFF
--- a/macosx/HBAppDelegate.m
+++ b/macosx/HBAppDelegate.m
@@ -136,7 +136,10 @@
         [self.mainController launchAction];
     }
 
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_LOW, 0), ^{
+    dispatch_queue_t logCleaningQueue = dispatch_queue_create_with_target("fr.handbrake.HandBrake.LogCleaningQueue",
+                                                                          DISPATCH_QUEUE_SERIAL,
+                                                                          dispatch_get_global_queue(QOS_CLASS_BACKGROUND, 0));
+    dispatch_async(logCleaningQueue, ^{
         // Remove encodes logs older than a month
         if ([ud boolForKey:HBClearOldLogs])
         {


### PR DESCRIPTION
This pull request moves the log cleaning that runs at startup onto a Background QoS dispatch queue, rather than one at Utility. Background is more appropriate for this task than Utility since log cleaning isn’t user-visible. I also added an explicit label to the queue in case it comes in handy during debugging.