### PR TITLE
flatpak: Update to Gnome 49 SDK

### DIFF
--- a/.github/workflows/flatpak.yml
+++ b/.github/workflows/flatpak.yml
@@ -18,7 +18,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y autoconf automake build-essential cmake git libnuma-dev libtool libtool-bin m4 make meson nasm ninja-build patch pkg-config tar flatpak flatpak-builder
         sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
-        sudo flatpak install -y flathub org.gnome.Platform//48 org.gnome.Sdk//48 org.freedesktop.Sdk.Extension.llvm18//24.08 org.freedesktop.Sdk.Extension.rust-stable//24.08
+        sudo flatpak install -y flathub org.gnome.Platform//49 org.gnome.Sdk//49 org.freedesktop.Sdk.Extension.llvm21//25.08 org.freedesktop.Sdk.Extension.rust-stable//25.08
    
     - name: Build HandBrake
       run: |

--- a/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.Plugin.IntelMediaSDK.json
@@ -3,7 +3,7 @@
     "branch": "1",
     "runtime": "fr.handbrake.ghb",
     "runtime-version": "development",
-    "sdk": "org.gnome.Sdk//48",
+    "sdk": "org.gnome.Sdk//49",
     "build-extension": true,
     "separate-locales": false,
     "modules": [
@@ -12,13 +12,14 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.5.2.tar.gz",
-                    "sha256": "dbf7cc401de7ff386306a23c1c61b3cf7bd86a4d9001b3a1d16a81e6b0e3ab2b"
+                    "url": "https://github.com/intel/gmmlib/archive/refs/tags/intel-gmmlib-22.8.2.tar.gz",
+                    "sha256": "2e43e538a002574f45d480a24e02297c960963dc7914b7328791d9836832ff43"
                 }
             ],
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.10",
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_LIBDIR=lib"
             ],
@@ -70,19 +71,21 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-24.3.4.tar.gz",
-                    "sha256": "58978f9ee4981532e60be2f2768673b1f3825db09971ebb98fbd7e8819cab6eb"
+                    "url": "https://github.com/intel/media-driver/archive/refs/tags/intel-media-25.3.4.tar.gz",
+                    "sha256": "ef9a7a0881b250d23df7d4676341a3729b28887bcf404a74d48db5f44ffa0220"
                 }
             ],
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.10",
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DMEDIA_RUN_TEST_SUITE=OFF",
                 "-DENABLE_PRODUCTION_KMD=ON"
             ],
             "build-options": {
+                "cxxflags": "-Wno-error=array-bounds=",
                 "prefix" : "/app/extensions/IntelMediaSDK",
                 "prepend-pkg-config-path": "/app/extensions/IntelMediaSDK/lib/pkgconfig",
                 "strip": true
@@ -93,6 +96,7 @@
             "buildsystem": "cmake-ninja",
             "builddir": true,
             "config-opts": [
+                "-DCMAKE_POLICY_VERSION_MINIMUM=3.10",
                 "-DCMAKE_BUILD_TYPE=Release",
                 "-DCMAKE_INSTALL_LIBDIR=lib",
                 "-DBUILD_SAMPLES=OFF",
@@ -141,8 +145,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/intel/vpl-gpu-rt/archive/refs/tags/intel-onevpl-24.3.4.tar.gz",
-                    "sha256": "978672104e6767223fbfb34fa9a0c0d954dcff9109891dc4911413dbc553ed71"
+                    "url": "https://github.com/intel/vpl-gpu-rt/archive/refs/tags/intel-onevpl-25.2.6.tar.gz",
+                    "sha256": "d236ede2ab87063d0d8d52932779ff446a885b8dc4ef840d1a756c6776ef6fef"
                 },
                 {
                     "type": "file",

--- a/pkg/linux/flatpak/fr.handbrake.ghb.json
+++ b/pkg/linux/flatpak/fr.handbrake.ghb.json
@@ -1,7 +1,7 @@
 {
     "app-id": "fr.handbrake.ghb",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "48",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "ghb",
     "finish-args": [
@@ -38,13 +38,13 @@
             "name": "numactl",
             "sources": [
                 {
-                    "type": "git",
-                    "url": "https://github.com/numactl/numactl.git",
-                    "tag": "v2.0.18",
-                    "commit": "3871b1c42fc71bceadafd745d2eff5dddfc2d67e",
+                    "type": "archive",
+                    "url": "https://github.com/numactl/numactl/archive/refs/tags/v2.0.19.tar.gz",
+                    "sha256": "8b84ffdebfa0d730fb2fc71bb7ec96bb2d38bf76fb67246fde416a68e04125e4",
                     "x-checker-data": {
-                        "type": "git",
-                        "tag-pattern": "^v([\\d.]+)$"
+                        "type": "anitya",
+                        "project-id": 2507,
+                        "url-template": "https://github.com/numactl/numactl/archive/refs/tags/v$version.tar.gz"
                     }
                 }
             ],

--- a/scripts/create_flatpak_manifest.py
+++ b/scripts/create_flatpak_manifest.py
@@ -74,9 +74,9 @@ class FlatpakManifest:
             self.manifest["runtime-version"] = runtime
 
         if "nvenc" in features:
-            self.extensions += ['org.freedesktop.Sdk.Extension.llvm18'];
-            self.build_path += ['/usr/lib/sdk/llvm18/bin'];
-            self.ld_path    += ['/usr/lib/sdk/llvm18/lib'];
+            self.extensions += ['org.freedesktop.Sdk.Extension.llvm21'];
+            self.build_path += ['/usr/lib/sdk/llvm21/bin'];
+            self.ld_path    += ['/usr/lib/sdk/llvm21/lib'];
 
         if "libdovi" in features:
             self.extensions += ['org.freedesktop.Sdk.Extension.rust-stable'];


### PR DESCRIPTION
**Description of Change:**

Updates the Flatpak to the latest SDK version, which allows H.265 video playback in the preview window. I've also updated all the Flatpak-specific components to the latest versions.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
