### PR TITLE
build: update build.xml to sign all execute and dll files

### DIFF
--- a/win/CS/build.xml
+++ b/win/CS/build.xml
@@ -120,8 +120,9 @@
   </PropertyGroup>
 
   <Target Name="CodeSign" Condition="'$(SignEnabled)' == 'true'">
-    <Exec Command="&quot;$(SignToolLocation)&quot; sign $(SignType) $(SignThumbprint)$(PfxFile) $(SignPwd) $(PfxPwd) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\publish\*Win_GUI.exe&quot;" />
-    <Exec Command="&quot;$(SignToolLocation)&quot; sign $(SignType) $(SignThumbprint)$(PfxFile) $(SignPwd) $(PfxPwd) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\publish\*Win_GUI.msi&quot;" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign $(SignType) $(SignThumbprint)$(PfxFile) $(SignPwd) $(PfxPwd) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\publish\*.exe&quot;" />
+    <Exec Command="&quot;$(SignToolLocation)&quot; sign $(SignType) $(SignThumbprint)$(PfxFile) $(SignPwd) $(PfxPwd) $(SignTimestamp) $(SignTimestampServer) /v &quot;$(MSBuildProjectDirectory)\HandBrakeWPF\bin\publish\*.dll&quot;" />
   </Target>
 
 </Project>
+


### PR DESCRIPTION
**Description of Change:**

Currently, the Windows CI workflow only signs installer packages, The binaries included inside the installer (such as `HandBrake.exe`, `hb.dll`) remain unsigned. This PR updates build.xml to ensuring every binary file is signed.

PS: It looks like Handbrake no longer provide msi installers package, I've already removed the obsolete exec command.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
