### PR TITLE
hwaccel: enable av1 and vp9 decoder support

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -195,8 +195,12 @@ ifeq (1,$(FEATURE.mf))
 FFMPEG.CONFIGURE.extra += \
       --enable-hwaccel=h264_d3d11va \
       --enable-hwaccel=hevc_d3d11va \
+      --enable-hwaccel=av1_d3d11va \
+      --enable-hwaccel=vp9_d3d11va \
       --enable-hwaccel=h264_d3d11va2 \
       --enable-hwaccel=hevc_d3d11va2 \
+      --enable-hwaccel=av1_d3d11va2 \
+      --enable-hwaccel=vp9_d3d11va2 \
       --enable-encoder=h264_mf \
       --enable-encoder=hevc_mf \
       --enable-encoder=av1_mf

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1934,7 +1934,11 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
     }
     else
 #endif
+    if (w->hw_device_ctx && w->codec_param == AV_CODEC_ID_AV1)
     {
+        pv->codec = avcodec_find_decoder_by_name("av1");
+    }
+    else {
         pv->codec = avcodec_find_decoder(w->codec_param);
     }
     if ( pv->codec == NULL )

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -22,7 +22,16 @@ enum AVHWDeviceType hb_hwaccel_available(int codec_id, const char *hwdevice_name
         return 0;
     }
 
-    const AVCodec *codec = avcodec_find_decoder(codec_id);
+    const AVCodec *codec;
+    if (codec_id == AV_CODEC_ID_AV1)
+    {
+        codec = avcodec_find_decoder_by_name("av1");
+    }
+    else
+    {
+        codec = avcodec_find_decoder(codec_id);
+    }
+
     enum AVHWDeviceType hw_type = av_hwdevice_find_type_by_name(hwdevice_name);
 
     if (hw_type != AV_HWDEVICE_TYPE_NONE)
@@ -75,7 +84,15 @@ int hb_hwaccel_hw_ctx_init(int codec_id, int hw_decode, void **hw_device_ctx)
     enum AVPixelFormat pix_fmt = AV_PIX_FMT_NONE;
     int err = 0;
 
-    const AVCodec *codec = avcodec_find_decoder(codec_id);
+    const AVCodec *codec;
+    if (codec_id == AV_CODEC_ID_AV1)
+    {
+        codec = avcodec_find_decoder_by_name("av1");
+    }
+    else
+    {
+        codec = avcodec_find_decoder(codec_id);
+    }
 
     if (hw_decode & HB_DECODE_SUPPORT_VIDEOTOOLBOX)
     {


### PR DESCRIPTION
**Description of Change:**
Enables AV1 and VP9 d3d11va hwaccel decoding for Windows ARM64 devices.

Since AV1 decoding defaults to libdav1d decoder, added a check to use `av1` decoder from FFmpeg when hwaccel is enabled. Should ideally fix #6339 

![image](https://github.com/user-attachments/assets/3dec62f7-af90-4657-accf-a574ddb74801)


**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
