### PR TITLE
contrib: update HarfBuzz to 10.4.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.2.0.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.2.0/harfbuzz-10.2.0.tar.xz
-HARFBUZZ.FETCH.sha256  = 620e3468faec2ea8685d32c46a58469b850ef63040b3565cde05959825b48227
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.3.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.3.0/harfbuzz-10.3.0.tar.xz
+HARFBUZZ.FETCH.sha256  = cd63fc3cbae32622588e46e0670fabf78ee6cff44a6348ca7f037dae9a32f9ea
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake

--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.3.0.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.3.0/harfbuzz-10.3.0.tar.xz
-HARFBUZZ.FETCH.sha256  = cd63fc3cbae32622588e46e0670fabf78ee6cff44a6348ca7f037dae9a32f9ea
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-10.4.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/10.4.0/harfbuzz-10.4.0.tar.xz
+HARFBUZZ.FETCH.sha256  = 480b6d25014169300669aa1fc39fb356c142d5028324ea52b3a27648b9beaad8
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 10.4.0:**

What's Changed
- Vastly improved “AAT” shaping performance. LucidaGrande benchmark-shape before: 14.6ms after: 5.9ms.
- Improved OpenType shaping performance (kerning / ligature), at the expense of ~1kb per face allocated cache memory. Roboto-Regular benchmark-shape before: 10.3ms after: 9.4ms.
- Improved “COLRv1” benchmark-font paint performance. Before: 7.85ms after 4.85ms.
- Don’t apply glyph substitutions in “morx” table of a font with known broken “morx” table (AALMAGHRIBI.ttf font).
- Update IANA and OT language registries.
- Various documentation updates.
- Various build improvements, and test speed-ups.
- The “hb_face_reference_blob()” API now works for faces created with “hb_face_create_for_tables()” if the face sets “get_table_tags” callback. This constructs a new face blob from individual table blobs.
- Various fixes to how “trak” table is handled to bring it closer to Core Text behaviour. Particularly, the tracking values for sizes not explicitly set in the table are now properly interpolated, and the tracking is applied to glyph advances when they are returned by ot-font functions, instead of applying them during shaping. The “trak” pseudo OpenType feature that could be used to disable “trak” table application have been dropped.
- Core Text font functions now support non-BMP code points.
- The drawing algorithm used by hb-draw for “glyf” table now match the algorithm used by FreeType and Core Text.
- The “hb_coretext_font_create()” API now copy font variations from Core Text font to the created HarfBuzz font.
- Add an API to get the feature tags enabled on a given shape-plan after executing it, which can be used to applications to show in the UI what features are applied by default (which can vary based on the font, the script, the language, and the direction set on the buffer).
- Add APIs to created HarfBuzz font from DirectWrite font, and copy the font variations.
- New API:
  +hb_directwrite_font_create()
  +hb_directwrite_font_get_dw_font() 
  +hb_ot_shape_plan_get_feature_tags()
  +hb_directwrite_face_get_dw_font_face()
  +hb_ft_font_get_ft_face()
- Drawing glyphs using hb-draw API now avoids any “malloc” calls, which improves drawing performance by 10+%.
- Add support new “GVAR” table fonts with more than 65535 glyphs. Support is currently behind a compilation flag and is disabled by default.
- Some hb-directwrite and hb-ft APIs got renamed with more clear names and the old names are deprecated.
- Various build and fuzzing fixes.
- Deprecated API:
  +hb_directwrite_face_get_font_face()
  +hb_ft_font_get_face()

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux