### PR TITLE
contrib: update libjpeg-turbo to 3.1.2

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.1.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.1.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 304165ae11e64ab752e9cfc07c37bfdc87abd0bfe4bc699e59f34036d9c84f72
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.2.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.2.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 560f6338b547544c4f9721b18d8b87685d433ec78b3c644c70d77adad22c55e6
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.1.2**

Significant changes relative to 3.1.1:
- Fixed a regression introduced by 3.1 beta1[5] that caused a segfault in TJBench if -copy or -c was passed as the last command-line argument.

- The build system now uses wrappers rather than CMake object libraries to compile source files for multiple data precisions. This improves code readability and facilitates adapting the libjpeg-turbo source code to non-CMake build systems.

- Fixed an issue whereby decompressing a 4:2:0 or 4:2:2 JPEG image with merged upsampling disabled/one-pass color quantization enabled, then reusing the same API instance to decompress a 4:2:0 or 4:2:2 JPEG image with merged upsampling enabled/color quantization disabled, caused jpeg_skip_scanlines() to use freed memory. In practice, the freed memory was not reclaimed before it was used. Thus, this issue did not cause a segfault or other user-visible errant behavior (it was only detectable with ASan), and it did not likely pose a security risk.

- The AArch64 (Arm 64-bit) Neon SIMD extensions and accelerated Huffman codec now support the Arm64EC ABI on Windows, which allows Windows/x64 applications to call native Arm64 functions when running under the Windows/x64 emulator on Windows/Arm.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux