### PR TITLE
contrib: update harfbuzz to 11.5.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.5.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.5/harfbuzz-11.4.5.tar.xz
-HARFBUZZ.FETCH.sha256  = 0f052eb4ab01d8bae98ba971c954becb32be57d7250f18af343b1d27892e03fa
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.5.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.5.0/harfbuzz-11.5.0.tar.xz
+HARFBUZZ.FETCH.sha256  = 2d30ba45c4c8ec4de661a1002b4f88d0841ff1a3087f34629275f5436d722109
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
- Update to Unicode 17.0.0.
- Subsetter optimizations.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Archlinux

**Screenshots (If relevant):**


**Log file output (If relevant):**
