### PR TITLE
contrib: update libjpeg-turbo to 3.1.4.1

### DIFF
--- a/contrib/libjpeg-turbo/module.defs
+++ b/contrib/libjpeg-turbo/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBJPEGTURBO,libjpeg-turbo))
 $(eval $(call import.CONTRIB.defs,LIBJPEGTURBO))
 
-LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.3.tar.gz
-LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.3.tar.gz
-LIBJPEGTURBO.FETCH.sha256  = 3a13a5ba767dc8264bc40b185e41368a80d5d5f945944d1dbaa4b2fb0099f4e5
+LIBJPEGTURBO.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libjpeg-turbo-3.1.4.1.tar.gz
+LIBJPEGTURBO.FETCH.url    += https://github.com/libjpeg-turbo/libjpeg-turbo/archive/refs/tags/3.1.4.1.tar.gz
+LIBJPEGTURBO.FETCH.sha256  = a7da42b640377c2a9a9665e2c4b0ea60cd5599afb48c2521e6df0c9dc9d15a25
 
 LIBJPEGTURBO.build_dir             = build
 LIBJPEGTURBO.CONFIGURE.exe         = cmake
@@ -12,6 +12,7 @@ LIBJPEGTURBO.CONFIGURE.deps        =
 LIBJPEGTURBO.CONFIGURE.static      =
 LIBJPEGTURBO.CONFIGURE.shared      = -DENABLE_SHARED=OFF
 LIBJPEGTURBO.CONFIGURE.extra       = -DCMAKE_INSTALL_LIBDIR=lib
+LIBJPEGTURBO.CONFIGURE.extra      += -DWITH_TOOLS=OFF -DWITH_TESTS=OFF
 
 ifeq (size-aggressive,$(GCC.O))
     LIBJPEGTURBO.CONFIGURE.extra += -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG" -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG"


### PR DESCRIPTION
**Significant changes relative to 3.1.4:**

- Fixed multiple issues, some long-standing and some that were regressions introduced in 3.1.4, that made the CMake package config files non-relocatable and broke the --prefix option to cmake --install.

**Significant changes relative to 3.1.3:**

- Fixed an issue in the TurboJPEG 2.x compatibility wrapper whereby, if a calling program attempted to decompress a lossless JPEG image using tjDecompress2() with decompression scaling, the decompressed image was unexpectedly unscaled. This could have led to a buffer overrun if the caller allocated the packed-pixel destination buffer based on the assumption that the decompressed image would be scaled down.

- The SIMD dispatchers now use getauxval() or elf_aux_info(), if available, to detect support for Neon and AltiVec instructions on AArch32 and PowerPC Linux, Android, and *BSD systems.

- Hardened the libjpeg API against hypothetical applications that may erroneously set one of the exposed quantization table values to 0 just before calling jpeg_start_compress(). (This would never happen in a correctly-written program, because jpeg_add_quant_table() clamps all values less than 1.)

- Fixed a division-by-zero error that occurred when attempting to use the jpegtran -drop option with a specially-crafted malformed drop image (specifically an image in which one or more of the quantization table values was 0.)

- Fixed an issue in the TurboJPEG API library's data destination manager that manifested as:
        **_1)_** a memory leak that occurred if a pre-allocated JPEG destination buffer was passed to tj3Compress*() or tj3Transform(), TJPARAM_NOREALLOC was unset, and it was necessary for the library to re-allocate the buffer to accommodate the destination image, and
       **_2)_** a potential caller double free that occurred if pre-allocated JPEG destination buffers were passed to tj3Transform(), multiple lossless transform operations were performed, and it was necessary for the library to re-allocate the second buffer to accommodate the second destination image.

- Fixed an issue in tj3Transform() whereby, if TJPARAM_SAVEMARKERS was set to 2 or 4, TJXOPT_COPYNONE was not specified, an ICC profile was extracted from the source image, and another ICC profile was associated with the TurboJPEG instance using tj3SetICCProfile(), both profiles were embedded in the destination image. The documented API behavior is for TJXOPT_COPYNONE to take precedence over TJPARAM_SAVEMARKERS and for TJPARAM_SAVEMARKERS to take precedence over the associated ICC profile. Thus, tj3Transform() now ignores the associated ICC profile unless TJXOPT_COPYNONE is specified or TJPARAM_SAVEMARKERS is set to something other than 2 or 4.

- Fixed an oversight in the libjpeg API whereby, if a calling application manually set cinfo.Ss (the predictor selection value) to a value less than 1 or greater than 7 after calling jpeg_enable_lossless() and prior to calling jpeg_start_compress(), an incorrect (all white) lossless JPEG image was silently generated.

- Further hardened the TurboJPEG Java API against hypothetical applications that may erroneously pass huge values to one of the compression, YUV encoding, decompression, YUV decoding, or packed-pixel image I/O methods, leading to signed integer overflow in the JNI wrapper's buffer size checks that rendered those checks ineffective.

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux