### PR TITLE
libhb: HB_ACODEC_FFALAC: disable unsupported HB_AMIXDOWN_7POINT1

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2654,6 +2654,9 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
 
         case HB_ACODEC_FFALAC:
         case HB_ACODEC_FFALAC24:
+            return (mixdown <= HB_AMIXDOWN_6POINT1 &&
+                    mixdown != HB_AMIXDOWN_QUAD);
+
         case HB_ACODEC_FFTRUEHD:
             return (mixdown <= HB_AMIXDOWN_7POINT1 &&
                     mixdown != HB_AMIXDOWN_QUAD);

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -141,8 +141,6 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                 out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
             if (in_channel_layout == AV_CH_LAYOUT_6POINT1)
                 out_channel_layout  = AV_CH_LAYOUT_6POINT1_BACK;
-            if (in_channel_layout == AV_CH_LAYOUT_7POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
             break;
 
         case HB_ACODEC_FFFLAC:


### PR DESCRIPTION
The libavcodec ALAC encoder does not support "standard" 7.1, and mapping it to 7.1(wide) does not give usable results:
- the output is recognized/decoded as 7.1(wide) by lavc as well as afinfo/afconvert (after extraction to e.g. CAF)
- decoding the HandBrake-produced audio track results in out of order channels, two of which are empty

**Description of Change:**

Removal of incorrect mapping/hack and disabling of erroneous encoder mixdown support.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux