### PR TITLE
Bugfix: include hwaccel.h in rotate.c to fix implicit declaration

### DIFF
--- a/libhb/rotate.c
+++ b/libhb/rotate.c
@@ -12,6 +12,7 @@
 
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
 #include "handbrake/qsv_common.h"
+#include "handbrake/hwaccel.h"
 #endif
 
 static int rotate_init(hb_filter_object_t * filter, hb_filter_init_t * init);


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**
This PR includes hwaccel.h in rotate.c, because line 187 calls the function `hb_hwaccel_is_full_hardware_pipeline_enabled`, see https://github.com/HandBrake/HandBrake/blob/f06ec695e3450ce53bc5a0b7bf79ac5991cf825a/libhb/rotate.c#L186

This function is declared in `handbrake/hwaccel.h`, which is supposed to be included:
https://github.com/HandBrake/HandBrake/blob/f06ec695e3450ce53bc5a0b7bf79ac5991cf825a/libhb/handbrake/hwaccel.h#L34

In older versions of GCC, this usage only throws a warning. [In GCC 14, this is now an error](https://gcc.gnu.org/gcc-14/porting_to.html) that breaks the build.

Simple problem, simple fix.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux

**Screenshots (If relevant):**
N/A

**Log file output (If relevant):**
Relevant error from previous build log:

```
  : /opt/toolchains/mingw-w64-x86_64/bin/x86_64-w64-mingw32-gcc -std=gnu99 -pipe -fmessage-length=0 -Wall -Wno-format-truncation -g0 -O3 -mfpmath=sse -msse2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -mno-ms-bitfields -D__LIBHB__ -DSYS_MINGW -DONEVPL_EXPERIMENTAL -DHAVE_THREADS=1 -DONEVPL_EXPERIMENTAL -DARCH_X86_64 -I./libhb/ -I./contrib/include -I./contrib/include/vpl -c ../libhb/rotate.c -o libhb/rotate.o
  : ../libhb/rotate.c: In function 'rotate_init':
  : ../libhb/rotate.c:186:9: error: implicit declaration of function 'hb_hwaccel_is_full_hardware_pipeline_enabled' [-Wimplicit-function-declaration]
  :   186 |     if (hb_hwaccel_is_full_hardware_pipeline_enabled(init->job) &&
  :       |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  : gmake: *** [../libhb/module.rules:12: libhb/rotate.o] Error 1
```