### PR TITLE
contrib: update libvpl to 2.15.0

### DIFF
--- a/contrib/libvpl/A00-cxx-MSVC.patch
+++ b/contrib/libvpl/A00-cxx-MSVC.patch
@@ -1,0 +1,13 @@
+diff --git a/libvpl/CMakeLists.txt b/libvpl/CMakeLists.txt
+--- a/libvpl/CMakeLists.txt	2025-04-18 17:44:33.000000000 +0200
++++ b/libvpl/CMakeLists.txt	2024-12-16 21:11:53.000000000 +0100
+@@ -190,6 +190,9 @@
+     # WIN32 in general
+     set(MINGW_LIBS "-lole32 -lgdi32 -luuid")
+   endif()
++  if(NOT MSVC)
++    set(CXX_LIB "-lstdc++")
++  endif()
+   set(VPL_PKGCONFIG_DEPENDENT_LIBS
+       "${DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${MINGW_LIBS} ${CXX_LIB}")
+   configure_file("pkgconfig/vpl.pc.in" "pkgconfig/vpl.pc" @ONLY)

--- a/contrib/libvpl/module.defs
+++ b/contrib/libvpl/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBVPL,libvpl))
 $(eval $(call import.CONTRIB.defs,LIBVPL))
 
-LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.14.0.tar.gz
-LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpl-2.14.0.tar.gz
-LIBVPL.FETCH.sha256    = 7c6bff1c1708d910032c2e6c44998ffff3f5fdbf06b00972bc48bf2dd9e5ac06
-LIBVPL.FETCH.basename  = libvpl-2.14.0.tar.gz
-LIBVPL.EXTRACT.tarbase = libvpl-2.14.0
+LIBVPL.FETCH.url       = https://github.com/intel/libvpl/archive/refs/tags/v2.15.0.tar.gz
+LIBVPL.FETCH.url      += https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpl-2.15.0.tar.gz
+LIBVPL.FETCH.sha256    = 7218c3b8206b123204c3827ce0cf7c008d5c693c1f58ab461958d05fe6f847b3
+LIBVPL.FETCH.basename  = libvpl-2.15.0.tar.gz
+LIBVPL.EXTRACT.tarbase = libvpl-2.15.0
 
 LIBVPL.build_dir             = build
 LIBVPL.CONFIGURE.exe         = cmake
@@ -15,8 +15,7 @@ LIBVPL.CONFIGURE.args.prefix = -DCMAKE_INSTALL_PREFIX="$(LIBVPL.CONFIGURE.prefix
 LIBVPL.CONFIGURE.deps        =
 LIBVPL.CONFIGURE.static      =
 LIBVPL.CONFIGURE.shared      = -DBUILD_SHARED_LIBS=OFF
-LIBVPL.CONFIGURE.extra       = -DBUILD_EXPERIMENTAL=ON -DBUILD_TOOLS=OFF -DBUILD_EXAMPLES=OFF
-
+LIBVPL.CONFIGURE.extra       = -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=OFF -DBUILD_EXPERIMENTAL=ON -DINSTALL_DEV=ON
 ifeq ($(GCC.O),$(filter $(GCC.O),size size-aggressive))
     LIBVPL.CONFIGURE.extra += -DCMAKE_BUILD_TYPE=MinSizeRel
 else


### PR DESCRIPTION
Intel® Video Processing Library (Intel® VPL) provides access to hardware accelerated video decode, encode, and processing capabilities on Intel® GPUs to support AI visual inference, media delivery, cloud gaming, and virtual desktop infrastructure use cases.
Added

    Intel® VPL API 2.15 support, including new property-based capabilities query
    interface, extended decoder and encoder capabilities reporting, and
    definitions for VVC Main 10 Still Picture profile and level 6.3.
    Explicit INSTALL_EXAMPLES build option to control installation of example
    source code and content

Changed

    Default Ubuntu build to 24.04
    Model demonstrated in interop example to a vehicle detection model

Fixed

    BUILD_EXAMPLES build option requiring INSTALL_DEV to have any effect

Removed

    Outdated Dockerfiles provided with examples

Known Issues

    vpl-infer unable to load model if built in debug mode

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux