### PR TITLE
contrib: update zlib to 1.3.2

### DIFF
--- a/contrib/zlib/P00-mingw-configure.patch
+++ b/contrib/zlib/P00-mingw-configure.patch
@@ -1,5 +1,6 @@
---- zlib-1.3.1/configure	2023-08-18 10:45:36.000000000 +0200
-+++ zlib-1.3.1-patched/configure	2023-08-19 23:06:46.875730600 +0200
+diff -ruN zlib-1.3.2/configure zlib-1.3.2-patched/configure
+--- zlib-1.3.2/configure	2026-02-17 10:13:25.000000000 +0100
++++ zlib-1.3.2-patched/configure	2026-03-15 20:29:14.096254153 +0100
 @@ -30,15 +30,6 @@
      SRCDIR="$SRCDIR/"
  fi
@@ -45,12 +46,12 @@
  # set defaults before processing command line options
  LDCONFIG=${LDCONFIG-"ldconfig"}
  LDSHAREDLIBC="${LDSHAREDLIBC--lc}"
-@@ -226,56 +195,7 @@
+@@ -288,57 +257,7 @@
    if test -z "$uname"; then
      uname=`(uname -s || echo unknown) 2>/dev/null`
    fi
 -  case "$uname" in
--  Linux* | linux* | *-linux* | GNU | GNU/* | solaris*)
+-  Linux* | linux* | *-linux* | GNU | GNU/* | solaris* | Haiku)
 -        case "$mname" in
 -        *sparc*)
 -            LDFLAGS="${LDFLAGS} -Wl,--no-warn-rwx-segments" ;;
@@ -81,6 +82,7 @@
 -            SHAREDLIB='libz.sl' ;;
 -        esac ;;
 -  AIX*)
+-        LDSHARED=${LDSHARED-"$cc -shared"}
 -        LDFLAGS="${LDFLAGS} -Wl,-brtl" ;;
 -  Darwin* | darwin* | *-darwin*)
 -        shared_ext='.dylib'

--- a/contrib/zlib/module.defs
+++ b/contrib/zlib/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,ZLIB,zlib))
 $(eval $(call import.CONTRIB.defs,ZLIB))
 
-ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zlib-1.3.1.tar.gz
-ZLIB.FETCH.url    += https://www.zlib.net/fossils/zlib-1.3.1.tar.gz
-ZLIB.FETCH.sha256  = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zlib-1.3.2.tar.gz
+ZLIB.FETCH.url    += https://www.zlib.net/fossils/zlib-1.3.2.tar.gz
+ZLIB.FETCH.sha256  = bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
 
 ZLIB.CONFIGURE.args = !sete @dir !env !exe @prefix !extra
 


### PR DESCRIPTION
- Address findings of the 7ASecurity audit of zlib.
       - Check for negative lengths in crc32_combine functions.
       - Copy only the initialized window contents in inflateCopy.
        - Prevent the use of insecure functions without an explicit request.
        - Add compressBound_z and deflateBound_z functions for large values.
        - Use atomics to build inflate fixed tables once.
        - Add --undefined option to ./configure for UBSan checker.
        - Copy only the initialized deflate state in deflateCopy.
        - Zero inflate state on allocation.
        - Add compress_z and uncompress_z functions. 
- Complete rewrite of cmake support.
- Remove untgz from contrib.
- Vectorize the CRC-32 calculation on the s390x.
- Remove vstudio projects in lieu of cmake-generated projects.
- Add zipAlreadyThere() to minizip zip.c to help avoid duplicates.
- Add deflateUsed() function to get the used bits in the last byte.
- Fix bug in inflatePrime() for 16-bit ints.
- Add a "G" option to force gzip, disabling transparency in gzread().
- Return all available uncompressed data on error in gzread.c.
- Support non-blocking devices in the gz* routines.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux