### PR TITLE
Fix copy paste error

### DIFF
--- a/libhb/hdr10plus.c
+++ b/libhb/hdr10plus.c
@@ -36,9 +36,9 @@ void hb_dynamic_hdr10_plus_to_itu_t_t35(const AVDynamicHDRPlus *s, uint8_t **buf
         const AVHDRPlusColorTransformParams *params = &s->params[w];
 
         hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
-        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
-        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
-        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_x.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_upper_left_corner_y.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_lower_right_corner_x.num, 16);
+        hb_bitstream_put_bits(&bs, params->window_lower_right_corner_y.num, 16);
 
         hb_bitstream_put_bits(&bs, params->center_of_ellipse_x, 16);
         hb_bitstream_put_bits(&bs, params->center_of_ellipse_y, 16);

--- a/macosx/HBRemoteCore.m
+++ b/macosx/HBRemoteCore.m
@@ -78,7 +78,7 @@
 
     _proxy = [_connection remoteObjectProxyWithErrorHandler:^(NSError * _Nonnull error) {
         dispatch_sync(dispatch_get_main_queue(), ^{
-            [self forwardError:@"XPC: Service did report an error\n"];
+            [weakSelf forwardError:@"XPC: Service did report an error\n"];
             [HBUtilities writeErrorToActivityLog:error];
         });
     }];


### PR DESCRIPTION
Copy-paste bug in HDR10+ metadata encoding where all four window corner coordinate writes used the same field (window_upper_left_corner_x) instead of the correct x/y upper-left and x/y lower-right corners. This caused corrupted HDR10+ dynamic metadata in all output files.

Fix retain cycle in XPC error handler block by using weakSelf instead of self, consistent with the other two handler blocks in the same method.