### PR TITLE
Fix typo on Video encoder options screen for AV1 (AMD VCE)

### DIFF
--- a/libhb/handbrake/vce_common.h
+++ b/libhb/handbrake/vce_common.h
@@ -27,7 +27,7 @@ static const char * const hb_vce_h264_level_names[] =
     "3.1", "3.2", "4.0", "4.1", "4.2", "5.0", "5.1", "5.2",  NULL,
 };
 
-static const char * const hb_vce_av1_preset_names[] = { "speed", "balanced", "quality" "high quality", NULL, };
+static const char * const hb_vce_av1_preset_names[] = { "speed", "balanced", "quality", "high quality", NULL, };
 
 static const char * const hb_vce_av1_level_names[] =
 {


### PR DESCRIPTION
Should fix https://github.com/HandBrake/HandBrake/issues/7567