### PR TITLE
contrib : update Freetype to 2.14.1

### DIFF
--- a/contrib/freetype/P00-mingw-lib.patch
+++ b/contrib/freetype/P00-mingw-lib.patch
@@ -1,8 +1,8 @@
-diff -ur freetype-2.10.4.orig/include/freetype/config/public-macros.h freetype-2.10.4/include/freetype/config/public-macros.h
---- freetype-2.10.4.orig/include/freetype/config/public-macros.h	2020-08-27 02:17:20.000000000 -0400
-+++ freetype-2.10.4/include/freetype/config/public-macros.h	2020-11-09 19:51:44.000000000 -0500
+diff -ur freetype-2.14.0.orig/include/freetype/config/public-macros.h freetype-2.14.0/include/freetype/config/public-macros.h
+--- freetype-2.14.0.orig/include/freetype/config/public-macros.h	2025-09-06 06:12:16.000000000 +0200
++++ freetype-2.14.0/include/freetype/config/public-macros.h	2025-09-08 21:32:38.077478424 +0200
 @@ -66,9 +66,9 @@
- #if defined( _WIN32 )
+ #if defined( _WIN32 ) || defined( __CYGWIN__ )
  
  #if defined( FT2_BUILD_LIBRARY ) && defined( DLL_EXPORT )
 -#define FT_PUBLIC_FUNCTION_ATTRIBUTE  __declspec( dllexport )

--- a/contrib/freetype/P00-mingw-lib.patch
+++ b/contrib/freetype/P00-mingw-lib.patch
@@ -1,6 +1,6 @@
-diff -ur freetype-2.14.0.orig/include/freetype/config/public-macros.h freetype-2.14.0/include/freetype/config/public-macros.h
---- freetype-2.14.0.orig/include/freetype/config/public-macros.h	2025-09-06 06:12:16.000000000 +0200
-+++ freetype-2.14.0/include/freetype/config/public-macros.h	2025-09-08 21:32:38.077478424 +0200
+diff -ur freetype-2.14.1.orig/include/freetype/config/public-macros.h freetype-2.14.1/include/freetype/config/public-macros.h
+--- freetype-2.14.1.orig/include/freetype/config/public-macros.h	2025-09-06 06:12:16.000000000 +0200
++++ freetype-2.14.1/include/freetype/config/public-macros.h	2025-09-08 21:32:38.077478424 +0200
 @@ -66,9 +66,9 @@
  #if defined( _WIN32 ) || defined( __CYGWIN__ )
  

--- a/contrib/freetype/module.defs
+++ b/contrib/freetype/module.defs
@@ -2,9 +2,9 @@ __deps__ := BZIP2 ZLIB
 $(eval $(call import.MODULE.defs,FREETYPE,freetype,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FREETYPE))
 
-FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.14.0.tar.gz
-FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.14.0.tar.gz
-FREETYPE.FETCH.sha256  = 73819bbf34c84f18b89ebbd35107d3ae92c604ff7336cd09ff1452930c2dcb9c
+FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.14.1.tar.gz
+FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.14.1.tar.gz
+FREETYPE.FETCH.sha256  = 174d9e53402e1bf9ec7277e22ec199ba3e55a6be2c0740cb18c0ee9850fc8c34
 
 FREETYPE.CONFIGURE.deps  =
 FREETYPE.CONFIGURE.extra = --with-harfbuzz=no --with-png=no --with-brotli=no

--- a/contrib/freetype/module.defs
+++ b/contrib/freetype/module.defs
@@ -2,9 +2,9 @@ __deps__ := BZIP2 ZLIB
 $(eval $(call import.MODULE.defs,FREETYPE,freetype,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FREETYPE))
 
-FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.13.3.tar.gz
-FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.13.3.tar.gz
-FREETYPE.FETCH.sha256  = 5c3a8e78f7b24c20b25b54ee575d6daa40007a5f4eea2845861c3409b3021747
+FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.14.0.tar.gz
+FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.14.0.tar.gz
+FREETYPE.FETCH.sha256  = 73819bbf34c84f18b89ebbd35107d3ae92c604ff7336cd09ff1452930c2dcb9c
 
 FREETYPE.CONFIGURE.deps  =
 FREETYPE.CONFIGURE.extra = --with-harfbuzz=no --with-png=no --with-brotli=no


### PR DESCRIPTION
**FreeType 2.14.1**

Changes between 2.13.3 and 2.14.1:
https://gitlab.freedesktop.org/freetype/freetype/-/blob/VER-2-14-1/docs/CHANGES?ref_type=tags

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu 24.04