### PR TITLE
AMD Threadripper transcode speed improvement

### DIFF
--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -558,7 +558,7 @@ static int init_cpu_count()
 #endif
 
     cpu_count = MAX( 1, cpu_count );
-    cpu_count = MIN( cpu_count, 64 );
+    cpu_count = MIN( cpu_count, 384 );
 
     return cpu_count;
 }


### PR DESCRIPTION
**Description of Problem:**

1. On systems with a large number of CPU cores, HandBrake currently imposes a limitation that caps the usable CPU count to 64. This restriction prevents optimal utilization of modern high-core-count processors like AMD ThreaDripper. 
2. Additionally, in segment encoding workflows, the current handling of segment height may allow values smaller than the minimum processing block size, leading to inefficiencies or incorrect behavior.

**Description of Change:**
1. Increased CPU Count Limit in ports.c
The upper limit for CPU detection has been increased from 64 to 384.
This change is motivated by the latest AMD Threadripper Pro W9995X, which supports up to 192 logical processors.
To accommodate this and provide headroom for future generations of processors, the limit was doubled to 384.
2. Segment Size Management
Adjustments were made to ensure the segment size calculation is better aligned with the number of CPU cores available on the system. 
A safeguard was added so that the segment height can never drop below 16, which corresponds to the block height used in processing. 
This ensures consistency and avoids inefficiencies from overly small segment sizes.


**Tested on:**
- [x] Windows 10+  (via MinGW)

**Screenshots:**
<img width="1439" height="866" alt="image" src="https://github.com/user-attachments/assets/3d413365-cd2c-4962-9937-1e33f46399c2" />