### PR TITLE
Update zimg to snapshot-20250624

### DIFF
--- a/contrib/zimg/module.defs
+++ b/contrib/zimg/module.defs
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.defs,ZIMG,zimg))
 $(eval $(call import.CONTRIB.defs,ZIMG))
 
-ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zimg-snapshot-20250624.tar.gz
+ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/zimg-snapshot-20250624.tar.gz
 #ZIMG.FETCH.url    += https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.5.tar.gz
 ZIMG.FETCH.sha256  = 19a96cdc266466be58be86a9271bedb1f080bf4cc14f5ed58ac39dc5b970fd17
 ZIMG.EXTRACT.tarbase = zimg-snapshot-20250624

--- a/contrib/zimg/module.defs
+++ b/contrib/zimg/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,ZIMG,zimg))
 $(eval $(call import.CONTRIB.defs,ZIMG))
 
-ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zimg-3.0.5.tar.gz
-ZIMG.FETCH.url    += https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.5.tar.gz
-ZIMG.FETCH.sha256  = a9a0226bf85e0d83c41a8ebe4e3e690e1348682f6a2a7838f1b8cbff1b799bcf
-ZIMG.EXTRACT.tarbase = zimg-release-3.0.5
+ZIMG.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zimg-snapshot-20250624.tar.gz
+#ZIMG.FETCH.url    += https://github.com/sekrit-twc/zimg/archive/refs/tags/release-3.0.5.tar.gz
+ZIMG.FETCH.sha256  = 19a96cdc266466be58be86a9271bedb1f080bf4cc14f5ed58ac39dc5b970fd17
+ZIMG.EXTRACT.tarbase = zimg-snapshot-20250624
 
 ZIMG.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache configure; autoreconf -fiv;


### PR DESCRIPTION
Changed the old zimg release to a snapshot to get the latest changes and bugfixes, as discussed in #6805.

The attached zimg-snapshot-20250624 package was generated via:
git clone https://github.com/sekrit-twc/zimg.git
cd zimg
sh autogen.sh
git submodule init
git submodule update --init --recursive

Somebody would need to upload it to HandBrake-contribs.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

Attached zimg-snapshot-20250624 package:
[zimg-snapshot-20250624.tar.gz](https://github.com/user-attachments/files/20887524/zimg-snapshot-20250624.tar.gz)


