### PR TITLE
libhb: add an audio filters chain

### DIFF
--- a/contrib/ffmpeg/module.defs
+++ b/contrib/ffmpeg/module.defs
@@ -83,6 +83,10 @@ FFMPEG.CONFIGURE.extra = \
     --enable-filter=hwupload \
     --enable-filter=bm3d \
     --enable-filter=deband \
+    --enable-filter=aresample \
+    --enable-filter=aformat \
+    --enable-filter=acompressor \
+    --enable-filter=agate \
     --cc="$(FFMPEG.GCC.gcc)"
 
 ifeq (size-aggressive,$(GCC.O))

--- a/libhb/acompressor.c
+++ b/libhb/acompressor.c
@@ -1,0 +1,86 @@
+/* acompressor.c
+
+   Copyright (c) 2003-2026 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "handbrake/avfilter_priv.h"
+
+const char acompressor_template[] =
+    "level-in=^"HB_FLOAT_REG"$:mode=^"HB_INT_REG"$:threshold=^"HB_FLOAT_REG"$:"
+    "ratio=^"HB_FLOAT_REG"$:attack=^"HB_FLOAT_REG"$:release=^"HB_FLOAT_REG"$:"
+    "makeup=^"HB_FLOAT_REG"$:knee=^"HB_FLOAT_REG"$:link=^"HB_INT_REG"$"
+    "detection=^"HB_INT_REG"$:level-sc=^"HB_FLOAT_REG"$:mix=^"HB_FLOAT_REG"$";
+
+static int acompressor_init(hb_filter_object_t *filter, hb_filter_init_t *init)
+{
+    hb_filter_private_t *pv = NULL;
+
+    pv = calloc(1, sizeof(struct hb_filter_private_s));
+    filter->private_data = pv;
+    if (pv == NULL)
+    {
+        return 1;
+    }
+
+    hb_filter_init_copy(&pv->input, init);
+
+    hb_dict_t *settings = filter->settings;
+
+    double level_in = 1, threshold = 0.125, ratio = 2, attack = 20;
+    double release = 250, makeup = 1, knee = 2.82843, level_sc = 1, mix = 1;
+    int    mode = 0, link = 0, detection = 1;
+
+    hb_dict_extract_double(&level_in, settings, "level-in");
+    hb_dict_extract_int(&mode, settings, "mode");
+    hb_dict_extract_double(&threshold, settings, "threshold");
+    hb_dict_extract_double(&ratio, settings, "ratio");
+    hb_dict_extract_double(&attack, settings, "attack");
+    hb_dict_extract_double(&release, settings, "release");
+    hb_dict_extract_double(&makeup, settings, "makeup");
+    hb_dict_extract_double(&knee, settings, "knee");
+    hb_dict_extract_int(&link, settings, "link");
+    hb_dict_extract_int(&detection, settings, "detection");
+    hb_dict_extract_double(&level_sc, settings, "level-sc");
+    hb_dict_extract_double(&mix, settings, "mix");
+
+    hb_dict_t *avfilter = hb_dict_init();
+    hb_dict_t *avsettings = hb_dict_init();
+
+    hb_dict_set(avsettings, "level_in",  hb_value_double(level_in));
+    hb_dict_set(avsettings, "mode",      hb_value_int(mode));
+    hb_dict_set(avsettings, "threshold", hb_value_double(threshold));
+    hb_dict_set(avsettings, "ratio",     hb_value_double(ratio));
+    hb_dict_set(avsettings, "attack",    hb_value_double(attack));
+    hb_dict_set(avsettings, "release",   hb_value_double(release));
+    hb_dict_set(avsettings, "makeup",    hb_value_double(makeup));
+    hb_dict_set(avsettings, "knee",      hb_value_double(knee));
+    hb_dict_set(avsettings, "link",      hb_value_int(link));
+    hb_dict_set(avsettings, "detection", hb_value_int(detection));
+    hb_dict_set(avsettings, "level_sc",  hb_value_double(level_sc));
+    hb_dict_set(avsettings, "mix",       hb_value_double(mix));
+
+    hb_dict_set(avfilter, "acompressor", avsettings);
+    pv->avfilters = avfilter;
+
+    hb_filter_init_copy(&pv->output, init);
+
+    return 0;
+}
+
+hb_filter_object_t hb_filter_acompressor =
+{
+    .id                = HB_AUDIO_FILTER_ACOMPRESSOR,
+    .enforce_order     = 1,
+    .skip              = 1,
+    .name              = "Compressor",
+    .settings          = NULL,
+    .init              = acompressor_init,
+    .work              = hb_avfilter_null_work,
+    .close             = hb_avfilter_alias_close,
+    .settings_template = acompressor_template,
+};

--- a/libhb/agate.c
+++ b/libhb/agate.c
@@ -1,0 +1,86 @@
+/* agate.c
+
+   Copyright (c) 2003-2026 HandBrake Team
+   This file is part of the HandBrake source code
+   Homepage: <http://handbrake.fr/>.
+   It may be used under the terms of the GNU General Public License v2.
+   For full terms see the file COPYING file or visit http://www.gnu.org/licenses/gpl-2.0.html
+ */
+
+#include "handbrake/common.h"
+#include "handbrake/avfilter_priv.h"
+
+const char agate_template[] =
+    "level-in=^"HB_FLOAT_REG"$:mode=^"HB_INT_REG"$:mix=^"HB_FLOAT_REG"$:sthreshold=^"HB_FLOAT_REG"$:"
+    "ratio=^"HB_FLOAT_REG"$:attack=^"HB_FLOAT_REG"$:release=^"HB_FLOAT_REG"$:"
+    "makeup=^"HB_FLOAT_REG"$:knee=^"HB_FLOAT_REG"$:link=^"HB_INT_REG"$"
+    "detection=^"HB_INT_REG"$:level-sc=^"HB_FLOAT_REG"$";
+
+static int agate_init(hb_filter_object_t *filter, hb_filter_init_t *init)
+{
+    hb_filter_private_t *pv = NULL;
+
+    pv = calloc(1, sizeof(struct hb_filter_private_s));
+    filter->private_data = pv;
+    if (pv == NULL)
+    {
+        return 1;
+    }
+
+    hb_filter_init_copy(&pv->input, init);
+
+    hb_dict_t *settings = filter->settings;
+
+    double level_in = 1, range = 0.06125, threshold = 0.125, ratio = 2, attack = 20;
+    double release = 250, makeup = 1, knee = 2.82843, level_sc = 1;
+    int    mode = 0, link = 0, detection = 1;
+
+    hb_dict_extract_double(&level_in, settings, "level-in");
+    hb_dict_extract_int(&mode, settings, "mode");
+    hb_dict_extract_double(&range, settings, "range");
+    hb_dict_extract_double(&threshold, settings, "threshold");
+    hb_dict_extract_double(&ratio, settings, "ratio");
+    hb_dict_extract_double(&attack, settings, "attack");
+    hb_dict_extract_double(&release, settings, "release");
+    hb_dict_extract_double(&makeup, settings, "makeup");
+    hb_dict_extract_double(&knee, settings, "knee");
+    hb_dict_extract_int(&detection, settings, "detection");
+    hb_dict_extract_int(&link, settings, "link");
+    hb_dict_extract_double(&level_sc, settings, "level-sc");
+
+    hb_dict_t *avfilter = hb_dict_init();
+    hb_dict_t *avsettings = hb_dict_init();
+
+    hb_dict_set(avsettings, "level_in",  hb_value_double(level_in));
+    hb_dict_set(avsettings, "mode",      hb_value_int(mode));
+    hb_dict_set(avsettings, "range", hb_value_double(range));
+    hb_dict_set(avsettings, "threshold", hb_value_double(threshold));
+    hb_dict_set(avsettings, "ratio",     hb_value_double(ratio));
+    hb_dict_set(avsettings, "attack",    hb_value_double(attack));
+    hb_dict_set(avsettings, "release",   hb_value_double(release));
+    hb_dict_set(avsettings, "makeup",    hb_value_double(makeup));
+    hb_dict_set(avsettings, "knee",      hb_value_double(knee));
+    hb_dict_set(avsettings, "link",      hb_value_int(link));
+    hb_dict_set(avsettings, "detection", hb_value_int(detection));
+    hb_dict_set(avsettings, "level_sc",  hb_value_double(level_sc));
+
+    hb_dict_set(avfilter, "agate", avsettings);
+    pv->avfilters = avfilter;
+
+    hb_filter_init_copy(&pv->output, init);
+
+    return 0;
+}
+
+hb_filter_object_t hb_filter_agate =
+{
+    .id                = HB_AUDIO_FILTER_AGATE,
+    .enforce_order     = 1,
+    .skip              = 1,
+    .name              = "Gate",
+    .settings          = NULL,
+    .init              = agate_init,
+    .work              = hb_avfilter_null_work,
+    .close             = hb_avfilter_alias_close,
+    .settings_template = agate_template,
+};

--- a/libhb/avfilter.c
+++ b/libhb/avfilter.c
@@ -11,26 +11,6 @@
 #include "handbrake/hbavfilter.h"
 #include "handbrake/avfilter_priv.h"
 
-static int  avfilter_init(hb_filter_object_t * filter, hb_filter_init_t * init);
-static int  avfilter_post_init( hb_filter_object_t * filter, hb_job_t * job );
-static void avfilter_close( hb_filter_object_t * filter );
-static int  avfilter_work( hb_filter_object_t * filter,
-                           hb_buffer_t ** buf_in, hb_buffer_t ** buf_out );
-static hb_filter_info_t * avfilter_info( hb_filter_object_t * filter );
-
-hb_filter_object_t hb_filter_avfilter =
-{
-    .id            = HB_FILTER_AVFILTER,
-    .enforce_order = 0,
-    .name          = "AVFilter",
-    .settings      = NULL,
-    .init          = avfilter_init,
-    .post_init     = avfilter_post_init,
-    .work          = avfilter_work,
-    .close         = avfilter_close,
-    .info          = avfilter_info,
-};
-
 int  hb_avfilter_null_work( hb_filter_object_t * filter,
                             hb_buffer_t ** buf_in, hb_buffer_t ** buf_out )
 {
@@ -223,6 +203,8 @@ void hb_avfilter_alias_close( hb_filter_object_t * filter )
         return;
     }
 
+    hb_filter_init_close(&pv->input);
+    hb_filter_init_close(&pv->output);
     hb_buffer_list_close(&pv->list);
     hb_value_free(&pv->avfilters);
     free(pv);
@@ -282,3 +264,151 @@ static int avfilter_work( hb_filter_object_t * filter,
 
     return HB_FILTER_OK;
 }
+
+hb_filter_object_t hb_filter_avfilter =
+{
+    .id            = HB_FILTER_AVFILTER,
+    .enforce_order = 0,
+    .name          = "AVFilter",
+    .settings      = NULL,
+    .init          = avfilter_init,
+    .post_init     = avfilter_post_init,
+    .work          = avfilter_work,
+    .close         = avfilter_close,
+    .info          = avfilter_info,
+};
+
+static int avfilter_audio_init(hb_filter_object_t *filter, hb_filter_init_t *init)
+{
+    hb_filter_private_t *pv = NULL;
+
+    pv = calloc(1, sizeof(struct hb_filter_private_s));
+    filter->private_data = pv;
+    if (pv == NULL)
+    {
+        return 1;
+    }
+    pv->input = *init;
+    pv->initialized = 1;
+
+    pv->graph = hb_avfilter_audio_graph_init(filter->settings, init);
+    if (pv->graph == NULL)
+    {
+        goto fail;
+    }
+
+    // Retrieve the parameters of the output filter
+    hb_avfilter_graph_update_init(pv->graph, init);
+    pv->output = *init;
+
+    hb_buffer_list_clear(&pv->list);
+
+    return 0;
+
+fail:
+    hb_avfilter_graph_close(&pv->graph);
+    free(pv);
+
+    return 1;
+}
+
+static int avfilter_audio_post_init(hb_filter_object_t *filter, hb_job_t *job)
+{
+    hb_filter_private_t *pv = filter->private_data;
+
+    if (pv == NULL)
+    {
+        return 1;
+    }
+    if (pv->initialized)
+    {
+        return 0;
+    }
+
+    pv->graph = hb_avfilter_audio_graph_init(filter->settings, &pv->input);
+    if (pv->graph == NULL)
+    {
+        goto fail;
+    }
+
+    // Retrieve the parameters of the output filter
+    pv->output = pv->input;
+    hb_avfilter_graph_update_init(pv->graph, &pv->output);
+
+    hb_buffer_list_clear(&pv->list);
+
+    return 0;
+
+fail:
+    hb_avfilter_graph_close(&pv->graph);
+    free(pv);
+
+    return 1;
+}
+
+static hb_buffer_t * filterAudioFrame(hb_filter_private_t *pv, hb_buffer_t **buf_in)
+{
+    hb_buffer_list_t  list;
+    hb_buffer_t      *buf = NULL, *next = NULL;
+
+    hb_audio_avfilter_add_buf(pv->graph, buf_in);
+    buf = hb_audio_avfilter_get_buf(pv->graph);
+
+    while (buf != NULL)
+    {
+        hb_buffer_list_append(&pv->list, buf);
+        buf = hb_avfilter_get_buf(pv->graph);
+    }
+    // Delay one frame so we can set the stop time of the output buffer
+    hb_buffer_list_clear(&list);
+    while (hb_buffer_list_count(&pv->list) > 1)
+    {
+        buf  = hb_buffer_list_rem_head(&pv->list);
+        next = hb_buffer_list_head(&pv->list);
+
+        buf->s.stop = next->s.start;
+        buf->s.duration = buf->s.stop - buf->s.start;
+        hb_buffer_list_append(&list, buf);
+    }
+
+    return hb_buffer_list_head(&list);
+}
+
+static int avfilter_audio_work(hb_filter_object_t *filter,
+                               hb_buffer_t **buf_in, hb_buffer_t **buf_out)
+{
+    hb_filter_private_t *pv = filter->private_data;
+    hb_buffer_t *in = *buf_in;
+
+    if (in->s.flags & HB_BUF_FLAG_EOF)
+    {
+        hb_buffer_t *out  = filterAudioFrame(pv, NULL);
+        hb_buffer_t *last = hb_buffer_list_tail(&pv->list);
+        if (last != NULL && last->s.start != AV_NOPTS_VALUE)
+        {
+            last->s.stop = last->s.start + last->s.duration;
+        }
+        hb_buffer_list_prepend(&pv->list, out);
+        hb_buffer_list_append(&pv->list, in);
+        *buf_out = hb_buffer_list_clear(&pv->list);
+        *buf_in = NULL;
+        return HB_FILTER_DONE;
+    }
+
+    *buf_out = filterAudioFrame(pv, buf_in);
+
+    return HB_FILTER_OK;
+}
+
+hb_filter_object_t hb_filter_avfilter_audio =
+{
+    .id            = HB_AUDIO_FILTER_AVFILTER,
+    .enforce_order = 0,
+    .name          = "AVFilter Audio",
+    .settings      = NULL,
+    .init          = avfilter_audio_init,
+    .post_init     = avfilter_audio_post_init,
+    .work          = avfilter_audio_work,
+    .close         = avfilter_close,
+    .info          = avfilter_info,
+};

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5018,6 +5018,40 @@ void hb_job_set_file(hb_job_t *job, const char *file)
     }
 }
 
+void hb_filter_init_copy(hb_filter_init_t *dst, hb_filter_init_t *src)
+{
+    dst->job = src->job;
+
+    dst->pix_fmt = src->pix_fmt;
+    dst->hw_pix_fmt = src->hw_pix_fmt;
+    dst->hw_frames_ctx = src->hw_frames_ctx;
+
+    dst->color_prim = src->color_prim;
+    dst->color_transfer = src->color_transfer;
+    dst->color_matrix = src->color_matrix;
+    dst->color_range = src->color_range;
+    dst->chroma_location = src->chroma_location;
+    dst->geometry = src->geometry;
+    dst->crop[0] = src->crop[0];
+    dst->crop[1] = src->crop[1];
+    dst->crop[2] = src->crop[2];
+    dst->crop[3] = src->crop[3];
+
+    dst->grayscale = src->grayscale;
+    dst->vrate = src->vrate;
+    dst->cfr = src->cfr;
+    dst->time_base = src->time_base;
+
+    dst->samplerate = src->samplerate;
+    dst->sample_fmt = src->sample_fmt;
+    av_channel_layout_copy(&dst->ch_layout, &src->ch_layout);
+}
+
+void hb_filter_init_close(hb_filter_init_t *init)
+{
+    av_channel_layout_uninit(&init->ch_layout);
+}
+
 hb_filter_object_t * hb_filter_copy( hb_filter_object_t * filter )
 {
     if( filter == NULL )
@@ -5248,6 +5282,18 @@ hb_filter_object_t * hb_filter_get( int filter_id )
             filter = &hb_filter_unsharp_vt;
             break;
 #endif
+
+        case HB_AUDIO_FILTER_ACOMPRESSOR:
+            filter = &hb_filter_acompressor;
+            break;
+
+        case HB_AUDIO_FILTER_AGATE:
+            filter = &hb_filter_agate;
+            break;
+
+        case HB_AUDIO_FILTER_AVFILTER:
+            filter = &hb_filter_avfilter_audio;
+            break;
 
         default:
             filter = NULL;
@@ -5726,6 +5772,10 @@ hb_audio_t *hb_audio_copy(const hb_audio_t *src)
             }
         }
         audio->priv.extradata = hb_data_dup(src->priv.extradata);
+        if (src->config.out.list_filter)
+        {
+            audio->config.out.list_filter = hb_filter_list_copy(src->config.out.list_filter);
+        }
     }
     return audio;
 }
@@ -5818,6 +5868,7 @@ void hb_audio_config_init(hb_audio_config_t * audiocfg)
     audiocfg->out.normalize_mix_level = 0;
     audiocfg->out.dither_method = hb_audio_dither_get_default();
     audiocfg->out.name = NULL;
+    audiocfg->out.list_filter = hb_list_init();
 }
 
 void hb_audio_config_close(hb_audio_config_t *audiocfg)
@@ -5825,6 +5876,7 @@ void hb_audio_config_close(hb_audio_config_t *audiocfg)
     if (audiocfg)
     {
         void *item;
+        hb_filter_object_t *filter;
 
         while ((item = hb_list_item(audiocfg->list_linked_index, 0)))
         {
@@ -5837,6 +5889,12 @@ void hb_audio_config_close(hb_audio_config_t *audiocfg)
             av_channel_layout_uninit(audiocfg->in.ch_layout);
             free(audiocfg->in.ch_layout);
         }
+        while ((filter = hb_list_item(audiocfg->out.list_filter, 0)))
+        {
+            hb_list_rem(audiocfg->out.list_filter, filter);
+            hb_filter_close(&filter);
+        }
+        hb_list_close(&audiocfg->out.list_filter);
     }
 }
 
@@ -5872,6 +5930,11 @@ int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg)
     if (audiocfg->out.name && *audiocfg->out.name)
     {
         audio->config.out.name = strdup(audiocfg->out.name);
+    }
+
+    if (audiocfg->out.list_filter)
+    {
+        audio->config.out.list_filter = hb_filter_list_copy(audiocfg->out.list_filter);
     }
 
     hb_list_add(job->list_audio, audio);

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1132,6 +1132,7 @@ struct hb_audio_config_s
         int      normalize_mix_level; /* mix level normalization (boolean) */
         int      dither_method; /* dither algorithm */
         const char * name; /* Output track name */
+        hb_list_t  * list_filter; /* List of hb_filter_object_t */
     } out;
 
     /* Input */
@@ -1184,6 +1185,7 @@ struct hb_audio_s
         hb_fifo_t * fifo_in;   /* AC3/MPEG/LPCM ES */
         hb_fifo_t * fifo_raw;  /* Raw audio */
         hb_fifo_t * fifo_sync; /* Resampled, synced raw audio */
+        hb_fifo_t * fifo_render;/* Filtered raw audio */
         hb_fifo_t * fifo_out;  /* MP3/AAC/Vorbis ES */
 
         hb_mux_data_t * mux_data;
@@ -1616,8 +1618,11 @@ extern hb_work_object_t hb_reader;
 typedef struct hb_filter_init_s
 {
     hb_job_t      * job;
+
     int             pix_fmt;
     int             hw_pix_fmt;
+    void          * hw_frames_ctx;
+
     int             color_prim;
     int             color_transfer;
     int             color_matrix;
@@ -1625,12 +1630,20 @@ typedef struct hb_filter_init_s
     int             chroma_location;
     hb_geometry_t   geometry;
     int             crop[4];
+    int             grayscale;
+
     hb_rational_t   vrate;
     int             cfr;
-    int             grayscale;
     hb_rational_t   time_base;
-    void          * hw_frames_ctx;
+
+    int             samplerate;
+    int             sample_fmt;
+    AVChannelLayout ch_layout;
+
 } hb_filter_init_t;
+
+void hb_filter_init_copy(hb_filter_init_t *dst, hb_filter_init_t *src);
+void hb_filter_init_close(hb_filter_init_t *init);
 
 typedef struct hb_filter_info_s
 {
@@ -1678,6 +1691,21 @@ struct hb_filter_object_s
 
     hb_filter_object_t  * sub_filter;
 #endif
+};
+
+enum
+{
+    HB_AUDIO_FILTER_INVALID = 0,
+    HB_AUDIO_FILTER_FIRST = 10001,
+
+    HB_AUDIO_FILTER_ACOMPRESSOR,
+    HB_AUDIO_FILTER_AGATE,
+
+    // Finally filters that don't care what order they are in,
+    // except that they must be after the above filters
+    HB_AUDIO_FILTER_AVFILTER,
+
+    HB_AUDIO_FILTER_LAST
 };
 
 // Update win/CS/HandBrake.Interop/HandBrakeInterop/HbLib/hb_filter_ids.cs when changing this enum

--- a/libhb/handbrake/handbrake.h
+++ b/libhb/handbrake/handbrake.h
@@ -93,9 +93,9 @@ void          hb_rotate_geometry( hb_geometry_crop_t * geo,
 void          hb_set_anamorphic_size2(hb_geometry_t          * src_geo,
                                       hb_geometry_settings_t * geo,
                                       hb_geometry_t          * result);
-void          hb_add_filter_dict( hb_job_t * job, hb_filter_object_t * filter,
+void          hb_add_filter_dict( hb_list_t * list_filter, hb_filter_object_t * filter,
                                   const hb_dict_t * settings_in );
-void          hb_add_filter( hb_job_t * job, hb_filter_object_t * filter,
+void          hb_add_filter( hb_list_t * list_filter, hb_filter_object_t * filter,
                              const char * settings );
 void          hb_add_filter2( hb_value_array_t * list, hb_dict_t * filter );
 

--- a/libhb/handbrake/hbavfilter.h
+++ b/libhb/handbrake/hbavfilter.h
@@ -18,6 +18,9 @@ typedef struct hb_avfilter_graph_s hb_avfilter_graph_t;
 hb_avfilter_graph_t *
 hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init);
 
+hb_avfilter_graph_t *
+hb_avfilter_audio_graph_init(hb_value_t *settings, hb_filter_init_t *init);
+
 void    hb_avfilter_graph_close(hb_avfilter_graph_t ** _g);
 
 const char *
@@ -35,9 +38,14 @@ int     hb_avfilter_add_buf(hb_avfilter_graph_t * graph, hb_buffer_t ** in);
 hb_buffer_t *
 hb_avfilter_get_buf(hb_avfilter_graph_t * graph);
 
+int hb_audio_avfilter_add_buf(hb_avfilter_graph_t *graph, hb_buffer_t **buf_in);
+
+hb_buffer_t * hb_audio_avfilter_get_buf(hb_avfilter_graph_t *graph);
+
 void    hb_avfilter_append_dict(hb_value_array_t * filters,
                                 const char * name, hb_dict_t * settings);
 
 void    hb_avfilter_combine(hb_list_t * list);
+void    hb_avfilter_audio_combine(hb_list_t *list);
 
 #endif // HANDBRAKE_AVFILTER_H

--- a/libhb/handbrake/internal.h
+++ b/libhb/handbrake/internal.h
@@ -477,6 +477,10 @@ extern hb_filter_object_t hb_filter_lapsharp_vt;
 extern hb_filter_object_t hb_filter_unsharp_vt;
 #endif
 
+extern hb_filter_object_t hb_filter_acompressor;
+extern hb_filter_object_t hb_filter_agate;
+extern hb_filter_object_t hb_filter_avfilter_audio;
+
 extern hb_motion_metric_object_t hb_motion_metric;
 extern hb_blend_object_t hb_blend;
 

--- a/libhb/hb.c
+++ b/libhb/hb.c
@@ -1668,12 +1668,12 @@ void hb_add_filter2( hb_value_array_t * list, hb_dict_t * filter_dict )
 }
 
 /**
- * Add a filter to a jobs filter list
+ * Add a filter to a  filter list
  *
- * @param job Handle to hb_job_t
+ * @param list Handle to a filter hb_list_t
  * @param settings to give the filter
  */
-void hb_add_filter_dict( hb_job_t * job, hb_filter_object_t * filter,
+void hb_add_filter_dict( hb_list_t * list_filter, hb_filter_object_t * filter,
                          const hb_dict_t * settings_in )
 {
     if (filter == NULL)
@@ -1701,12 +1701,12 @@ void hb_add_filter_dict( hb_job_t * job, hb_filter_object_t * filter,
     {
         // Find the position in the filter chain this filter belongs in
         int i;
-        for( i = 0; i < hb_list_count( job->list_filter ); i++ )
+        for( i = 0; i < hb_list_count( list_filter ); i++ )
         {
-            hb_filter_object_t * f = hb_list_item( job->list_filter, i );
+            hb_filter_object_t * f = hb_list_item( list_filter, i );
             if( f->id > filter->id )
             {
-                hb_list_insert( job->list_filter, i, filter );
+                hb_list_insert( list_filter, i, filter );
                 return;
             }
             else if( f->id == filter->id )
@@ -1718,16 +1718,16 @@ void hb_add_filter_dict( hb_job_t * job, hb_filter_object_t * filter,
         }
     }
     // No position found or order not enforced for this filter
-    hb_list_add( job->list_filter, filter );
+    hb_list_add( list_filter, filter );
 }
 
 /**
- * Add a filter to a jobs filter list
+ * Add a filter to a  filter list
  *
- * @param job Handle to hb_job_t
+ * @param list Handle to a filter hb_list_t
  * @param settings to give the filter
  */
-void hb_add_filter( hb_job_t * job, hb_filter_object_t * filter,
+void hb_add_filter( hb_list_t * list, hb_filter_object_t * filter,
                     const char * settings_in )
 {
     if (filter == NULL)
@@ -1741,7 +1741,7 @@ void hb_add_filter( hb_job_t * job, hb_filter_object_t * filter,
         hb_log("hb_add_filter: failed to parse filter settings!");
         return;
     }
-    hb_add_filter_dict(job, filter, settings);
+    hb_add_filter_dict(list, filter, settings);
     hb_value_free(&settings);
 }
 

--- a/libhb/hb_json.c
+++ b/libhb/hb_json.c
@@ -1007,6 +1007,26 @@ hb_dict_t* hb_job_to_dict( const hb_job_t * job )
             hb_dict_set_string(audio_dict, "Name", audio->config.out.name);
         }
 
+        if (hb_list_count(audio->config.out.list_filter))
+        {
+            hb_value_array_t *filter_list = hb_value_array_init();
+            for (int jj = 0; jj < hb_list_count(audio->config.out.list_filter); jj++)
+            {
+                hb_filter_object_t *filter = hb_list_item(audio->config.out.list_filter, jj);
+
+                hb_dict_t *filter_dict = json_pack_ex(&error, 0, "{s:o}",
+                                                      "ID", hb_value_int(filter->id));
+                if (filter->settings != NULL)
+                {
+                    hb_dict_set(filter_dict, "Settings",
+                                hb_value_dup(filter->settings));
+                }
+
+                hb_value_array_append(filter_list, filter_dict);
+            }
+            hb_dict_set(audio_dict, "FilterList", filter_list);
+        }
+
         hb_value_array_append(audio_list, audio_dict);
     }
 
@@ -1654,7 +1674,7 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             {
                 hb_filter_object_t *filter;
                 filter = hb_filter_init(filter_id);
-                hb_add_filter_dict(job, filter, filter_settings);
+                hb_add_filter_dict(job->list_filter, filter, filter_settings);
             }
         }
     }
@@ -1727,10 +1747,11 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             hb_value_t *acodec = NULL, *samplerate = NULL, *mixdown = NULL;
             hb_value_t *dither = NULL;
             const char *name = NULL;
+            hb_value_t *filter_list = NULL;
 
             hb_audio_config_init(&audio);
             result = json_unpack_ex(audio_dict, &error, 0,
-                "{s:i, s?s, s?o, s?F, s?F, s?o, s?b, s?o, s?o, s?i, s?F, s?F}",
+                "{s:i, s?s, s?o, s?F, s?F, s?o, s?b, s?o, s?o, s?i, s?F, s?F, s?o}",
                 "Track",                unpack_i(&audio.index),
                 "Name",                 unpack_s(&name),
                 "Encoder",              unpack_o(&acodec),
@@ -1742,7 +1763,8 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
                 "Samplerate",           unpack_o(&samplerate),
                 "Bitrate",              unpack_i(&audio.out.bitrate),
                 "Quality",              unpack_f(&audio.out.quality),
-                "CompressionLevel",     unpack_f(&audio.out.compression_level));
+                "CompressionLevel",     unpack_f(&audio.out.compression_level),
+                "FilterList",           unpack_o(&filter_list));
             if (result < 0)
             {
                 hb_error("hb_dict_to_job: failed to find audio settings: %s",
@@ -1802,6 +1824,36 @@ hb_job_t* hb_dict_to_job( hb_handle_t * h, hb_dict_t *dict )
             if (name != NULL)
             {
                 audio.out.name = name;
+            }
+            if (filter_list != NULL &&
+                hb_value_type(filter_list) == HB_VALUE_TYPE_ARRAY)
+            {
+                hb_dict_t *filter_dict;
+                int filter_count = hb_value_array_len(filter_list);
+
+                for (int jj = 0; jj < filter_count; jj++)
+                {
+                    filter_dict = hb_value_array_get(filter_list, ii);
+                    int filter_id = -1;
+                    hb_value_t *filter_settings = NULL;
+                    result = json_unpack_ex(filter_dict, &error, 0, "{s:i, s?o}",
+                                            "ID",       unpack_i(&filter_id),
+                                            "Settings", unpack_o(&filter_settings));
+                    if (result < 0)
+                    {
+                        hb_error("hb_dict_to_job: failed to find filter settings: %s",
+                                 error.text);
+                        goto fail;
+                    }
+                    if (filter_id >= HB_AUDIO_FILTER_FIRST &&
+                        filter_id <= HB_AUDIO_FILTER_LAST)
+                    {
+                        hb_filter_object_t *filter;
+                        filter = hb_filter_init(filter_id);
+                        hb_add_filter_dict(audio.out.list_filter, filter,
+                                           filter_settings);
+                    }
+                }
             }
             if (audio.index >= 0)
             {

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -16,6 +16,8 @@
 #include "handbrake/avfilter_priv.h"
 #include "handbrake/hwaccel.h"
 
+//#define HB_DEBUG_GRAPH 1
+
 struct hb_avfilter_graph_s
 {
     AVFilterGraph    * avgraph;
@@ -24,6 +26,12 @@ struct hb_avfilter_graph_s
     char             * settings;
     AVFrame          * frame;
     AVRational         out_time_base;
+
+    int                in_samplerate;
+    int                out_samplerate;
+    AVChannelLayout    in_ch_layout;
+    AVChannelLayout    out_ch_layout;
+
     hb_job_t         * job;
 };
 
@@ -57,7 +65,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 
-#if 0
+#if HB_DEBUG_GRAPH
     avfilter_graph_set_auto_convert(graph->avgraph, AVFILTER_AUTO_CONVERT_NONE);
 #endif
 
@@ -168,7 +176,7 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
         goto fail;
     }
 
-#if 0
+#if HB_DEBUG_GRAPHHB_DEBUG_GRAPH
     char *dump = avfilter_graph_dump(graph->avgraph, NULL);
     hb_log("\n%s", dump);
     free(dump);
@@ -197,6 +205,141 @@ fail:
     return NULL;
 }
 
+hb_avfilter_graph_t *
+hb_avfilter_audio_graph_init(hb_value_t *settings, hb_filter_init_t *init)
+{
+    hb_avfilter_graph_t *graph;
+    AVFilterInOut       *in = NULL, *out = NULL;
+    char                *filter_args;
+    char                *full_settings = NULL;
+    int                  result;
+
+    graph = calloc(1, sizeof(hb_avfilter_graph_t));
+    if (graph == NULL)
+    {
+        return NULL;
+    }
+
+    graph->settings = hb_filter_settings_string(HB_FILTER_AVFILTER, settings);
+    if (graph->settings == NULL)
+    {
+        hb_error("hb_audio_avfilter_graph_init: no filter settings specified");
+        goto fail;
+    }
+
+    graph->avgraph = avfilter_graph_alloc();
+    if (graph->avgraph == NULL)
+    {
+        hb_error("hb_audio_avfilter_graph_init: avfilter_graph_alloc failed");
+        goto fail;
+    }
+
+    // Build abuffer source filter args using AVChannelLayout API (FFmpeg 8+)
+    char ch_layout_str[64];
+    hb_layout_get_name(&init->ch_layout, ch_layout_str, sizeof(ch_layout_str));
+
+    // Append aformat to ensure output matches what HB expects:
+    // packed float, and optionally constrain the channel layout
+    full_settings = hb_strdup_printf("%s,aformat=sample_fmts=flt",
+                                    graph->settings);
+
+    free(graph->settings);
+    graph->settings = strdup(full_settings);
+
+    filter_args = hb_strdup_printf(
+                                   "sample_rate=%d:sample_fmt=%s:channel_layout=%s"
+                                   ":time_base=1/%d",
+                                   init->samplerate, av_get_sample_fmt_name(init->sample_fmt),
+                                   ch_layout_str, init->samplerate);
+
+#if HB_DEBUG_GRAPH
+    hb_log("hb_audio_avfilter_graph_init: abuffer args: %s", filter_args);
+#endif
+
+    result = avfilter_graph_create_filter(&graph->input,
+                                           avfilter_get_by_name("abuffer"),
+                                           "in", filter_args, NULL,
+                                           graph->avgraph);
+    free(filter_args);
+    if (result < 0)
+    {
+        hb_error("hb_audio_avfilter_graph_init: failed to create abuffer source (%d)", result);
+        goto fail;
+    }
+
+    // Parse filter settings and create the graph
+    result = avfilter_graph_parse2(graph->avgraph, full_settings, &in, &out);
+    if (result < 0)
+    {
+        hb_error("hb_audio_avfilter_graph_init: avfilter_graph_parse2 failed (%s)",
+                 full_settings);
+        goto fail;
+    }
+
+    // Link input -> filter chain
+    result = avfilter_link(graph->input, 0, in->filter_ctx, 0);
+    if (result != 0)
+    {
+        hb_error("hb_audio_avfilter_graph_init: failed to link abuffer source");
+        goto fail;
+    }
+
+    // Create abuffersink
+    result = avfilter_graph_create_filter(&graph->output,
+                                           avfilter_get_by_name("abuffersink"),
+                                           "out", NULL, NULL, graph->avgraph);
+    if (result < 0)
+    {
+        hb_error("hb_audio_avfilter_graph_init: failed to create abuffersink");
+        goto fail;
+    }
+
+    // Link filter chain -> output
+    result = avfilter_link(out->filter_ctx, 0, graph->output, 0);
+    if (result != 0)
+    {
+        hb_error("hb_audio_avfilter_graph_init: failed to link abuffersink");
+        goto fail;
+    }
+
+    // Configure the graph
+    result = avfilter_graph_config(graph->avgraph, NULL);
+    if (result < 0)
+    {
+        char errbuf[256];
+        av_strerror(result, errbuf, sizeof(errbuf));
+        hb_error("hb_audio_avfilter_graph_init: failed to configure filter graph (%d: %s)",
+                 result, errbuf);
+        goto fail;
+    }
+
+    graph->frame = av_frame_alloc();
+    if (graph->frame == NULL)
+    {
+        hb_error("hb_audio_avfilter_graph_init: failed to allocate AVFrame");
+        goto fail;
+    }
+
+    graph->in_samplerate = init->samplerate;
+    av_channel_layout_copy(&graph->in_ch_layout, &init->ch_layout);
+
+    graph->out_time_base = graph->output->inputs[0]->time_base;
+    graph->out_samplerate = graph->output->inputs[0]->sample_rate;
+    av_channel_layout_copy(&graph->out_ch_layout, &graph->output->inputs[0]->ch_layout);
+
+    free(full_settings);
+    avfilter_inout_free(&in);
+    avfilter_inout_free(&out);
+    return graph;
+
+fail:
+    free(full_settings);
+    avfilter_inout_free(&in);
+    avfilter_inout_free(&out);
+    hb_avfilter_graph_close(&graph);
+    return NULL;
+}
+
 const char * hb_avfilter_graph_settings(hb_avfilter_graph_t * graph)
 {
     return graph->settings;
@@ -215,6 +358,8 @@ void hb_avfilter_graph_close(hb_avfilter_graph_t ** _g)
         avfilter_graph_free(&graph->avgraph);
     }
     free(graph->settings);
+    av_channel_layout_uninit(&graph->in_ch_layout);
+    av_channel_layout_uninit(&graph->out_ch_layout);
     av_frame_free(&graph->frame);
     free(graph);
     *_g = NULL;
@@ -230,6 +375,9 @@ void hb_avfilter_graph_update_init(hb_avfilter_graph_t * graph,
     init->geometry.par.num = link->sample_aspect_ratio.num;
     init->geometry.par.den = link->sample_aspect_ratio.den;
     init->pix_fmt          = link->format;
+
+    init->samplerate       = link->sample_rate;
+    av_channel_layout_copy(&init->ch_layout, &link->ch_layout);
 }
 
 int hb_avfilter_add_frame(hb_avfilter_graph_t * graph, AVFrame * frame)
@@ -267,6 +415,86 @@ hb_buffer_t * hb_avfilter_get_buf(hb_avfilter_graph_t * graph)
     {
         hb_buffer_t *buf = hb_avframe_to_video_buffer(graph->frame, graph->out_time_base);
         av_frame_unref(graph->frame);
+        return buf;
+    }
+
+    return NULL;
+}
+
+int hb_audio_avfilter_add_buf(hb_avfilter_graph_t *graph, hb_buffer_t **buf_in)
+{
+    int ret;
+
+    if (buf_in != NULL && *buf_in != NULL)
+    {
+        hb_buffer_t *buf = *buf_in;
+        AVFrame *frame = graph->frame;
+
+        av_frame_unref(frame);
+        frame->nb_samples     = buf->size / (sizeof(float) * graph->in_ch_layout.nb_channels);
+        frame->format         = AV_SAMPLE_FMT_FLT;
+        frame->sample_rate    = graph->in_samplerate;
+        av_channel_layout_copy(&frame->ch_layout, &graph->in_ch_layout);
+
+        // Point frame data directly at buffer data (no copy needed for
+        // interleaved format)
+        frame->data[0]        = buf->data;
+        frame->linesize[0]    = buf->size;
+        frame->extended_data  = frame->data;
+
+        // Convert 90kHz timestamps to filter time_base
+        frame->pts = av_rescale_q(buf->s.start,
+                                   (AVRational){1, 90000},
+                                   (AVRational){1, graph->in_samplerate});
+
+        ret = av_buffersrc_add_frame(graph->input, frame);
+
+        // Don't unref since we didn't alloc the data
+        frame->data[0]       = NULL;
+        frame->extended_data = NULL;
+        av_frame_unref(frame);
+
+        hb_buffer_close(buf_in);
+    }
+    else
+    {
+        // Flush / EOF
+        ret = av_buffersrc_add_frame(graph->input, NULL);
+    }
+
+    return ret;
+}
+
+hb_buffer_t * hb_audio_avfilter_get_buf(hb_avfilter_graph_t *graph)
+{
+    int result = av_buffersink_get_frame(graph->output, graph->frame);
+    if (result >= 0)
+    {
+        AVFrame *frame = graph->frame;
+        int nb_samples = frame->nb_samples;
+        int size = nb_samples * sizeof(float) * graph->out_ch_layout.nb_channels;
+
+        hb_buffer_t *buf = hb_buffer_init(size);
+        if (buf == NULL)
+        {
+            av_frame_unref(frame);
+            return NULL;
+        }
+
+        // Copy interleaved float data from frame to buffer
+        memcpy(buf->data, frame->data[0], size);
+
+        // Convert timestamps back to 90kHz
+        buf->s.start = av_rescale_q(frame->pts,
+                                     graph->out_time_base,
+                                     (AVRational){1, 90000});
+        int64_t duration = av_rescale_q(nb_samples,
+                                         (AVRational){1, graph->out_samplerate},
+                                         (AVRational){1, 90000});
+        buf->s.stop = buf->s.start + duration;
+        buf->s.type = AUDIO_BUF;
+
+        av_frame_unref(frame);
         return buf;
     }
 
@@ -365,6 +593,50 @@ void hb_avfilter_combine( hb_list_t * list)
             {
                 hb_value_array_concat(avfilter->settings, settings);
             }
+        }
+    }
+}
+
+void hb_avfilter_audio_combine(hb_list_t *list)
+{
+    hb_filter_object_t  *avfilter = NULL;
+    hb_value_t          *settings = NULL;
+
+    for (int ii = 0; ii < hb_list_count(list); ii++)
+    {
+        hb_filter_object_t *filter = hb_list_item(list, ii);
+        hb_filter_private_t *pv = filter->private_data;
+        switch (filter->id)
+        {
+            case HB_AUDIO_FILTER_ACOMPRESSOR:
+            case HB_AUDIO_FILTER_AGATE:
+            {
+                settings = pv->avfilters;
+            } break;
+            default:
+            {
+                settings = NULL;
+                avfilter = NULL;
+            } break;
+        }
+        if (settings != NULL)
+        {
+            if (avfilter == NULL)
+            {
+                hb_filter_private_t *avpv = NULL;
+                avfilter = hb_filter_init(HB_AUDIO_FILTER_AVFILTER);
+                avfilter->aliased = 1;
+
+                avpv = calloc(1, sizeof(struct hb_filter_private_s));
+                avfilter->private_data = avpv;
+                avpv->input = pv->input;
+
+                avfilter->settings = hb_value_array_init();
+                hb_list_insert(list, ii, avfilter);
+                ii++;
+            }
+
+            hb_value_array_concat(avfilter->settings, settings);
         }
     }
 }

--- a/libhb/param.c
+++ b/libhb/param.c
@@ -245,6 +245,20 @@ static hb_filter_param_t bwdif_presets[] =
     { 0,  NULL,                NULL,           NULL             },
 };
 
+static hb_filter_param_t acompressor_presets[] =
+{
+    { 1, "Custom",             "custom",       NULL             },
+    { 3, "Default",            "default",      NULL             },
+    { 0,  NULL,                NULL,           NULL             },
+};
+
+static hb_filter_param_t agate_presets[] =
+{
+    { 1, "Custom",             "custom",       NULL             },
+    { 3, "Default",            "default",      NULL             },
+    { 0,  NULL,                NULL,           NULL             },
+};
+
 typedef struct
 {
     int                filter_id;
@@ -302,6 +316,12 @@ static filter_param_map_t param_map[] =
 
     { HB_FILTER_DEBAND, deband_presets, NULL,
       sizeof(deband_presets) / sizeof(hb_filter_param_t),      0, },
+
+    { HB_AUDIO_FILTER_ACOMPRESSOR, acompressor_presets, NULL,
+      sizeof(acompressor_presets) / sizeof(hb_filter_param_t), 0, },
+
+    { HB_AUDIO_FILTER_AGATE, agate_presets, NULL,
+      sizeof(agate_presets) / sizeof(hb_filter_param_t),       0, },
 
     { HB_FILTER_INVALID,     NULL,                NULL,     0, 0, },
 };
@@ -1294,6 +1314,8 @@ hb_generate_filter_settings(int filter_id, const char *preset, const char *tune,
         case HB_FILTER_YADIF:
         case HB_FILTER_BWDIF:
         case HB_FILTER_COLORSPACE:
+        case HB_AUDIO_FILTER_ACOMPRESSOR:
+        case HB_AUDIO_FILTER_AGATE:
             settings = generate_generic_settings(filter_id, preset,
                                                  tune, custom);
             break;

--- a/libhb/platform/macosx/vt_common.c
+++ b/libhb/platform/macosx/vt_common.c
@@ -488,7 +488,7 @@ static void replace_filter(hb_job_t *job, int prev_filter_id, int new_filter_id)
         {
             hb_list_rem(list, filter);
             hb_filter_object_t *new_filter = hb_filter_init(new_filter_id);
-            hb_add_filter_dict(job, new_filter, settings);
+            hb_add_filter_dict(job->list_filter, new_filter, settings);
             hb_filter_close(&filter);
         }
     }
@@ -503,7 +503,7 @@ void hb_vt_setup_hw_filters(hb_job_t *job)
         // Add adapter
         hb_filter_object_t *filter = hb_filter_init(HB_FILTER_ADAPTER_VT);
         char *settings = hb_strdup_printf("rotation=%d", job->title->rotation);
-        hb_add_filter(job, filter, settings);
+        hb_add_filter(job->list_filter, filter, settings);
         free(settings);
 
         replace_filter(job, HB_FILTER_COMB_DETECT, HB_FILTER_COMB_DETECT_VT);

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -412,6 +412,49 @@ hb_work_object_t* hb_audio_encoder(hb_handle_t *h, int codec)
     return NULL;
 }
 
+void hb_display_filters_info(hb_list_t *list_filter, const char *indent)
+{
+    if (hb_list_count(list_filter))
+    {
+        hb_log("%s+ %s", indent, hb_list_count(list_filter) > 1 ? "filters" : "filter");
+        for (int j = 0; j < hb_list_count(list_filter); j++)
+        {
+            hb_filter_object_t *filter = hb_list_item(list_filter, j);
+            if (filter->aliased && global_verbosity_level < 2)
+            {
+                continue;
+            }
+            char *settings = hb_filter_settings_string(filter->id,
+                                                       filter->settings);
+            if (settings != NULL && strlen(settings) > 0)
+                hb_log("%s   + %s (%s)", indent, filter->name, settings);
+            else
+                hb_log("%s   + %s (default settings)", indent, filter->name);
+            free(settings);
+            if (filter->info)
+            {
+                hb_filter_info_t *info;
+
+                info = filter->info(filter);
+                if (info != NULL &&
+                    info->human_readable_desc != NULL &&
+                    info->human_readable_desc[0] != 0)
+                {
+                    char *line, * pos = NULL;
+                    char *tmp = strdup(info->human_readable_desc);
+                    for (line = strtok_r(tmp,  "\n", &pos); line != NULL;
+                         line = strtok_r(NULL, "\n", &pos))
+                    {
+                        hb_log("%s     + %s", indent, line);
+                    }
+                    free(tmp);
+                }
+                hb_filter_info_close(&info);
+            }
+        }
+    }
+}
+
 /**
  * Displays job parameters in the debug log.
  * @param job Handle work hb_job_t.
@@ -535,46 +578,8 @@ void hb_display_job_info(hb_job_t *job)
         hb_log( "     + bitrate %d kbps", title->video_bitrate / 1000 );
     }
 
-    // Filters can modify dimensions.  So show them first.
-    if( hb_list_count( job->list_filter ) )
-    {
-        hb_log("   + %s", hb_list_count( job->list_filter) > 1 ? "filters" : "filter" );
-        for( i = 0; i < hb_list_count( job->list_filter ); i++ )
-        {
-            hb_filter_object_t * filter = hb_list_item( job->list_filter, i );
-            if (filter->aliased && global_verbosity_level < 2)
-            {
-                continue;
-            }
-            char * settings = hb_filter_settings_string(filter->id,
-                                                        filter->settings);
-            if (settings != NULL)
-                hb_log("     + %s (%s)", filter->name, settings);
-            else
-                hb_log("     + %s (default settings)", filter->name);
-            free(settings);
-            if (filter->info)
-            {
-                hb_filter_info_t * info;
-
-                info = filter->info(filter);
-                if (info != NULL &&
-                    info->human_readable_desc != NULL &&
-                    info->human_readable_desc[0] != 0)
-                {
-                    char * line, * pos = NULL;
-                    char * tmp = strdup(info->human_readable_desc);
-                    for (line = strtok_r(tmp,  "\n", &pos); line != NULL;
-                         line = strtok_r(NULL, "\n", &pos))
-                    {
-                        hb_log("       + %s", line);
-                    }
-                    free(tmp);
-                }
-                hb_filter_info_close(&info);
-            }
-        }
-    }
+    // Filters can modify dimensions. So show them first.
+    hb_display_filters_info(job->list_filter, "     ");
 
     hb_log( "   + Output geometry" );
     hb_log( "     + storage dimensions: %d x %d", job->width, job->height );
@@ -831,6 +836,8 @@ void hb_display_job_info(hb_job_t *job)
                     hb_log("     + compression level: %.2f",
                            audio->config.out.compression_level);
                 }
+
+                hb_display_filters_info(audio->config.out.list_filter, "     ");
             }
         }
     }
@@ -1104,7 +1111,7 @@ static int sanitize_subtitles( hb_job_t * job )
         // not required to add the subtitle rendering filter since
         // we will always try to do it here.
         hb_filter_object_t *filter = hb_filter_init(HB_FILTER_RENDER_SUB);
-        hb_add_filter_dict(job, filter, NULL);
+        hb_add_filter_dict(job->list_filter, filter, NULL);
     }
 
     return 0;
@@ -1504,7 +1511,7 @@ static void sanitize_filter_list_post(hb_job_t *job)
 
         hb_filter_object_t *filter = hb_filter_init(HB_FILTER_FORMAT);
         char *settings = hb_strdup_printf("format=%s", av_get_pix_fmt_name(encoder_pix_fmt));
-        hb_add_filter(job, filter, settings);
+        hb_add_filter(job->list_filter, filter, settings);
         free(settings);
     }
 }
@@ -1659,7 +1666,7 @@ static void sanitize_dynamic_hdr_metadata_passthru(hb_job_t *job)
                                           scale_factor_x, scale_factor_y,
                                           crop_top, crop_bottom, crop_left, crop_right,
                                           pad_top, pad_bottom, pad_left, pad_right);
-        hb_add_filter(job, filter, settings);
+        hb_add_filter(job->list_filter, filter, settings);
         free(settings);
 
         job->color_range = job->passthru_dynamic_hdr_metadata & HB_HDR_DYNAMIC_METADATA_DOVI &&
@@ -2011,6 +2018,68 @@ static void do_job(hb_job_t *job)
         {
             audio = hb_list_item( job->list_audio, i );
 
+            // Audio Filter Chain
+            hb_list_t *list_filter = audio->config.out.list_filter;
+            if (hb_list_count(list_filter))
+            {
+                hb_filter_init_t init;
+                memset(&init, 0, sizeof(init));
+
+                init.samplerate = audio->config.out.samplerate;
+                init.sample_fmt = AV_SAMPLE_FMT_FLT;
+                av_channel_layout_from_mask(&init.ch_layout, hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL));
+
+                for (int j = 0; j < hb_list_count(list_filter);)
+                {
+                    hb_filter_object_t *filter = hb_list_item(list_filter, j);
+                    filter->done = &job->done;
+                    if (filter->init != NULL && filter->init(filter, &init))
+                    {
+                        hb_log("Failure to initialise audio filter '%s', disabling",
+                                filter->name);
+                        hb_list_rem(list_filter, filter);
+                        hb_filter_close(&filter);
+                        continue;
+                    }
+                    j++;
+                }
+
+                // Combine HB_AUDIO_FILTER_AVFILTERs that are sequential
+                hb_avfilter_audio_combine(list_filter);
+
+                for (int j = 0; j < hb_list_count(list_filter);)
+                {
+                    hb_filter_object_t *filter = hb_list_item(list_filter, j);
+                    filter->done = &job->done;
+                    if (filter->post_init != NULL && filter->post_init(filter, job))
+                    {
+                        hb_log("Failure to initialise audio filter '%s', disabling",
+                               filter->name);
+                        hb_list_rem(list_filter, filter);
+                        hb_filter_close(&filter);
+                        continue;
+                    }
+                    j++;
+                }
+            }
+
+            // Set up the audio filter fifo pipeline
+            if (hb_list_count(list_filter))
+            {
+                hb_fifo_t *fifo_in = audio->priv.fifo_sync;
+                for (int j = 0; j < hb_list_count(list_filter); j++)
+                {
+                    hb_filter_object_t *filter = hb_list_item(list_filter, j);
+                    if (!filter->skip)
+                    {
+                        filter->fifo_in = fifo_in;
+                        filter->fifo_out = hb_fifo_init(FIFO_MINI, FIFO_MINI_WAKE);
+                        fifo_in = filter->fifo_out;
+                    }
+                }
+                audio->priv.fifo_render = fifo_in;
+            }
+
             /*
             * Audio Encoder Thread
             */
@@ -2024,7 +2093,14 @@ static void do_job(hb_job_t *job)
                 goto cleanup;
             }
             w->init_delay = &audio->priv.init_delay;
-            w->fifo_in    = audio->priv.fifo_sync;
+            if (audio->priv.fifo_render)
+            {
+                w->fifo_in    = audio->priv.fifo_render;
+            }
+            else
+            {
+                w->fifo_in    = audio->priv.fifo_sync;
+            }
             w->fifo_out   = audio->priv.fifo_out;
             w->extradata  = &audio->priv.extradata;
             w->audio      = audio;
@@ -2140,7 +2216,8 @@ static void do_job(hb_job_t *job)
         w = hb_list_item(job->list_work, i);
         w->thread = hb_thread_init(w->name, hb_work_loop, w, HB_LOW_PRIORITY);
     }
-    if (job->list_filter && !job->indepth_scan)
+
+    if (!job->indepth_scan)
     {
         for (i = 0; i < hb_list_count(job->list_filter); i++)
         {
@@ -2152,6 +2229,23 @@ static void do_job(hb_job_t *job)
                 // to start the filter's thread
                 filter->thread = hb_thread_init(filter->name, filter_loop,
                                                 filter, HB_LOW_PRIORITY);
+            }
+        }
+
+        for (i = 0; i < hb_list_count(job->list_audio); i++)
+        {
+            hb_list_t *list_filter = audio->config.out.list_filter;
+            for (int j = 0; j < hb_list_count(list_filter); j++)
+            {
+                hb_filter_object_t *filter = hb_list_item(list_filter, j);
+
+                if (!filter->skip)
+                {
+                    // Filters were initialized earlier, so we just need
+                    // to start the filter's thread
+                    filter->thread = hb_thread_init(filter->name, filter_loop,
+                                                    filter, HB_LOW_PRIORITY);
+                }
             }
         }
     }
@@ -2180,6 +2274,20 @@ cleanup:
         for (i = 0; i < hb_list_count(job->list_filter); i++)
         {
             hb_filter_object_t * filter = hb_list_item(job->list_filter, i);
+            if( filter->thread != NULL )
+            {
+                hb_thread_close(&filter->thread);
+            }
+            filter->close(filter);
+        }
+    }
+
+    for (i = 0; i < hb_list_count(job->list_audio); i++)
+    {
+        hb_list_t *list_filter = audio->config.out.list_filter;
+        for (int j = 0; j < hb_list_count(list_filter); j++)
+        {
+            hb_filter_object_t *filter = hb_list_item(list_filter, j);
             if( filter->thread != NULL )
             {
                 hb_thread_close(&filter->thread);
@@ -2227,6 +2335,16 @@ cleanup:
     }
     for (i = 0; i < hb_list_count( job->list_audio ); i++)
     {
+        hb_list_t *list_filter = audio->config.out.list_filter;
+        for (int j = 0; j < hb_list_count(list_filter); j++)
+        {
+            hb_filter_object_t *filter = hb_list_item(list_filter, j);
+            if (!filter->skip)
+            {
+                hb_fifo_close(&filter->fifo_out);
+            }
+        }
+
         audio = hb_list_item( job->list_audio, i );
         if( audio->priv.fifo_in != NULL )
             hb_fifo_close( &audio->priv.fifo_in );

--- a/macosx/HBJob+HBJobConversion.m
+++ b/macosx/HBJob+HBJobConversion.m
@@ -488,6 +488,7 @@
 
     // Now lets call the filters if applicable.
     hb_filter_object_t *filter;
+    hb_list_t *filter_list = job->list_filter;
 
     // Detelecine
     if (![self.filters.detelecine isEqualToString:@"off"])
@@ -498,7 +499,7 @@
                                                              NULL,
                                                              self.filters.detelecineCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 
@@ -511,7 +512,7 @@
                                                              NULL,
                                                              self.filters.combDetectionCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 
@@ -533,13 +534,13 @@
                                                             NULL,
                                                             self.filters.deinterlaceCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 
     // Add framerate shaping filter
     filter = hb_filter_init(HB_FILTER_VFR);
-    hb_add_filter(job, filter, [[NSString stringWithFormat:@"mode=%d:rate=%d/%d",
+    hb_add_filter(filter_list, filter, [[NSString stringWithFormat:@"mode=%d:rate=%d/%d",
                                  fps_mode, fps_num, fps_den] UTF8String]);
 
     // Deblock
@@ -551,7 +552,7 @@
                                                              self.filters.deblockTune.UTF8String,
                                                              self.filters.deblockCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 
@@ -569,7 +570,7 @@
                                                   self.filters.denoiseTune.UTF8String,
                                                   self.filters.denoiseCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_dict_free(&filter_dict);
     }
 
@@ -582,13 +583,13 @@
                                                              self.filters.chromaSmoothTune.UTF8String,
                                                              self.filters.chromaSmoothCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 
     // Add Crop/Scale filter
     filter = hb_filter_init(HB_FILTER_CROP_SCALE);
-    hb_add_filter( job, filter,
+    hb_add_filter( filter_list, filter,
                    [NSString stringWithFormat:
                     @"width=%d:height=%d:crop-top=%d:crop-bottom=%d:crop-left=%d:crop-right=%d",
                     self.picture.width, self.picture.height,
@@ -609,7 +610,7 @@
                                                   self.filters.sharpenTune.UTF8String,
                                                   self.filters.sharpenCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_dict_free(&filter_dict);
     }
 
@@ -617,7 +618,7 @@
     if (self.filters.grayscale)
     {
         filter = hb_filter_init(HB_FILTER_GRAYSCALE);
-        hb_add_filter(job, filter, NULL);
+        hb_add_filter(filter_list, filter, NULL);
     }
 
     // Rotate
@@ -630,7 +631,7 @@
                                                               self.picture.angle, self.picture.flip].UTF8String);
 
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_dict_free(&filter_dict);
     }
 
@@ -662,7 +663,7 @@
         hb_dict_t *filter_dict = hb_generate_filter_settings(filter_id, NULL, NULL, settings.UTF8String);
 
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_dict_free(&filter_dict);
     }
 
@@ -675,7 +676,7 @@
                                                              NULL,
                                                              self.filters.colorspaceCustomString.UTF8String);
         filter = hb_filter_init(filter_id);
-        hb_add_filter_dict(job, filter, filter_dict);
+        hb_add_filter_dict(filter_list, filter, filter_dict);
         hb_value_free(&filter_dict);
     }
 


### PR DESCRIPTION
plus libavfilter acompressor and agate filters.

Just some basics filters, with no channel layout changes at the moment. There is no cli and preset or UI to enable the audio filters yet, so the only way to test is to hardcode them somewhere. Anyway, the main goal here is to test if it breaks without audio filters. Additional controls will be added in a following PR.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux