### PR TITLE
libhb: fix typos

### DIFF
--- a/libhb/encx265.c
+++ b/libhb/encx265.c
@@ -572,7 +572,7 @@ void encx265Close(hb_work_object_t *w)
     pv->api->encoder_close(pv->x265);
     // x265 has got some global variables that prevents
     // multiple encode with different settings in the same process
-    // Clean-up it here to avoid unneccessary memory pressure,
+    // Clean-up it here to avoid unnecessary memory pressure,
     // they will be recreated in the next encode
     pv->api->cleanup();
     free(pv->csvfn);

--- a/libhb/platform/macosx/encvt.c
+++ b/libhb/platform/macosx/encvt.c
@@ -1538,15 +1538,15 @@ static OSStatus hb_vt_init_session(hb_work_object_t *w, hb_job_t *job, hb_work_p
 
 static void hb_vt_set_cookie(hb_work_object_t *w, CMFormatDescriptionRef format)
 {
-    CFDictionaryRef extentions = CMFormatDescriptionGetExtensions(format);
-    if (!extentions)
+    CFDictionaryRef extensions = CMFormatDescriptionGetExtensions(format);
+    if (!extensions)
     {
         hb_log("VTCompressionSession: Format Description Extensions error");
     }
     else
     {
         CFStringRef key = CMVideoFormatDescriptionGetCodecType(format) == kCMVideoCodecType_H264 ? CFSTR("avcC") : CFSTR("hvcC");
-        CFDictionaryRef atoms = CFDictionaryGetValue(extentions, kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms);
+        CFDictionaryRef atoms = CFDictionaryGetValue(extensions, kCMFormatDescriptionExtension_SampleDescriptionExtensionAtoms);
         if (atoms)
         {
             CFDataRef magicCookie = CFDictionaryGetValue(atoms, key);

--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -189,7 +189,7 @@ void hb_snooze( int delay )
 }
 
 /************************************************************************
- * Get information about the operaring system
+ * Get information about the operating system
  ************************************************************************/
 static void init_system_info();
 struct
@@ -1609,7 +1609,7 @@ static int try_adapter(const char * name, const char * dir,
 static int open_adapter(const char * name, const uint dri_render_node)
 {
     int fd;
-    // If dri_render_node is unknown enumerate across the predifined range of renders
+    // If dri_render_node is unknown enumerate across the predefined range of renders
     if (dri_render_node == 0)
     {
         fd = try_adapter(name, DRI_PATH, DRI_NODE_RENDER,

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -659,7 +659,7 @@ static int hb_qsv_make_adapters_list(hb_list_t **qsv_adapters_list, hb_list_t **
  * Check the actual availability of QSV implementations on the system
  * and collect GPU adapters capabilities.
  *
- * @returns encoder codec mask supported by QSV implemenation,
+ * @returns encoder codec mask supported by QSV implementation,
  *      0 if QSV is not available, -1 if HB_PROJECT_FEATURE_QSV is not enabled
  */
 int hb_qsv_available()

--- a/libhb/rendersub.c
+++ b/libhb/rendersub.c
@@ -836,7 +836,7 @@ static void ssa_work_init(hb_filter_private_t *pv, const hb_data_t *sub_data)
         break;
     //use video csp
     case YCBCR_UNKNOWN://cannot parse
-    case YCBCR_NONE:   //explicitely requested no override
+    case YCBCR_NONE:   //explicitly requested no override
     default:
         pv->rgb2yuv_fn = hb_get_rgb2yuv_function(pv->input.color_matrix);
         break;


### PR DESCRIPTION
**Description of Change:**

Just some random typos I've found in `libhb`.

Not tested, but should not have any changing effect since most are comments or a self-contained function.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux