### PR TITLE
contrib: update SVT-AV1 to version 3.0.0

### DIFF
--- a/contrib/cpuinfo/module.defs
+++ b/contrib/cpuinfo/module.defs
@@ -1,0 +1,47 @@
+$(eval $(call import.MODULE.defs,CPUINFO,cpuinfo))
+$(eval $(call import.CONTRIB.defs,CPUINFO))
+
+CPUINFO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/cpuinfo-b73ae6c.tar.gz
+CPUINFO.FETCH.sha256  = 589c9241d361667ef9a2f2ee68846795949331f13ed7acc86f5d3cc4b856b6a8
+
+CPUINFO.build_dir             = build
+CPUINFO.CONFIGURE.exe         = cmake
+CPUINFO.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(CPUINFO.CONFIGURE.prefix)"
+CPUINFO.CONFIGURE.deps        =
+CPUINFO.CONFIGURE.static      =
+CPUINFO.CONFIGURE.shared      = -DCPUINFO_LIBRARY_TYPE=static -DCPUINFO_BUILD_TOOLS=OFF -DCPUINFO_BUILD_UNIT_TESTS=OFF \
+                                -DCPUINFO_BUILD_MOCK_TESTS=OFF -DCPUINFO_BUILD_BENCHMARKS=OFF
+CPUINFO.CONFIGURE.extra       = -DCMAKE_INSTALL_LIBDIR=lib
+
+ifneq (none,$(CPUINFO.GCC.g))
+    CPUINFO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Debug
+else
+    CPUINFO.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=Release
+endif
+
+ifeq (darwin,$(HOST.system))
+    CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
+    CPUINFO.CONFIGURE.extra += -DCMAKE_OSX_ARCHITECTURES=$(HOST.machine)
+endif
+
+ifeq (1,$(HOST.cross))
+    ifeq (mingw,$(HOST.system))
+        CPUINFO.CONFIGURE.extra += -DWIN32=ON -DMINGW=ON
+        CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_NAME=Windows
+        CPUINFO.CONFIGURE.extra += -DCMAKE_SYSTEM_PROCESSOR=$(HOST.machine)
+        CPUINFO.CONFIGURE.extra += -DCMAKE_C_COMPILER=$(CPUINFO.GCC.gcc)
+        CPUINFO.CONFIGURE.extra += -DCMAKE_CXX_COMPILER=$(CPUINFO.GCC.gxx)
+        CPUINFO.CONFIGURE.extra += -DCMAKE_RC_COMPILER=$(HOST.cross.prefix)windres
+        CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+    else ifeq ($(HOST.system),darwin)
+        CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+    else
+        CPUINFO.CONFIGURE.args.host  = -DCMAKE_SYSTEM_NAME="$(CPUINFO.CONFIGURE.host)"
+    endif
+    CPUINFO.CONFIGURE.args.build = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.build)"
+else
+    CPUINFO.CONFIGURE.args.host  = -DCMAKE_HOST_SYSTEM="$(CPUINFO.CONFIGURE.host)"
+endif
+
+## find CMakeLists.txt
+CPUINFO.CONFIGURE.extra += "$(call fn.ABSOLUTE,$(CPUINFO.EXTRACT.dir/))"

--- a/contrib/cpuinfo/module.rules
+++ b/contrib/cpuinfo/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,CPUINFO))
+$(eval $(call import.CONTRIB.rules,CPUINFO))

--- a/contrib/svt-av1/A02-memory-leak-fix.patch
+++ b/contrib/svt-av1/A02-memory-leak-fix.patch
@@ -1,0 +1,10 @@
+diff --git a/Source/Lib/Codec/global_me.c b/Source/Lib/Codec/global_me.c
+index f6adbf59..53002238 100644
+--- a/Source/Lib/Codec/global_me.c
++++ b/Source/Lib/Codec/global_me.c
+@@ -454,4 +454,5 @@ void compute_global_motion(PictureParentControlSet *pcs, int *frm_corners, int n
+     *best_wm = global_motion;
+ 
+     for (int m = 0; m < RANSAC_NUM_MOTIONS; m++) { free(params_by_motion[m].inliers); }
++    free(correspondences);
+ }

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,4 +1,6 @@
-$(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
+__deps__ := CPUINFO
+
+$(eval $(call import.MODULE.defs,SVT-AV1,svt-av1,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
 SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v3.0.0.tar.gz

--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v2.3.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v2.3.0/SVT-AV1-v2.3.0.tar.gz
-SVT-AV1.FETCH.sha256  = ebb0b484ef4a0dc281e94342a9f73ad458496f5d3457eca7465bec943910c6c3
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v3.0.0.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v3.0.0/SVT-AV1-v3.0.0.tar.gz
+SVT-AV1.FETCH.sha256  = 7c5c357388859d15ba2b9b139c24e17ad6b84b94ca9b281921a6f0b839e78ebc
 
 SVT-AV1.GCC.args.c_std =
 

--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -40,6 +40,7 @@ ghb_deps = [
   dependency('libavformat'),
   dependency('libavutil'),
   dependency('libbluray'),
+  dependency('libcpuinfo'),
   dependency('libswresample'),
   dependency('libswscale'),
   dependency('libturbojpeg'),

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -99,7 +99,7 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
     EbErrorType svt_ret;
     int ret;
 
-    svt_ret = svt_av1_enc_init_handle(&pv->svt_handle, pv, &pv->enc_params);
+    svt_ret = svt_av1_enc_init_handle(&pv->svt_handle, &pv->enc_params);
     if (svt_ret != EB_ErrorNone)
     {
         hb_error("encsvtav1: error initializing encoder handle");

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -26,7 +26,7 @@ static const int          hb_av1_level_values[] = {
 
 static const char * const hb_av1_svt_preset_names[] =
 {
-    "13", "12", "11", "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL
+    "10", "9", "8", "7", "6", "5", "4", "3", "2", "1", "0", "-1", NULL
 };
 
 static const char * const hb_av1_svt_tune_names[] =

--- a/libhb/handbrake/preset_builtin.h
+++ b/libhb/handbrake/preset_builtin.h
@@ -10540,7 +10540,7 @@ const char hb_builtin_presets_json[] =
 "            \"x264Option\": \"\",\n"
 "            \"x264UseAdvancedOptions\": false\n"
 "        },\n"
-"        \"VersionMajor\": 63,\n"
+"        \"VersionMajor\": 64,\n"
 "        \"VersionMicro\": 0,\n"
 "        \"VersionMinor\": 0\n"
 "    }\n"

--- a/libhb/module.defs
+++ b/libhb/module.defs
@@ -1,4 +1,4 @@
-__deps__ := BZIP2 LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS \
+__deps__ := BZIP2 CPUINFO LIBVPX SVT-AV1 FFMPEG FREETYPE LAME LIBASS \
     LIBDVDREAD LIBDVDNAV LIBICONV LIBTHEORA LIBVORBIS LIBOGG \
     X264 X265 ZLIB LIBBLURAY FDKAAC LIBVPL LIBGNURX JANSSON \
     HARFBUZZ LIBOPUS LIBSPEEX LIBDAV1D LIBJPEGTURBO LIBDOVI
@@ -116,7 +116,7 @@ LIBHB.dll = $(LIBHB.build/)hb.dll
 LIBHB.lib = $(LIBHB.build/)hb.lib
 
 LIBHB.dll.libs = $(foreach n, \
-        ass avformat avfilter avcodec avutil swresample dvdnav dvdread \
+        ass avformat avfilter avcodec avutil swresample cpuinfo dvdnav dvdread \
         freetype mp3lame swscale vpx theora vorbis vorbisenc ogg x264 \
         bluray jansson harfbuzz opus speex dav1d turbojpeg zimg SvtAv1Enc, \
         $(CONTRIB.build/)lib/lib$(n).a )

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -2974,6 +2974,23 @@ static void und_to_any(hb_value_array_t * list)
     }
 }
 
+static void import_av1_preset_settings_63_0_0(hb_value_t *preset)
+{
+    const char *enc = hb_dict_get_string(preset, "VideoEncoder");
+    int codec = hb_video_encoder_get_from_name(enc);
+
+    if (codec == HB_VCODEC_SVT_AV1 || codec == HB_VCODEC_SVT_AV1_10BIT)
+    {
+        const char *value = hb_dict_get_string(preset, "VideoPreset");
+        int video_preset = value ? atoi(value) : 0;
+
+        if (video_preset > 10)
+        {
+            hb_dict_set_string(preset, "VideoPreset", "10");
+        }
+    }
+}
+
 static void import_svt_av1_tune_61_0_0(hb_value_t *preset)
 {
     const char *enc = hb_dict_get_string(preset, "VideoEncoder");
@@ -3749,9 +3766,17 @@ static void import_video_0_0_0(hb_value_t *preset)
     }
 }
 
+
+static void import_63_0_0(hb_value_t *preset)
+{
+    import_av1_preset_settings_63_0_0(preset);
+}
+
 static void import_61_0_0(hb_value_t *preset)
 {
     import_svt_av1_tune_61_0_0(preset);
+
+    import_63_0_0(preset);
 }
 
 static void import_60_0_0(hb_value_t *preset)
@@ -3989,6 +4014,11 @@ static int preset_import(hb_value_t *preset, int major, int minor, int micro)
         else if (cmpVersion(major, minor, micro, 61, 0, 0) <= 0)
         {
             import_61_0_0(preset);
+            result = 1;
+        }
+        else if (cmpVersion(major, minor, micro, 63, 0, 0) <= 0)
+        {
+            import_63_0_0(preset);
             result = 1;
         }
 

--- a/macosx/HandBrake.xcodeproj/project.pbxproj
+++ b/macosx/HandBrake.xcodeproj/project.pbxproj
@@ -204,6 +204,8 @@
 		A93341EF243E15BE003A82C2 /* HandBrakeXPCService3.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A93341D5243E158B003A82C2 /* HandBrakeXPCService3.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A93341F0243E15BE003A82C2 /* HandBrakeXPCService4.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A93341E6243E158E003A82C2 /* HandBrakeXPCService4.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		A93341F1243E15CE003A82C2 /* HandBrakeXPCService.xpc in Copy Files */ = {isa = PBXBuildFile; fileRef = A964D39522FDE8EE00DFCAEA /* HandBrakeXPCService.xpc */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		A935B1662D68B68C00486A51 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A935B1652D68B67F00486A51 /* libcpuinfo.a */; };
+		A935B1672D68B6D300486A51 /* libcpuinfo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A935B1652D68B67F00486A51 /* libcpuinfo.a */; };
 		A939DD8B1FC8826A00135F2A /* HBPresetsMenuBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = A939DD8A1FC8826A00135F2A /* HBPresetsMenuBuilder.m */; };
 		A93CD3172C47CAFC00B11335 /* HBTitleSelectionRange.m in Sources */ = {isa = PBXBuildFile; fileRef = A93CD3162C47CAFC00B11335 /* HBTitleSelectionRange.m */; };
 		A93E0ED31972957000FD67FB /* HBVideoController.m in Sources */ = {isa = PBXBuildFile; fileRef = A93E0ED11972957000FD67FB /* HBVideoController.m */; };
@@ -615,6 +617,7 @@
 		A93341C4243E1583003A82C2 /* HandBrakeXPCService2.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService2.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		A93341D5243E158B003A82C2 /* HandBrakeXPCService3.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService3.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
 		A93341E6243E158E003A82C2 /* HandBrakeXPCService4.xpc */ = {isa = PBXFileReference; explicitFileType = "wrapper.xpc-service"; includeInIndex = 0; path = HandBrakeXPCService4.xpc; sourceTree = BUILT_PRODUCTS_DIR; };
+		A935B1652D68B67F00486A51 /* libcpuinfo.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libcpuinfo.a; path = external/contrib/lib/libcpuinfo.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		A939DD891FC8826A00135F2A /* HBPresetsMenuBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = HBPresetsMenuBuilder.h; sourceTree = "<group>"; };
 		A939DD8A1FC8826A00135F2A /* HBPresetsMenuBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = HBPresetsMenuBuilder.m; sourceTree = "<group>"; };
 		A93B0DF61C804CF50051A3FA /* NSDictionary+HBAdditions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+HBAdditions.h"; sourceTree = "<group>"; };
@@ -1274,6 +1277,7 @@
 				A9AB9AA821181CC700BB3C7E /* CoreVideo.framework in Frameworks */,
 				A9AB9AA621181CA900BB3C7E /* VideoToolbox.framework in Frameworks */,
 				A9ABD1A91E2A0F8200EC8B65 /* CoreGraphics.framework in Frameworks */,
+				A935B1672D68B6D300486A51 /* libcpuinfo.a in Frameworks */,
 				A9ABD1A71E2A0F7500EC8B65 /* CoreText.framework in Frameworks */,
 				273F203014ADB9790021BE6D /* AudioToolbox.framework in Frameworks */,
 				273F203314ADB9F00021BE6D /* CoreServices.framework in Frameworks */,
@@ -1377,6 +1381,7 @@
 				A91CE2D01C7DABCE0068F46F /* libbz2.tbd in Frameworks */,
 				1CBC683520BE014800A26CC2 /* liblzma.a in Frameworks */,
 				1C53DE8D20BD598D006BBCA8 /* libspeex.a in Frameworks */,
+				A935B1662D68B68C00486A51 /* libcpuinfo.a in Frameworks */,
 				1C0695AF20BD193D001543DA /* libswresample.a in Frameworks */,
 				A900E6BD1D7B1B5A00CB6C0A /* libopus.a in Frameworks */,
 				A99E13392833B97A0006D720 /* libSvtAv1Enc.a in Frameworks */,
@@ -1421,7 +1426,6 @@
 		271BA4C714B1236D00BC1D2C /* Static Libraries */ = {
 			isa = PBXGroup;
 			children = (
-				A9E34AD4297871FE00C5DD82 /* libdovi.a */,
 				1CDCF0C1241F28D400FB62C6 /* libturbojpeg.a */,
 				1C280BF320BD58DD00D5ECC2 /* libspeex.a */,
 				1CBC683320BE014800A26CC2 /* liblzma.a */,
@@ -1450,6 +1454,7 @@
 				A9E165511C523016003EF30E /* libavfilter.a */,
 				1C15C82B1CD7722500368223 /* libharfbuzz.a */,
 				A9935867256C349B00A6875E /* libzimg.a */,
+				A935B1652D68B67F00486A51 /* libcpuinfo.a */,
 				A99E13372833B97A0006D720 /* libSvtAv1Enc.a */,
 			);
 			name = "Static Libraries";
@@ -1600,6 +1605,7 @@
 			isa = PBXGroup;
 			children = (
 				277EFE9217ED799E001D4A6A /* libfdk-aac.a */,
+				A9E34AD4297871FE00C5DD82 /* libdovi.a */,
 				22CC9E74191EBEA500C69D81 /* libx265.a */,
 			);
 			name = "Static Libraries (optional)";

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -49,6 +49,7 @@ ifeq (1,$(FEATURE.x265))
 endif
 
 MODULES += contrib/libdav1d
+MODULES += contrib/cpuinfo
 MODULES += contrib/svt-av1
 MODULES += contrib/zimg
 MODULES += contrib/ffmpeg

--- a/preset/preset_builtin.list
+++ b/preset/preset_builtin.list
@@ -1,6 +1,6 @@
 <resources>
     <section name="PresetTemplate">
-        <integer name="VersionMajor" value="63" />
+        <integer name="VersionMajor" value="64" />
         <integer name="VersionMinor" value="0" />
         <integer name="VersionMicro" value="0" />
         <json name="Preset" file="preset_template.json" />

--- a/test/module.defs
+++ b/test/module.defs
@@ -16,7 +16,7 @@ TEST.GCC.L = $(CONTRIB.build/)lib
 
 TEST.libs = $(LIBHB.a)
 
-TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswresample dvdnav \
+TEST.pkgconfig_libs = libass libavformat libavfilter libavcodec libavutil libswresample libcpuinfo dvdnav \
 	dvdread libswscale theoraenc theoradec vorbis vorbisenc ogg x264 libbluray \
 	jansson libturbojpeg SvtAv1Enc
 


### PR DESCRIPTION
> ## [3.0.0] - 2025-2-18
> 
> API updates
> - Refreshed API cleaning up unused fields, use stdbool type and cleanup redundant parameter in `svt_av1_enc_init_handle`
> - Repositioned the presets and removed one preset resulting in a max preset of M10 in the current version
> - Added temporal layer and averageQP fields in output picture structure, along with an option to specify a QP offset for the startup gop
> - The API changes are not backwards compatible, more details about the changes can be found in issue 2217
> 
> Encoder
> - Improved mid and high quality presets quality vs speed tradeoffs for fast-decode 2 mode:
> -  ~15-25% speedup for M3-M10 at the same quality levels - (!2376 and !2343)
> -  ~1% BD-rate improvement for presets M0-M2 - (!2376 and !2343)
> - Repositioned the `fast-decode 1` mode to produce ~10% decoder cycle reduction vs `fast-decode 0` while reducing the BD-rate loss to ~1% (!2376)
> - Further Arm Neon and SVE2 optimizations that improve high bitdepth encoding by an average of 10-25% for 480p-1080p resolutions beyond the architecture-agnostic algorithmic improvements since v2.3.0
> - Ported several features from SVT-AV1-SPY fork to further improve the perceptual quality of `tune 0` mode
> - Added an `avif` mode to reduce resource utilization when encoding still images
> 
> Cleanup Build and bug fixes and documentation
> - third_party: Removed vendored cpuinfo, will attempt to use one provided by the system. For those without cpuinfo, it will be pulled and compiled into the library, similar to before
> - Improved the unit test coverage for Arm Neon and SVE2 code
> - Updated documentation

Plus a memory leak fix. We might need to add cpuinfo as a dependency.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
