### PR TITLE
Update copyright dates to 2026

### DIFF
--- a/gtk/data/fr.handbrake.ghb.metainfo.xml.in.in
+++ b/gtk/data/fr.handbrake.ghb.metainfo.xml.in.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018-2025 John Stebbins <your@email.com> -->
+<!-- Copyright 2018-2026 John Stebbins <your@email.com> -->
 <component type="desktop-application">
   <id>fr.handbrake.ghb</id>
   <translation type="gettext">ghb</translation>

--- a/gtk/data/meson.build
+++ b/gtk/data/meson.build
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2025 HandBrake Team
+# Copyright (C) 2026-2026 HandBrake Team
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 data = gnome.compile_resources('data_res', 'data_res.gresource.xml',

--- a/gtk/icons/meson.build
+++ b/gtk/icons/meson.build
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2025 HandBrake Team
+# Copyright (C) 2026-2026 HandBrake Team
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 icons = gnome.compile_resources('icon_res', 'icon_res.gresource.xml',

--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 HandBrake Team
+# Copyright (C) 2026-2026 HandBrake Team
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 project('handbrake-gtk', 'c', 'cpp',

--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -1,6 +1,6 @@
 /* application.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/application.h
+++ b/gtk/src/application.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/audiohandler.c
+++ b/gtk/src/audiohandler.c
@@ -1,6 +1,6 @@
 /* audiohandler.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/audiohandler.h
+++ b/gtk/src/audiohandler.h
@@ -1,6 +1,6 @@
 /* audiohandler.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1,6 +1,6 @@
 /* callbacks.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -1,6 +1,6 @@
 /* callbacks.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/chapters.c
+++ b/gtk/src/chapters.c
@@ -1,6 +1,6 @@
 /* chapters.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/chapters.h
+++ b/gtk/src/chapters.h
@@ -1,6 +1,6 @@
 /* chapters.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/color-scheme.c
+++ b/gtk/src/color-scheme.c
@@ -1,6 +1,6 @@
 /* color-scheme.c
  *
- * Copyright (C) 2022-2025 HandBrake Team
+ * Copyright (C) 2022-2026 HandBrake Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/color-scheme.h
+++ b/gtk/src/color-scheme.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2022-2025 HandBrake Team
+/* Copyright (C) 2022-2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/common.h
+++ b/gtk/src/common.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/ghb-button.c
+++ b/gtk/src/ghb-button.c
@@ -1,6 +1,6 @@
 /* ghb-button.c
  *
- * Copyright (C) 2025 HandBrake Team
+ * Copyright (C) 2026 HandBrake Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/ghb-button.h
+++ b/gtk/src/ghb-button.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/ghb-chapter-row.c
+++ b/gtk/src/ghb-chapter-row.c
@@ -1,6 +1,6 @@
 /* ghb-chapter-row.c
  *
- * Copyright (C) 2025 HandBrake Team
+ * Copyright (C) 2026 HandBrake Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/ghb-chapter-row.h
+++ b/gtk/src/ghb-chapter-row.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/ghb-file-button.c
+++ b/gtk/src/ghb-file-button.c
@@ -1,6 +1,6 @@
 /* ghb-file-button.c
  *
- * Copyright (C) 2025 HandBrake Team
+ * Copyright (C) 2026 HandBrake Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/ghb-file-button.h
+++ b/gtk/src/ghb-file-button.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/ghb-queue-row.c
+++ b/gtk/src/ghb-queue-row.c
@@ -1,6 +1,6 @@
 /* ghb-queue-row.c
  *
- * Copyright (C) 2025 HandBrake Team
+ * Copyright (C) 2026 HandBrake Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/ghb-queue-row.h
+++ b/gtk/src/ghb-queue-row.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/ghb-string-list.c
+++ b/gtk/src/ghb-string-list.c
@@ -1,6 +1,6 @@
 /* ghb-string-list.c
  *
- * Copyright (C) 2025 HandBrake Team
+ * Copyright (C) 2026 HandBrake Team
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/ghb-string-list.h
+++ b/gtk/src/ghb-string-list.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2025 HandBrake Team
+/* Copyright (C) 2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -1,6 +1,6 @@
 /* hb-backend.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/hb-backend.h
+++ b/gtk/src/hb-backend.h
@@ -1,6 +1,6 @@
 /* hb-backend.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/hb-dvd.c
+++ b/gtk/src/hb-dvd.c
@@ -1,6 +1,6 @@
 /* hb-dvd.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/hb-dvd.h
+++ b/gtk/src/hb-dvd.h
@@ -1,6 +1,6 @@
 /* hb-dvd.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/jobdict.c
+++ b/gtk/src/jobdict.c
@@ -1,6 +1,6 @@
 /* jobdict.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/jobdict.h
+++ b/gtk/src/jobdict.h
@@ -1,6 +1,6 @@
 /* jobdict.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -1,6 +1,6 @@
 /* main.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/meson.build
+++ b/gtk/src/meson.build
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2025 HandBrake Team
+# Copyright (C) 2026-2026 HandBrake Team
 # SPDX-License-Identifier: GPL-2.0-or-later
 
 # Project sources

--- a/gtk/src/notifications.c
+++ b/gtk/src/notifications.c
@@ -1,6 +1,6 @@
 /* notifications.c
  *
- * Copyright (C) 2023-2025 HandBrake Team
+ * Copyright (C) 2026-2026 HandBrake Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/notifications.h
+++ b/gtk/src/notifications.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 HandBrake Team
+/* Copyright (C) 2026-2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/power-manager.c
+++ b/gtk/src/power-manager.c
@@ -1,6 +1,6 @@
 /* notifications.c
  *
- * Copyright (C) 2023-2025 HandBrake Team
+ * Copyright (C) 2026-2026 HandBrake Team
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/gtk/src/power-manager.h
+++ b/gtk/src/power-manager.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2023-2025 HandBrake Team
+/* Copyright (C) 2026-2026 HandBrake Team
  * SPDX-License-Identifier: GPL-2.0-or-later */
 
 #pragma once

--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1,6 +1,6 @@
 /* presets.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/presets.h
+++ b/gtk/src/presets.h
@@ -1,6 +1,6 @@
 /* presets.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -1,6 +1,6 @@
 /* preview.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/preview.h
+++ b/gtk/src/preview.h
@@ -1,6 +1,6 @@
 /* preview.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/queuehandler.c
+++ b/gtk/src/queuehandler.c
@@ -1,6 +1,6 @@
 /* queuehandler.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/queuehandler.h
+++ b/gtk/src/queuehandler.h
@@ -1,6 +1,6 @@
 /* queuehandler.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/resources.c
+++ b/gtk/src/resources.c
@@ -1,6 +1,6 @@
 /* resources.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/resources.h
+++ b/gtk/src/resources.h
@@ -1,6 +1,6 @@
 /* resources.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/settings.c
+++ b/gtk/src/settings.c
@@ -1,6 +1,6 @@
 /* settings.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/settings.h
+++ b/gtk/src/settings.h
@@ -1,6 +1,6 @@
 /* settings.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/subtitlehandler.c
+++ b/gtk/src/subtitlehandler.c
@@ -1,6 +1,6 @@
 /* subtitlehandler.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/subtitlehandler.h
+++ b/gtk/src/subtitlehandler.h
@@ -1,6 +1,6 @@
 /* subtitlehandler.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -1,6 +1,6 @@
 /* title-add.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/title-add.h
+++ b/gtk/src/title-add.h
@@ -1,6 +1,6 @@
 /* title-add.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/titledict.c
+++ b/gtk/src/titledict.c
@@ -1,6 +1,6 @@
 /* titledict.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/titledict.h
+++ b/gtk/src/titledict.h
@@ -1,6 +1,6 @@
 /* titledict.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -1300,8 +1300,8 @@ Resets the queue job to pending and ready to run again.</property>
     <property name="title" translatable="yes">About HandBrake</property>
     <property name="modal">1</property>
     <property name="program-name">HandBrake</property>
-    <property name="copyright" translatable="yes">Copyright © 2008-2024 John Stebbins
-Copyright © 2004-2024, HandBrake Devs</property>
+    <property name="copyright" translatable="yes">Copyright © 2008-2026 John Stebbins
+Copyright © 2004-2026, HandBrake Devs</property>
     <property name="comments" translatable="yes">Multithreaded video transcoder</property>
     <property name="website">https://handbrake.fr</property>
     <property name="website-label">https://handbrake.fr</property>

--- a/gtk/src/util.c
+++ b/gtk/src/util.c
@@ -1,6 +1,6 @@
 /* util.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/util.h
+++ b/gtk/src/util.h
@@ -1,6 +1,6 @@
 /* util.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/values.c
+++ b/gtk/src/values.c
@@ -1,6 +1,6 @@
 /* values.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/values.h
+++ b/gtk/src/values.h
@@ -1,6 +1,6 @@
 /* values.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/videohandler.c
+++ b/gtk/src/videohandler.c
@@ -1,6 +1,6 @@
 /* videohandler.c
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/gtk/src/videohandler.h
+++ b/gtk/src/videohandler.h
@@ -1,6 +1,6 @@
 /* videohandler.h
  *
- * Copyright (C) 2008-2025 John Stebbins <stebbins@stebbins>
+ * Copyright (C) 2008-2026 John Stebbins <stebbins@stebbins>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2,

--- a/libhb/audio_remap.c
+++ b/libhb/audio_remap.c
@@ -1,6 +1,6 @@
 /* audio_remap.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/audio_resample.c
+++ b/libhb/audio_resample.c
@@ -1,6 +1,6 @@
 /* audio_resample.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -1,6 +1,6 @@
 /* avfilter.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/batch.c
+++ b/libhb/batch.c
@@ -1,6 +1,6 @@
 /* batch.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/bd.c
+++ b/libhb/bd.c
@@ -1,6 +1,6 @@
 /* bd.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/bitstream.c
+++ b/libhb/bitstream.c
@@ -1,6 +1,6 @@
 /* bitstream.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/blend.c
+++ b/libhb/blend.c
@@ -1,6 +1,6 @@
 /* blend.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/chroma_smooth.c
+++ b/libhb/chroma_smooth.c
@@ -1,7 +1,7 @@
 /* chroma_smooth.c
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/colormap.c
+++ b/libhb/colormap.c
@@ -1,6 +1,6 @@
 /* colormap.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/colorspace.c
+++ b/libhb/colorspace.c
@@ -1,6 +1,6 @@
 /* colorspace.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/comb_detect.c
+++ b/libhb/comb_detect.c
@@ -1,6 +1,6 @@
 /* comb_detect.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -1,6 +1,6 @@
 /* common.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/compat.c
+++ b/libhb/compat.c
@@ -1,6 +1,6 @@
 /* compat.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -1,6 +1,6 @@
 /* cropscale.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/deblock.c
+++ b/libhb/deblock.c
@@ -1,6 +1,6 @@
 /* deblock.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1,6 +1,6 @@
 /* decavcodec.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/decavsub.c
+++ b/libhb/decavsub.c
@@ -1,6 +1,6 @@
 /* decavsub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/declpcm.c
+++ b/libhb/declpcm.c
@@ -1,6 +1,6 @@
 /* declpcm.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decomb.c
+++ b/libhb/decomb.c
@@ -1,6 +1,6 @@
 /* decomb.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decsrtsub.c
+++ b/libhb/decsrtsub.c
@@ -1,6 +1,6 @@
 /* decsrtsub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/decssasub.c
+++ b/libhb/decssasub.c
@@ -1,6 +1,6 @@
 /* decssasub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dectx3gsub.c
+++ b/libhb/dectx3gsub.c
@@ -1,6 +1,6 @@
 /* dectx3gsub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/deinterlace.c
+++ b/libhb/deinterlace.c
@@ -1,6 +1,6 @@
 /* deinterlace.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/demuxmpeg.c
+++ b/libhb/demuxmpeg.c
@@ -1,6 +1,6 @@
 /* demuxmpeg.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/detelecine.c
+++ b/libhb/detelecine.c
@@ -1,6 +1,6 @@
 /* detelecine.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dovi_common.c
+++ b/libhb/dovi_common.c
@@ -1,6 +1,6 @@
 /* dovi_common.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dvd.c
+++ b/libhb/dvd.c
@@ -1,6 +1,6 @@
 /* dvd.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/dvdnav.c
+++ b/libhb/dvdnav.c
@@ -1,6 +1,6 @@
 /* dvdnav.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/eedi2.c
+++ b/libhb/eedi2.c
@@ -1,6 +1,6 @@
 /* eedi2.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -1,6 +1,6 @@
 /* encavcodec.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -1,6 +1,6 @@
 /* encavcodecaudio.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encavsub.c
+++ b/libhb/encavsub.c
@@ -1,6 +1,6 @@
 /* encavsub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -1,6 +1,6 @@
 /* encsvtav1.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    partially based on FFmpeg libsvtav1.c
    Homepage: <http://handbrake.fr/>.

--- a/libhb/enctheora.c
+++ b/libhb/enctheora.c
@@ -1,6 +1,6 @@
 /* enctheora.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/enctx3gsub.c
+++ b/libhb/enctx3gsub.c
@@ -1,6 +1,6 @@
 /* enctx3gsub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -1,6 +1,6 @@
 /* encvorbis.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encx264.c
+++ b/libhb/encx264.c
@@ -1,6 +1,6 @@
 /* encx264.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -1,6 +1,6 @@
 /* encx265.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/extradata.c
+++ b/libhb/extradata.c
@@ -1,6 +1,6 @@
 /* extradata.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/fifo.c
+++ b/libhb/fifo.c
@@ -1,6 +1,6 @@
 /* fifo.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    Copyright 2022 NVIDIA Corporation
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/format.c
+++ b/libhb/format.c
@@ -1,6 +1,6 @@
 /* format.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/grayscale.c
+++ b/libhb/grayscale.c
@@ -1,6 +1,6 @@
 /* grayscale.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/audio_remap.h
+++ b/libhb/handbrake/audio_remap.h
@@ -1,6 +1,6 @@
 /* audio_remap.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/audio_resample.h
+++ b/libhb/handbrake/audio_resample.h
@@ -1,6 +1,6 @@
 /* audio_resample.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -1,6 +1,6 @@
 /* av1_common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/avfilter_priv.h
+++ b/libhb/handbrake/avfilter_priv.h
@@ -1,6 +1,6 @@
 /* avfilter_priv.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/bitstream.h
+++ b/libhb/handbrake/bitstream.h
@@ -1,6 +1,6 @@
 /* bitstream.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/colormap.h
+++ b/libhb/handbrake/colormap.h
@@ -1,6 +1,6 @@
 /* colormap.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1,6 +1,6 @@
 /* common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/compat.h
+++ b/libhb/handbrake/compat.h
@@ -1,6 +1,6 @@
 /* compat.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/decavsub.h
+++ b/libhb/handbrake/decavsub.h
@@ -1,6 +1,6 @@
 /* decavsub.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/decomb.h
+++ b/libhb/handbrake/decomb.h
@@ -1,6 +1,6 @@
 /* decomb.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/dovi_common.h
+++ b/libhb/handbrake/dovi_common.h
@@ -1,6 +1,6 @@
 /* dovi_common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/dvd.h
+++ b/libhb/handbrake/dvd.h
@@ -1,6 +1,6 @@
 /* dvd.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/eedi2.h
+++ b/libhb/handbrake/eedi2.h
@@ -1,6 +1,6 @@
 /* eedi2.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/encavsub.h
+++ b/libhb/handbrake/encavsub.h
@@ -1,6 +1,6 @@
 /* encavsub.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/encx264.h
+++ b/libhb/handbrake/encx264.h
@@ -1,6 +1,6 @@
 /* encx264.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/extradata.h
+++ b/libhb/handbrake/extradata.h
@@ -1,6 +1,6 @@
 /* extradata.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/h264_common.h
+++ b/libhb/handbrake/h264_common.h
@@ -1,6 +1,6 @@
 /* h264_common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/h265_common.h
+++ b/libhb/handbrake/h265_common.h
@@ -1,6 +1,6 @@
 /* h265_common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -1,6 +1,6 @@
 /* handbrake.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hb_dict.h
+++ b/libhb/handbrake/hb_dict.h
@@ -1,6 +1,6 @@
 /* hb_dict.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hb_json.h
+++ b/libhb/handbrake/hb_json.h
@@ -1,6 +1,6 @@
 /* hb_json.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbavfilter.h
+++ b/libhb/handbrake/hbavfilter.h
@@ -1,6 +1,6 @@
 /* hbavfilter.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -1,6 +1,6 @@
 /* hbffmpeg.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hbtypes.h
+++ b/libhb/handbrake/hbtypes.h
@@ -1,6 +1,6 @@
 /* hbtypes.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hdr10plus.h
+++ b/libhb/handbrake/hdr10plus.h
@@ -1,6 +1,6 @@
 /* hdr10plus.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/hwaccel.h
+++ b/libhb/handbrake/hwaccel.h
@@ -1,6 +1,6 @@
 /* hwaccel.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -1,6 +1,6 @@
 /* internal.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/lang.h
+++ b/libhb/handbrake/lang.h
@@ -1,6 +1,6 @@
 /* lang.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/mf_common.h
+++ b/libhb/handbrake/mf_common.h
@@ -1,7 +1,7 @@
 /* mf_common.h
  *
  * Copyright (c) Dash Santosh <dash.sathyanarayanan@multicorewareinc.com>
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nal_units.h
+++ b/libhb/handbrake/nal_units.h
@@ -1,6 +1,6 @@
 /* nal_units.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nlmeans.h
+++ b/libhb/handbrake/nlmeans.h
@@ -1,7 +1,7 @@
 /* nlmeans.h
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/nvenc_common.h
+++ b/libhb/handbrake/nvenc_common.h
@@ -1,6 +1,6 @@
 /* nvenc_common.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/param.h
+++ b/libhb/handbrake/param.h
@@ -1,6 +1,6 @@
 /* param.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/ports.h
+++ b/libhb/handbrake/ports.h
@@ -1,6 +1,6 @@
 /* ports.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/preset.h
+++ b/libhb/handbrake/preset.h
@@ -1,6 +1,6 @@
 /* preset.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/qsv_common.h
+++ b/libhb/handbrake/qsv_common.h
@@ -1,6 +1,6 @@
 /* qsv_common.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/rpu.h
+++ b/libhb/handbrake/rpu.h
@@ -1,6 +1,6 @@
 /* rpu.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/ssautil.h
+++ b/libhb/handbrake/ssautil.h
@@ -1,6 +1,6 @@
 /* ssautil.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/taskset.h
+++ b/libhb/handbrake/taskset.h
@@ -1,6 +1,6 @@
 /* taskset.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -1,6 +1,6 @@
 /* vce_common.h
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1,6 +1,6 @@
 /* hb.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb_dict.c
+++ b/libhb/hb_dict.c
@@ -1,6 +1,6 @@
 /* hb_dict.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1,6 +1,6 @@
 /* json.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -1,6 +1,6 @@
 /* hbavfilter.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -1,6 +1,6 @@
 /* hbffmpeg.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hdr10plus.c
+++ b/libhb/hdr10plus.c
@@ -1,6 +1,6 @@
 /* hdr10plus.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -1,6 +1,6 @@
 /* hwaccel.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/lang.c
+++ b/libhb/lang.c
@@ -1,6 +1,6 @@
 /* lang.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/lapsharp.c
+++ b/libhb/lapsharp.c
@@ -1,6 +1,6 @@
 /* lapsharp.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/mf_common.c
+++ b/libhb/mf_common.c
@@ -1,6 +1,6 @@
 /* mf_common.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/motion_metric.c
+++ b/libhb/motion_metric.c
@@ -1,6 +1,6 @@
 /* motionmetric.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/mt_frame_filter.c
+++ b/libhb/mt_frame_filter.c
@@ -1,6 +1,6 @@
 /* mt_frame_filter.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -1,6 +1,6 @@
 /* muxavformat.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/muxcommon.c
+++ b/libhb/muxcommon.c
@@ -1,6 +1,6 @@
 /* muxcommon.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nal_units.c
+++ b/libhb/nal_units.c
@@ -1,6 +1,6 @@
 /* nal_units.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * Copyright (c) FFmpeg
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.

--- a/libhb/nlmeans.c
+++ b/libhb/nlmeans.c
@@ -1,7 +1,7 @@
 /* nlmeans.c
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nlmeans_x86.c
+++ b/libhb/nlmeans_x86.c
@@ -1,7 +1,7 @@
 /* nlmeans_x86.c
 
    Copyright (c) 2013 Dirk Farin
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -1,6 +1,6 @@
 /* nvenc_common.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/pad.c
+++ b/libhb/pad.c
@@ -1,6 +1,6 @@
 /* pad.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -1,6 +1,6 @@
 /* param.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/blend_vt.m
+++ b/libhb/platform/macosx/blend_vt.m
@@ -1,6 +1,6 @@
 /* blend_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/chroma_smooth_vt.m
+++ b/libhb/platform/macosx/chroma_smooth_vt.m
@@ -1,7 +1,7 @@
 /* unsharp_vt.m
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/comb_detect_vt.m
+++ b/libhb/platform/macosx/comb_detect_vt.m
@@ -1,6 +1,6 @@
 /* comb_detect.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/config.m
+++ b/libhb/platform/macosx/config.m
@@ -1,6 +1,6 @@
 /* config.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/cropscale_vt.c
+++ b/libhb/platform/macosx/cropscale_vt.c
@@ -1,6 +1,6 @@
 /* cropscale_vt.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/cv_utils.c
+++ b/libhb/platform/macosx/cv_utils.c
@@ -1,6 +1,6 @@
 /* cv_utils.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/cv_utils.h
+++ b/libhb/platform/macosx/cv_utils.h
@@ -1,6 +1,6 @@
 /* cv_utils.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/deinterlace_vt.m
+++ b/libhb/platform/macosx/deinterlace_vt.m
@@ -1,6 +1,6 @@
 /* deinterlace_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/encca_aac.c
+++ b/libhb/platform/macosx/encca_aac.c
@@ -1,6 +1,6 @@
 /* encca_aac.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/encvt.c
+++ b/libhb/platform/macosx/encvt.c
@@ -1,6 +1,6 @@
 /* encvt.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/grayscale_vt.m
+++ b/libhb/platform/macosx/grayscale_vt.m
@@ -1,6 +1,6 @@
 /* grayscale_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/lapsharp_vt.m
+++ b/libhb/platform/macosx/lapsharp_vt.m
@@ -1,6 +1,6 @@
 /* lapsharp_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/metal_utils.h
+++ b/libhb/platform/macosx/metal_utils.h
@@ -1,6 +1,6 @@
 /* utils.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/metal_utils.m
+++ b/libhb/platform/macosx/metal_utils.m
@@ -1,6 +1,6 @@
 /* utils.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/motion_metric_vt.m
+++ b/libhb/platform/macosx/motion_metric_vt.m
@@ -1,6 +1,6 @@
 /* motion_metric_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/pad_vt.m
+++ b/libhb/platform/macosx/pad_vt.m
@@ -1,6 +1,6 @@
 /* pad_vt.m
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/prefilter_vt.c
+++ b/libhb/platform/macosx/prefilter_vt.c
@@ -1,6 +1,6 @@
 /* prefilter_vt.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/rotate_vt.c
+++ b/libhb/platform/macosx/rotate_vt.c
@@ -1,6 +1,6 @@
 /* rotate_vt.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/shaders/blend_vt.metal
+++ b/libhb/platform/macosx/shaders/blend_vt.metal
@@ -1,6 +1,6 @@
 /* blend_vt.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/bwdif_vt.metal
+++ b/libhb/platform/macosx/shaders/bwdif_vt.metal
@@ -1,6 +1,6 @@
 /* bwdif.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    Copyright (c) 2019 Philip Langdale <philipl@overt.org>
 
    port of FFmpeg vf_bwdif_cuda.

--- a/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
+++ b/libhb/platform/macosx/shaders/chroma_smooth_vt.metal
@@ -1,6 +1,6 @@
 /* chroma_smooth.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    port of FFmpeg unsharp.cl.
 

--- a/libhb/platform/macosx/shaders/comb_detect_vt.metal
+++ b/libhb/platform/macosx/shaders/comb_detect_vt.metal
@@ -1,6 +1,6 @@
 /* comb_detect.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/grayscale_vt.metal
+++ b/libhb/platform/macosx/shaders/grayscale_vt.metal
@@ -1,6 +1,6 @@
 /* grayscale.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    Copyright (c) 2021 Paul B Mahol
 
    port of vf_monochrome FFmpeg.

--- a/libhb/platform/macosx/shaders/lapsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/lapsharp_vt.metal
@@ -1,6 +1,6 @@
 /* lapsharp.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/motion_metric_vt.metal
+++ b/libhb/platform/macosx/shaders/motion_metric_vt.metal
@@ -1,6 +1,6 @@
 /* motion_metric_vt.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.

--- a/libhb/platform/macosx/shaders/pad_vt.metal
+++ b/libhb/platform/macosx/shaders/pad_vt.metal
@@ -1,6 +1,6 @@
 /* pad.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    port of FFmpeg pad.cl.
 

--- a/libhb/platform/macosx/shaders/unsharp_vt.metal
+++ b/libhb/platform/macosx/shaders/unsharp_vt.metal
@@ -1,6 +1,6 @@
 /* unsharp.metal
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
 
    port of FFmpeg unsharp.cl.
 

--- a/libhb/platform/macosx/unsharp_vt.m
+++ b/libhb/platform/macosx/unsharp_vt.m
@@ -1,7 +1,7 @@
 /* unsharp_vt.m
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -1,6 +1,6 @@
 /* vt_common.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/platform/macosx/vt_common.h
+++ b/libhb/platform/macosx/vt_common.h
@@ -1,6 +1,6 @@
 /* vt_common.h
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1,6 +1,6 @@
 /* ports.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -1,6 +1,6 @@
 /* preset.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -1,6 +1,6 @@
 /* qsv_common.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/reader.c
+++ b/libhb/reader.c
@@ -1,6 +1,6 @@
 /* reader.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -1,6 +1,6 @@
 /* rendersub.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rotate.c
+++ b/libhb/rotate.c
@@ -1,6 +1,6 @@
 /* rotate.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/rpu.c
+++ b/libhb/rpu.c
@@ -1,6 +1,6 @@
 /* rpu.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -1,6 +1,6 @@
 /* scan.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/ssautil.c
+++ b/libhb/ssautil.c
@@ -1,6 +1,6 @@
 /* ssautil.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -1,6 +1,6 @@
 /* stream.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/sync.c
+++ b/libhb/sync.c
@@ -1,6 +1,6 @@
 /* sync.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/taskset.c
+++ b/libhb/taskset.c
@@ -1,6 +1,6 @@
 /* taskset.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/comb_detect_template.c
+++ b/libhb/templates/comb_detect_template.c
@@ -1,6 +1,6 @@
 /* comb_detect_template.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/decomb_template.c
+++ b/libhb/templates/decomb_template.c
@@ -1,6 +1,6 @@
 /* decomb_template.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/eedi2_template.c
+++ b/libhb/templates/eedi2_template.c
@@ -1,6 +1,6 @@
 /* eedi2_template.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/templates/nlmeans_template.c
+++ b/libhb/templates/nlmeans_template.c
@@ -1,6 +1,6 @@
 /* common.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/unsharp.c
+++ b/libhb/unsharp.c
@@ -1,7 +1,7 @@
 /* unsharp.c
 
    Copyright (c) 2002 Rémi Guyomarch <rguyom at pobox.com>
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -1,6 +1,6 @@
 /* vce_common.c
  *
- * Copyright (c) 2003-2025 HandBrake Team
+ * Copyright (c) 2003-2026 HandBrake Team
  * This file is part of the HandBrake source code.
  * Homepage: <http://handbrake.fr/>.
  * It may be used under the terms of the GNU General Public License v2.

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -1,6 +1,6 @@
 /* vfr.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1,6 +1,6 @@
 /* work.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/libhb/workpass.c
+++ b/libhb/workpass.c
@@ -1,6 +1,6 @@
 /* worknull.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/macosx/Info.plist.m4
+++ b/macosx/Info.plist.m4
@@ -60,7 +60,7 @@ dnl
 	<key>LSMinimumSystemVersion</key>
 	<string>${MACOSX_DEPLOYMENT_TARGET}</string>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2003-2025 __HB_name Team.
+	<string>Copyright © 2003-2026 __HB_name Team.
 GPLv2 license.</string>
 	<key>NSMainNibFile</key>
 	<string>MainMenu</string>

--- a/macosx/hbsign
+++ b/macosx/hbsign
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # Copyright (C) 2012-2017 VLC authors and VideoLAN
 # Copyright (C) 2012-2014 Felix Paul Kühne <fkuehne at videolan dot org>
-# Copyright (C) 2018-2025 Damiano Galassi <damiog@gmail.com>
-# Copyright (C) 2018-2025 Bradley Sepos <bradley@bradleysepos.com>
+# Copyright (C) 2018-2026 Damiano Galassi <damiog@gmail.com>
+# Copyright (C) 2018-2026 Bradley Sepos <bradley@bradleysepos.com>
 #
 # Based on VLC's codesign.sh
 #

--- a/test/fr.handbrake.HandBrakeCLI.metainfo.xml.in.in
+++ b/test/fr.handbrake.HandBrakeCLI.metainfo.xml.in.in
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Copyright 2018-2025 John Stebbins <your@email.com> -->
+<!-- Copyright 2018-2026 John Stebbins <your@email.com> -->
 <component type="console-application">
   <id>fr.handbrake.HandBrakeCLI</id>
   <update_contact>jstebbins.hb_AT_gmail.com</update_contact>

--- a/test/parsecsv.c
+++ b/test/parsecsv.c
@@ -1,6 +1,6 @@
 /* parsecsv.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/test/parsecsv.h
+++ b/test/parsecsv.h
@@ -1,6 +1,6 @@
 /* parsecsv.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/test/test.c
+++ b/test/test.c
@@ -1,6 +1,6 @@
 /* test.c
 
-   Copyright (c) 2003-2025 HandBrake Team
+   Copyright (c) 2003-2026 HandBrake Team
    This file is part of the HandBrake source code
    Homepage: <http://handbrake.fr/>.
    It may be used under the terms of the GNU General Public License v2.

--- a/win/CS/HandBrake.App.Core/HandBrake.App.Core.csproj
+++ b/win/CS/HandBrake.App.Core/HandBrake.App.Core.csproj
@@ -6,7 +6,7 @@
 		<Version>1.10.3</Version>
 		<Authors>HandBrake Team</Authors>
 		<Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
-		<Copyright>Copyright © 2003-2025 HandBrake Team</Copyright>
+		<Copyright>Copyright © 2003-2026 HandBrake Team</Copyright>
 		<PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
 		<RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>

--- a/win/CS/HandBrake.Interop/HandBrake.Interop.csproj
+++ b/win/CS/HandBrake.Interop/HandBrake.Interop.csproj
@@ -6,7 +6,7 @@
     <Version>1.10.3</Version>
     <Authors>HandBrake Team</Authors>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
-    <Copyright>Copyright © 2003-2025 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2026 HandBrake Team</Copyright>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/win/CS/HandBrake.Worker/HandBrake.Worker.csproj
+++ b/win/CS/HandBrake.Worker/HandBrake.Worker.csproj
@@ -7,7 +7,7 @@
     <Authors>HandBrake Team</Authors>
     <Company>HandBrake Team</Company>
     <Product>HandBrake.Worker</Product>
-    <Copyright>Copyright © 2003-2025 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2026 HandBrake Team</Copyright>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>

--- a/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
+++ b/win/CS/HandBrakeWPF/HandBrakeWPF.csproj
@@ -9,7 +9,7 @@
     <Authors>HandBrake Team</Authors>
     <Company>HandBrake Team</Company>
     <Product>HandBrake</Product>
-    <Copyright>Copyright © 2003-2025 HandBrake Team</Copyright>
+    <Copyright>Copyright © 2003-2026 HandBrake Team</Copyright>
     <Description>HandBrake is an open-source, GPL-licensed, multiplatform,video transcoder.</Description>
     <PackageProjectUrl>https://handbrake.fr</PackageProjectUrl>
     <RepositoryUrl>https://github.com/HandBrake/HandBrake</RepositoryUrl>

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -61,7 +61,7 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Copyright (C) 2003-2024 The HandBrake Team.
+        ///   Looks up a localized string similar to Copyright (C) 2003-2026 The HandBrake Team.
         /// </summary>
         public static string About_Copyright {
             get {

--- a/win/CS/HandBrakeWPF/Properties/Resources.bg.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.bg.resx
@@ -2131,7 +2131,7 @@ You can drag/drop or enter the text above.</value>
     <value>Налична е нова версия!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Ниско ниво на батерията:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ca.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ca.resx
@@ -2130,7 +2130,7 @@ Quan sigui possible, s'importaran les configuracions predefinides de l'usuari.</
     <value>Hi ha una nova versió disponible!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Drets d'autor © 2003-2024 The HandBrake Team</value>
+    <value>Drets d'autor © 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Nivell de bateria baix:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.de.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.de.resx
@@ -2137,7 +2137,7 @@ Falls unterstützt, wird jede benutzerdefinierte Voreinstellung übernommen. </v
     <value>Eine neue Version ist verfügbar!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2025 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Geringe Batteriekapazität:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.el.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.el.resx
@@ -2155,7 +2155,7 @@ You can drag/drop or enter the text above.</value>
     <value>Μια νέα έκδοση του HandBrake είναι διαθέσιμη!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Χαμηλό επίπεδο μπαταρίας:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.es.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.es.resx
@@ -2135,7 +2135,7 @@ Cuando se admita, se habrán importado los preajustes de usuario.</value>
     <value>¡Una nueva versión está disponible!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Nivel de batería bajo:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.eu.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.eu.resx
@@ -2131,7 +2131,7 @@ Onartzen denean, erabiltzaile aurrezarpenak inportatuko dira.</value>
     <value>Bertsio berri bat dago eskuragarri!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Bateria maila baxua:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.fa-IR.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.fa-IR.resx
@@ -2129,7 +2129,7 @@ Where supported, any user presets will have been imported.</value>
     <value>A new version is available!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>سطح باتری کم:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.fr.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.fr.resx
@@ -2134,7 +2134,7 @@ Là où pris en charge, tous les préréglages utilisateur auront été importé
     <value>Une nouvelle version est disponible !</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Niveau de batterie faible :</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.gl-ES.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.gl-ES.resx
@@ -2120,7 +2120,7 @@ Cando sexa compatible, calquera preaxuste de usuario terá sido importado.</valu
     <value>Hai unha nova versión dispoñible!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 O equipo de HandBrake</value>
+    <value>Copyright (C) 2003-2026 O equipo de HandBrake</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Nivel de batería baixo:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.it.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.it.resx
@@ -2134,7 +2134,7 @@ Se supportata, ogni preimpostazione dell'utente verrà importata.</value>
     <value>È disponibile una nuova versione!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Livello batteria basso:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ja.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ja.resx
@@ -2132,7 +2132,7 @@ VLCとMPC-HCがサポートされています。他のプレイヤーではお�
     <value>新しいバージョンが利用できます！</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>バッテリー残量低下:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.ko.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.ko.resx
@@ -2133,7 +2133,7 @@ VLC 및 MPC-HC가 지원됩니다. 다른 재생기들도 작업을 할 수 있�
     <value>새 버전을 사용할 수 있습니다!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 HandBrake 팀</value>
+    <value>Copyright (C) 2003-2026 HandBrake 팀</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>저전력 단계:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.pl.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.pl.resx
@@ -2135,7 +2135,7 @@ Tam, gdzie jest to obsługiwane, zostaną zaimportowane dowolne ustawienia użyt
     <value>Dostępna jest nowa wersja!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Niski poziom baterii:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2134,7 +2134,7 @@ Where supported, any user presets will have been imported.</value>
     <value>A new version is available!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Low battery level:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.sv.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.sv.resx
@@ -2134,7 +2134,7 @@ Alla andra användarförval som stöds har importerats.</value>
     <value>En ny version finns tillgänglig!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 HandBrake-teamet</value>
+    <value>Copyright (C) 2003-2026 HandBrake-teamet</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Låg batterinivå:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.th.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.th.resx
@@ -2131,7 +2131,7 @@ You can drag/drop or enter the text above.</value>
     <value>A new version is available!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>ระดับแบตเตอรี่ต่ำ:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.uk.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.uk.resx
@@ -2134,7 +2134,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.<
     <value>Доступна нова версія!</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>Низький рівень заряду акумулятора:</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.zh-Hans.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.zh-Hans.resx
@@ -2129,7 +2129,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.</
     <value>新版本现已推出！</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>电量低：</value>

--- a/win/CS/HandBrakeWPF/Properties/Resources.zh-Hant.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.zh-Hant.resx
@@ -2125,7 +2125,7 @@ You can drag/drop or enter the text above.</value>
     <value>有新版本可供使用！</value>
   </data>
   <data name="About_Copyright" xml:space="preserve">
-    <value>Copyright (C) 2003-2024 The HandBrake Team</value>
+    <value>Copyright (C) 2003-2026 The HandBrake Team</value>
   </data>
   <data name="Options_LowBatteryLevel" xml:space="preserve">
     <value>低電量：</value>

--- a/win/CS/Properties/AssemblyInfo.cs.tmpl
+++ b/win/CS/Properties/AssemblyInfo.cs.tmpl
@@ -16,7 +16,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("HandBrake")]
 [assembly: AssemblyProduct("HandBrake")]
-[assembly: AssemblyCopyright("Copyright ©  2025")]
+[assembly: AssemblyCopyright("Copyright ©  2026")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 


### PR DESCRIPTION
Update copyright dates to 2026.

This time I used
```
git grep -l -i copyright | xargs perl -pi -e '
  s/((?:copyright|\x{00A9})[^0-9]*\d{4}-)2025/${1}2026/ig;
  s/((?:copyright|\x{00A9})[^0-9]*)2025/${1}2026/ig;
'
```
and checked all changes afterwards and reversed all unnecessary changes or changes I already did in #7504.