### PR TITLE
qsv: fix async-depth initialization

### DIFF
--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -215,6 +215,8 @@ typedef struct QSVFrame {
 
 #define HB_QSV_POOL_FFMPEG_SURFACE_SIZE (64)
 #define HB_QSV_POOL_SURFACE_SIZE (64)
+#define HB_QSV_FFMPEG_INITIAL_POOL_SIZE (0)
+#define HB_QSV_FFMPEG_EXTRA_HW_FRAMES (60)
 
 typedef struct HBQSVFramesContext {
     AVBufferRef *hw_frames_ctx;

--- a/libhb/handbrake/qsv_libav.h
+++ b/libhb/handbrake/qsv_libav.h
@@ -213,24 +213,11 @@ typedef struct QSVFrame {
     struct QSVFrame *next;
 } QSVFrame;
 
-#define HB_QSV_POOL_FFMPEG_SURFACE_SIZE (64)
-#define HB_QSV_POOL_SURFACE_SIZE (64)
 #define HB_QSV_FFMPEG_INITIAL_POOL_SIZE (0)
 #define HB_QSV_FFMPEG_EXTRA_HW_FRAMES (60)
 
 typedef struct HBQSVFramesContext {
     AVBufferRef *hw_frames_ctx;
-    //void *logctx;
-
-    /* The memory ids for the external frames.
-     * Refcounted, since we need one reference owned by the HBQSVFramesContext
-     * (i.e. by the encoder/decoder) and another one given to the MFX session
-     * from the frame allocator. */
-    AVBufferRef *mids_buf;
-    QSVMid *mids;
-    int  nb_mids;
-    int pool[HB_QSV_POOL_SURFACE_SIZE];
-    void *input_texture;
 } HBQSVFramesContext;
 
 typedef struct hb_qsv_list {

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -261,7 +261,7 @@ int hb_hwaccel_hwframes_ctx_init(AVCodecContext *ctx, hb_job_t *job)
     if (hb_hwaccel_is_full_hardware_pipeline_enabled(job) &&
             hb_qsv_decode_is_enabled(job))
     {
-        ctx->extra_hw_frames = 32;
+        ctx->extra_hw_frames = HB_QSV_FFMPEG_EXTRA_HW_FRAMES;
         ctx->sw_pix_fmt = job->input_pix_fmt;
     }
 #endif
@@ -280,11 +280,7 @@ int hb_hwaccel_hwframes_ctx_init(AVCodecContext *ctx, hb_job_t *job)
     {
         // Use input pix format for decoder and filters frame pools, output frame pools are created by FFmpeg
         frames_ctx->sw_format = job->input_pix_fmt;
-        frames_ctx->initial_pool_size = HB_QSV_POOL_FFMPEG_SURFACE_SIZE;
-        if (ctx->extra_hw_frames >= 0)
-        {
-            frames_ctx->initial_pool_size += ctx->extra_hw_frames;
-        }
+        frames_ctx->initial_pool_size = HB_QSV_FFMPEG_INITIAL_POOL_SIZE;
 
         AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
         frames_hwctx->frame_type = MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET;

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3961,9 +3961,6 @@ void hb_qsv_uninit_enc(hb_job_t *job)
     }
     if (job->qsv.ctx && job->qsv.ctx->hb_dec_qsv_frames_ctx)
     {
-        if (job->qsv.ctx->hb_dec_qsv_frames_ctx->mids_buf)
-            av_buffer_unref(&job->qsv.ctx->hb_dec_qsv_frames_ctx->mids_buf);
-        job->qsv.ctx->hb_dec_qsv_frames_ctx->mids_buf = NULL;
         if (job->qsv.ctx->hb_dec_qsv_frames_ctx->hw_frames_ctx)
             av_buffer_unref(&job->qsv.ctx->hb_dec_qsv_frames_ctx->hw_frames_ctx);
         job->qsv.ctx->hb_dec_qsv_frames_ctx->hw_frames_ctx = NULL;
@@ -3972,9 +3969,6 @@ void hb_qsv_uninit_enc(hb_job_t *job)
     }
     if (job->qsv.ctx && job->qsv.ctx->hb_vpp_qsv_frames_ctx)
     {
-        if (job->qsv.ctx->hb_vpp_qsv_frames_ctx->mids_buf)
-            av_buffer_unref(&job->qsv.ctx->hb_vpp_qsv_frames_ctx->mids_buf);
-        job->qsv.ctx->hb_vpp_qsv_frames_ctx->mids_buf = NULL;
         if (job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx)
             av_buffer_unref(&job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx);
         job->qsv.ctx->hb_vpp_qsv_frames_ctx->hw_frames_ctx = NULL;


### PR DESCRIPTION
**Description of Change:**

Fix for `--encopts async-depth={N>=32}` on QSV in conjunction with `--enable-qsv-decoding` which causes a crash while encoding

Log of crash with `av_log_set_level( AV_LOG_VERBOSE )`:
```
[h264_qsv @ 000000001195f000] Failed to allocate a qsv/nv12 frame from a fixed pool of hardware frames.
[h264_qsv @ 000000001195f000] Consider setting extra_hw_frames to a larger value (currently set to 32, giving a pool size of 96).
[h264_qsv @ 000000001195f000] get_buffer() failed
```


For example following pipeline crashes before reaching 10%, showing decoder errors:
```
./HandBrakeCLI.exe -i ./bbb_sunflower_2160p_60fps_normal.mp4 -v=5 -o output.mp4 -e qsv_h264 --enable-qsv-decoding --encopts async-depth=32
```
```
Encoding: task 1 of 1, 5.05 % (69.56 fps, avg 74.31 fps, ETA 00h08m06s)
[16:20:03] reader: done. 1 scr changes
Encoding: task 1 of 1, 5.13 % (69.56 fps, avg 74.31 fps, ETA 00h08m06s)
[16:20:05] work: average encoding speed for job is 74.311569 fps
Encoding: task 1 of 1, 5.13 % (69.56 fps, avg 74.31 fps, ETA 00h08m06s)
[16:20:05] vfr: 1955 frames output, 0 dropped
[16:20:05] vfr: lost time: 0 (0 frames)
[16:20:05] vfr: gained time: 0 (0 frames) (0 not accounted for)
[16:20:05] mp3float-decoder done: 26425 frames, 0 decoder errors
[16:20:05] h264_qsv-decoder done: 1956 frames, 36110 decoder errors
[16:20:05] sync: got 1955 frames, 38073 expected
```

Additionally, PR removes unused code.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

Collaborative effort with @galinart
