### PR TITLE
Fix for Vorbis passthrough checkbox not being applying when title changes

### DIFF
--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -514,7 +514,7 @@ ghb_preset_to_settings(GhbValue *settings, GhbValue *preset)
                     break;
                 case HB_ACODEC_VORBIS:
                 case HB_ACODEC_VORBIS_PASS:
-                    ghb_dict_set_bool(settings, "AudioAllowOPUSPass", 1);
+                    ghb_dict_set_bool(settings, "AudioAllowVORBISPass", 1);
                     break;
                 case HB_ACODEC_OPUS:
                 case HB_ACODEC_OPUS_PASS:

--- a/macosx/HBAudioDefaults.m
+++ b/macosx/HBAudioDefaults.m
@@ -260,9 +260,11 @@
     self.allowDTSPassthru    = NO;
     self.allowDTSHDPassthru  = NO;
     self.allowEAC3Passthru   = NO;
+    self.allowALACPassthru   = NO;
     self.allowFLACPassthru   = NO;
     self.allowMP2Passthru    = NO;
     self.allowMP3Passthru    = NO;
+    self.allowVorbisPassthru = NO;
     self.allowOpusPassthru   = NO;
     self.allowTrueHDPassthru = NO;
 


### PR DESCRIPTION
**Description of Change:**

Fixes the https://github.com/HandBrake/HandBrake/issues/7186. The code initially introduced the Vorbis passthrough has typo in ghb_dict_set_bool that prevents setting it correctly (It was setting `AudioAllowOPUSPass` instead).

As a drive-through fix, the macOs frontend was fixed to set the allowALACPassthru and allowVorbisPassthru flags to `NO` whenever we reinitialize audio settings (this portion was not tested but the change is quite trivial).

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
