### PR TITLE
Remove unsafe uses of setenv()

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -762,19 +762,6 @@ ghb_application_activate (GApplication *app)
     signal_user_data_t *ud = self->ud = g_malloc0(sizeof(signal_user_data_t));
     g_autoptr(GtkCssProvider) provider = gtk_css_provider_new();
 
-    if (ghb_dict_get_bool(ud->prefs, "CustomTmpEnable"))
-    {
-        const char *tmp_dir = ghb_dict_get_string(ud->prefs, "CustomTmpDir");
-        if (tmp_dir != NULL && tmp_dir[0] != 0)
-        {
-#if defined(_WIN32)
-           _putenv_s("TEMP", tmp_dir);
-#else
-            setenv("TEMP", tmp_dir, 1);
-#endif
-        }
-    }
-
     gtk_css_provider_load_from_resource(provider, "/fr/handbrake/ghb/ui/custom.css");
     color_scheme_set_async(APP_PREFERS_LIGHT);
 
@@ -859,6 +846,15 @@ ghb_application_activate (GApplication *app)
     ghb_prefs_load(ud);
     // Store user preferences into ud->prefs
     ghb_prefs_to_settings(ud->prefs);
+
+    if (ghb_dict_get_bool(ud->prefs, "CustomTmpEnable"))
+    {
+        const char *tmp_dir = ghb_dict_get_string(ud->prefs, "CustomTmpDir");
+        if (tmp_dir != NULL && tmp_dir[0] != 0)
+        {
+            hb_set_temporary_directory(tmp_dir);
+        }
+    }
 
     int logLevel = ghb_dict_get_int(ud->prefs, "LoggingLevel");
 

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -5908,6 +5908,7 @@ battery is charged.</property>
                                     <property name="hexpand">True</property>
                                     <property name="title" translatable="yes">Temp Directory</property>
                                     <property name="margin-start">21</property>
+                                    <signal name="notify::file" handler="temp_dir_changed_cb" swapped="no"/>
                                   </object>
                                 </child>
                                 <layout>

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -130,6 +130,7 @@ char * hb_strndup(const char * src, size_t len);
 /************************************************************************
  * File utils
  ***********************************************************************/
+void hb_set_temporary_directory(const char *tmp_dir);
 const char * hb_get_temporary_directory(void);
 char * hb_get_temporary_filename( char *fmt, ... );
 size_t hb_getline(char **lineptr, size_t *n, FILE *fp);


### PR DESCRIPTION
**Description of Change:**
Removes all uses of setenv() as it is [not thread-safe](https://blogs.gnome.org/mcatanzaro/2018/02/28/on-setenv-and-explosions/), replacing them with alternatives in order to prevent any potential issues. It also fixes the custom temp dir option which was broken before.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
