### PR TITLE
contrib: update harfbuzz to 12.2.0

### DIFF
--- a/contrib/harfbuzz/module.defs
+++ b/contrib/harfbuzz/module.defs
@@ -3,9 +3,9 @@ __deps__ := FREETYPE
 $(eval $(call import.MODULE.defs,HARFBUZZ,harfbuzz,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,HARFBUZZ))
 
-HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-11.4.5.tar.xz
-HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/11.4.5/harfbuzz-11.4.5.tar.xz
-HARFBUZZ.FETCH.sha256  = 0f052eb4ab01d8bae98ba971c954becb32be57d7250f18af343b1d27892e03fa
+HARFBUZZ.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/harfbuzz-12.2.0.tar.xz
+HARFBUZZ.FETCH.url    += https://github.com/harfbuzz/harfbuzz/releases/download/12.2.0/harfbuzz-12.2.0.tar.xz
+HARFBUZZ.FETCH.sha256  = ecb603aa426a8b24665718667bda64a84c1504db7454ee4cadbd362eea64e545
 
 HARFBUZZ.build_dir             = build
 HARFBUZZ.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**Harfbuzz 12.2.0**
- While Windows platform contain the matching of the ChainContext rules to within the syllable for those features that are applied per syllable (in Indic-like and USE shapers), in 2015 we decided that in HarfBuzz we would allow the backtrack / lookahead parts of the rule to match across syllables. However, our implementation had a latent bug, causing the backtrack sequence to be matched within syllable most of the time, and inconsistently so. As such, and after empirical testing, we have decided to match the Windows implementation for this, so now both backtrack and lookahead sequences are contained to within the syllable, just like DirectWrite does.
- Disable legacy `kern` table for most shapers, enabling it only for default, Arabic, Hangul, and Hebrew shapers.
- When dropping `STAT` table during subsetting, drop also named IDs that are referenced only by it.
- Don’t apply synthetic slant to glyph origin, fixing horizontal shift in slanted glyphs.
- Various build and fuzzing fixes.
- Documentation fixes.
- Build fixes with GCC 15 on some 32 bit platforms.
- Fix misaligned pointer use.
- New API, `hb_ot_layout_lookup_collect_glyph_alternates()`, to collect glyph substitutions from single and alternate substitution lookups in one call, instead of getting substitutions one by one using `hb_ot_layout_lookup_get_glyph_alternates()`.

- New API +hb_ot_layout_lookup_collect_glyph_alternates()

- The major feature of this release is that the Variable Composites / Components (`VARC` table) addition to the ISO OpenFontFormat has graduated from experimental, and is now enabled by default. It can be disabled at compile time by defining the `HB_NO_VAR_COMPOSITES`z macro.

  `VARC` table is a new way to store glyph outlines, that allows for better shape reuse, and can reduce font file size for Chinese, Japanese, Korean, and some other scripts drastically. Some font design tools provide a similar feature to designers, known as "smart components". This technology brings the same idea to the compiled font file. For the format specification, see: https://github.com/harfbuzz/boring-expansion-spec/blob/main/VARC.md

  Test fonts can be found at: https://github.com/notofonts/noto-cjk-varco/releases/tag/v0.003

  The Fontra font editor already supports this technology.

  Note that this new format involves just the HarfBuzz draw API and does not affect shaping.

- Correctly handle `markFilteringSet` lookup field during subsetting.
- Deduplicate features during subsetting.
- Disable “more” buffer messages that give more verbose output when using buffer messages callbacks, as it has a performance overhead. Users/tools that need the more verbose messages should define `HB_BUFFER_MESSAGE_MORE` to 1 when building HarfBuzz.
- Shaping and instancing optimizations.
- Fix subsetting issues when building with GCC 12.
- Optimized partial-instancing of fonts with a large number of axes. Now over two times faster.
- Fix C++ STL atomics implementation.
- Update to Unicode 17.0.0.
- Subsetter optimizations.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux