### PR TITLE
WinGUI: set NoResize to dark-mode messagebox by default

### DIFF
--- a/win/CS/HandBrakeWPF/Services/ErrorService.cs
+++ b/win/CS/HandBrakeWPF/Services/ErrorService.cs
@@ -115,6 +115,7 @@ namespace HandBrakeWPF.Services
                 {
                     window.Owner = Application.Current.MainWindow;
                     window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
+                    window.ResizeMode = ResizeMode.NoResize;
                 }
             
                 window.ShowDialog();


### PR DESCRIPTION
**Description of Change:**
set NoResize to dark-mode messagebox by default,make styles consistent with non-dark mode.


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
![non-dark-mode](https://github.com/user-attachments/assets/c811f99f-21d7-4936-95c6-9c76fb9ec7a4)

before (it can be resized):
![before](https://github.com/user-attachments/assets/e45b6299-7c8f-4ae9-8e61-6c3ba0ee780c)

after:
![after](https://github.com/user-attachments/assets/4fc52570-25c6-4ddd-ac75-1d2bf1977a24)

**Log file output (If relevant):**
