### PR TITLE
libhb: use RtlGetVersion() to get OS version on Windows (MinGW)

### DIFF
--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -230,6 +230,23 @@ static void init_system_info()
         hb_system_info.version = strdup(uts.release);
         hb_system_info.build   = strdup(uts.version);
     }
+#elif defined(SYS_MINGW)
+    NTSYSAPI NTSTATUS RtlGetVersion(PRTL_OSVERSIONINFOW);
+
+    OSVERSIONINFOW vi = {0};
+    vi.dwOSVersionInfoSize = sizeof(vi);
+    char buf[32];
+
+    if (RtlGetVersion(&vi) == 0)
+    {
+        snprintf(buf, sizeof(buf), "%lu.%lu", vi.dwMajorVersion, vi.dwMinorVersion);
+        hb_system_info.version = strdup(buf);
+
+        snprintf(buf, sizeof(buf), "%lu", vi.dwBuildNumber);
+        hb_system_info.build = strdup(buf);
+    }
+
+    hb_system_info.name = "Windows";
 #else
     hb_system_info.name    = NULL;
     hb_system_info.version = NULL;


### PR DESCRIPTION
Microsoft broke GetVersionEx() starting with Windows 8.1. The function now returns incorrect values unless the application manifest specifically lists the newer releases as supported:

https://learn.microsoft.com/en-us/windows/win32/w8cookbook/operating-system-version-changes-in-windows-8-1 https://sourceware.org/pipermail/cygwin/2024-March/255728.html

To avoid this problem, call the documented RtlGetVersion() from ntdll:

https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-rtlgetversion

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux