### PR TITLE
libhb: cli: ui: add custom channel layouts support

### DIFF
--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -119,7 +119,7 @@ ghb_adjust_audio_rate_combos(signal_user_data_t *ud, GhbValue *asettings)
 
         int track, mix, acodec;
         GhbValue * atrack;
-        uint64_t layout;
+        const char * layout;
 
         track = ghb_dict_get_int(asettings, "Track");
 
@@ -133,7 +133,7 @@ ghb_adjust_audio_rate_combos(signal_user_data_t *ud, GhbValue *asettings)
         {
             sr = ghb_dict_get_int(atrack, "SampleRate");
         }
-        layout = ghb_dict_get_int(atrack, "ChannelLayout");
+        layout = ghb_dict_get_string(atrack, "ChannelLayout");
         mix = ghb_get_best_mix(layout, acodec, mix);
         hb_audio_bitrate_get_limits(acodec, sr, mix, &low, &high);
 
@@ -549,7 +549,7 @@ audio_add_track(
     atrack = ghb_get_title_audio_track(settings, track);
     if (atrack != NULL)
     {
-        int layout = ghb_dict_get_int(atrack, "ChannelLayout");
+        const char * layout = ghb_dict_get_string(atrack, "ChannelLayout");
         mix = ghb_get_best_mix(layout, encoder, mix);
 
         int keep_name = ghb_dict_get_int(settings, "AudioTrackNamePassthru");
@@ -557,8 +557,8 @@ audio_add_track(
         int behavior = hb_audio_autonaming_behavior_get_from_name(behavior_name);
 
         const char * name = ghb_dict_get_string(atrack, "Name");
-        const char * generated_name = hb_audio_name_generate(name, layout, mix,
-                                                            keep_name, behavior);
+        const char * generated_name = hb_audio_name_generate_s(name, layout, mix,
+                                                               keep_name, behavior);
         if (generated_name != NULL)
         {
             ghb_dict_set_string(asettings, "Name", generated_name);
@@ -1016,7 +1016,7 @@ audio_codec_changed_cb (GtkWidget *widget, gpointer data)
         // pref settings
         gint track;
         gint br, sr, mix;
-        uint64_t layout;
+        const char * layout;
         GhbValue * atrack;
 
         if (asettings != NULL)
@@ -1045,7 +1045,7 @@ audio_codec_changed_cb (GtkWidget *widget, gpointer data)
         {
             sr = ghb_dict_get_int(atrack, "SampleRate");
         }
-        layout = ghb_dict_get_int(atrack, "ChannelLayout");
+        layout = ghb_dict_get_string(atrack, "ChannelLayout");
         mix = ghb_get_best_mix(layout, acodec, mix);
         br = hb_audio_bitrate_get_best(acodec, br, sr, mix);
         ghb_ui_update("AudioBitrate",

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1413,7 +1413,7 @@ ghb_mix_opts_filter(GtkComboBox *combo, gint acodec)
 }
 
 static void
-grey_mix_opts(signal_user_data_t *ud, gint acodec, uint64_t layout)
+grey_mix_opts(signal_user_data_t *ud, gint acodec, const char *layout)
 {
     ghb_log_func();
 
@@ -1422,7 +1422,7 @@ grey_mix_opts(signal_user_data_t *ud, gint acodec, uint64_t layout)
          mix = hb_mixdown_get_next(mix))
     {
         grey_builder_combo_box_item("AudioMixdown", mix->amixdown,
-                !hb_mixdown_is_supported(mix->amixdown, acodec, layout));
+                !hb_mixdown_is_supported_s(mix->amixdown, acodec, layout));
     }
 }
 
@@ -1496,8 +1496,18 @@ ghb_grey_combo_options(signal_user_data_t *ud)
 
     acodec = ghb_settings_audio_encoder_codec(ud->settings, "AudioEncoder");
 
-    uint64_t layout = aconfig != NULL ? aconfig->in.channel_layout : UINT64_MAX;
-    guint32 in_codec = aconfig != NULL ? aconfig->in.codec : 0;
+    const char *layout = "7.1";
+    guint32 in_codec = 0;
+    char layout_name[256];
+
+    if (aconfig != NULL)
+    {
+        hb_layout_get_name(aconfig->in.ch_layout,
+            layout_name, sizeof(layout_name));
+        layout = layout_name;
+        in_codec = aconfig->in.codec;
+    }
+
     fallback = ghb_select_fallback(ud->settings, acodec);
     gint copy_mask = ghb_get_copy_mask(ud->settings);
     acodec = ghb_select_audio_codec(mux->format, in_codec, acodec,
@@ -1506,12 +1516,12 @@ ghb_grey_combo_options(signal_user_data_t *ud)
 }
 
 gint
-ghb_get_best_mix(uint64_t layout, gint acodec, gint mix)
+ghb_get_best_mix(const char *layout, gint acodec, gint mix)
 {
     if (mix == HB_AMIXDOWN_NONE)
         mix = HB_INVALID_AMIXDOWN;
 
-    return hb_mixdown_get_best(acodec, layout, mix);
+    return hb_mixdown_get_best_s(acodec, layout, mix);
 }
 
 // Set up the model for the combo box

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -140,7 +140,7 @@ gint64 ghb_get_chapter_duration(const hb_title_t *title, gint chap);
 gint64 ghb_get_chapter_start(const hb_title_t *title, gint chap);
 gint64 ghb_chapter_range_get_duration(const hb_title_t *title,
                                       gint sc, gint ec);
-gint ghb_get_best_mix(uint64_t layout, gint acodec, gint mix);
+gint ghb_get_best_mix(const char *layout, gint acodec, gint mix);
 gboolean ghb_audio_is_passthru(gint acodec);
 gboolean ghb_audio_can_passthru(gint acodec);
 gint ghb_get_default_acodec(void);

--- a/libhb/audio_remap.c
+++ b/libhb/audio_remap.c
@@ -11,54 +11,20 @@
 #include "handbrake/hbffmpeg.h"
 #include "handbrake/audio_remap.h"
 
-// source: libavutil/channel_layout.h
-hb_chan_map_t hb_libav_chan_map =
-{
-    {
-        AV_CH_FRONT_LEFT,
-        AV_CH_FRONT_RIGHT,
-        AV_CH_FRONT_CENTER,
-        AV_CH_LOW_FREQUENCY,
-        AV_CH_BACK_LEFT,
-        AV_CH_BACK_RIGHT,
-        AV_CH_FRONT_LEFT_OF_CENTER,
-        AV_CH_FRONT_RIGHT_OF_CENTER,
-        AV_CH_BACK_CENTER,
-        AV_CH_SIDE_LEFT,
-        AV_CH_SIDE_RIGHT,
-        0
-    }
-};
-
-// source: liba52 documentation
-hb_chan_map_t hb_liba52_chan_map =
-{
-    {
-        AV_CH_LOW_FREQUENCY,
-        AV_CH_FRONT_LEFT,
-        AV_CH_FRONT_CENTER,
-        AV_CH_FRONT_RIGHT,
-        AV_CH_BACK_CENTER,
-        AV_CH_SIDE_LEFT,
-        AV_CH_SIDE_RIGHT,
-        0
-    }
-};
-
 // source: http://xiph.org/vorbis/doc/Vorbis_I_spec.html#x1-800004.3.9
 hb_chan_map_t hb_vorbis_chan_map =
 {
     {
-        AV_CH_FRONT_LEFT,
-        AV_CH_FRONT_CENTER,
-        AV_CH_FRONT_RIGHT,
-        AV_CH_SIDE_LEFT,
-        AV_CH_SIDE_RIGHT,
-        AV_CH_BACK_LEFT,
-        AV_CH_BACK_CENTER,
-        AV_CH_BACK_RIGHT,
-        AV_CH_LOW_FREQUENCY,
-        0
+        AV_CHAN_FRONT_LEFT,
+        AV_CHAN_FRONT_CENTER,
+        AV_CHAN_FRONT_RIGHT,
+        AV_CHAN_SIDE_LEFT,
+        AV_CHAN_SIDE_RIGHT,
+        AV_CHAN_BACK_LEFT,
+        AV_CHAN_BACK_CENTER,
+        AV_CHAN_BACK_RIGHT,
+        AV_CHAN_LOW_FREQUENCY,
+        AV_CHAN_NONE
     }
 };
 
@@ -66,20 +32,45 @@ hb_chan_map_t hb_vorbis_chan_map =
 hb_chan_map_t hb_aac_chan_map =
 {
     {
-        AV_CH_FRONT_CENTER,
-        AV_CH_FRONT_LEFT_OF_CENTER,
-        AV_CH_FRONT_RIGHT_OF_CENTER,
-        AV_CH_FRONT_LEFT,
-        AV_CH_FRONT_RIGHT,
-        AV_CH_SIDE_LEFT,
-        AV_CH_SIDE_RIGHT,
-        AV_CH_BACK_LEFT,
-        AV_CH_BACK_RIGHT,
-        AV_CH_BACK_CENTER,
-        AV_CH_LOW_FREQUENCY,
-        0
+        AV_CHAN_FRONT_CENTER,
+        AV_CHAN_FRONT_LEFT_OF_CENTER,
+        AV_CHAN_FRONT_RIGHT_OF_CENTER,
+        AV_CHAN_FRONT_LEFT,
+        AV_CHAN_FRONT_RIGHT,
+        AV_CHAN_SIDE_LEFT,
+        AV_CHAN_SIDE_RIGHT,
+        AV_CHAN_BACK_LEFT,
+        AV_CHAN_BACK_RIGHT,
+        AV_CHAN_BACK_CENTER,
+        AV_CHAN_LOW_FREQUENCY,
+        AV_CHAN_NONE
     }
 };
+
+void hb_audio_remap_map_channel_layout(hb_chan_map_t *map,
+                                       AVChannelLayout *ch_layout_out,
+                                       const AVChannelLayout *ch_layout_in)
+{
+    int nchannels, out_chan_idx;
+    uint64_t *channels_out;
+
+    nchannels = ch_layout_in->nb_channels;
+    av_channel_layout_custom_init(ch_layout_out, nchannels);
+
+    out_chan_idx = 0;
+    channels_out = map->channel_order_map;
+    for (int ii = 0; channels_out[ii] != AV_CHAN_NONE && out_chan_idx < nchannels; ii++)
+    {
+        enum AVChannel in_channel = channels_out[ii];
+        int in_chan_idx = av_channel_layout_index_from_channel(ch_layout_in, in_channel);
+
+        if (in_chan_idx > -1)
+        {
+            ch_layout_out->u.map[out_chan_idx].id = in_channel;
+            out_chan_idx++;
+        }
+    }
+}
 
 static void remap_planar(uint8_t **samples, int nsamples,
                          int nchannels, int *remap_table)
@@ -179,8 +170,8 @@ static void remap_dbl_interleaved(uint8_t **samples, int nsamples,
 }
 
 hb_audio_remap_t* hb_audio_remap_init(enum AVSampleFormat sample_fmt,
-                                      hb_chan_map_t *channel_map_out,
-                                      hb_chan_map_t *channel_map_in)
+                                      const AVChannelLayout *ch_layout_out,
+                                      const AVChannelLayout *ch_layout_in)
 {
     hb_audio_remap_t *remap = calloc(1, sizeof(hb_audio_remap_t));
     if (remap == NULL)
@@ -227,56 +218,40 @@ hb_audio_remap_t* hb_audio_remap_init(enum AVSampleFormat sample_fmt,
     }
 
     // input/output channel order
-    if (channel_map_in == NULL || channel_map_out == NULL)
+    if (ch_layout_in == NULL || ch_layout_out == NULL)
     {
         hb_error("hb_audio_remap_init: invalid channel map(s)");
         goto fail;
     }
-    remap->channel_map_in  = channel_map_in;
-    remap->channel_map_out = channel_map_out;
+    av_channel_layout_copy(&remap->ch_layout_in, ch_layout_in);
+    av_channel_layout_copy(&remap->ch_layout_out, ch_layout_out);
 
-    // remap can't be done until the channel layout has been set
     remap->remap_needed = 0;
+    remap->nchannels = ch_layout_in->nb_channels;
 
-    return remap;
-
-fail:
-    hb_audio_remap_free(remap);
-    return NULL;
-}
-
-void hb_audio_remap_set_channel_layout(hb_audio_remap_t *remap,
-                                       uint64_t channel_layout)
-{
-    if (remap != NULL)
+    // sanitize the layout
+    AVChannelLayout stereo_dowmix = AV_CHANNEL_LAYOUT_STEREO_DOWNMIX;
+    if (av_channel_layout_compare(ch_layout_in, &stereo_dowmix) == 0)
     {
-        int ii;
-        remap->remap_needed = 0;
+        // Dolby Surround is Stereo when it comes to remapping
+        AVChannelLayout stereo = AV_CHANNEL_LAYOUT_STEREO;
+        av_channel_layout_copy(&remap->ch_layout_in, &stereo);
+    }
 
-        // sanitize the layout
-        if (channel_layout == AV_CH_LAYOUT_STEREO_DOWNMIX)
-        {
-            channel_layout = AV_CH_LAYOUT_STEREO;
-        }
-        remap->nchannels = hb_layout_get_discrete_channel_count(channel_layout);
-
-        // in some cases, remapping is not necessary and/or supported
-        if (remap->nchannels > HB_AUDIO_REMAP_MAX_CHANNELS)
-        {
-            hb_log("hb_audio_remap_set_channel_layout: too many channels (%d)",
-                   remap->nchannels);
-            return;
-        }
-        if (remap->channel_map_in == remap->channel_map_out)
-        {
-            return;
-        }
-
+    // in some cases, remapping is not necessary and/or supported
+    if (remap->nchannels > HB_AUDIO_REMAP_MAX_CHANNELS)
+    {
+        hb_log("hb_audio_remap_init: too many channels (%d)",
+               remap->nchannels);
+        goto fail;
+    }
+    if (av_channel_layout_compare(&remap->ch_layout_in, &remap->ch_layout_out) != 0)
+    {
         // build the table and check whether remapping is necessary
-        hb_audio_remap_build_table(remap->channel_map_out,
-                                   remap->channel_map_in, channel_layout,
+        hb_audio_remap_build_table(&remap->ch_layout_out,
+                                   &remap->ch_layout_in,
                                    remap->table);
-        for (ii = 0; ii < remap->nchannels; ii++)
+        for (int ii = 0; ii < remap->nchannels; ii++)
         {
             if (remap->table[ii] != ii)
             {
@@ -285,13 +260,20 @@ void hb_audio_remap_set_channel_layout(hb_audio_remap_t *remap,
             }
         }
     }
-}
 
+    return remap;
+
+fail:
+    hb_audio_remap_free(remap);
+    return NULL;
+}
 
 void hb_audio_remap_free(hb_audio_remap_t *remap)
 {
     if (remap != NULL)
     {
+        av_channel_layout_uninit(&remap->ch_layout_out);
+        av_channel_layout_uninit(&remap->ch_layout_in);
         free(remap);
     }
 }
@@ -304,43 +286,25 @@ void hb_audio_remap(hb_audio_remap_t *remap, uint8_t **samples, int nsamples)
     }
 }
 
-void hb_audio_remap_build_table(hb_chan_map_t *channel_map_out,
-                                hb_chan_map_t *channel_map_in,
-                                uint64_t channel_layout,
+void hb_audio_remap_build_table(AVChannelLayout *ch_layout_out,
+                                AVChannelLayout *ch_layout_in,
                                 int *remap_table)
 {
-    int ii, jj, nchannels, out_chan_idx, remap_idx;
-    uint64_t *channels_in, *channels_out;
-
-    if (channel_layout == AV_CH_LAYOUT_STEREO_DOWNMIX)
-    {
-        // Dolby Surround is Stereo when it comes to remapping
-        channel_layout = AV_CH_LAYOUT_STEREO;
-    }
-    nchannels = hb_layout_get_discrete_channel_count(channel_layout);
+    int nchannels = ch_layout_in->nb_channels;
 
     // clear remap table before (re-)building it
     memset(remap_table, 0, nchannels * sizeof(int));
 
-    out_chan_idx = 0;
-    channels_in  = channel_map_in ->channel_order_map;
-    channels_out = channel_map_out->channel_order_map;
-    for (ii = 0; channels_out[ii] && out_chan_idx < nchannels; ii++)
+    for (int ii = 0; ii < nchannels; ii++)
     {
-        if (channel_layout & channels_out[ii])
+        enum AVChannel out_channel = av_channel_layout_channel_from_index(ch_layout_out, ii);
+        for (int jj = 0; jj < nchannels; jj++)
         {
-            remap_idx = 0;
-            for (jj = 0; channels_in[jj] && remap_idx < nchannels; jj++)
+            enum AVChannel in_channel = av_channel_layout_channel_from_index(ch_layout_in, jj);
+            if (out_channel == in_channel)
             {
-                if (channels_out[ii] == channels_in[jj])
-                {
-                    remap_table[out_chan_idx++] = remap_idx++;
-                    break;
-                }
-                else if (channel_layout & channels_in[jj])
-                {
-                    remap_idx++;
-                }
+                remap_table[ii] = jj;
+                break;
             }
         }
     }

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1479,7 +1479,7 @@ const hb_rate_t* hb_audio_bitrate_get_next(const hb_rate_t *last)
     return ((hb_rate_internal_t*)last)->next;
 }
 
-const char * hb_audio_name_get_default(uint64_t layout, int mixdown)
+const char * hb_audio_name_get_default(hb_channel_layout_t *ch_layout, int mixdown)
 {
     int mix_channels = 2;
 
@@ -1489,7 +1489,7 @@ const char * hb_audio_name_get_default(uint64_t layout, int mixdown)
     }
     else
     {
-        mix_channels = hb_layout_get_discrete_channel_count(layout);
+        mix_channels = hb_layout_get_discrete_channel_count(ch_layout);
     }
 
     switch (mix_channels)
@@ -1528,7 +1528,7 @@ int hb_audio_autonaming_behavior_get_from_name(const char *name)
 }
 
 const char * hb_audio_name_generate(const char *name,
-                                    uint64_t layout, int mixdown, int keep_name,
+                                    hb_channel_layout_t *ch_layout, int mixdown, int keep_name,
                                     hb_audio_autonaming_behavior_t behavior)
 {
     const char *out = NULL;
@@ -1554,10 +1554,28 @@ const char * hb_audio_name_generate(const char *name,
     if (behavior == HB_AUDIO_AUTONAMING_ALL ||
         (behavior == HB_AUDIO_AUTONAMING_UNNAMED && (name == NULL || name[0] == 0)))
     {
-        out = hb_audio_name_get_default(layout, mixdown);
+        out = hb_audio_name_get_default(ch_layout, mixdown);
     }
 
     return out;
+}
+
+const char * hb_audio_name_generate_s(const char *name,
+                                      const char *layout, int mixdown, int keep_name,
+                                      hb_audio_autonaming_behavior_t behaviour)
+{
+    int ret;
+    const char *generated_name = NULL;
+    AVChannelLayout ch_layout = {0};
+    ret = av_channel_layout_from_string(&ch_layout, layout);
+    if (ret < 0)
+    {
+        goto fail;
+    }
+    generated_name = hb_audio_name_generate(name, &ch_layout, mixdown, keep_name, behaviour);
+    av_channel_layout_uninit(&ch_layout);
+fail:
+    return generated_name;
 }
 
 // Get limits and hints for the UIs.
@@ -2523,10 +2541,30 @@ static int mixdown_get_opus_coupled_stream_count(int mixdown)
     }
 }
 
-int hb_mixdown_is_supported(int mixdown, uint32_t codec, uint64_t layout)
+int hb_mixdown_is_supported(int mixdown, uint32_t codec, hb_channel_layout_t *ch_layout)
 {
     return (hb_mixdown_has_codec_support(mixdown, codec) &&
-            hb_mixdown_has_remix_support(mixdown, layout));
+            hb_mixdown_has_remix_support(mixdown, ch_layout));
+}
+
+int hb_mixdown_is_supported_s(int mixdown, uint32_t codec, const char *layout)
+{
+    int ret;
+    AVChannelLayout ch_layout = {0};
+
+    if (layout == NULL)
+    {
+        return 0;
+    }
+
+    ret = av_channel_layout_from_string(&ch_layout, layout);
+    if (ret < 0)
+    {
+        return 0;
+    }
+    ret = hb_mixdown_is_supported(mixdown, codec, &ch_layout);
+    av_channel_layout_uninit(&ch_layout);
+    return ret;
 }
 
 int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
@@ -2565,54 +2603,56 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
     }
 }
 
-int hb_mixdown_has_remix_support(int mixdown, uint64_t layout)
+int hb_mixdown_has_remix_support(int mixdown, hb_channel_layout_t *ch_layout)
 {
     /*
      * Where there isn't a source (e.g. audio defaults panel), we have no input
      * layout; assume remix support, as the mixdown will be sanitized later on.
      */
-    if (!layout)
+    if (!ch_layout)
     {
         return 1;
     }
+
     switch (mixdown)
     {
         // stereo + front left/right of center
         case HB_AMIXDOWN_5_2_LFE:
-            return ((layout & AV_CH_FRONT_LEFT_OF_CENTER) &&
-                    (layout & AV_CH_FRONT_RIGHT_OF_CENTER) &&
-                    (layout & AV_CH_LAYOUT_STEREO) == AV_CH_LAYOUT_STEREO);
+            return (av_channel_layout_subset(ch_layout, AV_CH_FRONT_LEFT_OF_CENTER) &&
+                    av_channel_layout_subset(ch_layout, AV_CH_FRONT_RIGHT_OF_CENTER) &&
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_STEREO) == AV_CH_LAYOUT_STEREO);
 
         // 7.0 or better
         case HB_AMIXDOWN_7POINT1:
-            return ((layout & AV_CH_LAYOUT_7POINT0) == AV_CH_LAYOUT_7POINT0);
+            return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_7POINT0) == AV_CH_LAYOUT_7POINT0);
 
         // 6.0 or better
         case HB_AMIXDOWN_6POINT1:
-            return ((layout & AV_CH_LAYOUT_7POINT0) == AV_CH_LAYOUT_7POINT0 ||
-                    (layout & AV_CH_LAYOUT_6POINT0) == AV_CH_LAYOUT_6POINT0 ||
-                    (layout & AV_CH_LAYOUT_HEXAGONAL) == AV_CH_LAYOUT_HEXAGONAL);
+            return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_7POINT0) == AV_CH_LAYOUT_7POINT0 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_6POINT0) == AV_CH_LAYOUT_6POINT0 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_HEXAGONAL) == AV_CH_LAYOUT_HEXAGONAL);
 
         // stereo + either of front center, side or back left/right, back center
         case HB_AMIXDOWN_5POINT1:
-            return ((layout & AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||
-                    (layout & AV_CH_LAYOUT_2_2) == AV_CH_LAYOUT_2_2 ||
-                    (layout & AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD ||
-                    (layout & AV_CH_LAYOUT_SURROUND) == AV_CH_LAYOUT_SURROUND);
+            return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_2) == AV_CH_LAYOUT_2_2 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_SURROUND) == AV_CH_LAYOUT_SURROUND);
 
         // stereo + either of side or back left/right, back center
         // also, allow Dolby Surround output if the input is already Dolby
         case HB_AMIXDOWN_DOLBY:
         case HB_AMIXDOWN_DOLBYPLII:
-            return ((layout & AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||
-                    (layout & AV_CH_LAYOUT_2_2) == AV_CH_LAYOUT_2_2 ||
-                    (layout & AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD ||
-                    (layout == AV_CH_LAYOUT_STEREO_DOWNMIX && // decavcodecaBSInfo tells us the input signals matrix encoding
+            return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_2) == AV_CH_LAYOUT_2_2 ||
+                    av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD ||
+                    (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_STEREO_DOWNMIX) == AV_CH_LAYOUT_STEREO_DOWNMIX &&
+                     ch_layout->nb_channels == 2 &&  // decavcodecaBSInfo tells us the input signals matrix encoding
                      mixdown == HB_AMIXDOWN_DOLBY)); // allows signaling matrix encoding in output w/encoders that support it
 
         // more than 1 channel
         case HB_AMIXDOWN_STEREO:
-            return (hb_layout_get_discrete_channel_count(layout) > 1);
+            return (hb_layout_get_discrete_channel_count(ch_layout) > 1);
 
         /*
          * The following mixdowns have a very specific purpose!!!
@@ -2629,7 +2669,8 @@ int hb_mixdown_has_remix_support(int mixdown, uint64_t layout)
          */
         case HB_AMIXDOWN_LEFT:
         case HB_AMIXDOWN_RIGHT:
-            return (layout == AV_CH_LAYOUT_STEREO);
+            return av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_STEREO) == AV_CH_LAYOUT_STEREO &&
+                    ch_layout->nb_channels == 2;
 
         // mono remix always supported
         // HB_AMIXDOWN_NONE always supported (for Passthru)
@@ -2685,7 +2726,7 @@ int hb_mixdown_get_low_freq_channel_count(int amixdown)
     }
 }
 
-int hb_mixdown_get_best(uint32_t codec, uint64_t layout, int mixdown)
+int hb_mixdown_get_best(uint32_t codec, hb_channel_layout_t *ch_layout, int mixdown)
 {
     // Passthru, only "None" mixdown is supported
     if (codec & HB_ACODEC_PASS_FLAG)
@@ -2698,7 +2739,7 @@ int hb_mixdown_get_best(uint32_t codec, uint64_t layout, int mixdown)
     while ((audio_mixdown = hb_mixdown_get_next(audio_mixdown)) != NULL)
     {
         if ((mixdown == HB_INVALID_AMIXDOWN || audio_mixdown->amixdown <= mixdown) &&
-            (hb_mixdown_is_supported(audio_mixdown->amixdown, codec, layout)))
+            (hb_mixdown_is_supported(audio_mixdown->amixdown, codec, ch_layout)))
         {
             best_mixdown = audio_mixdown->amixdown;
         }
@@ -2706,7 +2747,27 @@ int hb_mixdown_get_best(uint32_t codec, uint64_t layout, int mixdown)
     return best_mixdown;
 }
 
-int hb_mixdown_get_default(uint32_t codec, uint64_t layout)
+int hb_mixdown_get_best_s(uint32_t codec, const char *layout, int mixdown)
+{
+    int ret;
+    AVChannelLayout ch_layout = {0};
+
+    if (layout == NULL)
+    {
+        return 0;
+    }
+
+    ret = av_channel_layout_from_string(&ch_layout, layout);
+    if (ret < 0)
+    {
+        return 0;
+    }
+    ret = hb_mixdown_get_best(codec, &ch_layout, mixdown);
+    av_channel_layout_uninit(&ch_layout);
+    return ret;
+}
+
+int hb_mixdown_get_default(uint32_t codec, hb_channel_layout_t *ch_layout)
 {
     int mixdown;
     switch (codec)
@@ -2739,7 +2800,27 @@ int hb_mixdown_get_default(uint32_t codec, uint64_t layout)
     }
 
     // return the best available mixdown up to the selected default
-    return hb_mixdown_get_best(codec, layout, mixdown);
+    return hb_mixdown_get_best(codec, ch_layout, mixdown);
+}
+
+int hb_mixdown_get_default_s(uint32_t codec, const char *layout)
+{
+    int ret;
+    AVChannelLayout ch_layout = {0};
+
+    if (layout == NULL)
+    {
+        return 0;
+    }
+
+    ret = av_channel_layout_from_string(&ch_layout, layout);
+    if (ret < 0)
+    {
+        return 0;
+    }
+    ret = hb_mixdown_get_default(codec, &ch_layout);
+    av_channel_layout_uninit(&ch_layout);
+    return ret;
 }
 
 hb_mixdown_t* hb_mixdown_get_from_mixdown(int mixdown)
@@ -2827,28 +2908,23 @@ const hb_mixdown_t* hb_mixdown_get_next(const hb_mixdown_t *last)
     return ((hb_mixdown_internal_t*)last)->next;
 }
 
-void hb_layout_get_name(char *name, int size, int64_t layout)
+int hb_layout_get_name(const hb_channel_layout_t *ch_layout, char *name, int size)
 {
-    AVChannelLayout ch_layout = {0};
-    av_channel_layout_from_mask(&ch_layout, layout);
-    av_channel_layout_describe(&ch_layout, name, size);
-    av_channel_layout_uninit(&ch_layout);
+    return av_channel_layout_describe(ch_layout, name, size);
 }
 
-int hb_layout_get_discrete_channel_count(int64_t layout)
+int hb_layout_get_discrete_channel_count(const hb_channel_layout_t *ch_layout)
 {
-    int nb_channels = 0;
-    AVChannelLayout ch_layout = {0};
-    av_channel_layout_from_mask(&ch_layout, layout);
-    nb_channels = ch_layout.nb_channels;
-    av_channel_layout_uninit(&ch_layout);
-    return nb_channels;
+    return ch_layout->nb_channels;
 }
 
-int hb_layout_get_low_freq_channel_count(int64_t layout)
+int hb_layout_get_low_freq_channel_count(const hb_channel_layout_t *ch_layout)
 {
-    return !!(layout & AV_CH_LOW_FREQUENCY) +
-           !!(layout & AV_CH_LOW_FREQUENCY_2);
+    uint64_t subset = av_channel_layout_subset(ch_layout,
+                                               AV_CH_LOW_FREQUENCY |
+                                               AV_CH_LOW_FREQUENCY_2);
+    return !!(subset & AV_CH_LOW_FREQUENCY) +
+           !!(subset & AV_CH_LOW_FREQUENCY_2);
 }
 
 int hb_video_encoder_get_default(int muxer)
@@ -3177,13 +3253,13 @@ void hb_autopassthru_apply_settings(hb_job_t *job)
                 {
                     audio->config.out.mixdown =
                         hb_mixdown_get_default(audio->config.out.codec,
-                                               audio->config.in.channel_layout);
+                                               audio->config.in.ch_layout);
                 }
                 else
                 {
                     audio->config.out.mixdown =
                         hb_mixdown_get_best(audio->config.out.codec,
-                                            audio->config.in.channel_layout,
+                                            audio->config.in.ch_layout,
                                             audio->config.out.mixdown);
                 }
                 if (audio->config.out.samplerate <= 0)
@@ -5500,6 +5576,9 @@ hb_audio_t *hb_audio_copy(const hb_audio_t *src)
     {
         audio = calloc(1, sizeof(*audio));
         memcpy(audio, src, sizeof(*audio));
+        AVChannelLayout *ch_layout = calloc(1, sizeof(*ch_layout));
+        av_channel_layout_copy(ch_layout, src->config.in.ch_layout);
+        audio->config.in.ch_layout = ch_layout;
         if ( src->config.out.name )
         {
             audio->config.out.name = strdup(src->config.out.name);
@@ -5559,15 +5638,9 @@ void hb_audio_close( hb_audio_t **_audio )
     if ( _audio && *_audio )
     {
         hb_audio_t * audio = *_audio;
-        void       * item;
 
         hb_data_close(&(audio)->priv.extradata);
-        while ((item = hb_list_item(audio->config.list_linked_index, 0)))
-        {
-            hb_list_rem(audio->config.list_linked_index, item);
-            free(item);
-        }
-        hb_list_close(&audio->config.list_linked_index);
+        hb_audio_config_close(&audio->config);
         free((char*)audio->config.in.name);
         free((char*)audio->config.out.name);
         free(audio);
@@ -5599,8 +5672,8 @@ void hb_audio_config_init(hb_audio_config_t * audiocfg)
     audiocfg->in.samples_per_frame = -1;
     audiocfg->in.bitrate = -1;
     audiocfg->in.matrix_encoding = AV_MATRIX_ENCODING_NONE;
-    audiocfg->in.channel_layout = 0;
-    audiocfg->in.channel_map = NULL;
+    audiocfg->in.ch_layout = calloc(1, sizeof(*audiocfg->in.ch_layout));
+    av_channel_layout_default(audiocfg->in.ch_layout, 0);
     audiocfg->lang.description[0] = 0;
     audiocfg->lang.simple[0] = 0;
     audiocfg->lang.iso639_2[0] = 0;
@@ -5619,6 +5692,26 @@ void hb_audio_config_init(hb_audio_config_t * audiocfg)
     audiocfg->out.normalize_mix_level = 0;
     audiocfg->out.dither_method = hb_audio_dither_get_default();
     audiocfg->out.name = NULL;
+}
+
+void hb_audio_config_close(hb_audio_config_t *audiocfg)
+{
+    if (audiocfg)
+    {
+        void *item;
+
+        while ((item = hb_list_item(audiocfg->list_linked_index, 0)))
+        {
+            hb_list_rem(audiocfg->list_linked_index, item);
+            free(item);
+        }
+        hb_list_close(&audiocfg->list_linked_index);
+        if (audiocfg->in.ch_layout != NULL)
+        {
+            av_channel_layout_uninit(audiocfg->in.ch_layout);
+            free(audiocfg->in.ch_layout);
+        }
+    }
 }
 
 /**********************************************************************

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -156,40 +156,40 @@ static void decodeAudio( hb_work_private_t *pv, packet_info_t * packet_info );
 #define HB_AV_CH_BACK_MASK (AV_CH_BACK_LEFT|AV_CH_BACK_RIGHT)
 #define HB_AV_CH_BOTH_MASK (HB_AV_CH_SIDE_MASK|HB_AV_CH_BACK_MASK)
 
-static int downmix_required(uint64_t target_layout_mask, uint64_t input_layout_mask)
+static int downmix_required(const AVChannelLayout *target_layout_mask, const AVChannelLayout *input_layout_mask)
 {
     /*
      * Side channels can easily be remapped to back channels and vice-versa.
      * Provided the other channels are the same, downmixing is not required.
      */
-    if ((input_layout_mask & HB_AV_CH_SIDE_MASK) == 0 &&
-        (input_layout_mask & HB_AV_CH_BACK_MASK) == HB_AV_CH_BACK_MASK)
+    if (av_channel_layout_subset(input_layout_mask, HB_AV_CH_SIDE_MASK) == 0 &&
+        av_channel_layout_subset(input_layout_mask, HB_AV_CH_BACK_MASK) == HB_AV_CH_BACK_MASK)
     {
-        if ((target_layout_mask & HB_AV_CH_BACK_MASK) == 0 &&
-            (target_layout_mask & HB_AV_CH_SIDE_MASK) == HB_AV_CH_SIDE_MASK)
+        if (av_channel_layout_subset(target_layout_mask, HB_AV_CH_BACK_MASK) == 0 &&
+            av_channel_layout_subset(target_layout_mask, HB_AV_CH_SIDE_MASK) == HB_AV_CH_SIDE_MASK)
         {
             // input has back channels but not side channels
             // target has the opposite (sides but not backs)
-            return ((input_layout_mask & ~HB_AV_CH_BOTH_MASK) !=
-                    (target_layout_mask & ~HB_AV_CH_BOTH_MASK));
+            return (av_channel_layout_subset(input_layout_mask, ~HB_AV_CH_BOTH_MASK) !=
+                    av_channel_layout_subset(target_layout_mask, ~HB_AV_CH_BOTH_MASK));
         }
     }
-    if ((input_layout_mask & HB_AV_CH_BACK_MASK) == 0 &&
-        (input_layout_mask & HB_AV_CH_SIDE_MASK) == HB_AV_CH_SIDE_MASK)
+    if (av_channel_layout_subset(input_layout_mask, HB_AV_CH_BACK_MASK) == 0 &&
+        av_channel_layout_subset(input_layout_mask, HB_AV_CH_SIDE_MASK) == HB_AV_CH_SIDE_MASK)
     {
-        if ((target_layout_mask & HB_AV_CH_SIDE_MASK) == 0 &&
-            (target_layout_mask & HB_AV_CH_BACK_MASK) == HB_AV_CH_BACK_MASK)
+        if (av_channel_layout_subset(target_layout_mask, HB_AV_CH_SIDE_MASK) == 0 &&
+            av_channel_layout_subset(target_layout_mask, HB_AV_CH_BACK_MASK) == HB_AV_CH_BACK_MASK)
         {
             // input has side channels but not back channels
             // target has the opposite (backs but not sides)
-            return ((input_layout_mask & ~HB_AV_CH_BOTH_MASK) !=
-                    (target_layout_mask & ~HB_AV_CH_BOTH_MASK));
+            return (av_channel_layout_subset(input_layout_mask, ~HB_AV_CH_BOTH_MASK) !=
+                    av_channel_layout_subset(target_layout_mask, ~HB_AV_CH_BOTH_MASK));
         }
     }
-    return (input_layout_mask != target_layout_mask);
+    return av_channel_layout_compare(input_layout_mask, target_layout_mask);
 }
 
-static uint64_t ac3_downmix_mask(int hb_mixdown, int normalized, uint64_t input_layout_mask, const char **dmix_mode)
+static uint64_t ac3_downmix_mask(int hb_mixdown, int normalized, const AVChannelLayout *input_layout, const char **dmix_mode)
 {
     /*
      * ac3/eac3 bitstreams contain mix levels for center, surround and LFE channels.
@@ -220,22 +220,30 @@ static uint64_t ac3_downmix_mask(int hb_mixdown, int normalized, uint64_t input_
             default:
                 return 0;
         }
-        if (mask && downmix_required(mask, input_layout_mask))
+        if (mask)
         {
-            /*
-             * We also set the existing decoder option "dmix_mode" to 2 (AC3_DMIXMOD_LORO)
-             * which is currently ignored by the decoder but should (theoretically) ensure
-             * we always get a regular Lo/Ro downmix, if the decoder were to ever gain the
-             * ability to do a Dolby/PLII downmix in the future.
-             */
-            *dmix_mode = "2";
-            return mask;
+            AVChannelLayout mask_layout = {0};
+            av_channel_layout_from_mask(&mask_layout, mask);
+
+            if (downmix_required(&mask_layout, input_layout))
+            {
+                /*
+                 * We also set the existing decoder option "dmix_mode" to 2 (AC3_DMIXMOD_LORO)
+                 * which is currently ignored by the decoder but should (theoretically) ensure
+                 * we always get a regular Lo/Ro downmix, if the decoder were to ever gain the
+                 * ability to do a Dolby/PLII downmix in the future.
+                 */
+                *dmix_mode = "2";
+                av_channel_layout_uninit(&mask_layout);
+                return mask;
+            }
+            av_channel_layout_uninit(&mask_layout);
         }
     }
     return 0;
 }
 
-static uint64_t dca_downmix_mask(int hb_mixdown, int normalized, uint64_t input_layout_mask)
+static uint64_t dca_downmix_mask(int hb_mixdown, int normalized, const AVChannelLayout *input_layout)
 {
     /*
      * AV_CODEC_ID_DTS
@@ -254,7 +262,7 @@ static uint64_t dca_downmix_mask(int hb_mixdown, int normalized, uint64_t input_
     return 0;
 }
 
-static uint64_t truehd_downmix_mask(int hb_mixdown, int normalized, uint64_t input_layout_mask)
+static uint64_t truehd_downmix_mask(int hb_mixdown, int normalized, const AVChannelLayout *input_layout)
 {
     /*
      * TrueHD bitstreams are made up of multiple "substreams" which are
@@ -282,50 +290,56 @@ static uint64_t truehd_downmix_mask(int hb_mixdown, int normalized, uint64_t inp
                 mask = hb_ff_mixdown_xlat(hb_mixdown, NULL);
                 break;
         }
-        if (mask && downmix_required(mask, input_layout_mask))
+        if (mask)
         {
-            if (mask == AV_CH_LAYOUT_STEREO)
+            AVChannelLayout mask_layout = {0};
+            av_channel_layout_from_mask(&mask_layout, mask);
+
+            if (downmix_required(&mask_layout, input_layout))
             {
+                if (mask == AV_CH_LAYOUT_STEREO)
+                {
+                    /*
+                     * The majority of TrueHD tracks have a Stereo first
+                     * substream, even when the second substream is Mono.
+                     */
+                    return mask;
+                }
+                if (hb_mixdown == HB_AMIXDOWN_MONO)
+                {
+                    /*
+                     * It is unlikely that any substream configuration will
+                     * give us an embedded Mono downmix (except in the case
+                     * where the full input layout is Mono, but in said case
+                     * a downmix is not required) however it may be possible
+                     * to extract a Stereo downmix and let hb_audio_resample
+                     * take care of downmixing that to Mono for final output.
+                     *
+                     * Do it after downmix_required() so we don't accidentally
+                     * request a Stereo downmix when the input is already Mono.
+                     */
+                    return AV_CH_LAYOUT_STEREO;
+                }
                 /*
-                 * The majority of TrueHD tracks have a Stereo first
-                 * substream, even when the second substream is Mono.
-                 */
-                return mask;
-            }
-            if (hb_mixdown == HB_AMIXDOWN_MONO)
-            {
-                /*
-                 * It is unlikely that any substream configuration will
-                 * give us an embedded Mono downmix (except in the case
-                 * where the full input layout is Mono, but in said case
-                 * a downmix is not required) however it may be possible
-                 * to extract a Stereo downmix and let hb_audio_resample
-                 * take care of downmixing that to Mono for final output.
+                 * Which downmix(es) are possible depend on the layout for each specific substream
+                 * combination, but we cannot query the substream-specific layout from the decoder.
+                 * However, excepting the Stereo to Mono case already handled above, it should be
+                 * safe to assume that each additional substream contains more channels than the
+                 * previous one, thus a downmix should only be possible when the all-substreams
+                 * layout is a superset of the target layout.
                  *
-                 * Do it after downmix_required() so we don't accidentally
-                 * request a Stereo downmix when the input is already Mono.
+                 * Note: when requesting a layout with fewer channels than a given substream's
+                 * layout but more channels than the previous substream, libavcodec's decoder
+                 * will give us the substream with more channels, so we don't have to worry
+                 * about having to accidentally upmix in hb_audio_resample down the line.
+                 * For example input with embedded stereo and 5.1(side) then finally 7.1,
+                 * and a downmix channel layout of, say, "3.1" (from an imaginary future
+                 * HB mixdown), the decoder would give us "5.1(side)" rather than stereo.
                  */
-                return AV_CH_LAYOUT_STEREO;
-            }
-            /*
-             * Which downmix(es) are possible depend on the layout for each specific substream
-             * combination, but we cannot query the substream-specific layout from the decoder.
-             * However, excepting the Stereo to Mono case already handled above, it should be
-             * safe to assume that each additional substream contains more channels than the
-             * previous one, thus a downmix should only be possible when the all-substreams
-             * layout is a superset of the target layout.
-             *
-             * Note: when requesting a layout with fewer channels than a given substream's
-             * layout but more channels than the previous substream, libavcodec's decoder
-             * will give us the substream with more channels, so we don't have to worry
-             * about having to accidentally upmix in hb_audio_resample down the line.
-             * For example input with embedded stereo and 5.1(side) then finally 7.1,
-             * and a downmix channel layout of, say, "3.1" (from an imaginary future
-             * HB mixdown), the decoder would give us "5.1(side)" rather than stereo.
-             */
-            if (mask == (mask & input_layout_mask))
-            {
-                return mask;
+                if (mask == (mask & av_channel_layout_subset(input_layout, mask)))
+                {
+                    return mask;
+                }
             }
         }
     }
@@ -429,19 +443,19 @@ static int decavcodecaInit( hb_work_object_t * w, hb_job_t * job )
             case AV_CODEC_ID_EAC3:
                 downmix_mask = ac3_downmix_mask(w->audio->config.out.mixdown,
                                                 w->audio->config.out.normalize_mix_level,
-                                                w->audio->config.in.channel_layout, &dmix_mode);
+                                                w->audio->config.in.ch_layout, &dmix_mode);
                 break;
 
             case AV_CODEC_ID_DTS:
                 downmix_mask = dca_downmix_mask(w->audio->config.out.mixdown,
                                                 w->audio->config.out.normalize_mix_level,
-                                                w->audio->config.in.channel_layout);
+                                                w->audio->config.in.ch_layout);
                 break;
 
             case AV_CODEC_ID_TRUEHD:
                 downmix_mask = truehd_downmix_mask(w->audio->config.out.mixdown,
                                                    w->audio->config.out.normalize_mix_level,
-                                                   w->audio->config.in.channel_layout);
+                                                   w->audio->config.in.ch_layout);
                 break;
 
             default:
@@ -826,6 +840,7 @@ static int decavcodecaBSInfo( hb_work_object_t *w, const hb_buffer_t *buf,
     hb_audio_t *audio = w->audio;
 
     memset( info, 0, sizeof(*info) );
+    info->ch_layout = calloc(1, sizeof(*info->ch_layout));
 
     if ( pv && pv->context )
     {
@@ -1003,46 +1018,21 @@ static int decavcodecaBSInfo( hb_work_object_t *w, const hb_buffer_t *buf,
                          * Only do this in BSInfo as overriding the layout
                          * elsewhere could break downmixing, remapping etc.
                          */
-                        info->channel_layout = AV_CH_LAYOUT_STEREO_DOWNMIX;
+                        AVChannelLayout stereo_downmix = AV_CHANNEL_LAYOUT_STEREO_DOWNMIX;
+                        av_channel_layout_copy(info->ch_layout, &stereo_downmix);
                     }
                     else
                     {
-                        if (frame->ch_layout.order == AV_CHANNEL_ORDER_NATIVE)
+                        if (frame->ch_layout.order == AV_CHANNEL_ORDER_UNSPEC)
                         {
-                            info->channel_layout = frame->ch_layout.u.mask;
-                        }
-                        else if (frame->ch_layout.order == AV_CHANNEL_ORDER_CUSTOM)
-                        {
-                            AVChannelLayout channel_layout;
-                            av_channel_layout_copy(&channel_layout, &frame->ch_layout);
-                            int result = av_channel_layout_retype(&channel_layout,
-                                                                  AV_CHANNEL_ORDER_NATIVE,
-                                                                  0);
-                            if (result == 0)
-                            {
-                                info->channel_layout = channel_layout.u.mask;
-                            }
-                            else
-                            {
-                                hb_deep_log(2, "decavcodec: unsupported custom channel order");
-                            }
-                            av_channel_layout_uninit(&channel_layout);
+                            av_channel_layout_default(info->ch_layout, frame->ch_layout.nb_channels);
                         }
                         else
                         {
-                            hb_deep_log(2, "decavcodec: unsupported custom channel order");
+                            av_channel_layout_copy(info->ch_layout, &frame->ch_layout);
                         }
                     }
 
-                    if (info->channel_layout == 0)
-                    {
-                        // Channel layout was not set.  Guess a layout based
-                        // on number of channels.
-                        AVChannelLayout channel_layout;
-                        av_channel_layout_default(&channel_layout, frame->ch_layout.nb_channels);
-                        info->channel_layout = channel_layout.u.mask;
-                        av_channel_layout_uninit(&channel_layout);
-                    }
                     if (context->codec_id == AV_CODEC_ID_AC3 ||
                         context->codec_id == AV_CODEC_ID_EAC3)
                     {
@@ -1079,7 +1069,6 @@ static int decavcodecaBSInfo( hb_work_object_t *w, const hb_buffer_t *buf,
 
     info->profile = context->profile;
     info->level = context->level;
-    info->channel_map = &hb_libav_chan_map;
 
     if ( parser != NULL )
         av_parser_close( parser );
@@ -2609,7 +2598,7 @@ static void decodeAudio(hb_work_private_t *pv, packet_info_t * packet_info)
                 log_decoder_downmix_mismatch(pv->downmix_mask, channel_layout.u.mask);
                 pv->downmix_mask = 0; // don't spam the log
             }
-            if (channel_layout.order != AV_CHANNEL_ORDER_NATIVE || channel_layout.u.mask == 0)
+            if (channel_layout.order == AV_CHANNEL_ORDER_UNSPEC)
             {
                 AVChannelLayout default_ch_layout;
                 av_channel_layout_default(&default_ch_layout, pv->frame->ch_layout.nb_channels);

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -401,8 +401,7 @@ static int declpcmBSInfo( hb_work_object_t *w, const hb_buffer_t *b,
     info->bitrate = bitrate;
     info->flags = ( b->data[3] << 16 ) | ( b->data[4] << 8 ) | b->data[5];
     info->matrix_encoding = AV_MATRIX_ENCODING_NONE;
-    info->channel_layout = hdr2layout[nchannels - 1];
-    info->channel_map = &hb_libav_chan_map;
+    av_channel_layout_from_mask(info->ch_layout, hdr2layout[nchannels - 1]);
     info->sample_bit_depth = sample_size;
     info->samples_per_frame = ( duration * rate ) / 90000;
 

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -175,7 +175,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             // audio, and will error out unless we translate the layout
             if (in_channel_layout == AV_CH_LAYOUT_5POINT1)
                 out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
-            if (hb_layout_get_discrete_channel_count(in_channel_layout) > 2)
+
+            AVChannelLayout ch_layout = {0};
+            av_channel_layout_from_mask(&ch_layout, out_channel_layout);
+            if (hb_layout_get_discrete_channel_count(&ch_layout) > 2)
                 av_dict_set(&av_opts, "mapping_family", "1", 0);
             break;
 

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -133,10 +133,16 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
     pv->list = hb_list_init();
 
     // channel remapping
-    uint64_t layout = hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL);
-    hb_audio_remap_build_table(&hb_vorbis_chan_map,
-                               audio->config.in.channel_map, layout,
+    AVChannelLayout out_layout, mixdown_layout;
+    hb_ff_mixdown_ch_xlat(&mixdown_layout, audio->config.out.mixdown, NULL);
+    hb_audio_remap_map_channel_layout(&hb_vorbis_chan_map, &out_layout, &mixdown_layout);
+
+    hb_audio_remap_build_table(&out_layout,
+                               &mixdown_layout,
                                pv->remap_table);
+
+    av_channel_layout_uninit(&out_layout);
+    av_channel_layout_uninit(&mixdown_layout);
 
     return 0;
 }

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -34,6 +34,7 @@ const char* const* hb_av_preset_get_names(int encoder);
 const char* const* hb_av_tune_get_names(int encoder);
 
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode);
+int      hb_ff_mixdown_ch_xlat(AVChannelLayout *channel_layout, int hb_mixdown, int *downmix_mode);
 void     hb_ff_set_sample_fmt(AVCodecContext *, const AVCodec *, enum AVSampleFormat);
 
 int hb_sws_get_colorspace(int color_matrix);

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -15,6 +15,8 @@
 #include "libavutil/frame.h"
 #include "handbrake/project.h"
 
+typedef AVChannelLayout hb_channel_layout_t;
+
 /***********************************************************************
  * common.c
  **********************************************************************/

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -416,24 +416,23 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
     for (ii = 0; ii < hb_list_count(title->list_audio); ii++)
     {
         const char * codec_name;
-        char         channel_layout_name[64];
+        char         channel_layout_name[256];
         int          channel_count, lfe_count;
         hb_dict_t  * audio_dict, * attributes;
         hb_audio_t * audio = hb_list_item(title->list_audio, ii);
 
         codec_name = hb_audio_decoder_get_name(audio->config.in.codec,
                                                audio->config.in.codec_param);
-        hb_layout_get_name(channel_layout_name, sizeof(channel_layout_name),
-                           audio->config.in.channel_layout);
+        hb_layout_get_name(audio->config.in.ch_layout,
+                           channel_layout_name, sizeof(channel_layout_name));
         channel_count = hb_layout_get_discrete_channel_count(
-                                     audio->config.in.channel_layout);
+                                     audio->config.in.ch_layout);
         lfe_count     = hb_layout_get_low_freq_channel_count(
-                                     audio->config.in.channel_layout);
-
+                                     audio->config.in.ch_layout);
 
         attributes = hb_audio_attributes_to_dict(audio->config.lang.attributes);
         audio_dict = json_pack_ex(&error, 0,
-        "{s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
+        "{s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o, s:o}",
             "TrackNumber",       hb_value_int(ii + 1),
             "Description",       hb_value_string(audio->config.lang.description),
             "Language",          hb_value_string(audio->config.lang.simple),
@@ -444,8 +443,7 @@ static hb_dict_t* hb_title_to_dict_internal( hb_title_t *title )
             "CodecName",         hb_value_string(codec_name),
             "SampleRate",        hb_value_int(audio->config.in.samplerate),
             "BitRate",           hb_value_int(audio->config.in.bitrate),
-            "ChannelLayout",     hb_value_int(audio->config.in.channel_layout),
-            "ChannelLayoutName", hb_value_string(channel_layout_name),
+            "ChannelLayout",     hb_value_string(channel_layout_name),
             "ChannelCount",      hb_value_int(channel_count),
             "LFECount",          hb_value_int(lfe_count));
         if (audio_dict == NULL)
@@ -1692,6 +1690,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                 audio.out.track = ii;
                 hb_audio_add(job, &audio);
             }
+            hb_audio_config_close(&audio);
         }
     }
 

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -671,6 +671,12 @@ hb_dovi_conf_t hb_dovi_ff_to_hb(AVDOVIDecoderConfigurationRecord dovi)
     return hb_dovi;
 }
 
+int hb_ff_mixdown_ch_xlat(AVChannelLayout *channel_layout, int hb_mixdown, int *downmix_mode)
+{
+    uint64_t layout = hb_ff_mixdown_xlat(hb_mixdown, downmix_mode);
+    return av_channel_layout_from_mask(channel_layout, layout);
+}
+
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
     uint64_t ff_layout = 0;

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -757,9 +757,7 @@ static int avformatInit( hb_mux_object_t * m )
         track->st->codecpar->sample_rate = audio->config.out.samplerate;
         if (audio->config.out.codec & HB_ACODEC_PASS_FLAG)
         {
-            AVChannelLayout ch_layout = {0};
-            av_channel_layout_from_mask(&ch_layout, audio->config.in.channel_layout);
-            track->st->codecpar->ch_layout = ch_layout;
+            av_channel_layout_copy(&track->st->codecpar->ch_layout, audio->config.in.ch_layout);
         }
         else
         {

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1498,6 +1498,8 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
         hb_buffer_t * tmp;
         tmp = hb_fifo_get( audio->priv.scan_cache );
         hb_buffer_close( &tmp );
+        av_channel_layout_uninit(info.ch_layout);
+        free(info.ch_layout);
         free( w );
         audio->priv.scan_error_count++;
         return;
@@ -1507,6 +1509,8 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
         // didn't find any info
         // Additional buffer data may be required to obtain
         // audio attributes
+        av_channel_layout_uninit(info.ch_layout);
+        free(info.ch_layout);
         free( w );
         return;
     }
@@ -1518,8 +1522,8 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
     audio->config.in.samples_per_frame = info.samples_per_frame;
     audio->config.in.bitrate = info.bitrate;
     audio->config.in.matrix_encoding = info.matrix_encoding;
-    audio->config.in.channel_layout = info.channel_layout;
-    audio->config.in.channel_map = info.channel_map;
+    audio->config.in.ch_layout = calloc(1, sizeof(*audio->config.in.ch_layout));
+    av_channel_layout_copy(audio->config.in.ch_layout, info.ch_layout);
     audio->config.in.version = info.version;
     audio->config.in.flags = info.flags;
     audio->config.in.mode = info.mode;
@@ -1724,11 +1728,10 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
                 strlen(audio->config.lang.description) - 1);
     }
 
-    if (audio->config.in.channel_layout)
+    if (audio->config.in.ch_layout->nb_channels)
     {
-        int lfes     = (!!(audio->config.in.channel_layout & AV_CH_LOW_FREQUENCY) +
-                        !!(audio->config.in.channel_layout & AV_CH_LOW_FREQUENCY_2));
-        int channels = hb_layout_get_discrete_channel_count(audio->config.in.channel_layout);
+        int lfes     = hb_layout_get_low_freq_channel_count(audio->config.in.ch_layout);
+        int channels = hb_layout_get_discrete_channel_count(audio->config.in.ch_layout);
         char *desc   = audio->config.lang.description +
                         strlen(audio->config.lang.description);
         size_t size = sizeof(audio->config.lang.description) - strlen(audio->config.lang.description);
@@ -1783,6 +1786,8 @@ static void LookForAudio(hb_scan_t *scan, hb_title_t * title, hb_audio_t * audio
             info.name, audio->config.in.samplerate, audio->config.in.bitrate,
             audio->config.lang.description );
 
+    av_channel_layout_uninit(info.ch_layout);
+    free(info.ch_layout);
     free( w );
     return;
 

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1203,7 +1203,7 @@ static int sanitize_audio(hb_job_t *job)
             /* Mixdown not specified, set the default mixdown */
             audio->config.out.mixdown =
                 hb_mixdown_get_default(audio->config.out.codec,
-                                       audio->config.in.channel_layout);
+                                       audio->config.in.ch_layout);
             hb_log("work: mixdown not specified, track %d setting mixdown %s",
                    audio->config.out.track,
                    hb_mixdown_get_name(audio->config.out.mixdown));
@@ -1212,7 +1212,7 @@ static int sanitize_audio(hb_job_t *job)
         {
             best_mixdown =
                 hb_mixdown_get_best(audio->config.out.codec,
-                                    audio->config.in.channel_layout,
+                                    audio->config.in.ch_layout,
                                     audio->config.out.mixdown);
             if (audio->config.out.mixdown != best_mixdown)
             {

--- a/macosx/HBAudio.m
+++ b/macosx/HBAudio.m
@@ -58,10 +58,10 @@ NSString *HBAudioEncoderChangedNotification = @"HBAudioEncoderChangedNotificatio
 {
     HBTitleAudioTrack *track = [self sourceTrackAtIndex:idx];
 
-    const char *title = hb_audio_name_generate(track.title.UTF8String,
-                                               track.channelLayout, mixdown,
-                                               self.defaults.passthruName,
-                                               (hb_audio_autonaming_behavior_t)self.defaults.automaticNamingBehavior);
+    const char *title = hb_audio_name_generate_s(track.title.UTF8String,
+                                                 track.chLayout.UTF8String, mixdown,
+                                                 self.defaults.passthruName,
+                                                 (hb_audio_autonaming_behavior_t)self.defaults.automaticNamingBehavior);
 
     return title ? @(title) : nil;
 }

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -478,6 +478,7 @@
             }
 
             hb_audio_add(job, &audio);
+            hb_audio_config_close(&audio);
         }
     }
 

--- a/macosx/HBTitle.h
+++ b/macosx/HBTitle.h
@@ -38,7 +38,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) int sampleRate;
 @property (nonatomic, readonly) int codec;
 @property (nonatomic, readonly) int codecParam;
-@property (nonatomic, readonly) uint64_t channelLayout;
+@property (nonatomic, readonly) NSString *chLayout;
 
 @property (nonatomic, readonly) NSString *isoLanguageCode;
 

--- a/macosx/HBTitle.m
+++ b/macosx/HBTitle.m
@@ -60,6 +60,7 @@
         _displayName = [displayName copy];
         _title = @"";
         _isoLanguageCode = @"";
+        _chLayout = @"";
     }
     return self;
 }
@@ -76,7 +77,10 @@
         _sampleRate = audio->in.samplerate;
         _codec = audio->in.codec;
         _codecParam = audio->in.codec_param;
-        _channelLayout = audio->in.channel_layout;
+
+        char channelLayoutDescription[256];
+        hb_layout_get_name(audio->in.ch_layout, channelLayoutDescription, sizeof(channelLayoutDescription));
+        _chLayout = @(channelLayoutDescription);
 
         _isoLanguageCode = @(audio->lang.iso639_2);
     }
@@ -94,8 +98,7 @@
     encodeInt(_sampleRate);
     encodeInt(_codec);
     encodeInt(_codecParam);
-    encodeInteger(_channelLayout);
-
+    encodeObject(_chLayout);
     encodeObject(_isoLanguageCode);
 }
 
@@ -111,7 +114,7 @@
         decodeInt(_sampleRate);
         decodeInt(_codec);
         decodeInt(_codecParam);
-        decodeInteger(_channelLayout);
+        decodeObjectOrFail(_chLayout, NSString);
         decodeObjectOrFail(_isoLanguageCode, NSString);
     }
     return self;

--- a/test/test.c
+++ b/test/test.c
@@ -1620,8 +1620,8 @@ static void ShowHelp(void)
     {
         if (!(encoder->codec & HB_ACODEC_PASS_FLAG))
         {
-            // layout: UINT64_MAX (all channels) should work with any mixdown
-            int mixdown = hb_mixdown_get_default(encoder->codec, UINT64_MAX);
+            // layout: 7.1 should work with all supported mixdowns
+            int mixdown = hb_mixdown_get_default_s(encoder->codec, "7.1");
             // assumes that the encoder short name is <= 16 characters long
             fprintf(out, "                               %-16s up to %s\n",
                     encoder->short_name, hb_mixdown_get_short_name(mixdown));
@@ -5521,7 +5521,7 @@ PrepareJob(hb_handle_t *h, hb_title_t *title, hb_dict_t *preset_dict)
                     int mixdown = hb_mixdown_get_from_name(mixdown_name);
 
                     const char *name = hb_audio_name_generate(audio->in.name,
-                                                              audio->in.channel_layout,
+                                                              (void *)&audio->in.ch_layout,
                                                               mixdown, keep_name, behavior);
 
                     if (name)

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -144,7 +144,7 @@ namespace HandBrake.Interop.Interop.HbLib
         public static extern int hb_audio_autonaming_behavior_get_from_name(IntPtr name);
 
         [DllImport("hb", EntryPoint = "hb_audio_name_generate", CallingConvention = CallingConvention.Cdecl)]
-        public static extern IntPtr hb_audio_name_generate(IntPtr name, ulong layout, int mixdown, int keep_name, int behaviour);
+        public static extern IntPtr hb_audio_name_generate_s(IntPtr name, IntPtr layout, int mixdown, int keep_name, int behaviour);
 
         [DllImport("hb", EntryPoint = "hb_video_quality_get_limits", CallingConvention = CallingConvention.Cdecl)]
         public static extern void hb_video_quality_get_limits(uint codec, ref float low, ref float high, ref float granularity, ref int direction);
@@ -179,8 +179,8 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_audio_encoder_get_fallback_for_passthru", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_audio_encoder_get_fallback_for_passthru(int passthru);
         
-        [DllImport("hb", EntryPoint = "hb_mixdown_is_supported", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_mixdown_is_supported(int mixdown, uint codec, ulong layout);
+        [DllImport("hb", EntryPoint = "hb_mixdown_is_supported_s", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_mixdown_is_supported_s(int mixdown, uint codec, IntPtr layout);
 
         [DllImport("hb", EntryPoint = "hb_mixdown_has_codec_support", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_mixdown_has_codec_support(int mixdown, uint codec);
@@ -188,11 +188,11 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_mixdown_has_remix_support", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_mixdown_has_remix_support(int mixdown, ulong layout);
 
-        [DllImport("hb", EntryPoint = "hb_mixdown_get_best", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_mixdown_get_best(uint codec, ulong layout, int mixdown);
+        [DllImport("hb", EntryPoint = "hb_mixdown_get_best_s", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_mixdown_get_best_s(uint codec, IntPtr layout, int mixdown);
 
-        [DllImport("hb", EntryPoint = "hb_mixdown_get_default", CallingConvention = CallingConvention.Cdecl)]
-        public static extern int hb_mixdown_get_default(uint codec, ulong layout);
+        [DllImport("hb", EntryPoint = "hb_mixdown_get_default_s", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_mixdown_get_default_s(uint codec, IntPtr layout);
 
         [DllImport("hb", EntryPoint = "hb_mixdown_get_next", CallingConvention = CallingConvention.Cdecl)]
         public static extern IntPtr hb_mixdown_get_next(IntPtr last);

--- a/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
+++ b/win/CS/HandBrake.Interop/Interop/Json/Scan/SourceAudioTrack.cs
@@ -27,7 +27,7 @@ namespace HandBrake.Interop.Interop.Json.Scan
         /// <summary>
         /// Gets or sets the channel layout.
         /// </summary>
-        public long ChannelLayout { get; set; }
+        public string ChannelLayout { get; set; }
 
         /// <summary>
         /// Gets or sets the description.
@@ -62,8 +62,6 @@ namespace HandBrake.Interop.Interop.Json.Scan
         public string CodecName { get; set; }
 
         public long LFECount { get; set; }
-
-        public string ChannelLayoutName { get; set; }
 
         public int ChannelCount { get; set; }
 

--- a/win/CS/HandBrakeWPF/Services/Encode/Model/Models/AudioTrack.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Model/Models/AudioTrack.cs
@@ -133,7 +133,7 @@ namespace HandBrakeWPF.Services.Encode.Model.Models
             // If the mixdown isn't supported, downgrade it.
             if (track.IsPassthru && track.MixDown != null && validatedEncoder != null && !HandBrakeEncoderHelpers.MixdownIsSupported(track.MixDown, validatedEncoder, sourceTrack.ChannelLayout))
             {
-                HBMixdown changedMixdown = HandBrakeEncoderHelpers.GetDefaultMixdown(validatedEncoder, (ulong)sourceTrack.ChannelLayout);
+                HBMixdown changedMixdown = HandBrakeEncoderHelpers.GetDefaultMixdown(validatedEncoder, sourceTrack.ChannelLayout);
                 if (changedMixdown != null)
                 {
                     this.mixDown = changedMixdown.ShortName;
@@ -517,7 +517,7 @@ namespace HandBrakeWPF.Services.Encode.Model.Models
 
                 if (this.ScannedTrack != null)
                 {
-                    ulong layout = (ulong)this.scannedTrack.ChannelLayout;
+                    string layout = this.scannedTrack.ChannelLayout;
                     bool keep = PassthruTracks != null ? PassthruTracks() : true;
                     HBMixdown currentMixdown = HandBrakeEncoderHelpers.GetMixdown(this.mixDown);
                     this.TrackName = HandBrakeEncoderHelpers.GetAutonameAudioTrack(this.TrackName,
@@ -644,11 +644,11 @@ namespace HandBrakeWPF.Services.Encode.Model.Models
             }
 
             HBMixdown currentMixdown = HandBrakeEncoderHelpers.GetMixdown(this.mixDown);
-            HBMixdown sanitisedMixdown = HandBrakeEncoderHelpers.SanitizeMixdown(currentMixdown, this.Encoder, (uint)this.ScannedTrack.ChannelLayout);
+            HBMixdown sanitisedMixdown = HandBrakeEncoderHelpers.SanitizeMixdown(currentMixdown, this.Encoder, this.ScannedTrack.ChannelLayout);
             HBMixdown defaultMixdown = sanitisedMixdown;
             if (this.Encoder != null)
             {
-                defaultMixdown = HandBrakeEncoderHelpers.GetDefaultMixdown(this.Encoder, (uint)this.ScannedTrack.ChannelLayout);
+                defaultMixdown = HandBrakeEncoderHelpers.GetDefaultMixdown(this.Encoder, this.ScannedTrack.ChannelLayout);
             }
          
             if (this.mixDown == null || this.mixDown == "none")

--- a/win/CS/HandBrakeWPF/Services/Scan/Model/Audio.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/Model/Audio.cs
@@ -51,7 +51,7 @@ namespace HandBrakeWPF.Services.Scan.Model
         /// <param name="channelLayout">
         /// The channel Layout.
         /// </param>
-        public Audio(int trackNumber, string language, string languageCode, string description, int codec, int sampleRate, int bitrate, long channelLayout, string name)
+        public Audio(int trackNumber, string language, string languageCode, string description, int codec, int sampleRate, int bitrate, string channelLayout, string name)
         {
             this.ChannelLayout = channelLayout;
             this.Name = name;
@@ -107,7 +107,7 @@ namespace HandBrakeWPF.Services.Scan.Model
         /// <summary>
         /// Gets or sets the channel layout of the source track (mixdown)
         /// </summary>
-        public long ChannelLayout { get; set; }
+        public string ChannelLayout { get; set; }
 
         public string Name { get; set; }
 


### PR DESCRIPTION
Add a minimum support for channel layouts with a custom channels order. Usually channels are in the canonical FFmpeg order, but recently the AVChannelLayout API has been expanded to support custom orders, and it's already in use for PCM audio for example.

Needs some testing to check if everything is still working as usual.

Will fix #6300.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux