### PR TITLE
contrib: update libdvdread to 7.0.1

### DIFF
--- a/contrib/libdvdread/A03-macOS-hardened-runtime-dlopen.patch
+++ b/contrib/libdvdread/A03-macOS-hardened-runtime-dlopen.patch
@@ -1,7 +1,7 @@
 diff --git a/src/dvd_input.c b/src/dvd_input.c
---- a/src/dvd_input.c	2025-09-25 21:59:39.000000000 +0200
-+++ b/src/dvd_input.c	2025-09-29 19:21:29.888738600 +0200
-@@ -479,6 +479,7 @@
+--- a/src/dvd_input.c	2025-11-09 14:26:34.000000000 +0100
++++ b/src/dvd_input.c	2025-11-09 17:44:15.972121760 +0100
+@@ -480,6 +480,7 @@
  
  #ifdef __APPLE__
    #define CSS_LIB "libdvdcss.2.dylib"
@@ -9,7 +9,7 @@ diff --git a/src/dvd_input.c b/src/dvd_input.c
  #elif defined(_WIN32)
    #define CSS_LIB "libdvdcss-2.dll"
  #elif defined(__OS2__)
-@@ -515,6 +516,13 @@
+@@ -523,6 +524,13 @@
    dvdcss_library = dlopen(CSS_LIB, RTLD_LAZY);
  #endif
  
@@ -20,6 +20,6 @@ diff --git a/src/dvd_input.c b/src/dvd_input.c
 +  }
 +#endif
 +
+   /* Locate the functions, DVD_V or DVD_A */
    if(dvdcss_library != NULL) {
- #ifdef __OS2__
- #define U_S "_"
+     /* functions should have the same template*/

--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,5 +1,3 @@
-__deps__ := DVDCSS
-
 $(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
@@ -24,10 +22,6 @@ LIBDVDREAD.CONFIGURE.env         =
 
 ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
      LIBDVDREAD.CONFIGURE.extra += -Ddlfcn=builtin
-endif
-
-ifneq (darwin,$(HOST.system))
-     LIBDVDREAD.CONFIGURE.extra += -Dlibdvdcss=enabled
 endif
 
 LIBDVDREAD.GCC.args.extra += $(LIBDVDREAD.GCC.args.O.$(LIBDVDREAD.GCC.O))

--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,9 +1,11 @@
-$(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread))
+__deps__ := DVDCSS
+
+$(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
-LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libdvdread-7.0.0.tar.bz2
-LIBDVDREAD.FETCH.url    += https://code.videolan.org/videolan/libdvdread/-/archive/7.0.0/libdvdread-7.0.0.tar.bz2
-LIBDVDREAD.FETCH.sha256  = ecb58701294d0d27c142494fbf3255278c349a54f5532e35d5dc98c5ec0dec7c
+LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libdvdread-7.0.1.tar.bz2
+LIBDVDREAD.FETCH.url    += https://code.videolan.org/videolan/libdvdread/-/archive/7.0.1/libdvdread-7.0.1.tar.bz2
+LIBDVDREAD.FETCH.sha256  = b69f74d9ceea1ed173b579deba99f669c2cb42f3fd06d7d23b33ff222aa63763
 
 LIBDVDREAD.build_dir             = build/
 LIBDVDREAD.CONFIGURE.exe         = $(MESON.exe) setup
@@ -22,7 +24,11 @@ LIBDVDREAD.CONFIGURE.env         =
 
 ifeq (1-mingw,$(HOST.cross)-$(HOST.system))
      LIBDVDREAD.CONFIGURE.extra += -Ddlfcn=builtin
- endif
+endif
+
+ifneq (darwin,$(HOST.system))
+     LIBDVDREAD.CONFIGURE.extra += -Dlibdvdcss=enabled
+endif
 
 LIBDVDREAD.GCC.args.extra += $(LIBDVDREAD.GCC.args.O.$(LIBDVDREAD.GCC.O))
 


### PR DESCRIPTION
**libdvdread 7.0.1:**
* Minor release that fixed crash when libdvdcss wasn't present

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux