### PR TITLE
[macOS] Make it possible to use the password within 'make notarize'

### DIFF
--- a/macosx/hbnotarize
+++ b/macosx/hbnotarize
@@ -88,7 +88,7 @@ if [[ -z "${PASSWORD:-}" ]]; then
     echo
 fi
 
-if [[ "${PASSWORD}" == "" ]]; then
+if [[ -z "${PASSWORD}" ]]; then
     exit_with_error 1 "${SELF_NAME}: password not specified" true
 fi
 

--- a/macosx/hbnotarize
+++ b/macosx/hbnotarize
@@ -82,9 +82,12 @@ fi
 echo "Username: ${USERNAME}"
 echo "TeamID: ${TEAMID}"
 
-echo -n "Password: "
-read -s PASSWORD
-echo
+if [[ -z "${PASSWORD:-}" ]]; then
+    echo -n "Password: "
+    read -s PASSWORD
+    echo
+fi
+
 if [[ "${PASSWORD}" == "" ]]; then
     exit_with_error 1 "${SELF_NAME}: password not specified" true
 fi

--- a/macosx/hbnotarize
+++ b/macosx/hbnotarize
@@ -63,14 +63,14 @@ while getopts ":h" OPT; do
 done
 shift $((${OPTIND} - 1))
 
-USERNAME="${1:-}"
-if [[ "${USERNAME}" == "" ]]; then
+USERNAME="${1:-${USERNAME:-}}"
+if [[ -z "${USERNAME}" ]]; then
     exit_with_error 1 "${SELF_NAME}: username not specified" true
 fi
 shift 1
 
-TEAMID="${1:-}"
-if [[ "${TEAMID}" == "" ]]; then
+TEAMID="${1:-${TEAMID:-}}"
+if [[ -z "${TEAMID}" ]]; then
     exit_with_error 1 "${SELF_NAME}: TeamID not specified" true
 fi
 shift 1


### PR DESCRIPTION
**Description of Change:**
Make it possible to use `make notarize USERNAME="" TEAMID="" PASSWORD=""` for notarization on macOS. I have an automatic build script to build, sign and notarize HandBrake locally. At the moment this script always pauses with a password prompt when notarizing. My script automatically gets the notarizing password from keychain and passes it to `make notarize`. This MR makes this possible to work and preserves also the current behavior.




**Tested on:**

- [N/A ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [N/A ] Ubuntu Linux
