### PR TITLE
Change frame range setting to accurately reflect user intention

### DIFF
--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -717,12 +717,12 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
         if (job->frame_to_start > 0)
         {
             hb_dict_set(range_dict, "Start",
-                        hb_value_int(job->frame_to_start + 1));
+                        hb_value_int(job->frame_to_start));
         }
         if (job->frame_to_stop > 0)
         {
             hb_dict_set(range_dict, "End",
-                        hb_value_int(job->frame_to_start + job->frame_to_stop));
+                        hb_value_int(job->frame_to_start + job->frame_to_stop + 1));
         }
     }
     else
@@ -1382,9 +1382,9 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
         else if (!strcasecmp(range_type, "frame"))
         {
             if (range_start > 0)
-                job->frame_to_start = range_start - 1;
+                job->frame_to_start = range_start;
             if (range_end > 0)
-                job->frame_to_stop = range_end - job->frame_to_start;
+                job->frame_to_stop = range_end - job->frame_to_start + 1;
         }
     }
 

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -722,7 +722,7 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
         if (job->frame_to_stop > 0)
         {
             hb_dict_set(range_dict, "End",
-                        hb_value_int(job->frame_to_start + job->frame_to_stop + 1));
+                        hb_value_int(job->frame_to_start + job->frame_to_stop - 1));
         }
     }
     else


### PR DESCRIPTION
**Description of Change:**

In relation to #6694 this PR will change the way the frame range tool selects the start and end frames and communicates the selection in the Activity Log. 

Using the example from #6694 if a user asks for frame 3 to frame 100, it makes sense that they want encoding to start at zero-indexed frame number 3, and end with frame 100, inclusive. This is implied from the fact that the GUI defaults the "Start" frame to the value 0, and also from the [documentation](https://handbrake.fr/docs/en/latest/advanced/point-to-point.html) of the feature discussing how frame 25 would be the first frame to exist _after_ the first second of 25fps video, along with the [CLI docs](https://handbrake.fr/docs/en/latest/cli/command-line-reference.html) `--starts-at` flag describing the frame as an offset. However, the current behavior causes the start and end frame to have an offset of minus 1.

```
  "Source": {
    "Angle": 1,
    "Range": {
      "Type": "frame",
      "Start": 3,
      "End": 100
    },
	
[..]

[11:57:56] job configuration:
[11:57:56]  * source
[11:57:56]    + R:\Digitalisierung\ScenalzyerLive\capture\DVi-12\DVi-12'20060514 06.47.43.avi
[11:57:56]    + title 1, frames 2 to 99
[11:57:56]    + container: avi
[11:57:56]    + data rate: 30427 kbps
```

After the change, using this same example, the output would be as such:
```
  "Source": {
    "Angle": 1,
    "Range": {
      "Type": "frame",
      "Start": 3,
      "End": 100
    },
	
[..]

[11:57:56] job configuration:
[11:57:56]  * source
[11:57:56]    + R:\Digitalisierung\ScenalzyerLive\capture\DVi-12\DVi-12'20060514 06.47.43.avi
[11:57:56]    + title 1, frames 3 to 100
[11:57:56]    + container: avi
[11:57:56]    + data rate: 30427 kbps
```

You might read this and say, "So what? Handbrake isn't a video editor," but I think this is still important to be consistent with the messaging a user receives. I'd love to hear others' thoughts on this.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

