### PR TITLE
[scripts] Fix for translate_mac.sh

### DIFF
--- a/scripts/localization/translate_mac.sh
+++ b/scripts/localization/translate_mac.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Usage: Set environment variables, then run ./translate_mac.sh
 # Using your own HandBrake Fork, example:
 #     export HB_GIT_REPO=https://github.com/<your-username>/HandBrake.git
@@ -7,64 +8,104 @@
 #     Click on the resource to delve into it
 #     The three dots button top right will have a Download all option.
 
-if [[ -z ${HB_GIT_REPO} ]]; then
-    echo "HB_GIT_REPO should be set to your HandBrake Repo Fork URL, including .git";
-    exit 1;
+# Preconditions
+if [[ -z "${HB_GIT_REPO:-}" ]]; then
+    echo "HB_GIT_REPO should be set to your HandBrake Repo Fork URL, including .git"
+    exit 1
 fi
 
-if [[ -z ${HB_BRANCH_NAME} ]]; then
-    echo "HB_BRANCH_NAME should be set to a new unique branch name for updating translations";
-    exit 1;
+if [[ -z "${HB_BRANCH_NAME:-}" ]]; then
+    echo "HB_BRANCH_NAME should be set to a new unique branch name for updating translations"
+    exit 1
 fi
 
 echo ""
 echo "Using: "
-echo "Git Repo: $HB_GIT_REPO"
+echo "Git Repo:   $HB_GIT_REPO"
 echo "Git Branch: $HB_BRANCH_NAME"
 echo ""
 
 # Cleanup Past Runs
 echo ""
 echo "- Tidyup any previous run"
-rm -rf HandBrake
-rm *.xlf
+rm -rf HandBrake Translations
+mkdir Translations
 
 # Create a bit branch for the pull request
 echo ""
 echo "- Download git fork and create a translation branch."
-echo $HB_GIT_REPO
-git clone $HB_GIT_REPO
-git branch translation_update
-git checkout translation_update
+git clone "$HB_GIT_REPO" HandBrake
+cd HandBrake
+git checkout -b "$HB_BRANCH_NAME"
+cd ..
 
 # Unpack
 echo ""
 echo "- Unpacking the transifex files"
-unzip handbrakeproject_mac-ui_enxliff*.zip 
+unzip handbrakeproject_mac-ui_*.zip -d Translations
 
-# Run xcode to manage the translations
-echo ""
-echo "- Process Translation Files"
-for f in *; do
-        case $f in 
-               enxliff_*.xlf)
-                        [[ $f =~ enxliff_(.*) ]]
-                        suffix=${BASH_REMATCH[1]}
-                        y="$suffix"
-                  						
-						echo "Processing $f ... "
-                        xcodebuild -importLocalizations -project /HandBrake/macosx/HandBrake.xcodeproj -localizationPath $f 
-						mv /HandBrake/macosx/build/release/external/macosx/$y.lproj/Localizable.strings /HandBrake/macosx/HandBrakeKit/$y.lproj
-						;;
-        esac
+cd HandBrake || exit 1
+
+# Supported languages (add all available languages in macosx here)
+SUPPORTED_LANGS=("bg" "co" "de" "fr" "it" "ja_jp" "ko" "pt_br" "ru" "sv_se" "uk_ua" "zh") 
+
+# Function to check whether a language is supported
+is_supported_lang() {
+    local lang="$1"
+    for l in "${SUPPORTED_LANGS[@]}"; do
+        [[ "$l" == "$lang" ]] && return 0
+    done
+    return 1
+}
+
+# Process XLIFF files
+find ../Translations -name "*.xlf" | while read -r xlf; do
+    filename=$(basename "$xlf")
+
+    if [[ "$filename" =~ ^enxliff-([A-Za-z0-9_]+)\.xlf$ ]]; then
+        lang="${BASH_REMATCH[1]}"
+    else
+        echo "Skipping unrecognized file: $filename"
+        continue
+    fi
+
+    if ! is_supported_lang "$lang"; then
+        echo "Skipping unsupported language: $lang (from $filename)"
+        continue
+    fi
+
+    echo "Importing localization for language: $lang"
+
+    xcodebuild \
+        -importLocalizations \
+        -project macosx/HandBrake.xcodeproj \
+        -localizationPath "$xlf"
+
+    src="macosx/build/release/external/macosx/$lang.lproj/Localizable.strings"
+    dst="macosx/$lang.lproj/Localizable.strings"
+
+    if [[ -f "$src" ]]; then
+        mkdir -p "macosx/$lang.lproj"
+        mv "$src" "$dst"
+    else
+        echo "No output generated for language: $lang"
+    fi
+done
+
+# Fix CocoaBindingsConnection bug
+echo "Fixing CocoaBindingsConnection placeholders"
+
+find macosx -name "MainWindow.strings" | while read -r f; do
+    sed -i '' \
+        's/^\(".*\.ibShadowedIsNilPlaceholder"\)[[:space:]]*=[[:space:]]*".*";/\1 = "";/' \
+        "$f"
 done
 
 # Commit the change
 echo ""
 echo "- Creating a Git commit"
-cd HandBrake
-git add --all
-git commit -m "Updating Mac UI Translations"
+git add macosx
+git commit -m "Update Mac UI translations"
 
 echo ""
 echo "Done: git push then create a pull request on GitHub."


### PR DESCRIPTION
The script translate_mac.sh currently does not work (at all). So I tried to fix this over the last few weeks.

This change fixes and stabilizes the translate_mac.sh script used to import macOS UI translations from Transifex into the HandBrake repository. The updated version makes the import process deterministic, safe, and compatible with the existing HandBrake macOS localization structure.

What the script now does (current behavior):
Verifies required environment variables (HB_GIT_REPO, HB_BRANCH_NAME)
Cleans any previous run
Clones the HandBrake fork and creates a new branch
Unpacks the Transifex “Download All” ZIP
Iterates over all XLIFF files
Imports only existing languages using xcodebuild -importLocalizations
Moves generated Localizable.strings files from the external folder into the correct .lproj directories
Fixes known CocoaBindings placeholder issue

I should note, however, that I drew inspiration from ChatGPT for some lines. The script has been checked several times and now provides me with usable output. It is now a great help when creating a MR for new translations.