### PR TITLE
Fix issues with Flathub permissions

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -568,6 +568,7 @@ _ghb_idle_ui_init (signal_user_data_t *ud)
     }
 
     ghb_bind_dependencies();
+    ghb_check_send_to_available();
 
     return FALSE;
 }

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -88,5 +88,6 @@ void ghb_break_pts_duration(gint64 ptsDuration,
 void ghb_break_duration(gint64 duration, gint *hh, gint *mm, gint *ss);
 GtkFileFilter *ghb_add_file_filter(GtkFileChooser *chooser,
                                    const char *name, const char *id);
+void ghb_check_send_to_available (void);
 
 G_END_DECLS

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -13,7 +13,6 @@
         "--filesystem=xdg-run/gvfs",
         "--filesystem=xdg-run/gvfsd",
         "--talk-name=org.gtk.vfs.*",
-        "--talk-name=org.freedesktop.Flatpak",
         "--system-talk-name=org.freedesktop.login1",
         "--system-talk-name=org.freedesktop.UPower",
         "--env=PATH=/app/bin:/app/extensions/bin:/usr/bin",


### PR DESCRIPTION
**Description of Change:**

Removes --talk-name=org.freedesktop.Flatpak permission from the Flatpak manifest, as the Flathub guidelines don't allow it for security reasons. In addition, there's a fix to ensure that the user at least gets some warning if the permission is unavailable by disabling the Send To checkbox in the preferences, and logging a warning if a command is run.

In the next release I'll try to fix it to give a proper warning in the UI, but this should at least make it not look like the option doesn't work. Sorry for not spotting this sooner.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
- [x] Flatpak
