### PR TITLE
contrib: update HarfBuzz to 11.4.4

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.2.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.2/harfbuzz-11.4.2.tar.xz
-HARFBUZZ.FETCH.sha256  = 49ff7bd4a506486057f2918ecc856a249e3972f27ea49e3d2aa0f2afb59a57dd
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.4.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.4/harfbuzz-11.4.4.tar.xz
+HARFBUZZ.FETCH.sha256  = 1053f17146ea587fafa9f56c9e4e0f4b3fefae4ba2569155d8bc9a35208f58c5
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake

--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.4.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.4/harfbuzz-11.4.4.tar.xz
-HARFBUZZ.FETCH.sha256  = 1053f17146ea587fafa9f56c9e4e0f4b3fefae4ba2569155d8bc9a35208f58c5
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.5.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.5/harfbuzz-11.4.5.tar.xz
+HARFBUZZ.FETCH.sha256  = 0f052eb4ab01d8bae98ba971c954becb32be57d7250f18af343b1d27892e03fa
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 11.4.4:**

What's Changed:
- Fix a shaping regression affecting mark glyphs in certain fonts.
- Fix pruning of mark filtering sets when subsetting fonts, which caused changes in shaping behaviour.
- Make shaping fail much faster for certain malformed fonts (e.g., those that trigger infinite recursion).
- Fix undefined behaviour introduced in 11.4.2.
- Fix detection of the “Cambria Math” font when fonts are scaled, so the workaround for the bad `MATH` table constant is applied.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux