### PR TITLE
contrib: update sse2neon to 1.9.0

### DIFF
--- a/contrib/sse2neon/module.defs
+++ b/contrib/sse2neon/module.defs
@@ -1,11 +1,11 @@
 $(eval $(call import.MODULE.defs,SSE2NEON,sse2neon))
 $(eval $(call import.CONTRIB.defs,SSE2NEON))
 
-SSE2NEON.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/sse2neon-1.8.0.tar.gz
-SSE2NEON.FETCH.url      += https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.8.0.tar.gz
-SSE2NEON.FETCH.sha256    = e251746e3b761f3f0de1ad462b1efe53532341b6b0498d394765fceb85ce8a46
-SSE2NEON.FETCH.basename  = sse2neon-1.8.0.tar.gz
-SSE2NEON.EXTRACT.tarbase = sse2neon-1.8.0
+SSE2NEON.FETCH.url       = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/sse2neon-1.9.0.tar.gz
+SSE2NEON.FETCH.url      += https://github.com/DLTcollab/sse2neon/archive/refs/tags/v1.9.0.tar.gz
+SSE2NEON.FETCH.sha256    = d5340e2d7bad27e4a20acc72b8ad0ec538e5e502980194b691cad2f0ab10cb8a
+SSE2NEON.FETCH.basename  = sse2neon-1.9.0.tar.gz
+SSE2NEON.EXTRACT.tarbase = sse2neon-1.9.0
 
 SSE2NEON.CONFIGURE = $(TOUCH.exe) $@
 SSE2NEON.BUILD     = $(TOUCH.exe) $@


### PR DESCRIPTION
Release notes (too much to list here):
https://github.com/DLTcollab/sse2neon/releases/tag/v1.9.0

**Tested on:**
I've unfortunately could not test this PR on ARM because of no ARM hardware.