### PR TITLE
contrib: update libvpx to 1.16.0

### DIFF
--- a/NEWS.markdown
+++ b/NEWS.markdown
@@ -52,7 +52,7 @@ Download available from Microsoft:
   - libjpeg-turbo 3.1.3 (preview image compression)
   - liblzma (xz) 5.8.2 (LZMA video decoding, e.g. TIFF)
   - libopus 1.6.1 (Opus audio encoding)
-  - libvpx 1.15.2 (VP8/VP9 video encoding)
+  - libvpx 1.16.0 (VP8/VP9 video encoding)
   - oneVPL 2.16.0 (Intel QSV video encoding/decoding)
   - SVT-AV1 4.0.1 (AV1 video encoding)
   - x265 r13309 (H.265/HEVC video encoding)

--- a/contrib/libvpx/module.defs
+++ b/contrib/libvpx/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBVPX,libvpx))
 $(eval $(call import.CONTRIB.defs,LIBVPX))
 
-LIBVPX.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpx-1.15.2.tar.gz
-LIBVPX.FETCH.url    += https://github.com/webmproject/libvpx/archive/refs/tags/v1.15.2.tar.gz
-LIBVPX.FETCH.sha256  = 26fcd3db88045dee380e581862a6ef106f49b74b6396ee95c2993a260b4636aa
+LIBVPX.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libvpx-1.16.0.tar.gz
+LIBVPX.FETCH.url    += https://github.com/webmproject/libvpx/archive/refs/tags/v1.16.0.tar.gz
+LIBVPX.FETCH.sha256  = 7a479a3c66b9f5d5542a4c6a1b7d3768a983b1e5c14c60a9396edc9b649e015c
 
 LIBVPX.GCC.args.c_std =
 


### PR DESCRIPTION
**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux