### PR TITLE
contrib: update libjpeg-turbo to 3.1.3

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.2.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.2.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 560f6338b547544c4f9721b18d8b87685d433ec78b3c644c70d77adad22c55e6
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.3.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.3.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = 3a13a5ba767dc8264bc40b185e41368a80d5d5f945944d1dbaa4b2fb0099f4e5
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake


### PR DESCRIPTION
**libjpeg-turbo 3.1.3:**
Significant changes relative to 3.1.3:

- Hardened the TurboJPEG API against hypothetical applications that may erroneously call `tj*Compress*()` or `tj*Transform()` with a reused JPEG destination buffer pointer while specifying a destination buffer size of 0.

- Hardened the TurboJPEG API against hypothetical applications that may erroneously set `TJPARAM_LOSSLESS` or `TJPARAM_COLORSPACE` prior to calling `tj3EncodeYUV*8()` or `tj3CompressFromYUV*8()`. `tj3EncodeYUV*8()` and `tj3CompressFromYUV*8()` now ignore `TJPARAM_LOSSLESS` and `TJPARAM_COLORSPACE`.

- Hardened the TurboJPEG Java API against hypothetical applications that may erroneously pass huge X or Y offsets to one of the compression, YUV encoding, decompression, or YUV decoding methods, leading to signed integer overflow in the JNI wrapper's buffer size checks that rendered those checks ineffective.

- Fixed an issue in the TurboJPEG Java API whereby `TJCompressor.getSourceBuf()` sometimes returned the buffer from a previous invocation of `TJCompressor.loadSourceImage()` if the target data precision was changed before the most recent invocation.

- Fixed an issue in the PPM reader that caused incorrect pixels to be generated when using `tj3LoadImage*()` or `TJCompressor.loadSourceImage()` to load a PBMPLUS (PPM/PGM) file into a CMYK buffer with a different data precision than that of the file.

**Tested on:**
- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux