### PR TITLE
Fix MP3 audio for Quicktime

### DIFF
--- a/contrib/ffmpeg/A25-movenc-use-mp3-tag-for-mp3-in-mp4.patch
+++ b/contrib/ffmpeg/A25-movenc-use-mp3-tag-for-mp3-in-mp4.patch
@@ -1,0 +1,26 @@
+From 32ea2ce275f412056de9e1f3842aec4407869bd1 Mon Sep 17 00:00:00 2001
+From: Nomis101 <Nomis101@web.de>
+Date: Sun, 15 Feb 2026 17:41:37 +0100
+Subject: MP3 Quicktime fix
+
+Signed-off-by: Nomis101 <Nomis101@web.de>
+---
+ libavformat/movenc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavformat/movenc.c b/libavformat/movenc.c
+index efd6329d70..bc65cdce2c 100644
+--- a/libavformat/movenc.c
++++ b/libavformat/movenc.c
+@@ -8791,7 +8791,7 @@ static const AVCodecTag codec_mp4_tags[] = {
+     { AV_CODEC_ID_AAC,             MKTAG('m', 'p', '4', 'a') },
+     { AV_CODEC_ID_ALAC,            MKTAG('a', 'l', 'a', 'c') },
+     { AV_CODEC_ID_MP4ALS,          MKTAG('m', 'p', '4', 'a') },
+-    { AV_CODEC_ID_MP3,             MKTAG('m', 'p', '4', 'a') },
++    { AV_CODEC_ID_MP3,             MKTAG('.', 'm', 'p', '3') },
+     { AV_CODEC_ID_MP2,             MKTAG('m', 'p', '4', 'a') },
+     { AV_CODEC_ID_AC3,             MKTAG('a', 'c', '-', '3') },
+     { AV_CODEC_ID_EAC3,            MKTAG('e', 'c', '-', '3') },
+-- 
+2.52.0
+


### PR DESCRIPTION
Currently audio streams encoded to MP3 are not recognized in Quicktime. FFmpeg's MP4 muxer sets `mp4a` FourCC for MP3 streams. But Apple's QuickTime/AVFoundation expects MP3 to use the `.mp3` FourCC.
I confirmed that after the fix MP3 audio streams are recognized on Quicktime and are still working with mpv player and ffplay.