### PR TITLE
libhb: move filters out of decavcodec.c

### DIFF
--- a/libhb/adapter.c
+++ b/libhb/adapter.c
@@ -1,0 +1,392 @@
+/* adapter.c
+
+   Copyright (c) 2003-2025 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/handbrake.h"
+#include "handbrake/hbffmpeg.h"
+#include "handbrake/hbavfilter.h"
+
+struct hb_filter_private_s
+{
+    hb_filter_init_t input;
+    hb_filter_init_t output;
+
+    hb_list_t *list_filter;
+    hb_fifo_t *fifo_first;
+    hb_fifo_t *fifo_last;
+
+    int rotation;
+
+    struct
+    {
+        int width;
+        int height;
+        int rotation;
+        int color_range;
+        int pix_fmt;
+    } resample;
+
+    int resample_needed;
+    int done;
+};
+
+static int adapter_init(hb_filter_object_t *filter, hb_filter_init_t *init)
+{
+    filter->private_data = calloc(sizeof(struct hb_filter_private_s), 1);
+    if (filter->private_data == NULL)
+    {
+        hb_error("adapter: calloc failed");
+        return -1;
+    }
+    hb_filter_private_t *pv = filter->private_data;
+
+    int rotation = 0;
+    hb_dict_t *settings = filter->settings;
+
+    hb_dict_extract_int(&rotation, settings, "rotation");
+    if (rotation >= HB_ROTATION_0 && rotation <= HB_ROTATION_270)
+    {
+        pv->rotation = rotation;
+    }
+
+    pv->input  = *init;
+    pv->output = *init;
+
+    return 0;
+}
+
+static void close_filters(hb_filter_private_t *pv)
+{
+    if (pv->list_filter)
+    {
+        hb_filter_object_t *filter;
+        while ((filter = hb_list_item(pv->list_filter, 0)))
+        {
+            if (filter->thread != NULL)
+            {
+                hb_thread_close(&filter->thread);
+            }
+            filter->close(filter);
+
+            if (!filter->skip)
+            {
+                hb_fifo_close(&filter->fifo_out);
+            }
+
+            hb_list_rem(pv->list_filter, filter);
+            hb_filter_close(&filter);
+        }
+    }
+
+    hb_fifo_close(&pv->fifo_first);
+    hb_list_close(&pv->list_filter);
+}
+
+static void adapter_close(hb_filter_object_t *filter)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return;
+    }
+
+    close_filters(pv);
+    free(pv);
+    filter->private_data = NULL;
+}
+
+static void set_properties(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    if (pv->rotation == HB_ROTATION_90 ||
+        pv->rotation == HB_ROTATION_270)
+    {
+        pv->input.geometry.width  = in->f.height;
+        pv->input.geometry.height = in->f.width;
+    }
+    else
+    {
+        pv->input.geometry.width  = in->f.width;
+        pv->input.geometry.height = in->f.height;
+    }
+
+    pv->input.color_range = in->f.color_range;
+
+    if (in->storage_type == AVFRAME)
+    {
+        AVFrame *frame = (AVFrame *)in->storage;
+        // AVFrame format contains the hw format when using an hw decoder,
+        // so extract the actual pixel format from the hw frames context
+        if (frame->hw_frames_ctx)
+        {
+            AVHWFramesContext *frames_ctx = (AVHWFramesContext *)frame->hw_frames_ctx->data;
+            pv->input.pix_fmt = frames_ctx->sw_format;
+        }
+        else
+        {
+            pv->input.pix_fmt = frame->format;
+        }
+    }
+    else
+    {
+        pv->input.pix_fmt = in->f.fmt;
+    }
+}
+
+static void process_filter(hb_filter_object_t *filter)
+{
+    hb_buffer_t *in, *out;
+
+    in = hb_fifo_get_wait(filter->fifo_in);
+    if (in == NULL)
+    {
+        return;
+    }
+
+    out = NULL;
+    filter->status = filter->work(filter, &in, &out);
+    if (in != NULL)
+    {
+        hb_buffer_close(&in);
+    }
+    if (out != NULL)
+    {
+        hb_fifo_push(filter->fifo_out, out);
+    }
+}
+
+static hb_buffer_t * filter_buf(hb_filter_private_t *pv, hb_buffer_t *in)
+{
+    // Feed frame to filter chain
+    hb_fifo_push(pv->fifo_first, in);
+
+    // Process the frame through all filters
+    for (int ii = 0; ii < hb_list_count(pv->list_filter); ii++)
+    {
+        hb_filter_object_t *filter = hb_list_item(pv->list_filter, ii);
+        if (!filter->skip)
+        {
+            process_filter(filter);
+        }
+    }
+    // Retrieve the filtered frame
+    return hb_fifo_get(pv->fifo_last);
+}
+
+static int update_filters(hb_filter_private_t *pv)
+{
+    int resample_changed;
+
+    pv->resample_needed =
+        (pv->output.geometry.width  != pv->input.geometry.width  ||
+         pv->output.geometry.height != pv->input.geometry.height ||
+         pv->output.color_range     != pv->input.color_range ||
+         pv->output.pix_fmt         != pv->input.pix_fmt ||
+         pv->rotation               != HB_ROTATION_0);
+
+    resample_changed =
+        (pv->resample_needed &&
+         (pv->resample.width       != pv->input.geometry.width  ||
+          pv->resample.height      != pv->input.geometry.height ||
+          pv->resample.color_range != pv->input.color_range ||
+          pv->resample.pix_fmt     != pv->input.pix_fmt ||
+          pv->resample.rotation    != pv->rotation));
+
+    if (resample_changed || (pv->resample_needed && pv->list_filter == NULL))
+    {
+        close_filters(pv);
+        hb_list_t *list_filter = hb_list_init();
+        hb_filter_init_t init = pv->input;
+
+        hb_filter_object_t *filter;
+
+        if (pv->rotation == HB_ROTATION_90 ||
+            pv->rotation == HB_ROTATION_270)
+        {
+            init.geometry.width  = pv->input.geometry.height;
+            init.geometry.height = pv->input.geometry.width;
+        }
+
+        // Crop Scale
+        if (pv->output.geometry.width  != pv->input.geometry.width  ||
+            pv->output.geometry.height != pv->input.geometry.height ||
+            pv->output.color_range     != pv->input.color_range)
+        {
+            filter = hb_filter_init(HB_FILTER_CROP_SCALE);
+            filter->settings = hb_dict_init();
+
+            hb_dict_set_int(filter->settings, "width",  init.geometry.width);
+            hb_dict_set_int(filter->settings, "height", init.geometry.height);
+
+            if (pv->output.geometry.width  != pv->input.geometry.width  ||
+                pv->output.geometry.height != pv->input.geometry.height)
+            {
+                hb_log("adapter: scaling video from %d x %d",
+                       pv->input.geometry.width,
+                       pv->input.geometry.height);
+            }
+
+            if (pv->output.color_range != pv->input.color_range)
+            {
+                hb_dict_set_int(filter->settings, "range",  pv->output.color_range);
+                hb_log("adapter: converting video from %s color range",
+                       av_color_range_name(pv->input.color_range));
+            }
+
+            hb_list_add(list_filter, filter);
+            if (filter->init != NULL && filter->init(filter, &init))
+            {
+                hb_error("adapter: failure to initialize filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+            }
+        }
+
+        // Format
+        if (pv->output.pix_fmt != pv->input.pix_fmt)
+        {
+            filter = hb_filter_init(HB_FILTER_FORMAT);
+            filter->settings = hb_dict_init();
+
+            if (pv->output.pix_fmt != pv->input.pix_fmt)
+            {
+                hb_dict_set_string(filter->settings, "format", av_get_pix_fmt_name(pv->output.pix_fmt));
+                hb_log("adapter: converting video pixel format from %s", av_get_pix_fmt_name(pv->input.pix_fmt));
+            }
+
+            hb_list_add(list_filter, filter);
+            if (filter->init != NULL && filter->init(filter, &init))
+            {
+                hb_error("adapter: failure to initialize filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+            }
+        }
+
+        // Rotate
+        if (pv->rotation != HB_ROTATION_0)
+        {
+            filter = hb_filter_init(HB_FILTER_ROTATE);
+            filter->settings = hb_dict_init();
+
+            switch (pv->rotation)
+            {
+                case HB_ROTATION_90:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("270"));
+                    hb_log("adapter: auto-rotating video 90 degrees");
+                    break;
+                case HB_ROTATION_180:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("180"));
+                    hb_log("adapter: auto-rotating video 180 degrees");
+                    break;
+                case HB_ROTATION_270:
+                    hb_dict_set(filter->settings, "angle", hb_value_string("90"));
+                    hb_log("adapter: auto-rotating video 270 degrees");
+                    break;
+                default:
+                    hb_log("adapter: reinit_video_filters: unknown rotation, failed");
+            }
+
+            hb_list_add(list_filter, filter);
+            if (filter->init != NULL && filter->init(filter, &init))
+            {
+                hb_error("adapter: failure to initialize filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+            }
+        }
+
+
+        hb_avfilter_combine(list_filter);
+
+        for (int ii = 0; ii < hb_list_count(list_filter);)
+        {
+            filter = hb_list_item(list_filter, ii);
+            filter->done = &pv->done;
+            filter->output_immediately = 1;
+            if (filter->post_init != NULL && filter->post_init(filter, pv->input.job))
+            {
+                hb_log("adapter: failure to initialise filter '%s'", filter->name);
+                hb_list_rem(list_filter, filter);
+                hb_filter_close(&filter);
+                continue;
+            }
+            ii++;
+        }
+
+        // Set up filter fifos
+        hb_fifo_t *fifo_in, *fifo_first, *fifo_last;
+
+        fifo_last = fifo_in = fifo_first = hb_fifo_init(1, 1);
+        for (int ii = 0; ii < hb_list_count(list_filter); ii++)
+        {
+            filter = hb_list_item(list_filter, ii);
+            if (!filter->skip)
+            {
+                filter->fifo_in = fifo_in;
+                filter->fifo_out = hb_fifo_init(1, 1);
+                fifo_last = fifo_in = filter->fifo_out;
+            }
+        }
+        pv->fifo_first  = fifo_first;
+        pv->fifo_last   = fifo_last;
+        pv->list_filter = list_filter;
+
+        pv->resample.width       = pv->input.geometry.width;
+        pv->resample.height      = pv->input.geometry.height;
+        pv->resample.color_range = pv->input.color_range;
+        pv->resample.rotation    = pv->rotation;
+        pv->resample.pix_fmt     = pv->input.pix_fmt;
+    }
+
+    return 0;
+}
+
+static int adapter_work(hb_filter_object_t *filter,
+                        hb_buffer_t **buf_in,
+                        hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        *buf_out = in;
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    set_properties(pv, in);
+    update_filters(pv);
+
+    if (pv->resample_needed)
+    {
+        *buf_out = filter_buf(pv, in);
+    }
+    else
+    {
+        *buf_out = in;
+    }
+    *buf_in = NULL;
+
+    return HB_FILTER_OK;
+}
+
+static const char adapter_template[] = "rotation=^(0|1|2|3)";
+
+hb_filter_object_t hb_filter_adapter =
+{
+    .id                = HB_FILTER_ADAPTER,
+    .enforce_order     = 1,
+    .name              = "Adapter",
+    .settings          = NULL,
+    .init              = adapter_init,
+    .work              = adapter_work,
+    .close             = adapter_close,
+    .settings_template = adapter_template,
+};

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -43,6 +43,8 @@ static int avfilter_init( hb_filter_object_t * filter, hb_filter_init_t * init )
 
     hb_buffer_list_clear(&pv->list);
 
+    pv->delay = filter->output_immediately == 0;
+
     return 0;
 
 fail:
@@ -81,6 +83,8 @@ static int avfilter_post_init( hb_filter_object_t * filter, hb_job_t * job )
     hb_avfilter_graph_update_init(pv->graph, &pv->output);
 
     hb_buffer_list_clear(&pv->list);
+
+    pv->delay = filter->output_immediately == 0;
 
     return 0;
 
@@ -226,13 +230,23 @@ static hb_buffer_t* filterFrame( hb_filter_private_t * pv, hb_buffer_t ** buf_in
     }
     // Delay one frame so we can set the stop time of the output buffer
     hb_buffer_list_clear(&list);
-    while (hb_buffer_list_count(&pv->list) > 1)
+    while (hb_buffer_list_count(&pv->list) > pv->delay)
     {
         buf  = hb_buffer_list_rem_head(&pv->list);
-        next = hb_buffer_list_head(&pv->list);
 
-        buf->s.stop = next->s.start;
-        buf->s.duration = buf->s.stop - buf->s.start;
+        // Delay one frame so we can set the stop time of the output buffer
+        if (pv->delay)
+        {
+            next = hb_buffer_list_head(&pv->list);
+
+            buf->s.stop = next->s.start;
+            buf->s.duration = buf->s.stop - buf->s.start;
+        }
+        else
+        {
+            buf->s.stop = buf->s.start + buf->s.duration;
+        }
+
         hb_buffer_list_append(&list, buf);
     }
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5042,6 +5042,10 @@ hb_filter_object_t * hb_filter_get( int filter_id )
     hb_filter_object_t * filter;
     switch( filter_id )
     {
+        case HB_FILTER_ADAPTER:
+            filter = &hb_filter_adapter;
+            break;
+
         case HB_FILTER_DETELECINE:
             filter = &hb_filter_detelecine;
             break;

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5330,6 +5330,10 @@ hb_filter_object_t * hb_filter_get( int filter_id )
     hb_filter_object_t * filter;
     switch( filter_id )
     {
+        case HB_FILTER_ADAPTER:
+            filter = &hb_filter_adapter;
+            break;
+
         case HB_FILTER_DETELECINE:
             filter = &hb_filter_detelecine;
             break;

--- a/libhb/cropscale.c
+++ b/libhb/cropscale.c
@@ -21,7 +21,8 @@ static hb_filter_info_t * crop_scale_info( hb_filter_object_t * filter );
 static const char crop_scale_template[] =
     "width=^"HB_INT_REG"$:height=^"HB_INT_REG"$:"
     "crop-top=^"HB_INT_REG"$:crop-bottom=^"HB_INT_REG"$:"
-    "crop-left=^"HB_INT_REG"$:crop-right=^"HB_INT_REG"$";
+    "crop-left=^"HB_INT_REG"$:crop-right=^"HB_INT_REG"$:"
+    "range=^"HB_INT_REG"$";
 
 hb_filter_object_t hb_filter_crop_scale =
 {
@@ -47,6 +48,7 @@ hb_filter_object_t hb_filter_crop_scale =
  *  crop-bottom - bottom crop margin
  *  crop-left   - left crop margin
  *  crop-right  - right crop margin
+ *  range       - color range
  *
  */
 static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
@@ -66,6 +68,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     int                width, height;
     int                cropped_width, cropped_height;
     int                top = 0, bottom = 0, left = 0, right = 0;
+    int                color_range = AVCOL_RANGE_UNSPECIFIED;
 
     // Convert crop settings to 'crop' avfilter
     hb_dict_extract_int(&top, settings, "crop-top");
@@ -90,6 +93,13 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
     width  = cropped_width;
     height = cropped_height;
 
+    color_range = hb_dict_extract_int(&color_range, settings, "range");
+
+    if (color_range == AVCOL_RANGE_UNSPECIFIED)
+    {
+        color_range = AVCOL_RANGE_MPEG;
+    }
+
     // Convert scale settings to 'scale' avfilter
     hb_dict_extract_int(&width, settings, "width");
     hb_dict_extract_int(&height, settings, "height");
@@ -110,6 +120,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
 
         hb_dict_set_int(avsettings, "w", width);
         hb_dict_set_int(avsettings, "h", height);
+        hb_dict_set_string(avsettings, "out_range", ((color_range == AVCOL_RANGE_JPEG) ? "full" : "limited"));
         hb_dict_set_int(avsettings, "async_depth", init->job->hw_device_async_depth);
         if (init->job->qsv_ctx->vpp_scale_mode)
         {
@@ -132,6 +143,14 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
             hb_dict_set_string(avsettings, "interp_algo", "lanczos");
             hb_dict_set_string(avsettings, "format", av_get_pix_fmt_name(init->pix_fmt));
             hb_dict_set(avfilter, "scale_cuda", avsettings);
+
+            // FIXME
+//            if (color_range != pv->frame->color_range)
+//            {
+//                hb_dict_set_int(settings, "range", color_range);
+//                hb_avfilter_append_dict(filters, "colorspace_cuda", settings);
+//                settings = hb_dict_init();
+//            }
         }
         else if (init->hw_pix_fmt == AV_PIX_FMT_D3D11)
         {
@@ -153,6 +172,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
         {
             hb_dict_set_int(avsettings, "width", width);
             hb_dict_set_int(avsettings, "height", height);
+            hb_dict_set_string(avsettings, "range", av_color_range_name(color_range));
             hb_dict_set_string(avsettings, "filter", "lanczos");
             hb_dict_set(avfilter, "zscale", avsettings);
         }
@@ -160,6 +180,7 @@ static int crop_scale_init(hb_filter_object_t * filter, hb_filter_init_t * init)
         {
             hb_dict_set_int(avsettings, "width", width);
             hb_dict_set_int(avsettings, "height", height);
+            hb_dict_set_int(avsettings, "out_range", color_range);
             hb_dict_set_string(avsettings, "flags", "lanczos+accurate_rnd");
             hb_dict_set(avfilter, "scale", avsettings);
         }

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -99,16 +99,6 @@ struct reordered_data_s
 #define REORDERED_HASH_SZ   (2 << 7)
 #define REORDERED_HASH_MASK (REORDERED_HASH_SZ - 1)
 
-struct video_filters_s
-{
-    hb_avfilter_graph_t * graph;
-
-    int                   width;
-    int                   height;
-    int                   color_range;
-    int                   pix_fmt;
-};
-
 struct hb_work_private_s
 {
     hb_job_t             * job;
@@ -137,7 +127,6 @@ struct hb_work_private_s
     int64_t                sequence;
     int                    last_scr_sequence;
     int                    last_chapter;
-    struct video_filters_s video_filters;
 
     hb_audio_t           * audio;
     hb_audio_resample_t  * resample;
@@ -552,11 +541,6 @@ static int decavcodecaInit( hb_work_object_t * w, hb_job_t * job )
  ***********************************************************************
  *
  **********************************************************************/
-static void close_video_filters(hb_work_private_t *pv)
-{
-    hb_avfilter_graph_close(&pv->video_filters.graph);
-}
-
 static void closePrivData( hb_work_private_t ** ppv )
 {
     hb_work_private_t * pv = *ppv;
@@ -572,7 +556,6 @@ static void closePrivData( hb_work_private_t ** ppv )
         }
         av_frame_free(&pv->frame);
         av_frame_free(&pv->hw_frame);
-        close_video_filters(pv);
         if ( pv->parser )
         {
             av_parser_close(pv->parser);
@@ -1145,10 +1128,8 @@ static hb_buffer_t * cc_fill_buffer(hb_work_private_t *pv, uint8_t *cc, int size
     return buf;
 }
 
-// copy one video frame into an HB buf. If the frame isn't in our color space
-// or at least one of its dimensions is odd, use sws_scale to convert/rescale it.
-// Otherwise just copy the bits.
-static hb_buffer_t *copy_frame( hb_work_private_t *pv )
+// Wrap one video frame into an HB buf
+static hb_buffer_t *wrap_frame(hb_work_private_t *pv)
 {
     reordered_data_t * reordered = NULL;
     hb_buffer_t      * out;
@@ -1347,281 +1328,6 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
     return out;
 }
 
-int reinit_video_filters(hb_work_private_t * pv)
-{
-    int                orig_width;
-    int                orig_height;
-    hb_value_array_t * filters;
-    hb_dict_t        * settings;
-    hb_filter_init_t   filter_init;
-    enum AVPixelFormat pix_fmt;
-    enum AVColorRange  color_range;
-
-    if (!pv->job)
-    {
-        // HandBrake's preview pipeline uses yuv420 color.  This means all
-        // dimensions must be even.  So we must adjust the dimensions
-        // of incoming video if not even.
-        orig_width = pv->context->width & ~1;
-        orig_height = pv->context->height & ~1;
-        pix_fmt = AV_PIX_FMT_YUV420P;
-        color_range = AVCOL_RANGE_MPEG;
-    }
-    else
-    {
-        if (pv->job->hw_pix_fmt == AV_PIX_FMT_VIDEOTOOLBOX)
-        {
-            // Filtering is done in a separate filter
-            return 0;
-        }
-
-        if (pv->title->rotation == HB_ROTATION_90 ||
-            pv->title->rotation == HB_ROTATION_270)
-        {
-            orig_width = pv->job->title->geometry.height;
-            orig_height = pv->job->title->geometry.width;
-        }
-        else
-        {
-            orig_width = pv->job->title->geometry.width;
-            orig_height = pv->job->title->geometry.height;
-        }
-        pix_fmt = pv->job->hw_pix_fmt != AV_PIX_FMT_NONE ? pv->job->hw_pix_fmt : pv->job->input_pix_fmt;
-        color_range = pv->job->color_range;
-    }
-
-    if (pix_fmt            == pv->frame->format  &&
-        orig_width         == pv->frame->width   &&
-        orig_height        == pv->frame->height  &&
-        color_range        == pv->frame->color_range &&
-        HB_ROTATION_0      == pv->title->rotation)
-    {
-        // No filtering required.
-        close_video_filters(pv);
-        return 0;
-    }
-
-    if (pv->video_filters.graph       != NULL              &&
-        pv->video_filters.width       == pv->frame->width  &&
-        pv->video_filters.height      == pv->frame->height &&
-        pv->video_filters.color_range == pv->frame->color_range &&
-        pv->video_filters.pix_fmt     == pv->frame->format)
-    {
-        // Current filter settings are good
-        return 0;
-    }
-
-    pv->video_filters.width       = pv->frame->width;
-    pv->video_filters.height      = pv->frame->height;
-    pv->video_filters.color_range = pv->frame->color_range;
-    pv->video_filters.pix_fmt     = pv->frame->format;
-
-    // New filter required, create filter graph
-    close_video_filters(pv);
-
-    int clock_min, clock_max, clock;
-    hb_rational_t vrate;
-
-    hb_video_framerate_get_limits(&clock_min, &clock_max, &clock);
-    vrate.num = clock;
-    vrate.den = pv->duration * (clock / 90000.);
-
-    filters = hb_value_array_init();
-    if (pix_fmt            != pv->frame->format ||
-        orig_width         != pv->frame->width  ||
-        orig_height        != pv->frame->height ||
-        color_range        != pv->frame->color_range)
-    {
-        settings = hb_dict_init();
-#if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
-        if (pv->frame->hw_frames_ctx && pv->job->hw_pix_fmt == AV_PIX_FMT_QSV)
-        {
-            hb_dict_set(settings, "w", hb_value_int(orig_width));
-            hb_dict_set(settings, "h", hb_value_int(orig_height));
-            hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
-            hb_dict_set_string(settings, "out_range", ((color_range == AVCOL_RANGE_JPEG) ? "full" : "limited"));
-            hb_avfilter_append_dict(filters, "vpp_qsv", settings);
-        }
-        else
-#endif
-        if (pv->frame->hw_frames_ctx && pv->job && pv->job->hw_pix_fmt == AV_PIX_FMT_CUDA)
-        {
-            if (color_range != pv->frame->color_range)
-            {
-                hb_dict_set_int(settings, "range", color_range);
-                hb_avfilter_append_dict(filters, "colorspace_cuda", settings);
-                settings = hb_dict_init();
-            }
-            hb_dict_set(settings, "w", hb_value_int(orig_width));
-            hb_dict_set(settings, "h", hb_value_int(orig_height));
-            hb_dict_set(settings, "interp_algo", hb_value_string("lanczos"));
-            hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
-            hb_avfilter_append_dict(filters, "scale_cuda", settings);
-        }
-        else if (pv->frame->hw_frames_ctx && pv->job->hw_pix_fmt == AV_PIX_FMT_D3D11)
-        {
-            hb_dict_set(settings, "width", hb_value_int(orig_width));
-            hb_dict_set(settings, "height", hb_value_int(orig_height));
-            hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
-            hb_avfilter_append_dict(filters, "scale_d3d11", settings);
-        }
-#if HB_PROJECT_FEATURE_AMFDEC
-        else if (pv->frame->hw_frames_ctx && pv->job && pv->job->hw_pix_fmt == AV_PIX_FMT_AMF_SURFACE)
-        {
-            hb_dict_set(settings, "format", hb_value_string(av_get_pix_fmt_name(pv->job->input_pix_fmt)));
-            hb_avfilter_append_dict(filters, "vpp_amf", settings);
-        }
-#endif
-        else if (hb_av_can_use_zscale(pv->frame->format,
-                                      pv->frame->width, pv->frame->height,
-                                      orig_width, orig_height))
-        {
-            hb_dict_set(settings, "w", hb_value_int(orig_width));
-            hb_dict_set(settings, "h", hb_value_int(orig_height));
-            hb_dict_set_string(settings, "filter", "lanczos");
-            hb_dict_set_string(settings, "range", av_color_range_name(color_range));
-            hb_avfilter_append_dict(filters, "zscale", settings);
-
-            settings = hb_dict_init();
-            hb_dict_set(settings, "pix_fmts", hb_value_string(av_get_pix_fmt_name(pix_fmt)));
-            hb_avfilter_append_dict(filters, "format", settings);
-        }
-        // Fallback to swscale, zscale requires a mod 2 width and height
-        else
-        {
-            hb_dict_set(settings, "w", hb_value_int(orig_width));
-            hb_dict_set(settings, "h", hb_value_int(orig_height));
-            hb_dict_set(settings, "flags", hb_value_string("lanczos+accurate_rnd"));
-            hb_dict_set_int(settings, "in_range", pv->frame->color_range);
-            hb_dict_set_int(settings, "out_range", color_range);
-            hb_avfilter_append_dict(filters, "scale", settings);
-
-            settings = hb_dict_init();
-            hb_dict_set(settings, "pix_fmts", hb_value_string(av_get_pix_fmt_name(pix_fmt)));
-            hb_avfilter_append_dict(filters, "format", settings);
-        }
-    }
-    if (pv->title->rotation != HB_ROTATION_0)
-    {
-#if HB_PROJECT_FEATURE_QSV
-        if (pv->frame->hw_frames_ctx && pv->job->hw_pix_fmt == AV_PIX_FMT_QSV)
-        {
-            switch (pv->title->rotation)
-            {
-                case HB_ROTATION_90:
-                {
-                    settings = hb_dict_init();
-                    hb_dict_set(settings, "transpose", hb_value_string("clock"));
-                    hb_avfilter_append_dict(filters, "vpp_qsv", settings);
-                    hb_log("Auto-Rotating video 90 degrees");
-                    break;
-                }
-                case HB_ROTATION_180:
-                    settings = hb_dict_init();
-                    hb_dict_set(settings, "transpose", hb_value_string("reversal"));
-                    hb_avfilter_append_dict(filters, "vpp_qsv", settings);
-                    hb_log("Auto-Rotating video 180 degrees");
-                    break;
-                case HB_ROTATION_270:
-                {
-                    settings = hb_dict_init();
-                    hb_dict_set(settings, "transpose", hb_value_string("cclock"));
-                    hb_avfilter_append_dict(filters, "vpp_qsv", settings);
-                    hb_log("Auto-Rotating video 270 degrees");
-                    break;
-                }
-                default:
-                    hb_log("reinit_video_filters: Unknown rotation, failed");
-            }
-        }
-        else
-#endif
-        {
-            switch (pv->title->rotation)
-            {
-                case HB_ROTATION_90:
-                    settings = hb_dict_init();
-                    hb_dict_set(settings, "dir", hb_value_string("cclock"));
-                    hb_avfilter_append_dict(filters, "transpose", settings);
-                    hb_log("Auto-Rotating video 90 degrees");
-                    break;
-                case HB_ROTATION_180:
-                    hb_avfilter_append_dict(filters, "hflip", hb_value_null());
-                    hb_avfilter_append_dict(filters, "vflip", hb_value_null());
-                    hb_log("Auto-Rotating video 180 degrees");
-                    break;
-                case HB_ROTATION_270:
-                    settings = hb_dict_init();
-                    hb_dict_set(settings, "dir", hb_value_string("clock"));
-                    hb_avfilter_append_dict(filters, "transpose", settings);
-                    hb_log("Auto-Rotating video 270 degrees");
-                    break;
-                default:
-                    hb_log("reinit_video_filters: Unknown rotation, failed");
-            }
-
-            const AVPixFmtDescriptor *desc = av_pix_fmt_desc_get(pix_fmt);
-            if (desc->log2_chroma_w != desc->log2_chroma_h)
-            {
-                settings = hb_dict_init();
-                hb_dict_set(settings, "pix_fmts", hb_value_string(av_get_pix_fmt_name(pix_fmt)));
-                hb_avfilter_append_dict(filters, "format", settings);
-            }
-        }
-    }
-
-    enum AVPixelFormat sw_pix_fmt = pv->frame->format;
-    enum AVPixelFormat hw_pix_fmt = AV_PIX_FMT_NONE;
-    enum AVColorSpace color_matrix = pv->frame->colorspace;
-
-    if (!pv->job)
-    {
-        // Sanitize the color_matrix when decoding preview images
-        hb_rational_t par = {pv->frame->sample_aspect_ratio.num, pv->frame->sample_aspect_ratio.den};
-        hb_geometry_t geo = {pv->frame->width, pv->frame->height, par};
-        color_matrix = hb_get_color_matrix(pv->frame->colorspace, geo);
-    }
-
-    AVHWFramesContext *frames_ctx = NULL;
-    if (pv->frame->hw_frames_ctx)
-    {
-        frames_ctx = (AVHWFramesContext *)pv->frame->hw_frames_ctx->data;
-        sw_pix_fmt = frames_ctx->sw_format;
-        hw_pix_fmt = frames_ctx->format;
-    }
-
-    memset((void*)&filter_init, 0, sizeof(filter_init));
-
-    filter_init.job               = pv->job;
-    filter_init.pix_fmt           = sw_pix_fmt;
-    filter_init.hw_pix_fmt        = hw_pix_fmt;
-    filter_init.geometry.width    = pv->frame->width;
-    filter_init.geometry.height   = pv->frame->height;
-    filter_init.geometry.par.num  = pv->frame->sample_aspect_ratio.num;
-    filter_init.geometry.par.den  = pv->frame->sample_aspect_ratio.den;
-    filter_init.color_matrix      = color_matrix;
-    filter_init.color_range       = pv->frame->color_range;
-    filter_init.time_base.num     = 1;
-    filter_init.time_base.den     = 1;
-    filter_init.vrate.num         = vrate.num;
-    filter_init.vrate.den         = vrate.den;
-
-    pv->video_filters.graph = hb_avfilter_graph_init(filters, &filter_init);
-    hb_value_free(&filters);
-    if (pv->video_filters.graph == NULL)
-    {
-        hb_error("reinit_video_filters: failed to create filter graph");
-        goto fail;
-    }
-
-    return 0;
-
-fail:
-    close_video_filters(pv);
-
-    return 1;
-}
-
 static void sanitize_deprecated_pix_fmts(AVFrame *frame)
 {
     switch (frame->format)
@@ -1648,55 +1354,6 @@ static void sanitize_deprecated_pix_fmts(AVFrame *frame)
             break;
         default:
             break;
-    }
-}
-
-static void filter_video(hb_work_private_t *pv)
-{
-    // Make sure every frame is tagged
-    if (pv->job)
-    {
-        pv->frame->color_primaries = pv->title->color_prim;
-        pv->frame->color_trc       = pv->title->color_transfer;
-        pv->frame->colorspace      = pv->title->color_matrix;
-        pv->frame->color_range     = pv->title->color_range;
-    }
-
-    // FIXME: AVCOL_SPC_IPT_C2 is not well supported
-    // by filter graph link negotiation yet
-    if (pv->frame->colorspace == AVCOL_SPC_IPT_C2)
-    {
-        pv->frame->color_primaries = AVCOL_PRI_UNSPECIFIED;
-        pv->frame->color_trc       = AVCOL_TRC_UNSPECIFIED;
-        pv->frame->colorspace      = AVCOL_SPC_UNSPECIFIED;
-    }
-
-    // J pixel formats are mostly deprecated, however
-    // they are still set by decoders, breaking some filters
-    sanitize_deprecated_pix_fmts(pv->frame);
-
-    reinit_video_filters(pv);
-    if (pv->video_filters.graph != NULL)
-    {
-        int result;
-
-        hb_avfilter_add_frame(pv->video_filters.graph, pv->frame);
-        result = hb_avfilter_get_frame(pv->video_filters.graph, pv->frame);
-        while (result >= 0)
-        {
-            hb_buffer_t * buf = copy_frame(pv);
-            hb_buffer_list_append(&pv->list, buf);
-            av_frame_unref(pv->frame);
-            ++pv->nframes;
-            result = hb_avfilter_get_frame(pv->video_filters.graph, pv->frame);
-        }
-    }
-    else
-    {
-        hb_buffer_t * buf = copy_frame(pv);
-        hb_buffer_list_append(&pv->list, buf);
-        av_frame_unref(pv->frame);
-        ++pv->nframes;
     }
 }
 
@@ -1814,7 +1471,37 @@ static int decodeFrame( hb_work_private_t * pv, packet_info_t * packet_info )
 
         // recompute the frame/field duration, because sometimes it changes
         compute_frame_duration( pv );
-        filter_video(pv);
+
+        // Make sure every frame is tagged
+        if (pv->job)
+        {
+            pv->frame->color_primaries = pv->title->color_prim;
+            pv->frame->color_trc       = pv->title->color_transfer;
+            pv->frame->colorspace      = pv->title->color_matrix;
+        }
+
+        // FIXME: AVCOL_SPC_IPT_C2 is not well supported
+        // by filter graph link negotiation yet
+        if (pv->frame->colorspace == AVCOL_SPC_IPT_C2)
+        {
+            pv->frame->color_primaries = AVCOL_PRI_UNSPECIFIED;
+            pv->frame->color_trc       = AVCOL_TRC_UNSPECIFIED;
+            pv->frame->colorspace      = AVCOL_SPC_UNSPECIFIED;
+        }
+
+        if (pv->frame->color_range == AVCOL_RANGE_UNSPECIFIED)
+        {
+            pv->frame->color_range = AVCOL_RANGE_MPEG;
+        }
+
+        // J pixel formats are mostly deprecated, however
+        // they are still set by some decoders, breaking some filters
+        sanitize_deprecated_pix_fmts(pv->frame);
+
+        hb_buffer_t *buf = wrap_frame(pv);
+        hb_buffer_list_append(&pv->list, buf);
+        av_frame_unref(pv->frame);
+        ++pv->nframes;
     } while (ret >= 0);
 
     if ( global_verbosity_level <= 1 )

--- a/libhb/handbrake/avfilter_priv.h
+++ b/libhb/handbrake/avfilter_priv.h
@@ -25,6 +25,8 @@ struct hb_filter_private_s
     hb_value_t          * avfilters;
     hb_filter_init_t      input;
     hb_filter_init_t      output;
+
+    int                   delay;
 };
 
 int  hb_avfilter_null_work( hb_filter_object_t * filter,

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1609,6 +1609,8 @@ struct hb_filter_object_s
     hb_fifo_t           * fifo_in;
     hb_fifo_t           * fifo_out;
 
+    int                   output_immediately;
+
     hb_subtitle_t       * subtitle;
 
     hb_filter_private_t * private_data;
@@ -1632,6 +1634,7 @@ enum
     HB_FILTER_INVALID = 0,
     HB_FILTER_FIRST = 1,
 
+    HB_FILTER_ADAPTER,
     HB_FILTER_ADAPTER_VT,
     // First, filters that may change the framerate (drop or dup frames)
     HB_FILTER_DETELECINE,

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1693,6 +1693,8 @@ struct hb_filter_object_s
     hb_fifo_t           * fifo_in;
     hb_fifo_t           * fifo_out;
 
+    int                   output_immediately;
+
     hb_subtitle_t       * subtitle;
 
     hb_filter_private_t * private_data;
@@ -1731,6 +1733,7 @@ enum
     HB_FILTER_INVALID = 0,
     HB_FILTER_FIRST = 1,
 
+    HB_FILTER_ADAPTER,
     HB_FILTER_ADAPTER_VT,
     // First, filters that may change the framerate (drop or dup frames)
     HB_FILTER_DETELECINE,

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -438,6 +438,7 @@ enum
     WORK_ENCAVSUB
 };
 
+extern hb_filter_object_t hb_filter_adapter;
 extern hb_filter_object_t hb_filter_detelecine;
 extern hb_filter_object_t hb_filter_comb_detect;
 extern hb_filter_object_t hb_filter_decomb;

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -97,6 +97,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
                                                            initial_pool_size);
         if (!par->hw_frames_ctx)
         {
+            hb_log("hb_avfilter_graph_init: failed to init hw frames ctx");
             goto fail;
         }
     }

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -109,6 +109,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
                                                            0);
         if (!par->hw_frames_ctx)
         {
+            hb_log("hb_avfilter_graph_init: failed to init hw frames ctx");
             goto fail;
         }
     }

--- a/libhb/mf_common.c
+++ b/libhb/mf_common.c
@@ -242,6 +242,8 @@ int hb_mf_are_filters_supported(hb_list_t *filters)
 
         switch (filter->id)
         {
+            case HB_FILTER_ADAPTER:
+                break;
             case HB_FILTER_CROP_SCALE:
                 hb_log("D3D11: Scaling filter supported");
                 break;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -261,6 +261,7 @@ static int hb_nvenc_are_filters_supported(hb_list_t *filters)
                 // Mode 0 doesn't require access to the frame data
                 supported = hb_dict_get_int(filter->settings, "mode") == 0;
                 break;
+            case HB_FILTER_ADAPTER:
             case HB_FILTER_FORMAT:
             case HB_FILTER_AVFILTER:
                 break;

--- a/libhb/nvenc_common.c
+++ b/libhb/nvenc_common.c
@@ -301,6 +301,7 @@ static int hb_nvenc_are_filters_supported(hb_list_t *filters)
                 // Mode 0 doesn't require access to the frame data
                 supported = hb_dict_get_int(filter->settings, "mode") == 0;
                 break;
+            case HB_FILTER_ADAPTER:
             case HB_FILTER_FORMAT:
             case HB_FILTER_AVFILTER:
                 break;

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -500,12 +500,7 @@ void hb_vt_setup_hw_filters(hb_job_t *job)
     {
         fix_prores_pix_fmt(job);
 
-        // Add adapter
-        hb_filter_object_t *filter = hb_filter_init(HB_FILTER_ADAPTER_VT);
-        char *settings = hb_strdup_printf("rotation=%d", job->title->rotation);
-        hb_add_filter(job, filter, settings);
-        free(settings);
-
+        replace_filter(job, HB_FILTER_ADAPTER, HB_FILTER_ADAPTER_VT);
         replace_filter(job, HB_FILTER_COMB_DETECT, HB_FILTER_COMB_DETECT_VT);
         replace_filter(job, HB_FILTER_YADIF, HB_FILTER_YADIF_VT);
         replace_filter(job, HB_FILTER_BWDIF, HB_FILTER_BWDIF_VT);

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -507,12 +507,7 @@ void hb_vt_setup_hw_filters(hb_job_t *job)
     {
         fix_prores_pix_fmt(job);
 
-        // Add adapter
-        hb_filter_object_t *filter = hb_filter_init(HB_FILTER_ADAPTER_VT);
-        char *settings = hb_strdup_printf("rotation=%d", job->title->rotation);
-        hb_add_filter(job->list_filter, filter, settings);
-        free(settings);
-
+        replace_filter(job, HB_FILTER_ADAPTER, HB_FILTER_ADAPTER_VT);
         replace_filter(job, HB_FILTER_COMB_DETECT, HB_FILTER_COMB_DETECT_VT);
         replace_filter(job, HB_FILTER_YADIF, HB_FILTER_YADIF_VT);
         replace_filter(job, HB_FILTER_BWDIF, HB_FILTER_BWDIF_VT);

--- a/libhb/qsv_common.c
+++ b/libhb/qsv_common.c
@@ -2293,6 +2293,7 @@ static int are_filters_supported(hb_list_t *filters)
         hb_filter_object_t *filter = hb_list_item(filters, i);
         switch (filter->id)
         {
+            case HB_FILTER_ADAPTER:
             // pixel format conversion is done via VPP filter
             case HB_FILTER_FORMAT:
             // cropping and scaling always done via VPP filter

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -641,6 +641,104 @@ static hb_buffer_t * read_buf(hb_scan_t * data, hb_stream_t * stream)
     return NULL;
 }
 
+static int init_video_filter(hb_filter_object_t **filter, hb_work_info_t vid_info, int rotation)
+{
+    if (*filter != NULL)
+    {
+        return 0;
+    }
+
+    hb_filter_init_t init;
+    memset(&init, 0, sizeof(init));
+
+    init.time_base.num = 1;
+    init.time_base.den = 90000;
+    init.pix_fmt = AV_PIX_FMT_YUV420P;
+    init.hw_pix_fmt = AV_PIX_FMT_NONE;
+
+    init.color_prim     = vid_info.color_prim;
+    init.color_transfer = vid_info.color_transfer;
+    init.color_matrix   = vid_info.color_matrix;
+    init.color_range    = AVCOL_RANGE_MPEG;
+    init.chroma_location = vid_info.chroma_location;
+    init.geometry = vid_info.geometry;
+    init.geometry.par.num = 1;
+    init.geometry.par.den = 1;
+    memset(init.crop, 0, sizeof(int[4]));
+    init.vrate = vid_info.rate;
+
+    hb_filter_object_t *_filter = hb_filter_init(HB_FILTER_ADAPTER);
+    _filter->settings = hb_dict_init();
+
+    hb_dict_set_int(_filter->settings, "rotation",  rotation);
+
+    if (_filter->init != NULL && _filter->init(_filter, &init))
+    {
+        hb_error("scan: failure to initialize filter '%s'", _filter->name);
+        hb_filter_close(&_filter);
+        return 1;
+    }
+
+    if (_filter->post_init != NULL && _filter->post_init(_filter, NULL))
+    {
+        hb_log("scan: failure to initialise filter '%s'", _filter->name);
+        hb_filter_close(&_filter);
+        return 1;
+    }
+
+    // Set up filter fifos
+    _filter->fifo_in  = hb_fifo_init(1, 1);
+    _filter->fifo_out = hb_fifo_init(1, 1);
+
+    *filter = _filter;
+
+    return 0;
+}
+
+static hb_buffer_t * filter_buf(hb_filter_object_t *filter, hb_buffer_t *in)
+{
+    // Feed frame to filter chain
+    hb_fifo_push(filter->fifo_in, in);
+
+    in = hb_fifo_get_wait(filter->fifo_in);
+    if (in == NULL)
+    {
+        return NULL;
+    }
+
+    // Process the frame through filter
+    hb_buffer_t *out = NULL;
+    filter->status = filter->work(filter, &in, &out);
+    if (in != NULL)
+    {
+        hb_buffer_close(&in);
+    }
+    if (out != NULL)
+    {
+        hb_fifo_push(filter->fifo_out, out);
+    }
+
+    // Retrieve the filtered frame
+    out = hb_fifo_get(filter->fifo_out);
+
+    return out;
+}
+
+static void close_video_filter(hb_filter_object_t **filter)
+{
+    if (filter == NULL || *filter == NULL)
+    {
+        return;
+    }
+
+    hb_filter_object_t *_filter = *filter;
+    _filter->close(_filter);
+    hb_fifo_close(&_filter->fifo_in);
+    hb_fifo_close(&_filter->fifo_out);
+
+    hb_filter_close(filter);
+}
+
 /***********************************************************************
  * DecodePreviews
  ***********************************************************************
@@ -739,6 +837,8 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
         hb_hwaccel_hw_device_ctx_close(&hw_device_ctx);
         return 0;
     }
+
+    hb_filter_object_t *filter = NULL;
 
     for( i = 0; i < data->preview_count; i++ )
     {
@@ -959,6 +1059,10 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
             hb_buffer_close( &vid_buf );
             continue;
         }
+
+        // Do filtering
+        init_video_filter(&filter, vid_info, title->rotation);
+        vid_buf = filter_buf(filter, vid_buf);
 
         if (vid_info.geometry.width  != vid_buf->f.width ||
             vid_info.geometry.height != vid_buf->f.height)
@@ -1429,6 +1533,7 @@ skip_preview:
             title->detected_interlacing = 0;
         }
     }
+    close_video_filter(&filter);
     crop_record_free( crops );
     free( info_list );
 

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1353,6 +1353,12 @@ static void sanitize_filter_list_pre(hb_job_t *job, hb_geometry_t src_geo)
 {
     hb_list_t *list = job->list_filter;
 
+    // Add adapter
+    hb_filter_object_t *filter = hb_filter_init(HB_FILTER_ADAPTER);
+    char *settings = hb_strdup_printf("rotation=%d", job->title->rotation);
+    hb_add_filter(job, filter, settings);
+    free(settings);
+
     // Add selective deinterlacing mode if comb detection is enabled
     if (hb_filter_find(list, HB_FILTER_COMB_DETECT) != NULL)
     {
@@ -1373,7 +1379,7 @@ static void sanitize_filter_list_pre(hb_job_t *job, hb_geometry_t src_geo)
     }
 
     int angle = 0;
-    hb_filter_object_t *filter = hb_filter_find(list, HB_FILTER_ROTATE);
+    filter = hb_filter_find(list, HB_FILTER_ROTATE);
     if (filter != NULL)
     {
         hb_dict_t *settings = filter->settings;

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1404,6 +1404,12 @@ static void sanitize_filter_list_pre(hb_job_t *job, hb_geometry_t src_geo)
 {
     hb_list_t *list = job->list_filter;
 
+    // Add adapter
+    hb_filter_object_t *filter = hb_filter_init(HB_FILTER_ADAPTER);
+    char *settings = hb_strdup_printf("rotation=%d", job->title->rotation);
+    hb_add_filter(list, filter, settings);
+    free(settings);
+
     // Add selective deinterlacing mode if comb detection is enabled
     if (hb_filter_find(list, HB_FILTER_COMB_DETECT) != NULL)
     {
@@ -1424,7 +1430,7 @@ static void sanitize_filter_list_pre(hb_job_t *job, hb_geometry_t src_geo)
     }
 
     int angle = 0;
-    hb_filter_object_t *filter = hb_filter_find(list, HB_FILTER_ROTATE);
+    filter = hb_filter_find(list, HB_FILTER_ROTATE);
     if (filter != NULL)
     {
         hb_dict_t *settings = filter->settings;

--- a/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/hb_filter_ids.cs
@@ -11,7 +11,8 @@ namespace HandBrake.Interop.Interop.HbLib
         HB_FILTER_INVALID = 0,
         HB_FILTER_FIRST = 1,
 
-        HB_FILTER_PRE_VT,
+        HB_FILTER_ADAPTER,
+        HB_FILTER_ADAPTER_VT,
         // First, filters that may change the framerate (drop or dup frames)
         HB_FILTER_DETELECINE,
         HB_FILTER_COMB_DETECT,


### PR DESCRIPTION
Moves the filters used to handle the video changing format/size/rotation/range mid stream outside of decavcodec.c, to a filter chain inside the main filter chain.

It's cleaner, we won't have to maintain two different sets of filters, and it will make it possible in the future to avoid running the same filter twice when the source is not interlaced, and to run hardware filters in additional places.

@antonkesy could you check why VPP is failing with an "Error running VPP: undefined behavior (-16) when I run:

./HandBrakeCLI.exe -I size-changes.mp4 --preset "Hardware/H.265 QSV 1080p" --enable-hw-decoding qsv -o output.mp4

with this cursed file https://www.swisstransfer.com/d/02460563-65a5-4667-9599-9c28249ac580

VPP has been flaky even before this PR, so it would be nice if you could take a look.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux