### PR TITLE
WinGui: Make debug-menu and activity-log text-translatable

### DIFF
--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -8324,5 +8324,59 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("Yes", resourceCulture);
             }
         }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Choose Log file in activity log.
+        /// </summary>
+        public static string LogView_ChooseLogFile {
+            get {
+                return ResourceManager.GetString("LogView_ChooseLogFile", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to autoscroll ScanLog.
+        /// </summary>
+        public static string LogView_AutoScrolling {
+            get {
+                return ResourceManager.GetString("LogView_AutoScrolling", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to Debug menu.
+        /// </summary>
+        public static string MainView_DebugMenu {
+            get {
+                return ResourceManager.GetString("MainView_DebugMenu", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to export debug data.
+        /// </summary>
+        public static string MainView_DebugExportData {
+            get {
+                return ResourceManager.GetString("MainView_DebugExportData", resourceCulture);
+            }
+        }
+		
+		/// <summary>
+        ///   Looks up a localized string similar to import debug data.
+        /// </summary>
+        public static string MainView_DebugImportData {
+            get {
+                return ResourceManager.GetString("MainView_DebugImportData", resourceCulture);
+            }
+        }
+        
+		/// <summary>
+        ///   Looks up a localized string similar to Add to Queue - QualitySweep.
+        /// </summary>
+        public static string MainView_DebugQualitySweep {
+            get {
+                return ResourceManager.GetString("MainView_DebugQualitySweep", resourceCulture);
+            }
+        }
     }
 }

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2944,4 +2944,22 @@ To allow multiple simultaneous encodes, turn on "Process Isolation" in Tools Men
   <data name="MetaData_Add" xml:space="preserve">
     <value>Add Row</value>
   </data>
+ <data name="MainView_DebugMenu" xml:space="preserve">
+    <value>Debug Menu</value>
+  </data>
+  <data name="MainView_DebugExportData" xml:space="preserve">
+    <value>Export debug file (JSON)</value>
+  </data>
+  <data name="MainView_DebugImportData" xml:space="preserve">
+    <value>Import debug file (JSON)</value>
+  </data>
+  <data name="MainView_DebugQualitySweep" xml:space="preserve">
+    <value>Add to Queue - Quality Sweep</value>
+  </data>
+  <data name="LogView_ChooseLogFile" xml:space="preserve">
+    <value>Choose log file :</value>
+  </data>
+  <data name="LogView_AutoScrolling" xml:space="preserve">
+    <value>Auto Scroll</value>
+  </data>
 </root>

--- a/win/CS/HandBrakeWPF/Views/LogView.xaml
+++ b/win/CS/HandBrakeWPF/Views/LogView.xaml
@@ -30,7 +30,7 @@
                      >
 
                 <StackPanel Orientation="Horizontal">
-                    <TextBlock Text="Choose Log File: " Margin="5,0,5,0"></TextBlock>
+                    <TextBlock Text="{x:Static Properties:Resources.LogView_ChooseLogFile}" Margin="5,0,5,0"></TextBlock>
                     <ComboBox ItemsSource="{Binding LogFiles}" SelectedItem="{Binding SelectedLogFile}" DisplayMemberPath="FileDisplayName" Width="250" MaxWidth="300" />
                 </StackPanel>
 
@@ -66,7 +66,7 @@
                             </MenuItem.Icon>
                         </MenuItem>
                         <Separator />
-                        <MenuItem Header="Auto Scroll" IsCheckable="True" IsChecked="True" x:Name="AutoScroll" />
+                        <MenuItem Header="{x:Static Properties:Resources.LogView_AutoScrolling}" IsCheckable="True" IsChecked="True" x:Name="AutoScroll" />
                         
                     </ContextMenu>
                 </TextBox.ContextMenu>

--- a/win/CS/HandBrakeWPF/Views/MainView.xaml
+++ b/win/CS/HandBrakeWPF/Views/MainView.xaml
@@ -158,11 +158,11 @@
                     <MenuItem Header="{x:Static Properties:Resources.MainView_About}" Command="{Binding RelayCommand}" CommandParameter="OpenAboutApplication" />
                 </MenuItem>
 
-                <MenuItem Header="Debug" Visibility="{Binding IsNightly, Converter={StaticResource boolToVisConverter}}">
-                    <MenuItem Header="Export Scan Data" Command="{Binding RelayCommand}" CommandParameter="ExportSourceData" />
-                    <MenuItem Header="Import Scan Data" Command="{Binding RelayCommand}" CommandParameter="ImportSourceData" />
+                <MenuItem Header="{x:Static Properties:Resources.MainView_DebugMenu}" Visibility="{Binding IsNightly, Converter={StaticResource boolToVisConverter}}">
+                    <MenuItem Header="{x:Static Properties:Resources.MainView_DebugExportData}" Command="{Binding RelayCommand}" CommandParameter="ExportSourceData" />
+                    <MenuItem Header="{x:Static Properties:Resources.MainView_DebugImportData}" Command="{Binding RelayCommand}" CommandParameter="ImportSourceData" />
                     <Separator/>
-                    <MenuItem Header="Add to Queue - Quality Sweep" Command="{Binding AddToQueueQualitySweepCommand}" />
+                    <MenuItem Header="{x:Static Properties:Resources.MainView_DebugQualitySweep}" Command="{Binding AddToQueueQualitySweepCommand}" />
                 </MenuItem>
             </Menu>
 


### PR DESCRIPTION
Make Debug menu and "Choose log file ." + "Auto Scroll" in activity log text-translatable:
![grafik](https://github.com/user-attachments/assets/2dce2b88-0c2e-4f8d-9953-77c3c6097e24)

![grafik](https://github.com/user-attachments/assets/a9cecf82-f156-47df-85b8-7c6b40b7dc2d)
