### PR TITLE
contrib: update HarfBuzz to 11.4.2

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.3.3.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.3.3/harfbuzz-11.3.3.tar.xz
-HARFBUZZ.FETCH.sha256  = e1fbca6b32a91ae91ecd9eb2ca8d47a5bfe2b1cb2e54855ab7a0b464919ef358
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.1.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.1/harfbuzz-11.4.1.tar.xz
+HARFBUZZ.FETCH.sha256  = 7aafab93115eb56cdc9a931ab7d19ff60d7f2937b599d140f17236f374e32698
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake

--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.1.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.1/harfbuzz-11.4.1.tar.xz
-HARFBUZZ.FETCH.sha256  = 7aafab93115eb56cdc9a931ab7d19ff60d7f2937b599d140f17236f374e32698
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.2.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.2/harfbuzz-11.4.2.tar.xz
+HARFBUZZ.FETCH.sha256  = 49ff7bd4a506486057f2918ecc856a249e3972f27ea49e3d2aa0f2afb59a57dd
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 11.4.2:**

What's Changed:
- Fix clang compiler warnings.
- General shaping and subsetting speedups.
- Various performance and memory usage improvements.
- Fix in Graphite shaping backend when glyph advances became negative.
- Subsetting improvements, pruning empty mark-attachment lookups.
- Don't use the macro name `_S`, which is reserved by system liberaries.
- Build fixes and speedup.
- Add a `kbts` shaping backend that calls into the `kb_text_shape` single-header shaping library. This is purely for testing and
  performance evaluation and we do NOT recommend using it for any other purposes.
- The `hb-shape` command line tool can now be built with the amalgamated `harfbuzz.cc` source.
- Fix regression in handling version 2 of `avar` table.
- Increase various buffer length limits for better handling of fonts that generate huge number of glyphs per codepoint (e.g. Noto Sans Duployan)
- Improvements to the `harfrust` shaper for more accurate testing.






**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux
