### PR TITLE
contrib: fix zlib-1.3.2 link to use HB-contrib2

### DIFF
--- a/contrib/zlib/module.defs
+++ b/contrib/zlib/module.defs
@@ -1,7 +1,7 @@
 $(eval $(call import.MODULE.defs,ZLIB,zlib))
 $(eval $(call import.CONTRIB.defs,ZLIB))
 
-ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs/zlib-1.3.2.tar.gz
+ZLIB.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/zlib-1.3.2.tar.gz
 ZLIB.FETCH.url    += https://www.zlib.net/fossils/zlib-1.3.2.tar.gz
 ZLIB.FETCH.sha256  = bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
 


### PR DESCRIPTION
Download URL for zlib-1.3.2 pointed to wrong HB-contribs instead of HB-contribs2