### PR TITLE
decavcodec: Increase decoder thread count from (cpu_count/2 + 1) to (…

### DIFF
--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -84,8 +84,13 @@ int hb_avcodec_open(AVCodecContext *avctx, const AVCodec *codec,
     if ((thread_count == HB_FFMPEG_THREADS_AUTO || thread_count > 0) &&
         (codec->type == AVMEDIA_TYPE_VIDEO))
     {
+#if defined (__aarch64__) && defined(_WIN32)
+        avctx->thread_count = (thread_count == HB_FFMPEG_THREADS_AUTO) ?
+                               hb_get_cpu_count() + 1 : thread_count;
+#else
         avctx->thread_count = (thread_count == HB_FFMPEG_THREADS_AUTO) ?
                                hb_get_cpu_count() / 2 + 1 : thread_count;
+#endif
         avctx->thread_type = FF_THREAD_FRAME|FF_THREAD_SLICE;
     }
     else


### PR DESCRIPTION
Increase decoder thread count from (cpu_count/2 + 1) to (cpu_count + 1) for snapdragon devices
 
On profiling different modules of Handbrake in Snapdragon Xelite devices, idle times in encoder threads were seen, due to waiting on decoder threads. Increasing the decoder threads resulted in lesser idle times in encoder threads as well as higher performance in terms of FPS overall

Results:

VERY FAST 1080P PRESET
| Decoder | Encoder         | FPS ( Decoder Threads = CPU_COUNT/2 + 1) | FPS (DecoderThreads = CPU_COUNT + 1) |
| ------- | --------------- | ------------------------- | ----------------------- |
| h264    | x264\_10bit     | 98.12                     | 104.89                  |
|         | x265\_10bit     | 74.57                     | 78.02                   |
|         | svt\_av1\_10bit | 68.52                     | 70.84                   |
|         | mf\_h264        | 119.09                    | 151.61                  |
|         | mf\_h265        | 119.26                    | 151.82                  |
| hevc    | x264\_10bit     | 82.47                     | 96.62                   |
|         | x265\_10bit     | 66.91                     | 73.68                   |
|         | svt\_av1\_10bit | 62.37                     | 66.06                   |
|         | mf\_h264        | 91.94                     | 123.25                  |
|         | mf\_h265        | 92.43                     | 122.90                  |

VERY FAST 720P PRESET
| Decoder | Encoder         | FPS (Decoder Threads = CPU_COUNT/2 + 1) | FPS (Decoder Threads = CPU_COUNT + 1) |
| ------- | --------------- | ------------------------- | ----------------------- |
| h264    | x264\_10bit     | 110.99                    | 129.35                  |
|         | x265\_10bit     | 96.72                     | 107.45                  |
|         | svt\_av1\_10bit | 85.53                     | 93.36                   |
|         | mf\_h264        | 121.15                    | 155.73                  |
|         | mf\_h265        | 120.55                    | 155.56                  |
| hevc    | x264\_10bit     | 89.28                     | 111.86                  |
|         | x265\_10bit     | 82.02                     | 97.03                   |
|         | svt\_av1\_10bit | 73.93                     | 85.99                   |
|         | mf\_h264        | 94.34                     | 123.34                  |
|         | mf\_h265        | 94.29                     | 123.86                  |




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
