### PR TITLE
contrib: add libplacebo

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -27,7 +27,7 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install autoconf automake build-essential libass-dev libbz2-dev libfontconfig1-dev libfreetype6-dev libfribidi-dev libharfbuzz-dev libjansson-dev liblzma-dev libmp3lame-dev libnuma-dev libturbojpeg0-dev libssl-dev
-        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build meson patch tar zlib1g-dev appstream
+        sudo apt-get install libogg-dev libopus-dev libsamplerate-dev libspeex-dev libtheora-dev libtool libtool-bin libvorbis-dev libx264-dev libxml2-dev libvpx-dev make nasm ninja-build meson patch tar zlib1g-dev appstream python3-jinja2
         sudo apt-get install gettext libglib2.0-dev libgtk-4-dev
         sudo apt-get install libva-dev libdrm-dev llvm clang
 

--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -1,4 +1,4 @@
-__deps__ := BZIP2 ZLIB FDKAAC LIBDAV1D LIBVPX LAME LIBOPUS LIBSPEEX XZ ZIMG LIBICONV
+__deps__ := BZIP2 ZLIB FDKAAC LIBDAV1D LIBVPX LAME LIBOPUS LIBSPEEX XZ ZIMG LIBICONV VULKAN LIBPLACEBO
 ifeq (1,$(FEATURE.qsv))
 __deps__ += LIBVPL
 endif
@@ -79,6 +79,9 @@ FFMPEG.CONFIGURE.extra = \
     --enable-filter=hwdownload \
     --enable-filter=hwmap \
     --enable-filter=hwupload \
+    --enable-vulkan \
+    --enable-libplacebo \
+    --enable-filter=libplacebo \
     --cc="$(FFMPEG.GCC.gcc)"
 
 ifeq (size-aggressive,$(GCC.O))

--- a/contrib/libplacebo/module.defs
+++ b/contrib/libplacebo/module.defs
@@ -16,7 +16,9 @@ LIBPLACEBO.CONFIGURE.host =
 LIBPLACEBO.CONFIGURE.build =
 LIBPLACEBO.CONFIGURE.static = -Ddefault_library=static
 LIBPLACEBO.CONFIGURE.extra = --libdir=$(call fn.ABSOLUTE,$(LIBPLACEBO.prefix/))contrib/lib/ \
-                                -Dvulkan=enabled -Dopengl=disabled -Ddemos=false
+                                -Dvulkan=enabled -Dopengl=disabled -Ddemos=false \
+                                -Dc_args="-I$(call fn.ABSOLUTE,$(CONTRIB.build/)include) $(call fn.ARGS,LIBPLACEBO.GCC,*archs *sysroot *minver ?extra)" \
+                                -Dc_link_args="-L$(call fn.ABSOLUTE,$(CONTRIB.build/)lib) $(call fn.ARGS,LIBPLACEBO.GCC,*archs *sysroot *minver ?extra.exe)"
 LIBPLACEBO.CONFIGURE.env =
 
 LIBPLACEBO.BUILD.make = $(NINJA.exe)

--- a/contrib/libplacebo/module.defs
+++ b/contrib/libplacebo/module.defs
@@ -1,0 +1,26 @@
+__deps__ := VULKAN
+
+$(eval $(call import.MODULE.defs,LIBPLACEBO,libplacebo))
+$(eval $(call import.CONTRIB.defs,LIBPLACEBO))
+
+LIBPLACEBO.FETCH.url = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libplacebo-v7.351.0.tar.gz
+LIBPLACEBO.FETCH.url += https://code.videolan.org/videolan/libplacebo/-/archive/v7.351.0/libplacebo-v7.351.0.tar.gz
+LIBPLACEBO.FETCH.sha256 = 4efe1c8d4da3c61295eb5fdfa50e6037409d8425eb3c15dd86788679c4ce59ee
+
+LIBPLACEBO.build_dir = build/
+LIBPLACEBO.CONFIGURE.exe = $(MESON.exe) setup
+LIBPLACEBO.prefix = $(call fn.ABSOLUTE,$(LIBPLACEBO.prefix/))contrib/
+LIBPLACEBO.CONFIGURE.deps =
+LIBPLACEBO.CONFIGURE.shared =
+LIBPLACEBO.CONFIGURE.host =
+LIBPLACEBO.CONFIGURE.build =
+LIBPLACEBO.CONFIGURE.static = -Ddefault_library=static
+LIBPLACEBO.CONFIGURE.extra = --libdir=$(call fn.ABSOLUTE,$(LIBPLACEBO.prefix/))contrib/lib/ \
+                                -Dvulkan=enabled -Dopengl=disabled -Ddemos=false
+LIBPLACEBO.CONFIGURE.env =
+
+LIBPLACEBO.BUILD.make = $(NINJA.exe)
+LIBPLACEBO.BUILD.extra = -v
+LIBPLACEBO.INSTALL.make = $(NINJA.exe)
+LIBPLACEBO.CLEAN.make = $(NINJA.exe)
+LIBPLACEBO.UNINSTALL.make = $(NINJA.exe)

--- a/contrib/libplacebo/module.rules
+++ b/contrib/libplacebo/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,LIBPLACEBO))
+$(eval $(call import.CONTRIB.rules,LIBPLACEBO))

--- a/contrib/vulkan/module.defs
+++ b/contrib/vulkan/module.defs
@@ -1,0 +1,22 @@
+$(eval $(call import.MODULE.defs,VULKAN,vulkan))
+$(eval $(call import.CONTRIB.defs,VULKAN))
+
+VULKAN.FETCH.url = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/vulkan-v1.4.337.tar.gz
+VULKAN.FETCH.url += https://github.com/KhronosGroup/Vulkan-Headers/archive/refs/tags/v1.4.337.tar.gz
+VULKAN.FETCH.sha256 = 13845b9dc873758cdc1f2be6219f7fc99afea0a2c80586043b5bb435b99e590b
+VULKAN.FETCH.basename = Vulkan-Headers-1.4.337.tar.gz
+VULKAN.EXTRACT.tarbase = Vulkan-Headers-1.4.337
+
+VULKAN.CONFIGURE = $(TOUCH.exe) $@
+VULKAN.BUILD = $(TOUCH.exe) $@
+
+define VULKAN.INSTALL
+    $(MKDIR.exe) -p $(CONTRIB.build/)include/vulkan
+    $(CP.exe) -R $(VULKAN.EXTRACT.dir/)include/vulkan/* $(CONTRIB.build/)include/vulkan/
+    $(TOUCH.exe) $@
+endef
+
+define VULKAN.UNINSTALL
+    $(RM.exe) -rf $(CONTRIB.build/)include/vulkan
+    $(RM.exe) -f $(VULKAN.INSTALL.target)
+endef

--- a/contrib/vulkan/module.defs
+++ b/contrib/vulkan/module.defs
@@ -12,11 +12,14 @@ VULKAN.BUILD = $(TOUCH.exe) $@
 
 define VULKAN.INSTALL
     $(MKDIR.exe) -p $(CONTRIB.build/)include/vulkan
+    $(MKDIR.exe) -p $(CONTRIB.build/)include/vk_video
     $(CP.exe) -R $(VULKAN.EXTRACT.dir/)include/vulkan/* $(CONTRIB.build/)include/vulkan/
+    $(CP.exe) -R $(VULKAN.EXTRACT.dir/)include/vk_video/* $(CONTRIB.build/)include/vk_video/
     $(TOUCH.exe) $@
 endef
 
 define VULKAN.UNINSTALL
     $(RM.exe) -rf $(CONTRIB.build/)include/vulkan
+    $(RM.exe) -rf $(CONTRIB.build/)include/vk_video
     $(RM.exe) -f $(VULKAN.INSTALL.target)
 endef

--- a/contrib/vulkan/module.rules
+++ b/contrib/vulkan/module.rules
@@ -1,0 +1,2 @@
+$(eval $(call import.MODULE.rules,VULKAN))
+$(eval $(call import.CONTRIB.rules,VULKAN))

--- a/make/include/main.defs
+++ b/make/include/main.defs
@@ -55,6 +55,8 @@ MODULES += contrib/ffmpeg
 MODULES += contrib/libdvdread
 MODULES += contrib/libdvdnav
 MODULES += contrib/libbluray
+MODULES += contrib/vulkan
+MODULES += contrib/libplacebo
 
 ifeq (1,$(FEATURE.qsv))
 ifeq (,$(filter $(HOST.system),freebsd))


### PR DESCRIPTION
## Draft PR, opening for guidance

I've been having a go at adding libplacebo (https://github.com/HandBrake/HandBrake/discussions/7609#discussioncomment-15651104), but I've run into a roadblock getting ffmpeg to 'see' libplacebo

```
set -e; /usr/bin/mkdir -p ./contrib/ffmpeg/ffmpeg-8.0.1/; cd ./contrib/ffmpeg/ffmpeg-8.0.1/; CC=/usr/bin/gcc CFLAGS="-I/home/sam/git/samhutchins/HandBrake/build/contrib/include -mfpmath=sse -msse2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -DNDEBUG" CXX=/usr/bin/g++ CXXFLAGS="-I/home/sam/git/samhutchins/HandBrake/build/contrib/include -mfpmath=sse -msse2 -fstack-protector-strong -D_FORTIFY_SOURCE=2 -DNDEBUG" CPPFLAGS="-I/home/sam/git/samhutchins/HandBrake/build/contrib/include -DNDEBUG" LDFLAGS="-L/home/sam/git/samhutchins/HandBrake/build/contrib/lib -fstack-protector-strong -DNDEBUG" PKG_CONFIG_PATH="/home/sam/git/samhutchins/HandBrake/build/contrib/lib/pkgconfig:/home/sam/git/samhutchins/HandBrake/build/contrib/lib/pkgconfig/" PATH="/home/sam/git/samhutchins/HandBrake/build/contrib/bin:/usr/local/bin:/usr/bin:/bin:/usr/local/games:/usr/games" ./configure --prefix=/home/sam/git/samhutchins/HandBrake/build/contrib/ --disable-shared --enable-static --enable-gpl --disable-doc --disable-programs --disable-avdevice --disable-muxers --disable-network --disable-filters --disable-hwaccels --disable-vdpau --disable-encoders --enable-libmp3lame --enable-encoder=aac --enable-encoder=ac3 --enable-encoder=eac3 --enable-encoder=alac --enable-encoder=flac --enable-encoder=mpeg2video --enable-encoder=mpeg4 --enable-encoder=libmp3lame --enable-encoder=movtext --enable-encoder=subrip --enable-libopus --enable-encoder=libopus --enable-libspeex --disable-encoder=libspeex --enable-decoder=libspeex --enable-encoder=truehd --enable-encoder=pcm_s16le --enable-encoder=pcm_s24le --enable-libvpx --disable-decoder=libvpx_* --enable-encoder=libvpx_vp8 --enable-encoder=libvpx_vp9 --enable-encoder=ffv1 --enable-decoder=av1 --enable-libdav1d --enable-decoder=libdav1d --enable-libzimg --enable-filter=format --enable-filter=crop --enable-filter=scale --enable-filter=zscale --enable-filter=pad --enable-filter=transpose --enable-filter=hflip --enable-filter=vflip --enable-filter=yadif --enable-filter=bwdif --enable-filter=deblock --enable-filter=tonemap --enable-filter=monochrome --enable-filter=hwdownload --enable-filter=hwmap --enable-filter=hwupload --enable-vulkan --enable-libplacebo --enable-filter=libplacebo --cc="/usr/bin/gcc" --disable-vaapi --enable-muxer=matroska --enable-muxer=webm --enable-muxer=mov --enable-muxer=mp4 --enable-muxer=psp --enable-muxer=ipod --enable-muxer=ass --enable-muxer=srt --enable-muxer=sup --extra-libs="-lm -lstdc++" --disable-debug --enable-ffnvcodec --enable-encoder=h264_nvenc --enable-encoder=hevc_nvenc --enable-encoder=av1_nvenc
ERROR: libplacebo >= 5.229.0 not found using pkg-config

If you think configure made a mistake, make sure you are using the latest
version from Git.  If the latest version fails, report the problem to the
ffmpeg-user@ffmpeg.org mailing list or IRC #ffmpeg on irc.libera.chat.
Include the log file "ffbuild/config.log" produced by configure as this will help
solve the problem.
make: *** [../contrib/ffmpeg/module.rules:2: contrib/ffmpeg/.stamp.ffmpeg.configure] Error 1
make: Leaving directory '/home/sam/git/samhutchins/HandBrake/build'
```

I can see that libplacebo is built, further up the log

```
touch contrib/libplacebo/.stamp.libplacebo.build
/usr/bin/ninja -j 1 -C ./contrib/libplacebo/libplacebo-v7.351.0/build/ install
ninja: Entering directory `./contrib/libplacebo/libplacebo-v7.351.0/build/'
[1/2] Installing files
Installing src/libplacebo.a to /home/sam/git/samhutchins/HandBrake/build/contrib/lib
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/cache.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/colorspace.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/common.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/d3d11.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/dispatch.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/dither.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/dummy.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/filters.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/gamut_mapping.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/gpu.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/log.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/opengl.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/options.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/renderer.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/colorspace.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/custom.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/deinterlacing.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/dithering.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/film_grain.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/icc.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/lut.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders/sampling.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/shaders
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/shaders.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/swapchain.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/tone_mapping.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/dav1d.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/dav1d_internal.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/dolbyvision.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/frame_queue.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/libav.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/libav_internal.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/utils/upload.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo/utils
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/src/include/libplacebo/vulkan.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/build/src/./include/libplacebo/config.h to /home/sam/git/samhutchins/HandBrake/build/contrib/include/libplacebo
Installing /home/sam/git/samhutchins/HandBrake/build/contrib/libplacebo/libplacebo-v7.351.0/build/meson-private/libplacebo.pc to /home/sam/git/samhutchins/HandBrake/build/contrib/lib/pkgconfig
touch contrib/libplacebo/.stamp.libplacebo.install
```

The `.pc` file seems to end up in the right place (same place as other files, at least), so I'm not sure why ffmpeg isn't seeing it.

---

I'm mostly interested in adding libplacebo to open up some GPU-accelerated options for crop/scale, tonemapping, etc, rather than the GLSL use-case in the thread above. Not sure if the project would consider changing the implementation of those filters to be backed by libplacebo rather than their current libav filters though.