### PR TITLE
contrib: libvpx: do not build tools

### DIFF
--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -17,6 +17,7 @@ LIBVPX.CONFIGURE.extra =     \
     --disable-vp9-decoder       \
     --enable-vp9-highbitdepth   \
     --disable-examples          \
+    --disable-tools             \
     --disable-docs              \
     --disable-unit-tests
 


### PR DESCRIPTION
No need to build the tiny_ssim binary.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux