### PR TITLE
WinGUI: fix darkmode resize bug

### DIFF
--- a/win/CS/HandBrakeWPF/Controls/MessageBoxWindow.xaml.cs
+++ b/win/CS/HandBrakeWPF/Controls/MessageBoxWindow.xaml.cs
@@ -15,6 +15,7 @@ namespace HandBrakeWPF.Controls
         public MessageBoxWindow()
         {
             InitializeComponent();
+            this.ResizeMode = ResizeMode.NoResize;
         }
 
         protected override void OnSourceInitialized(EventArgs e)

--- a/win/CS/HandBrakeWPF/Services/ErrorService.cs
+++ b/win/CS/HandBrakeWPF/Services/ErrorService.cs
@@ -115,7 +115,6 @@ namespace HandBrakeWPF.Services
                 {
                     window.Owner = Application.Current.MainWindow;
                     window.WindowStartupLocation = WindowStartupLocation.CenterOwner;
-                    window.ResizeMode = ResizeMode.NoResize;
                 }
             
                 window.ShowDialog();


### PR DESCRIPTION
**Description of Change:**
I made a mistake where the `NoResize` option was not enabled for the Queue Recovery dialog because the main window was not active. To resolve this, I added the necessary NoResize setting directly in `MessageBoxWindow.xaml.cs` to ensure the dialog cannot be resized, regardless of the main window's state.



**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**
![image](https://github.com/user-attachments/assets/b6394b66-e7e0-4dcc-a8c9-04d70a9be0b7)
![image](https://github.com/user-attachments/assets/47c7ff88-74cd-4234-ab3a-7aca40d6339a)


**Log file output (If relevant):**
