### PR TITLE
Update libiconv to 1.18.0

### DIFF
--- a/contrib/libiconv/module.defs
+++ b/contrib/libiconv/module.defs
@@ -1,18 +1,13 @@
 $(eval $(call import.MODULE.defs,LIBICONV,libiconv))
 $(eval $(call import.CONTRIB.defs,LIBICONV))
 
-LIBICONV.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/libiconv-1.17.tar.gz
-LIBICONV.FETCH.url    += https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.17.tar.gz
-LIBICONV.FETCH.sha256  = 8f74213b56238c85a50a5329f77e06198771e70dd9a739779f4c02f65d971313
+LIBICONV.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libiconv-1.18.tar.gz
+LIBICONV.FETCH.url    += https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz
+LIBICONV.FETCH.sha256  = 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e
 
 LIBICONV.GCC.args.extra += $(LIBICONV.GCC.args.O.$(LIBICONV.GCC.O))
 
 ifeq (1,$(HOST.cross))
-# this contrib will not build under MinGW with -std=gnu99
-    ifeq (mingw,$(HOST.system))
-        LIBICONV.GCC.args.c_std = -std=gnu89
-    endif
-
     ifeq (msys,$(BUILD.system))
         LIBICONV.CONFIGURE.args.build = --build=$(BUILD.machine)-unknown-linux-gnu
     endif

--- a/contrib/libiconv/module.defs
+++ b/contrib/libiconv/module.defs
@@ -3,7 +3,7 @@ $(eval $(call import.CONTRIB.defs,LIBICONV))
 
 LIBICONV.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libiconv-1.18.tar.gz
 LIBICONV.FETCH.url    += https://ftp.gnu.org/pub/gnu/libiconv/libiconv-1.18.tar.gz
-LIBICONV.FETCH.sha256  = 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e
+LIBICONV.FETCH.sha256  = 3b08f5f4f9b4eb82f151a7040bfd6fe6c6fb922efe4b1659c66ea933276965e8
 
 LIBICONV.GCC.args.extra += $(LIBICONV.GCC.args.O.$(LIBICONV.GCC.O))
 


### PR DESCRIPTION
`-std=gnu89` in MinGW no longer needed. 
Since version 1.15, it compiles normally with `-std=gnu99`.

Thanks to @marcosfrm
#6750

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux  (via Windows 10 WSL 2)
- [X] Ubuntu Linux  MinGW (via Windows 10 WSL 2)
