### PR TITLE
contrib: update libbluray to 1.4.1

### DIFF
--- a/contrib/libbluray/A00-disable-ssp-library.patch
+++ b/contrib/libbluray/A00-disable-ssp-library.patch
@@ -4,8 +4,8 @@ diff --git a/meson.build b/meson.build
 @@ -43,7 +43,6 @@
  if host_machine.system() == 'windows'
      test_args += ['-D_WIN32_WINNT=0x0502', '-D_WIN32_IE=0x0501']
-     if cc.get_argument_syntax() != 'msvc'
+     if cc.get_define('_MSC_VER') == ''
 -        extra_dependencies += cc.find_library('ssp')
          test_args += '-D__USE_MINGW_ANSI_STDIO=1'
-     endif
- else
+    else
+        test_args += ['-D_CRT_NONSTDC_NO_WARNINGS', '-D_CRT_SECURE_NO_WARNINGS']

--- a/contrib/libbluray/module.defs
+++ b/contrib/libbluray/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBBLURAY,libbluray))
 $(eval $(call import.CONTRIB.defs,LIBBLURAY))
 
-LIBBLURAY.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libbluray-1.4.0.tar.xz
-LIBBLURAY.FETCH.url    += https://download.videolan.org/pub/videolan/libbluray/1.4.0/libbluray-1.4.0.tar.xz
-LIBBLURAY.FETCH.sha256  = 77937baf07eadda4b2b311cf3af4c50269d2ea3165041f5843d96476c4c92777
+LIBBLURAY.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libbluray-1.4.1.tar.xz
+LIBBLURAY.FETCH.url    += https://download.videolan.org/pub/videolan/libbluray/1.4.1/libbluray-1.4.1.tar.xz
+LIBBLURAY.FETCH.sha256  = 76b5dc40097f28dca4ebb009c98ed51321b2927453f75cc72cf74acd09b9f449
 
 LIBBLURAY.build_dir             = build/
 LIBBLURAY.CONFIGURE.exe         = $(MESON.exe) setup


### PR DESCRIPTION
**Changes:**
- Add SSIF files support to bd_open_file_dec()
- Add player setting for UO restriction level
- Add all UOs to BD_EVENT_UO_MASK_CHANGED
- Improve resilence against invalid input
- Fix memory leak in UHD playlists
- BD-J: Implement TVTimer, TVTimerSpec
- BD-J: Improve Java 1.4 compatibility
- BD-J: Fix MediaPresentedEvent event emission on start
- BD-J: Fix filesystem hooking in Java 25
- BD-J: Fix locators from org.bluray.ti.[PlayItemImpl,TitleComponentImpl]
- BD-J: Multiple compability and performance improvements

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux