### PR TITLE
hwaccel: enable full HW pipeline when color_range is auto

### DIFF
--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1744,7 +1744,7 @@ static void do_job(hb_job_t *job)
                                                 job->list_filter,
                                                 job->vcodec,
                                                 job->title->rotation,
-                                                job->color_range != job->title->color_range))
+                                                job->color_range && job->color_range != job->title->color_range))
         {
             job->hw_accel = hwaccel;
             job->hw_pix_fmt = hwaccel->hw_pix_fmt;


### PR DESCRIPTION
**Description of Change:**
Currently the output color_range has to be set to the input color_range explicitly to enable full HW pipeline. This PR fixes it by checking if color_range is 0 (`auto`/`same as source`)




**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux