### PR TITLE
contrib: update jansson to 2.15.0

### DIFF
--- a/contrib/jansson/module.defs
+++ b/contrib/jansson/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,JANSSON,jansson))
 $(eval $(call import.CONTRIB.defs,JANSSON))
 
-JANSSON.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/jansson-2.14.1.tar.bz2
-JANSSON.FETCH.url    += https://github.com/akheron/jansson/releases/download/v2.14.1/jansson-2.14.1.tar.bz2
-JANSSON.FETCH.sha256  = 6bd82d3043dadbcd58daaf903d974891128d22aab7dada5d399cb39094af49ce
+JANSSON.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/jansson-2.15.0.tar.bz2
+JANSSON.FETCH.url    += https://github.com/akheron/jansson/releases/download/v2.15.0/jansson-2.15.0.tar.bz2
+JANSSON.FETCH.sha256  = a7eac7765000373165f9373eb748be039c10b2efc00be9af3467ec92357d8954
 
 JANSSON.CONFIGURE.bootstrap = rm -fr aclocal.m4 autom4te.cache; mkdir m4; autoreconf -fiv;
 


### PR DESCRIPTION
**New features:**
Add support for realloc by adding json_set_alloc_funcs2, json_get_alloc_funcs2

**Fixes:**
Optimize serialization
Fix docstrings in hashtable.h

**Build:**
Use target-based cmake settings

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux