### PR TITLE
Check SVT-AV1 version to use the correct svt_av1_enc_init_handle

### DIFF
--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -99,7 +99,11 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
     EbErrorType svt_ret;
     int ret;
 
+#if SVT_AV1_CHECK_VERSION(3, 0, 0)
     svt_ret = svt_av1_enc_init_handle(&pv->svt_handle, &pv->enc_params);
+#else
+    svt_ret = svt_av1_enc_init_handle(&pv->svt_handle, pv, &pv->enc_params);
+#endif
     if (svt_ret != EB_ErrorNone)
     {
         hb_error("encsvtav1: error initializing encoder handle");


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

**Description of Change:**

Check SVT-AV1 version to use the correct svt_av1_enc_init_handle
    
For those who don't use the bundled SVT-AV1 but depends on system wide  version, it is interesting to be able to still build against SVT-AV1 2.x.x.
    
 With this simple check, we can handle this scenario gracefully.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Fedora Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
