### PR TITLE
contrib: update HarfBuzz to 11.3.3

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.2.1.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.2.1/harfbuzz-11.2.1.tar.xz
-HARFBUZZ.FETCH.sha256  = 093714c8548a285094685f0bdc999e202d666b59eeb3df2ff921ab68b8336a49
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.3.3.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.3.3/harfbuzz-11.3.3.tar.xz
+HARFBUZZ.FETCH.sha256  = e1fbca6b32a91ae91ecd9eb2ca8d47a5bfe2b1cb2e54855ab7a0b464919ef358
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 11.3.3:**

What's Changed:
- Fix bug in vertical shaping of fonts without the vmtx table.
- Fix build with non-compliant C++11 compilers that don't recognize the "and" keyword.
- Speed up handling fonts with very large number of variations:
	Drawing by up to 40%.
	Calculating glyph extents by up to 15%.
	Getting horizontal glyph advances by up to 45%.
- Speed up getting horizontal and vertical glyph advances by up to 24%.
- Significantly speed up vertical text shaping.
- Various documentation improvements.
- Various build improvements.
- Various subsetting improvements.
- Various improvements to Rust font functions (fontations integration) and shaper (HarfRust integration).
- Rename harfruzz option and shaper to harfrust following upstream rename.
- Implement hb_face_reference_blob() for DirectWrite font functions.
- New API:
	+hb_font_get_glyph_origins_func_t
	+hb_font_get_glyph_h_origins_func_t
	+hb_font_get_glyph_v_origins_func_t
	+hb_font_funcs_set_glyph_h_origins_func()
	+hb_font_funcs_set_glyph_v_origins_func()
	+hb_font_get_glyph_h_origins()
	+hb_font_get_glyph_v_origins()

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux