### PR TITLE
hb_audio_mixdowns: rename "7.1 (5F/2R/LFE)" to "7.1 (SDDS)"

### DIFF
--- a/NEWS.markdown
+++ b/NEWS.markdown
@@ -11,6 +11,16 @@ Download available from Microsoft:
 - [For Arm64 (Qualcomm or other)](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-arm64.exe)
 
 
+## HandBrake 1.12.0
+
+### All platforms
+
+#### Audio
+
+- Renamed "7.1 (5F/2R/LFE)" mixdown to "7.1 (SDDS)" (speaker layout used by Sony Dynamic Digital Sound)
+
+## HandBrake 1.11.2
+
 ## HandBrake 1.11.1
 
 ### All platforms

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -255,6 +255,7 @@ hb_mixdown_internal_t hb_audio_mixdowns[]  =
     { { "DTS Passthru",       "",           HB_AMIXDOWN_NONE,      }, NULL, 0, },
     { { "DTS-HD Passthru",    "",           HB_AMIXDOWN_NONE,      }, NULL, 0, },
     { { "6-channel discrete", "6ch",        HB_AMIXDOWN_5POINT1,   }, NULL, 0, },
+    { { "7.1 (5F/2R/LFE)",    "5_2_lfe",    HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 0, },
     // actual mixdowns
     { { "None",               "none",       HB_AMIXDOWN_NONE,      }, NULL, 1, },
     { { "Mono",               "mono",       HB_AMIXDOWN_MONO,      }, NULL, 1, },
@@ -269,7 +270,7 @@ hb_mixdown_internal_t hb_audio_mixdowns[]  =
     { { "5.1 Channels",       "5point1",    HB_AMIXDOWN_5POINT1,   }, NULL, 1, },
     { { "6.1 Channels",       "6point1",    HB_AMIXDOWN_6POINT1,   }, NULL, 1, },
     { { "7.1 Channels",       "7point1",    HB_AMIXDOWN_7POINT1,   }, NULL, 1, },
-    { { "7.1 (5F/2R/LFE)",    "5_2_lfe",    HB_AMIXDOWN_5_2_LFE,   }, NULL, 1, },
+    { { "7.1 (SDDS)",    "7point1_sdds",    HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 1, }, // https://en.wikipedia.org/wiki/Sony_Dynamic_Digital_Sound
 };
 int hb_audio_mixdowns_count = sizeof(hb_audio_mixdowns) / sizeof(hb_audio_mixdowns[0]);
 
@@ -2608,8 +2609,8 @@ static int mixdown_get_opus_coupled_stream_count(int mixdown)
 
         case HB_AMIXDOWN_NONE:
         case HB_INVALID_AMIXDOWN:
-        case HB_AMIXDOWN_5_2_LFE:
-            // The 5F/2R/LFE configuration is currently not supported by Opus,
+        case HB_AMIXDOWN_7POINT1_SDDS:
+            // The 7.1 SDDS configuration is currently not supported by Opus,
             // so don't set coupled streams.
             return 0;
 
@@ -2676,14 +2677,14 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
                     (mixdown == HB_AMIXDOWN_6POINT1)   ||
                     (mixdown == HB_AMIXDOWN_7POINT1)   ||
-                    (mixdown == HB_AMIXDOWN_5_2_LFE));
+                    (mixdown == HB_AMIXDOWN_7POINT1_SDDS));
 
         case HB_ACODEC_CA_HAAC:
             return ((mixdown <= HB_AMIXDOWN_DOLBYPLII) ||
                     (mixdown == HB_AMIXDOWN_QUAD)      ||
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
                     (mixdown == HB_AMIXDOWN_7POINT1)   ||
-                    (mixdown == HB_AMIXDOWN_5_2_LFE));
+                    (mixdown == HB_AMIXDOWN_7POINT1_SDDS));
 
         case HB_ACODEC_FDK_AAC:
         case HB_ACODEC_FDK_HAAC:
@@ -2707,7 +2708,7 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_4POINT0)   ||
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
                     (mixdown == HB_AMIXDOWN_6POINT1)   ||
-                    (mixdown == HB_AMIXDOWN_5_2_LFE));
+                    (mixdown == HB_AMIXDOWN_7POINT1_SDDS));
 
         case HB_ACODEC_FFFLAC:
         case HB_ACODEC_FFFLAC24:
@@ -2718,7 +2719,7 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
                     (mixdown == HB_AMIXDOWN_6POINT1)   ||
                     (mixdown == HB_AMIXDOWN_7POINT1)   ||
-                    (mixdown == HB_AMIXDOWN_5_2_LFE));
+                    (mixdown == HB_AMIXDOWN_7POINT1_SDDS));
 
         case HB_ACODEC_FFPCM16:
         case HB_ACODEC_FFPCM24:
@@ -2729,7 +2730,7 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
                     (mixdown == HB_AMIXDOWN_6POINT1)   ||
                     (mixdown == HB_AMIXDOWN_7POINT1)   ||
-                    (mixdown == HB_AMIXDOWN_5_2_LFE));
+                    (mixdown == HB_AMIXDOWN_7POINT1_SDDS));
 
         case HB_ACODEC_FFTRUEHD:
             return ((mixdown <= HB_AMIXDOWN_DOLBYPLII) ||
@@ -2777,7 +2778,7 @@ int hb_mixdown_has_remix_support(int mixdown, hb_channel_layout_t *ch_layout)
     switch (mixdown)
     {
         // stereo + front left/right of center
-        case HB_AMIXDOWN_5_2_LFE:
+        case HB_AMIXDOWN_7POINT1_SDDS:
             return (av_channel_layout_subset(ch_layout, AV_CH_FRONT_LEFT_OF_CENTER) &&
                     av_channel_layout_subset(ch_layout, AV_CH_FRONT_RIGHT_OF_CENTER) &&
                     av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_STEREO) == AV_CH_LAYOUT_STEREO);
@@ -2860,7 +2861,7 @@ int hb_mixdown_get_discrete_channel_count(int amixdown)
 {
     switch (amixdown)
     {
-        case HB_AMIXDOWN_5_2_LFE:
+        case HB_AMIXDOWN_7POINT1_SDDS:
         case HB_AMIXDOWN_7POINT1:
             return 8;
 
@@ -2897,7 +2898,7 @@ int hb_mixdown_get_low_freq_channel_count(int amixdown)
         case HB_AMIXDOWN_5POINT1:
         case HB_AMIXDOWN_6POINT1:
         case HB_AMIXDOWN_7POINT1:
-        case HB_AMIXDOWN_5_2_LFE:
+        case HB_AMIXDOWN_7POINT1_SDDS:
             return 1;
 
         default:

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -251,26 +251,26 @@ hb_mixdown_t *hb_audio_mixdowns_last_item  = NULL;
 hb_mixdown_internal_t hb_audio_mixdowns[]  =
 {
     // legacy mixdowns, back to HB 0.9.4 whenever possible (disabled)
-    { { "AC3 Passthru",       "",           HB_AMIXDOWN_NONE,      }, NULL, 0, },
-    { { "DTS Passthru",       "",           HB_AMIXDOWN_NONE,      }, NULL, 0, },
-    { { "DTS-HD Passthru",    "",           HB_AMIXDOWN_NONE,      }, NULL, 0, },
-    { { "6-channel discrete", "6ch",        HB_AMIXDOWN_5POINT1,   }, NULL, 0, },
-    { { "7.1 (5F/2R/LFE)",    "5_2_lfe",    HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 0, },
+    { { "AC3 Passthru",       "",             HB_AMIXDOWN_NONE,         }, NULL, 0, },
+    { { "DTS Passthru",       "",             HB_AMIXDOWN_NONE,         }, NULL, 0, },
+    { { "DTS-HD Passthru",    "",             HB_AMIXDOWN_NONE,         }, NULL, 0, },
+    { { "6-channel discrete", "6ch",          HB_AMIXDOWN_5POINT1,      }, NULL, 0, },
+    { { "7.1 (5F/2R/LFE)",    "5_2_lfe",      HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 0, },
     // actual mixdowns
-    { { "None",               "none",       HB_AMIXDOWN_NONE,      }, NULL, 1, },
-    { { "Mono",               "mono",       HB_AMIXDOWN_MONO,      }, NULL, 1, },
-    { { "Mono (Left Only)",   "left_only",  HB_AMIXDOWN_LEFT,      }, NULL, 1, },
-    { { "Mono (Right Only)",  "right_only", HB_AMIXDOWN_RIGHT,     }, NULL, 1, },
-    { { "Stereo",             "stereo",     HB_AMIXDOWN_STEREO,    }, NULL, 1, },
-    { { "Dolby Surround",     "dpl1",       HB_AMIXDOWN_DOLBY,     }, NULL, 1, },
-    { { "Dolby Pro Logic II", "dpl2",       HB_AMIXDOWN_DOLBYPLII, }, NULL, 1, },
-    { { "3.0 Channels",       "3point0",    HB_AMIXDOWN_3POINT0,   }, NULL, 1, },
-    { { "4.0 Channels",       "4point0",    HB_AMIXDOWN_4POINT0,   }, NULL, 1, },
-    { { "Quadrophonic",       "quad",       HB_AMIXDOWN_QUAD,      }, NULL, 1, },
-    { { "5.1 Channels",       "5point1",    HB_AMIXDOWN_5POINT1,   }, NULL, 1, },
-    { { "6.1 Channels",       "6point1",    HB_AMIXDOWN_6POINT1,   }, NULL, 1, },
-    { { "7.1 Channels",       "7point1",    HB_AMIXDOWN_7POINT1,   }, NULL, 1, },
-    { { "7.1 (SDDS)",    "7point1_sdds",    HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 1, }, // https://en.wikipedia.org/wiki/Sony_Dynamic_Digital_Sound
+    { { "None",               "none",         HB_AMIXDOWN_NONE,         }, NULL, 1, },
+    { { "Mono",               "mono",         HB_AMIXDOWN_MONO,         }, NULL, 1, },
+    { { "Mono (Left Only)",   "left_only",    HB_AMIXDOWN_LEFT,         }, NULL, 1, },
+    { { "Mono (Right Only)",  "right_only",   HB_AMIXDOWN_RIGHT,        }, NULL, 1, },
+    { { "Stereo",             "stereo",       HB_AMIXDOWN_STEREO,       }, NULL, 1, },
+    { { "Dolby Surround",     "dpl1",         HB_AMIXDOWN_DOLBY,        }, NULL, 1, },
+    { { "Dolby Pro Logic II", "dpl2",         HB_AMIXDOWN_DOLBYPLII,    }, NULL, 1, },
+    { { "3.0 Channels",       "3point0",      HB_AMIXDOWN_3POINT0,      }, NULL, 1, },
+    { { "4.0 Channels",       "4point0",      HB_AMIXDOWN_4POINT0,      }, NULL, 1, },
+    { { "Quadrophonic",       "quad",         HB_AMIXDOWN_QUAD,         }, NULL, 1, },
+    { { "5.1 Channels",       "5point1",      HB_AMIXDOWN_5POINT1,      }, NULL, 1, },
+    { { "6.1 Channels",       "6point1",      HB_AMIXDOWN_6POINT1,      }, NULL, 1, },
+    { { "7.1 Channels",       "7point1",      HB_AMIXDOWN_7POINT1,      }, NULL, 1, },
+    { { "7.1 (SDDS)",         "7point1_sdds", HB_AMIXDOWN_7POINT1_SDDS, }, NULL, 1, }, // https://en.wikipedia.org/wiki/Sony_Dynamic_Digital_Sound
 };
 int hb_audio_mixdowns_count = sizeof(hb_audio_mixdowns) / sizeof(hb_audio_mixdowns[0]);
 

--- a/libhb/common.c
+++ b/libhb/common.c
@@ -3007,15 +3007,24 @@ int hb_mixdown_get_default_s(uint32_t codec, const char *layout)
 
 hb_mixdown_t* hb_mixdown_get_from_mixdown(int mixdown)
 {
-    int i;
-    for (i = 0; i < hb_audio_mixdowns_count; i++)
+    /*
+     * Return the first matching *enabled* mixdown.
+     *
+     * Disabled mixdowns are meant for mapping of legacy mixdowns by name with
+     * hb_mixdown_get_from_name() e.g. someone specifying 6ch or 5_2_lfe using
+     * HandBrakeCLI.
+     *
+     * The full mixdown list should always have a single, current enabled
+     * mixdown for any disabled legacy mixdowns also present in said list.
+     */
+    for (int i = 0; i < hb_audio_mixdowns_count; i++)
     {
-        if (hb_audio_mixdowns[i].item.amixdown == mixdown)
+        if (hb_audio_mixdowns[i].enabled &&
+            hb_audio_mixdowns[i].item.amixdown == mixdown)
         {
             return &hb_audio_mixdowns[i].item;
         }
     }
-
     return NULL;
 }
 

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1119,7 +1119,7 @@ struct hb_audio_config_s
             HB_AMIXDOWN_5POINT1,
             HB_AMIXDOWN_6POINT1,
             HB_AMIXDOWN_7POINT1,
-            HB_AMIXDOWN_5_2_LFE,
+            HB_AMIXDOWN_7POINT1_SDDS,
         } mixdown; /* Audio mixdown */
         int      track; /* Output track number */
         uint32_t codec; /* Output audio codec */

--- a/libhb/handbrake/preset_builtin.h
+++ b/libhb/handbrake/preset_builtin.h
@@ -12380,7 +12380,7 @@ const char hb_builtin_presets_json[] =
 "            \"x264Option\": \"\",\n"
 "            \"x264UseAdvancedOptions\": false\n"
 "        },\n"
-"        \"VersionMajor\": 72,\n"
+"        \"VersionMajor\": 73,\n"
 "        \"VersionMicro\": 0,\n"
 "        \"VersionMinor\": 0\n"
 "    }\n"

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -799,10 +799,8 @@ uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
             ff_layout = AV_CH_LAYOUT_7POINT1;
             break;
 
-        case HB_AMIXDOWN_5_2_LFE:
-            ff_layout = (AV_CH_LAYOUT_5POINT1_BACK|
-                         AV_CH_FRONT_LEFT_OF_CENTER|
-                         AV_CH_FRONT_RIGHT_OF_CENTER);
+        case HB_AMIXDOWN_7POINT1_SDDS:
+            ff_layout = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
             break;
 
         default:

--- a/libhb/preset.c
+++ b/libhb/preset.c
@@ -3066,6 +3066,33 @@ static void und_to_any(hb_value_array_t * list)
     }
 }
 
+static void import_mixdown_72_0_0(hb_value_t *preset)
+{
+    hb_value_array_t *audio_list = hb_dict_get(preset, "AudioList");
+    int audio_count = hb_value_array_len(audio_list);
+    hb_value_t *audio_dict, *audio_amix;
+    hb_mixdown_t *mixdown;
+    int amixdown, ii;
+    for (ii = 0; ii < audio_count; ii++)
+    {
+        audio_dict = hb_value_array_get(audio_list, ii);
+        audio_amix = hb_dict_get(audio_dict, "AudioMixdown");
+        if (hb_value_type(audio_amix) == HB_VALUE_TYPE_STRING)
+        {
+            amixdown = hb_mixdown_get_from_name(hb_value_get_string(audio_amix));
+        }
+        else
+        {
+            amixdown = hb_value_get_int(audio_amix);
+        }
+        if ((amixdown == HB_AMIXDOWN_7POINT1_SDDS) &&
+            (mixdown = hb_mixdown_get_from_mixdown(amixdown)))
+        {
+            hb_dict_set(audio_dict, "AudioMixdown", hb_value_string(mixdown->short_name));
+        }
+    }
+}
+
 static void import_pic_par_settings_69_0_0(hb_value_t *preset)
 {
     const char *pic_par = hb_dict_get_string(preset, "PicturePAR");
@@ -3876,9 +3903,16 @@ static void import_video_0_0_0(hb_value_t *preset)
     }
 }
 
+static void import_72_0_0(hb_value_t *preset)
+{
+    import_mixdown_72_0_0(preset);
+}
+
 static void import_69_0_0(hb_value_t *preset)
 {
     import_pic_par_settings_69_0_0(preset);
+
+    import_72_0_0(preset);
 }
 
 static void import_64_0_0(hb_value_t *preset)
@@ -4152,6 +4186,11 @@ static int preset_import(hb_value_t *preset, int major, int minor, int micro)
         else if (cmpVersion(major, minor, micro, 69, 0, 0) <= 0)
         {
             import_69_0_0(preset);
+            result = 1;
+        }
+        else if (cmpVersion(major, minor, micro, 72, 0, 0) <= 0)
+        {
+            import_72_0_0(preset);
             result = 1;
         }
 

--- a/macosx/HBAudioTransformers.m
+++ b/macosx/HBAudioTransformers.m
@@ -141,7 +141,7 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
           @"5.1 Channels": HBKitLocalizedString(@"5.1 Channels", @"HBAudio -> Mixdown"),
           @"6.1 Channels": HBKitLocalizedString(@"6.1 Channels", @"HBAudio -> Mixdown"),
           @"7.1 Channels": HBKitLocalizedString(@"7.1 Channels", @"HBAudio -> Mixdown"),
-          @"7.1 (5F/2R/LFE)": HBKitLocalizedString(@"7.1 (5F/2R/LFE)", @"HBAudio -> Mixdown"),
+          @"7.1 (SDDS)": HBKitLocalizedString(@"7.1 (SDDS)", @"HBAudio -> Mixdown"),
           };
 
         localizedReversedMixdownsNames =
@@ -158,7 +158,7 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
           HBKitLocalizedString(@"5.1 Channels", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_5POINT1),
           HBKitLocalizedString(@"6.1 Channels", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_6POINT1),
           HBKitLocalizedString(@"7.1 Channels", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_7POINT1),
-          HBKitLocalizedString(@"7.1 (5F/2R/LFE)", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_5_2_LFE),
+          HBKitLocalizedString(@"7.1 (SDDS)", @"HBAudio -> Mixdown"): @(HB_AMIXDOWN_7POINT1_SDDS),
           };
     }
 }
@@ -193,8 +193,8 @@ static NSDictionary<NSString *, NSNumber *> *localizedReversedMixdownsNames;
             return HBKitLocalizedString(@"6.1 Channels", @"HBAudio -> Mixdown");
         case HB_AMIXDOWN_7POINT1:
             return HBKitLocalizedString(@"7.1 Channels", @"HBAudio -> Mixdown");
-        case HB_AMIXDOWN_5_2_LFE:
-            return HBKitLocalizedString(@"7.1 (5F/2R/LFE)", @"HBAudio -> Mixdown");
+        case HB_AMIXDOWN_7POINT1_SDDS:
+            return HBKitLocalizedString(@"7.1 (SDDS)", @"HBAudio -> Mixdown");
         default:
         {
             const char *name = hb_mixdown_get_name(mixdown);

--- a/preset/preset_builtin.list
+++ b/preset/preset_builtin.list
@@ -1,6 +1,6 @@
 <resources>
     <section name="PresetTemplate">
-        <integer name="VersionMajor" value="72" />
+        <integer name="VersionMajor" value="73" />
         <integer name="VersionMinor" value="0" />
         <integer name="VersionMicro" value="0" />
         <json name="Preset" file="preset_template.json" />


### PR DESCRIPTION
**Description of Change:**

More meaningful name throughout for an uncommon/confusing channel layout.

The legacy mixdown list should take care of mapping when importing from presets or legacy CLI scripts for users who have those.

**Tested on:**

- [x] Windows 10+  (via MinGW) (build only)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**With:**

```bash
./build.macos/xroot/HandBrakeCLI -o ~/Downloads/test.mkv --preset-import-file legacy52lfe.json --preset legacy52lfe -i AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv > /dev/null
```
```bash
./build.macos/xroot/HandBrakeCLI -o ~/Downloads/test.mkv -6 5_2_lfe -i AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv > /dev/null
```
```bash
./build.macos/xroot/HandBrakeCLI -o ~/Downloads/test.mkv --preset-import-file new7point1sdds.json --preset new7point1sdds -i AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv > /dev/null
```
```bash
./build.macos/xroot/HandBrakeCLI -o ~/Downloads/test.mkv -6 7point1_sdds -i AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv > /dev/null
```

**Samples:**

[legacy52lfe.json](https://github.com/user-attachments/files/26658183/legacy52lfe.json)

[new7point1sdds.json](https://github.com/user-attachments/files/26658186/new7point1sdds.json)

[AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv.zip](https://github.com/user-attachments/files/26658194/AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv.zip)
