### PR TITLE
contrib: update libdav1d to 1.5.2

### DIFF
--- a/contrib/libdav1d/A99-pkgconfig-location.patch
+++ b/contrib/libdav1d/A99-pkgconfig-location.patch
@@ -1,6 +1,6 @@
 --- dav1d-1.4.0/src/meson.build	2024-02-14 19:06:02.000000000 +0100
 +++ dav1d-1.4.0-patched/src/meson.build	2024-02-15 17:27:23.400210200 +0100
-@@ -400,6 +400,7 @@
+@@ -401,6 +401,7 @@
  #
  pkg_mod = import('pkgconfig')
  pkg_mod.generate(libraries: libdav1d,

--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,12 +1,11 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.5.1.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.5.1/dav1d-1.5.1.tar.bz2
-LIBDAV1D.FETCH.sha256  = 4eddffd108f098e307b93c9da57b6125224dc5877b1b3d157b31be6ae8f1f093
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.5.2.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.5.2/dav1d-1.5.2.tar.bz2
+LIBDAV1D.FETCH.sha256  = c748a3214cf02a6d23bc179a0e8caea9d6ece1e46314ef21f5508ca6b5de6262
 
-LIBDAV1D.build_dir     = build/
-
+LIBDAV1D.build_dir        = build/
 LIBDAV1D.CONFIGURE.exe    = $(MESON.exe) setup
 LIBDAV1D.CONFIGURE.deps   =
 LIBDAV1D.CONFIGURE.shared =
@@ -41,7 +40,5 @@ endif
 
 LIBDAV1D.BUILD.make       = $(NINJA.exe)
 LIBDAV1D.BUILD.extra      = -v
-
 LIBDAV1D.INSTALL.make     = $(NINJA.exe)
-
 LIBDAV1D.CLEAN.make       = $(NINJA.exe)


### PR DESCRIPTION
**libdav1d 1.5.2:**

Changes for 1.5.2 'Sonic':

1.5.2 is a minor release of dav1d, focusing on minor speed optimizations, reduce code size and other small fixes on tools and compilation.

Notably, minor speed improvement in recon, improvements on loongarch symbols, reducing the code size of the frame header parsing, and minor fixes on tools and CI and nasm 3.0

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux