### PR TITLE
contrib: update freetype to 2.14.3

### DIFF
--- a/contrib/freetype/module.defs
+++ b/contrib/freetype/module.defs
@@ -2,9 +2,9 @@ __deps__ := BZIP2 ZLIB
 $(eval $(call import.MODULE.defs,FREETYPE,freetype,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,FREETYPE))
 
-FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.14.2.tar.gz
-FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.14.2.tar.gz
-FREETYPE.FETCH.sha256  = 752c2671f85c54a84b7f0dd2b5cd26b6b741117033886ffbc5ac89a68464b848
+FREETYPE.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/freetype-2.14.3.tar.gz
+FREETYPE.FETCH.url    += https://download.savannah.gnu.org/releases/freetype/freetype-2.14.3.tar.gz
+FREETYPE.FETCH.sha256  = e61b31ab26358b946e767ed7eb7f4bb2e507da1cfefeb7a8861ace7fd5c899a1
 
 FREETYPE.CONFIGURE.deps  =
 FREETYPE.CONFIGURE.extra = --with-harfbuzz=no --with-png=no --with-brotli=no


### PR DESCRIPTION
**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux