### PR TITLE
Replace ad-hoc window restoration with native Resume

### DIFF
--- a/macosx/Base.lproj/MainWindow.xib
+++ b/macosx/Base.lproj/MainWindow.xib
@@ -31,7 +31,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="HandBrake" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="HBMainWindow" animationBehavior="default" toolbarStyle="expanded" id="21" userLabel="MainWindow">
+        <window identifier="MainWindow" title="HandBrake" allowsToolTipsWhenApplicationIsInactive="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="HBMainWindow" animationBehavior="default" toolbarStyle="expanded" id="21" userLabel="MainWindow">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/macosx/Base.lproj/OutputPanel.xib
+++ b/macosx/Base.lproj/OutputPanel.xib
@@ -14,7 +14,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Activity" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="OutputPanelFrame" animationBehavior="default" id="5" userLabel="OutputPanel">
+        <window identifier="OutputPanel" title="Activity" separatorStyle="line" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="OutputPanelFrame" animationBehavior="default" id="5" userLabel="OutputPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="74" y="449" width="378" height="439"/>

--- a/macosx/Base.lproj/Queue.xib
+++ b/macosx/Base.lproj/Queue.xib
@@ -13,7 +13,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Queue" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="QueueWindow" animationBehavior="default" id="2576" userLabel="Window">
+        <window identifier="Queue" title="Queue" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="QueueWindow" animationBehavior="default" id="2576" userLabel="Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenPrimary="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/macosx/HBAppDelegate.m
+++ b/macosx/HBAppDelegate.m
@@ -371,6 +371,14 @@
         window = appDelegate.queueController.window;
     } else if ([identifier isEqualToString:@"MainWindow"]) {
         window = appDelegate.mainController.window;
+
+        // Removing this call to `dispatch_async` results in the open panel
+        // being positioned in the bottom left corner since AppKit hasn’t had a
+        // chance yet to restore the main window’s position. Delaying the
+        // presentation of the open panel by one runloop turn fixes this.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [appDelegate.mainController launchAction];
+        });
     }
 
     completionHandler(window, nil);

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -129,6 +129,10 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 
 @property (nonatomic) HBControllerToolbarDelegate *toolbarDelegate;
 
+#pragma mark - Resume
+
+@property (nonatomic) BOOL openPanelVisible;
+
 @end
 
 @interface HBController (TouchBar) <NSTouchBarProvider, NSTouchBarDelegate>
@@ -1090,8 +1094,14 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     panel.accessoryView = self.openTitleView;
     panel.accessoryViewDisclosed = YES;
 
+    self.openPanelVisible = YES;
+    [self invalidateRestorableState];
+
     [panel beginSheetModalForWindow:self.window completionHandler: ^(NSInteger result)
     {
+        self.openPanelVisible = NO;
+        [self invalidateRestorableState];
+
         if (result == NSModalResponseOK)
          {
              BOOL recursive = [NSUserDefaults.standardUserDefaults boolForKey:HBRecursiveScan];
@@ -1773,6 +1783,22 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     // Retrieve the preset stored in the NSMenuItem
     HBPreset *preset = [sender representedObject];
     [self applyPreset:preset];
+}
+
+#pragma mark - Resume
+
+- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
+{
+    [super encodeRestorableStateWithCoder:coder];
+    [coder encodeBool:self.openPanelVisible forKey:@"openPanelVisible"];
+}
+
+- (void)restoreStateWithCoder:(NSCoder *)coder
+{
+    [super restoreStateWithCoder:coder];
+    if ([coder decodeBoolForKey:@"openPanelVisible"]) {
+        [self browseSources:self];
+    }
 }
 
 @end

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -129,10 +129,6 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 
 @property (nonatomic) HBControllerToolbarDelegate *toolbarDelegate;
 
-#pragma mark - Resume
-
-@property (nonatomic) BOOL openPanelVisible;
-
 @end
 
 @interface HBController (TouchBar) <NSTouchBarProvider, NSTouchBarDelegate>
@@ -1094,14 +1090,8 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     panel.accessoryView = self.openTitleView;
     panel.accessoryViewDisclosed = YES;
 
-    self.openPanelVisible = YES;
-    [self invalidateRestorableState];
-
     [panel beginSheetModalForWindow:self.window completionHandler: ^(NSInteger result)
     {
-        self.openPanelVisible = NO;
-        [self invalidateRestorableState];
-
         if (result == NSModalResponseOK)
          {
              BOOL recursive = [NSUserDefaults.standardUserDefaults boolForKey:HBRecursiveScan];
@@ -1783,22 +1773,6 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
     // Retrieve the preset stored in the NSMenuItem
     HBPreset *preset = [sender representedObject];
     [self applyPreset:preset];
-}
-
-#pragma mark - Resume
-
-- (void)encodeRestorableStateWithCoder:(NSCoder *)coder
-{
-    [super encodeRestorableStateWithCoder:coder];
-    [coder encodeBool:self.openPanelVisible forKey:@"openPanelVisible"];
-}
-
-- (void)restoreStateWithCoder:(NSCoder *)coder
-{
-    [super restoreStateWithCoder:coder];
-    if ([coder decodeBoolForKey:@"openPanelVisible"]) {
-        [self browseSources:self];
-    }
 }
 
 @end

--- a/macosx/HBQueue.m
+++ b/macosx/HBQueue.m
@@ -463,8 +463,14 @@ static void powerSourceCallback(void *context)
     NSIndexSet *indexes = [self.itemsInternal HB_indexesOfObjectsUsingBlock:^BOOL(id<HBQueueItem> item) {
         return (item.state == HBQueueItemStateCompleted || item.state == HBQueueItemStateCanceled);
     }];
+
+    if (indexes.count == 0)
+    {
+        return;
+    }
+
     [self removeItemsAtIndexes:indexes];
-    [NSNotificationCenter.defaultCenter postNotificationName:HBQueueDidRemoveItemNotification object:self userInfo:@{@"indexes": indexes}];
+    [NSNotificationCenter.defaultCenter postNotificationName:HBQueueDidRemoveItemNotification object:self userInfo:@{HBQueueItemNotificationIndexesKey: indexes}];
     [self save];
 }
 


### PR DESCRIPTION
Currently HandBrake on macOS will automatically re-open the output panel and queue window if they were open the last time the app was launched. These windows are not automatically re-opened if they were minimized.

This PR removes this custom window restoration logic, instead relying on the Resume feature built into AppKit. This means that minimized windows are restored correctly, the Quit and Keep Windows menu item works now, and logging out or restarting while keeping windows is now respected by HandBrake.

As per WWDC 2011 Session 119, I’ve removed any code that makes windows appear from `applicationDidFinishLaunching:`. Instead, “default” windows are created in `applicationOpenUntitledFile:`, which is called when the app has no open windows and is double-clicked in Finder or clicked in the Dock. This results in essentially the same behavior as before, except that HandBrake now plays nicely with Resume.

Supporting Resume also opens the door for supporting Automatic Termination in future.