### PR TITLE
Fix incorrect value written in RpuDataNlq

### DIFF
--- a/contrib/libdovi/A01-RpuDataNlq.patch
+++ b/contrib/libdovi/A01-RpuDataNlq.patch
@@ -1,0 +1,57 @@
+From fd624d6b1bda6b6f2ccb30ca960439dbe0375b7f Mon Sep 17 00:00:00 2001
+From: quietvoid <tcChlisop0@gmail.com>
+Date: Tue, 18 Mar 2025 18:30:13 -0400
+Subject: [PATCH] Fix incorrect value written in RpuDataNlq
+
+Bug present since #1
+---
+ dolby_vision/src/rpu/rpu_data_nlq.rs | 32 +++++++++++++++++++++++++++-
+ 1 file changed, 31 insertions(+), 1 deletion(-)
+
+diff --git a/dolby_vision/src/rpu/rpu_data_nlq.rs b/dolby_vision/src/rpu/rpu_data_nlq.rs
+index bfc1d4c..5b63f93 100644
+--- a/dolby_vision/src/rpu/rpu_data_nlq.rs
++++ b/dolby_vision/src/rpu/rpu_data_nlq.rs
+@@ -137,7 +137,7 @@ impl RpuDataNlq {
+                     )?;
+ 
+                     if header.coefficient_data_type == 0 {
+-                        writer.write_ue(&self.linear_deadzone_slope_int[cmp])?;
++                        writer.write_ue(&self.linear_deadzone_threshold_int[cmp])?;
+                     }
+ 
+                     writer.write_n(
+@@ -207,3 +207,33 @@ impl Display for DoviELType {
+         f.write_str(self.as_str())
+     }
+ }
++
++#[cfg(test)]
++mod tests {
++    use anyhow::Result;
++
++    use crate::rpu::{dovi_rpu::DoviRpu, generate::GenerateConfig};
++
++    #[test]
++    fn write_linear_dz_threshold() -> Result<()> {
++        let mut rpu = DoviRpu::profile81_config(&GenerateConfig::default())?;
++        rpu.convert_with_mode(1)?;
++
++        {
++            let nlq = rpu
++                .rpu_data_mapping
++                .as_mut()
++                .and_then(|rpu_data_mapping| rpu_data_mapping.nlq.as_mut())
++                .unwrap();
++            nlq.linear_deadzone_threshold_int = [1, 2, 3];
++        }
++
++        let out = rpu.write_rpu()?;
++        let rpu = DoviRpu::parse(&out)?;
++
++        let nlq = rpu.rpu_data_mapping.and_then(|e| e.nlq).unwrap();
++        assert_eq!(nlq.linear_deadzone_threshold_int, [1, 2, 3]);
++
++        Ok(())
++    }
++}


### PR DESCRIPTION
This PR adds this libdovi commit https://github.com/quietvoid/dovi_tool/commit/fd624d6b1bda6b6f2ccb30ca960439dbe0375b7f
Patch can be removed after new libdovi release.