### PR TITLE
Part 1: First implementation of FFmpeg filters (Add 3.0 channel layout)

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -260,6 +260,7 @@ hb_mixdown_internal_t hb_audio_mixdowns[]  =
     { { "Mono (Left Only)",   "left_only",  HB_AMIXDOWN_LEFT,      }, NULL, 1, },
     { { "Mono (Right Only)",  "right_only", HB_AMIXDOWN_RIGHT,     }, NULL, 1, },
     { { "Stereo",             "stereo",     HB_AMIXDOWN_STEREO,    }, NULL, 1, },
+    { { "3.0 Channels",       "3point0",    HB_AMIXDOWN_3POINT0,   }, NULL, 1, },
     { { "Dolby Surround",     "dpl1",       HB_AMIXDOWN_DOLBY,     }, NULL, 1, },
     { { "Dolby Pro Logic II", "dpl2",       HB_AMIXDOWN_DOLBYPLII, }, NULL, 1, },
     { { "5.1 Channels",       "5point1",    HB_AMIXDOWN_5POINT1,   }, NULL, 1, },
@@ -2629,6 +2630,9 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
     switch (codec)
     {
         case HB_ACODEC_VORBIS:
+            return (mixdown <= HB_AMIXDOWN_7POINT1 &&
+                    mixdown != HB_AMIXDOWN_3POINT0);
+
         case HB_ACODEC_FFALAC:
         case HB_ACODEC_FFALAC24:
         case HB_ACODEC_FFFLAC:
@@ -2637,16 +2641,24 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
         case HB_ACODEC_FFPCM24:
         case HB_ACODEC_OPUS:
         case HB_ACODEC_CA_AAC:
-        case HB_ACODEC_CA_HAAC:
         case HB_ACODEC_FFAAC:
             return (mixdown <= HB_AMIXDOWN_7POINT1);
 
+        case HB_ACODEC_CA_HAAC:
+            return (mixdown <= HB_AMIXDOWN_7POINT1 &&
+                    mixdown != HB_AMIXDOWN_3POINT0);
+
         case HB_ACODEC_LAME:
-            return (mixdown <= HB_AMIXDOWN_DOLBYPLII);
+            return (mixdown <= HB_AMIXDOWN_DOLBYPLII &&
+                    mixdown != HB_AMIXDOWN_3POINT0);
 
         case HB_ACODEC_FDK_AAC:
-        case HB_ACODEC_FDK_HAAC:
             return ((mixdown <= HB_AMIXDOWN_5POINT1) ||
+                    (mixdown == HB_AMIXDOWN_7POINT1));
+
+        case HB_ACODEC_FDK_HAAC:
+            return ((mixdown <= HB_AMIXDOWN_5POINT1 &&
+                     mixdown != HB_AMIXDOWN_3POINT0) ||
                     (mixdown == HB_AMIXDOWN_7POINT1));
 
         default:
@@ -2683,6 +2695,10 @@ int hb_mixdown_has_remix_support(int mixdown, hb_channel_layout_t *ch_layout)
                     av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_6POINT0) == AV_CH_LAYOUT_6POINT0 ||
                     av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_HEXAGONAL) == AV_CH_LAYOUT_HEXAGONAL);
 
+        // stereo + front center
+        case HB_AMIXDOWN_3POINT0:
+            return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_SURROUND) == AV_CH_LAYOUT_SURROUND);
+            
         // stereo + either of front center, side or back left/right, back center
         case HB_AMIXDOWN_5POINT1:
             return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_1) == AV_CH_LAYOUT_2_1 ||
@@ -2749,6 +2765,9 @@ int hb_mixdown_get_discrete_channel_count(int amixdown)
         case HB_AMIXDOWN_5POINT1:
             return 6;
 
+        case HB_AMIXDOWN_3POINT0:
+            return 3;
+            
         case HB_AMIXDOWN_MONO:
         case HB_AMIXDOWN_LEFT:
         case HB_AMIXDOWN_RIGHT:

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1062,6 +1062,7 @@ struct hb_audio_config_s
             HB_AMIXDOWN_LEFT,
             HB_AMIXDOWN_RIGHT,
             HB_AMIXDOWN_STEREO,
+            HB_AMIXDOWN_3POINT0,
             HB_AMIXDOWN_DOLBY,
             HB_AMIXDOWN_DOLBYPLII,
             HB_AMIXDOWN_5POINT1,

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -707,6 +707,10 @@ uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
             ff_layout = AV_CH_LAYOUT_STEREO;
             break;
 
+        case HB_AMIXDOWN_3POINT0:
+            ff_layout = AV_CH_LAYOUT_SURROUND;
+            break;
+            
         case HB_AMIXDOWN_5POINT1:
             ff_layout = AV_CH_LAYOUT_5POINT1;
             break;

--- a/macosx/HBAudioTransformers.m
+++ b/macosx/HBAudioTransformers.m
@@ -133,6 +133,7 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
           @"Mono (Left Only)": HBKitLocalizedString(@"Mono (Left Only)", @"HBAudio -> Mixdown"),
           @"Mono (Right Only)": HBKitLocalizedString(@"Mono (Right Only)", @"HBAudio -> Mixdown"),
           @"Stereo": HBKitLocalizedString(@"Stereo", @"HBAudio -> Mixdown"),
+          @"3.0 Channels": HBKitLocalizedString(@"3.0 Channels", @"HBAudio -> Mixdown"),
           @"Dolby Surround": HBKitLocalizedString(@"Dolby Surround", @"HBAudio -> Mixdown"),
           @"Dolby Pro Logic II": HBKitLocalizedString(@"Dolby Pro Logic II", @"HBAudio -> Mixdown"),
           @"5.1 Channels": HBKitLocalizedString(@"5.1 Channels", @"HBAudio -> Mixdown"),
@@ -147,6 +148,7 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
           HBKitLocalizedString(@"Mono (Left Only)", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_LEFT),
           HBKitLocalizedString(@"Mono (Right Only)", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_RIGHT),
           HBKitLocalizedString(@"Stereo", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_STEREO),
+          HBKitLocalizedString(@"3.0 Channels", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_3POINT0),
           HBKitLocalizedString(@"Dolby Surround", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_DOLBY),
           HBKitLocalizedString(@"Dolby Pro Logic II", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_DOLBYPLII),
           HBKitLocalizedString(@"5.1 Channels", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_5POINT1),
@@ -171,6 +173,8 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
             return HBKitLocalizedString(@"Mono (Right Only)", @"HBAudio -> Mixdown");
         case HB_AMIXDOWN_STEREO:
             return HBKitLocalizedString(@"Stereo", @"HBAudio -> Mixdown");
+        case HB_AMIXDOWN_3POINT0:
+            return HBKitLocalizedString(@"3.0 Channels", @"HBAudio -> Mixdown");
         case HB_AMIXDOWN_DOLBY:
             return HBKitLocalizedString(@"Dolby Surround", @"HBAudio -> Mixdown");
         case HB_AMIXDOWN_DOLBYPLII:


### PR DESCRIPTION
**Description of Change:**
Add 3.0 channel layout to HandBrake. This is the first part of divided #7654. 3.0 channel layout is needed for the dialog enhancement audio filter. 3.0 channel layout it not supported by MP3, HE-AAC and Vorbis.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux