### PR TITLE
filter: add scale_d3d11 support for MF encoders

### DIFF
--- a/contrib/ffmpeg/A23-fix-d3d11-static-pool-size-error.patch
+++ b/contrib/ffmpeg/A23-fix-d3d11-static-pool-size-error.patch
@@ -1,0 +1,74 @@
+diff --git a/libavutil/hwcontext_d3d11va.c b/libavutil/hwcontext_d3d11va.c
+index 9831f530c1..dac659ea9a 100644
+--- a/libavutil/hwcontext_d3d11va.c
++++ b/libavutil/hwcontext_d3d11va.c
+@@ -85,6 +85,9 @@ typedef struct D3D11VAFramesContext {
+     int nb_surfaces;
+     int nb_surfaces_used;
+ 
++    int max_retries;
++    int retries;
++
+     DXGI_FORMAT format;
+ 
+     ID3D11Texture2D *staging_texture;
+@@ -260,8 +263,10 @@ static AVBufferRef *d3d11va_pool_alloc(void *opaque, size_t size)
+     ID3D11Texture2D_GetDesc(hwctx->texture, &texDesc);
+ 
+     if (s->nb_surfaces_used >= texDesc.ArraySize) {
+-        av_log(ctx, AV_LOG_ERROR, "Static surface pool size exceeded.\n");
+-        return NULL;
++        if (s->retries >= s->max_retries) {
++            av_log(ctx, AV_LOG_ERROR, "Static surface pool size exceeded.\n");
++        }
++        return NULL;
+     }
+ 
+     ID3D11Texture2D_AddRef(hwctx->texture);
+@@ -343,20 +348,34 @@ static int d3d11va_frames_init(AVHWFramesContext *ctx)
+ static int d3d11va_get_buffer(AVHWFramesContext *ctx, AVFrame *frame)
+ {
+     AVD3D11FrameDescriptor *desc;
++    D3D11VAFramesContext       *s = ctx->hwctx;
++    s->retries = 0;
++    s->max_retries = 50;
+ 
+-    frame->buf[0] = av_buffer_pool_get(ctx->pool);
+-    if (!frame->buf[0])
+-        return AVERROR(ENOMEM);
+-
+-    desc = (AVD3D11FrameDescriptor *)frame->buf[0]->data;
+-
+-    frame->data[0] = (uint8_t *)desc->texture;
+-    frame->data[1] = (uint8_t *)desc->index;
+-    frame->format  = AV_PIX_FMT_D3D11;
+-    frame->width   = ctx->width;
+-    frame->height  = ctx->height;
++    /**
++     * Loop until a buffer becomes available from the pool.
++     * In a full hardware pipeline, all buffers may be temporarily in use by
++     * other modules (encoder/filter/decoder). Rather than immediately failing
++     * with ENOMEM, we wait for a buffer to be released back to the pool, which
++     * maintains pipeline flow and prevents unnecessary allocation failures
++     * during normal operation.
++     */
++    while (s->retries < s->max_retries) {
++        frame->buf[0] = av_buffer_pool_get(ctx->pool);
++        if (frame->buf[0]) {
++            desc = (AVD3D11FrameDescriptor *)frame->buf[0]->data;
++            frame->data[0] = (uint8_t *)desc->texture;
++            frame->data[1] = (uint8_t *)desc->index;
++            frame->format  = AV_PIX_FMT_D3D11;
++            frame->width   = ctx->width;
++            frame->height  = ctx->height;
++            return 0;
++        }
+ 
+-    return 0;
++        av_usleep(1000);
++    }
++ 
++    return AVERROR(ENOMEM);
+ }
+ 
+ static int d3d11va_transfer_get_formats(AVHWFramesContext *ctx,

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -208,6 +208,7 @@ FFMPEG.CONFIGURE.extra += \
       --enable-hwaccel=hevc_d3d11va2 \
       --enable-hwaccel=av1_d3d11va2 \
       --enable-hwaccel=vp9_d3d11va2 \
+      --enable-filter=scale_d3d11 \
       --enable-encoder=h264_mf \
       --enable-encoder=hevc_mf \
       --enable-encoder=av1_mf

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -132,6 +132,12 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
             hb_dict_set_string(avsettings, "format", av_get_pix_fmt_name(init->pix_fmt));
             hb_dict_set(avfilter, "scale_cuda", avsettings);
         }
+        else if (init->hw_pix_fmt == AV_PIX_FMT_D3D11)
+        {
+            hb_dict_set_int(avsettings, "width", width);
+            hb_dict_set_int(avsettings, "height", height);
+            hb_dict_set(avfilter, "scale_d3d11", avsettings);
+        }
         else if (hb_av_can_use_zscale(init->pix_fmt,
                                       init->geometry.width, init->geometry.height,
                                       width, height))

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1469,6 +1469,13 @@ int reinit_video_filters(hb_work_private_t * pv)
             hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
             hb_avfilter_append_dict(filters, "scale_cuda", settings);
         }
+        else if (pv->frame->hw_frames_ctx && pv->job->hw_pix_fmt == AV_PIX_FMT_D3D11)
+        {
+            hb_dict_set(settings, "width", hb_value_int(orig_width));
+            hb_dict_set(settings, "height", hb_value_int(orig_height));
+            hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
+            hb_avfilter_append_dict(filters, "scale_d3d11", settings);
+        }
         else if (hb_av_can_use_zscale(pv->frame->format,
                                       pv->frame->width, pv->frame->height,
                                       orig_width, orig_height))
@@ -1895,6 +1902,13 @@ static int decavcodecvInit( hb_work_object_t * w, hb_job_t * job )
             {
                 av_dict_set( &av_opts, "load_plugin", "hevc_hw", 0 );
             }
+        }
+#endif
+
+#if HB_PROJECT_FEATURE_MF
+        if (w->hw_accel && w->hw_accel->type == AV_HWDEVICE_TYPE_D3D11VA)
+        {
+           pv->context->extra_hw_frames = 30;
         }
 #endif
 

--- a/libhb/format.c
+++ b/libhb/format.c
@@ -65,6 +65,13 @@ static int format_init(hb_filter_object_t *filter, hb_filter_init_t *init)
         hb_dict_set(avfilter, "vpp_qsv", avsettings);
     }
     else
+#elif HB_PROJECT_FEATURE_MF
+    if (init->hw_pix_fmt == AV_PIX_FMT_D3D11)
+    {
+        hb_dict_set_string(avsettings, "format", format);
+        hb_dict_set(avfilter, "scale_d3d11", avsettings);
+    }
+    else
 #endif
     {
         if (init->hw_pix_fmt == AV_PIX_FMT_CUDA)

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -240,6 +240,7 @@ struct hb_encoder_s
 #define HB_HWACCEL_CAP_SCAN                 0x01
 #define HB_HWACCEL_CAP_ROTATE               0x02
 #define HB_HWACCEL_CAP_FORMAT_REQUIRED      0x04
+#define HB_HWACCEL_CAP_COLOR_RANGE          0x08
 
 
 struct hb_hwaccel_s

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -237,8 +237,10 @@ struct hb_encoder_s
 
 #ifdef __LIBHB__
 
-#define HB_HWACCEL_CAP_SCAN   0x1
-#define HB_HWACCEL_CAP_ROTATE 0x2
+#define HB_HWACCEL_CAP_SCAN                 0x01
+#define HB_HWACCEL_CAP_ROTATE               0x02
+#define HB_HWACCEL_CAP_FORMAT_REQUIRED      0x04
+
 
 struct hb_hwaccel_s
 {

--- a/libhb/handbrake/hwaccel.h
+++ b/libhb/handbrake/hwaccel.h
@@ -36,6 +36,6 @@ AVBufferRef *hb_hwaccel_init_hw_frames_ctx(AVBufferRef *hw_device_ctx,
 
 int hb_hwaccel_is_available(hb_hwaccel_t *hwaccel, int codec_id);
 int hb_hwaccel_can_use_full_hw_pipeline(hb_hwaccel_t *hwaccel, hb_list_t *list_filter,
-                                        int encoder, int rotation);
+                                        int encoder, int rotation, int color_range);
 
 #endif // HANDBRAKE_HWACCEL_COMMON_H

--- a/libhb/handbrake/mf_common.h
+++ b/libhb/handbrake/mf_common.h
@@ -34,5 +34,6 @@ int hb_mf_h264_available();
 int hb_mf_h265_available();
 int hb_mf_av1_available();
 int hb_check_mf_available();
+int hb_mf_are_filters_supported(hb_list_t *filters);
 
 #endif // HANDBRAKE_MF_COMMON_H

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -346,6 +346,22 @@ void hb_avfilter_combine( hb_list_t * list)
             }
             else
 #endif
+#if HB_PROJECT_FEATURE_MF
+            // Concat d3d11 settings as one scale_d3d11 filter to optimize pipeline
+            hb_dict_t * avfilter_settings_dict = hb_value_array_get(avfilter->settings, 0);
+            hb_dict_t * cur_settings_dict = hb_value_array_get(settings, 0);
+            if (cur_settings_dict && avfilter_settings_dict && hb_dict_get(avfilter_settings_dict, "scale_d3d11"))
+            {
+                hb_dict_t *avfilter_settings_dict_d3d11 = hb_dict_get(avfilter_settings_dict, "scale_d3d11");
+                hb_dict_t *cur_settings_dict_d3d11 = hb_dict_get(cur_settings_dict, "scale_d3d11");
+                if (avfilter_settings_dict_d3d11 && cur_settings_dict_d3d11)
+                {
+                    hb_dict_merge(avfilter_settings_dict_d3d11, cur_settings_dict_d3d11);
+                    
+                }
+            }
+            else
+#endif
             {
                 hb_value_array_concat(avfilter->settings, settings);
             }

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -157,11 +157,17 @@ static int is_rotation_supported(hb_hwaccel_t *hwaccel, int rotation)
     return rotation != HB_ROTATION_0 && (hwaccel->caps & HB_HWACCEL_CAP_ROTATE) == 0 ? 0 : 1;
 }
 
-int hb_hwaccel_can_use_full_hw_pipeline(hb_hwaccel_t *hwaccel, hb_list_t *list_filter, int encoder, int rotation)
+static int is_color_range_supported(hb_hwaccel_t *hwaccel, int color_range)
+{
+    return color_range != 0 && (hwaccel->caps & HB_HWACCEL_CAP_COLOR_RANGE) == 0 ? 0 : 1;
+}
+
+int hb_hwaccel_can_use_full_hw_pipeline(hb_hwaccel_t *hwaccel, hb_list_t *list_filter, int encoder, int rotation, int color_range)
 {
     return hwaccel != NULL &&
         hwaccel->can_filter(list_filter) &&
         is_rotation_supported(hwaccel, rotation) &&
+        is_color_range_supported(hwaccel, color_range) &&
         is_encoder_supported(hwaccel, encoder);
 }
 

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -304,5 +304,5 @@ hb_hwaccel_t hb_hwaccel_nvdec =
     .type       = AV_HWDEVICE_TYPE_CUDA,
     .hw_pix_fmt = AV_PIX_FMT_CUDA,
     .can_filter = hb_nvenc_are_filters_supported,
-    .caps       = HB_HWACCEL_CAP_SCAN
+    .caps       = HB_HWACCEL_CAP_SCAN | HB_HWACCEL_CAP_COLOR_RANGE
 };

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -539,5 +539,5 @@ hb_hwaccel_t hb_hwaccel_videotoolbox =
     .hw_pix_fmt = AV_PIX_FMT_VIDEOTOOLBOX,
     .can_filter = are_filters_supported,
     .upload     = copy_video_buffer_to_hw_video_buffer,
-    .caps       = HB_HWACCEL_CAP_SCAN | HB_HWACCEL_CAP_ROTATE
+    .caps       = HB_HWACCEL_CAP_SCAN | HB_HWACCEL_CAP_ROTATE | HB_HWACCEL_CAP_COLOR_RANGE
 };

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -3897,7 +3897,7 @@ hb_hwaccel_t hb_hwaccel_qsv =
     .hw_pix_fmt   = AV_PIX_FMT_QSV,
     .can_filter   = are_filters_supported,
     .find_decoder = find_decoder,
-    .caps         = HB_HWACCEL_CAP_ROTATE
+    .caps         = HB_HWACCEL_CAP_ROTATE | HB_HWACCEL_CAP_COLOR_RANGE
 };
 
 #else // HB_PROJECT_FEATURE_QSV

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1455,7 +1455,10 @@ static void sanitize_filter_list_post(hb_job_t *job)
     }
 #endif
 
-    if (hb_video_encoder_pix_fmt_is_supported(job->vcodec, job->input_pix_fmt, job->encoder_profile) == 0)
+    hb_hwaccel_t *hwaccel = job->hw_accel;
+
+    if (hb_video_encoder_pix_fmt_is_supported(job->vcodec, job->input_pix_fmt, job->encoder_profile) == 0 ||
+        (job->hw_pix_fmt != AV_PIX_FMT_NONE && hwaccel && (hwaccel->caps & HB_HWACCEL_CAP_FORMAT_REQUIRED)))
     {
         // Some encoders require a specific input pixel format
         // that could be different from the current pipeline format.

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1743,7 +1743,8 @@ static void do_job(hb_job_t *job)
         if (hb_hwaccel_can_use_full_hw_pipeline(hwaccel,
                                                 job->list_filter,
                                                 job->vcodec,
-                                                job->title->rotation))
+                                                job->title->rotation,
+                                                job->color_range != job->title->color_range))
         {
             job->hw_accel = hwaccel;
             job->hw_pix_fmt = hwaccel->hw_pix_fmt;


### PR DESCRIPTION
**Description of Change:**
Adds support for scale_d3d11 hardware scaling filter when using MediaFoundation encoders on Windows ARM64 devices

Patch A38 in contrib/ffmpeg fixes the static pool size exceeded error when using the full Hardware pipleine (#6523)




**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux