### PR TITLE
gtk: fix crash when preset categories contain `'`

### DIFF
--- a/gtk/src/presets.c
+++ b/gtk/src/presets.c
@@ -1400,6 +1400,7 @@ ghb_presets_menu_init(signal_user_data_t *ud)
                     char * preset_path;
                     char * detail_action;
 
+                    g_string_replace(preset_str, "'", "\\'", 0);
                     preset_path = g_string_free(preset_str, FALSE);
                     if (preset_enabled)
                         detail_action = g_strdup_printf("app.preset-select('%s')", preset_path);


### PR DESCRIPTION
Fixes #7405

**Description of Change:**

There's a comment with an explanation here: https://github.com/HandBrake/HandBrake/issues/7405#issuecomment-3756303092



**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Linux Mint Debian Edition

**Screenshots (If relevant):**

<img width="960" height="711" alt="image" src="https://github.com/user-attachments/assets/b4396f04-104a-4d0e-810b-a3aaa9ac3462" />


**Log file output (If relevant):**
