### PR TITLE
contrib: update libjpeg-turbo to 3.1.1

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.0.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.0.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 35fec2e1ddfb05ecf6d93e50bc57c1e54bc81c16d611ddf6eff73fff266d8285
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.1.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.1.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 304165ae11e64ab752e9cfc07c37bfdc87abd0bfe4bc699e59f34036d9c84f72
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.1.1:**

Significant changes relative to 3.1.0:

Hardened the libjpeg API against hypothetical calling applications that may erroneously change the value of the data_precision field in jpeg_compress_struct or jpeg_decompress_struct after calling jpeg_start_compress() or jpeg_start_decompress().

Packaging Changes:

The macOS packages are now notarized, which eliminates a Gatekeeper warning with recent macOS releases. (Previously, installing libjpeg-turbo on recent macOS releases required overriding the warning in the Privacy & Security pane under System Settings.)
A Windows/Arm package is now provided.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux