### PR TITLE
contrib: update HarfBuzz to 11.2.1

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.2.0.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.2.0/harfbuzz-11.2.0.tar.xz
-HARFBUZZ.FETCH.sha256  = 50f7d0a208367e606dbf6eecc5cfbecc01a47be6ee837ae7aff2787e24b09b45
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.2.1.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.2.1/harfbuzz-11.2.1.tar.xz
+HARFBUZZ.FETCH.sha256  = 093714c8548a285094685f0bdc999e202d666b59eeb3df2ff921ab68b8336a49
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 11.2.1:**

What's Changed:
- Various build improvements.
- Fix build with HB_NO_DRAW and HB_NO_PAINT
- Add an optional harfruzz shaper that uses HarfRuzz; an ongoing Rust port of HarfBuzz shaping. 
  This shaper is mainly used for testing the output of the Rust implementation.
- Fix regression that caused applying unsafe_to_break() to the whole buffer to be ignored.
- Update USE data files.
- Fix getting advances of out-of-rage glyph indices in DirectWrite font functions.


**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux