### PR TITLE
Add "AudioVideoEditing" category to .desktop file

### DIFF
--- a/gtk/data/fr.handbrake.ghb.desktop.in
+++ b/gtk/data/fr.handbrake.ghb.desktop.in
@@ -6,6 +6,6 @@ Exec=ghb %f
 Icon=fr.handbrake.ghb
 Terminal=false
 Type=Application
-Categories=GTK;AudioVideo;Video;
+Categories=GTK;AudioVideo;Video;AudioVideoEditing;
 Keywords=Format Converter;Video Encoder;
 MimeType=application/ogg;application/x-extension-mp4;application/x-flac;application/x-matroska;application/x-ogg;audio/ac3;audio/mp4;audio/mpeg;audio/ogg;audio/x-flac;audio/x-matroska;audio/x-mp2;audio/x-mp3;audio/x-mpeg;audio/x-vorbis;video/mp4;video/mp4v-es;video/mpeg;video/msvideo;video/quicktime;video/vnd.divx;video/webm;video/x-avi;video/x-m4v;video/x-matroska;video/x-mpeg;video/x-ms-wmv;video/ogg;video/x-ogm+ogg;video/x-theora+ogg;x-content/video-dvd;x-content/video-vcd;x-content/video-svcd;


### PR DESCRIPTION
Plasma Discover uses that category for Audio and Video Editors.

Link: https://github.com/KDE/discover/blob/1b0dae7945c84c06e3b266941331c9b34b09dfb4/libdiscover/backends/FlatpakBackend/flatpak-backend-categories.xml#L494
Link: https://specifications.freedesktop.org/menu/latest/additional-category-registry.html

Fixes #7838 ("Plasma Discover doesn't show HandBrake in the list of Audio and Video Editors").

**Description of Change:**

Add "AudioVideoEditing" category to .desktop file.