### PR TITLE
Remove unused `-[HBQueueController visible]` property

### DIFF
--- a/macosx/HBQueueController.m
+++ b/macosx/HBQueueController.m
@@ -32,10 +32,6 @@
 @property (nonatomic) HBQueueInfoViewController *infoViewController;
 @property (nonatomic) HBQueueMultiSelectionViewController *multiSelectionViewController;
 
-/// Whether the window is visible or occluded,
-/// useful to avoid updating the UI needlessly
-@property (nonatomic) BOOL visible;
-
 @property (nonatomic) HBQueueToolbarDelegate *toolbarDelegate;
 
 @property (nonatomic) IBOutlet NSToolbarItem *ripToolbarItem;
@@ -287,11 +283,6 @@
 - (BOOL)validateToolbarItem:(NSToolbarItem *)theItem
 {
     return [self validateUserIterfaceItemForAction:theItem.action];
-}
-
-- (void)windowDidChangeOcclusionState:(NSNotification *)notification
-{
-    self.visible = self.window.occlusionState & NSWindowOcclusionStateVisible ? YES : NO;
 }
 
 #pragma mark - Private queue editing methods


### PR DESCRIPTION
From what I can tell this property is never read from, so keeping it around is pointless. Correct me if I’m wrong! Also, apologies if this sort of drive-by PR is frowned upon. Thanks! :D