### PR TITLE
Fix Linux locale selection

### DIFF
--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -126,6 +126,7 @@
         "window_width": 1,
         "window_height": 1,
         "presets_window_width": 1,
-        "presets_window_height": 1
+        "presets_window_height": 1,
+        "UiLanguage": ""
     }
 }

--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -763,8 +763,11 @@ ghb_application_activate (GApplication *app)
     const char *ui_language = ghb_dict_get_string(ud->prefs, "UiLanguage");
     if (ui_language && ui_language[0])
     {
-        g_autofree char *locale = g_strdup_printf("%s.UTF-8", ui_language);
-        setlocale(LC_ALL, locale);
+        // Set the LANGUAGE environment variable for gettext.
+        // This accepts short locale codes (e.g. "fr", "de", "pt_BR")
+        // that match the .po filenames in gtk/po/.
+        g_setenv("LANGUAGE", ui_language, TRUE);
+        setlocale(LC_ALL, "");
     }
 
     self->builder = create_builder_or_die(BUILDER_NAME);

--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -767,7 +767,6 @@ ghb_application_activate (GApplication *app)
         // This accepts short locale codes (e.g. "fr", "de", "pt_BR")
         // that match the .po filenames in gtk/po/.
         g_setenv("LANGUAGE", ui_language, TRUE);
-        setlocale(LC_ALL, "");
     }
 
     self->builder = create_builder_or_die(BUILDER_NAME);

--- a/gtk/src/hb-backend.c
+++ b/gtk/src/hb-backend.c
@@ -445,7 +445,7 @@ static options_map_t d_ui_language_opts[] =
 //  {"Hrvatski (Croatian)",             "hr_HR",  8},
 //  {"čeština (Czech)",                 "cs_CZ",  9},
 //  {"Dansk (Danish)",                  "da_DK", 10},
-//  {"English",                         "en_US", 12},
+    {"English",                         "en",    19},
 //  {"ქართული (Georgian)",              "ka_GE", 15},
 //  {"עברית (Hebrew)",                  "he_IL", 17},
 //  {"Norsk (Norwegian)",               "no_NO", 21},

--- a/gtk/src/main.c
+++ b/gtk/src/main.c
@@ -21,6 +21,8 @@
 #include "settings.h"
 #include "ui_res.h"
 
+#include <locale.h>
+
 static char *
 get_locale_dir (const char *app_dir)
 {
@@ -56,13 +58,15 @@ main (int argc, char *argv[])
     // Tell gdk pixbuf where it's loader config file is.
     _putenv_s("GDK_PIXBUF_MODULE_FILE", "ghb.exe.local/loaders.cache");
 #endif
+    setlocale(LC_ALL, "");
+
     g_autofree char *app_dir = get_app_dir(argv ? argv[0] : NULL);
     const char *textdomaindir = getenv("TEXTDOMAINDIR");
     g_autofree char *locale_dir;
     if (textdomaindir)
         locale_dir = g_strdup(textdomaindir);
     else
-        locale_dir = get_locale_dir(app_dir); 
+        locale_dir = get_locale_dir(app_dir);
     bindtextdomain(GETTEXT_PACKAGE, locale_dir);
     bind_textdomain_codeset(GETTEXT_PACKAGE, "UTF-8");
     textdomain(GETTEXT_PACKAGE);


### PR DESCRIPTION
I am unable to test on Linux. But what I found out about Linux language selection, this should fix it.

1. application.c: Use LANGUAGE env var (the GNU gettext override mechanism) instead of trying to construct a glibc locale string. This should be the correct way to force gettext to use a specific language regardless of system locale.
2. main.c: Add setlocale(LC_ALL, "") before gettext init - this seems the standard gettext requirement to enable locale-aware translations from the start.
 3. internal_defaults.json: Add "UiLanguage": "" default so the preference always has a known initial value.


Can somebody test this on Linux?


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux
