### PR TITLE
contrib/ffmpeg: backport nvenc MVHEVC codec_id guard

### DIFF
--- a/contrib/ffmpeg/A26-avcodec-nvenc-gate-MVHEVC-capability-check-on-codec_id.patch
+++ b/contrib/ffmpeg/A26-avcodec-nvenc-gate-MVHEVC-capability-check-on-codec_id.patch
@@ -1,0 +1,30 @@
+From bdc0a29204104301f0ce3b02481d7603d8d70577 Mon Sep 17 00:00:00 2001
+From: Semih Baskan <strst.gs@gmail.com>
+Date: Sun, 26 Apr 2026 12:00:00 +0000
+Subject: [PATCH] avcodec/nvenc: gate MVHEVC capability check on codec_id
+
+NV_ENC_H264_PROFILE_HIGH_10 and NV_ENC_HEVC_PROFILE_MULTIVIEW_MAIN
+both equal 3 when their respective NVENC_HAVE_* flags are defined.
+The MVHEVC check in nvenc_check_capabilities() matches against
+ctx->profile alone, so an H.264 encode with profile=high10 is
+rejected as if it were an HEVC multiview request on hardware
+without MVHEVC support.
+
+Signed-off-by: Semih Baskan <strst.gs@gmail.com>
+---
+ libavcodec/nvenc.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/libavcodec/nvenc.c
++++ b/libavcodec/nvenc.c
+@@ -700,7 +700,9 @@ static int nvenc_check_capabilities(AVCodecContext *avctx)
+
+ #ifdef NVENC_HAVE_MVHEVC
+     ctx->multiview_supported = nvenc_check_cap(avctx, NV_ENC_CAPS_SUPPORT_MVHEVC_ENCODE) > 0;
+-    if(ctx->profile == NV_ENC_HEVC_PROFILE_MULTIVIEW_MAIN && !ctx->multiview_supported) {
++    if (avctx->codec_id == AV_CODEC_ID_HEVC &&
++        ctx->profile == NV_ENC_HEVC_PROFILE_MULTIVIEW_MAIN &&
++        !ctx->multiview_supported) {
+         av_log(avctx, AV_LOG_WARNING, "Multiview not supported by the device\n");
+         return AVERROR(ENOSYS);
+     }


### PR DESCRIPTION
HandBrake's contrib/ffmpeg is pinned at FFmpeg 8.1. That release has the H.264 High10 plumbing (NVENC_HAVE_H264_10BIT_SUPPORT) but is missing the codec_id guard on the MVHEVC capability check in nvenc_check_capabilities(). Without that guard, every H.264 encode with profile=high10 is misidentified as an HEVC multiview request and rejected on any GPU that doesn't support MVHEVC, which is basically all consumer cards through Blackwell.

#7844 merged the new nvenc_h264_10bit encoder, but against the unpatched FFmpeg 8.1 in contrib/ffmpeg it fails at runtime with "No capable devices found". On current snapshots, Blackwell users see the encoder in the dropdown and every encode dies there.

This PR backports the upstream fix https://github.com/FFmpeg/FFmpeg/commit/bdc0a29204104301f0ce3b02481d7603d8d70577 (avcodec/nvenc: gate MVHEVC capability check on codec_id).

Tested on an RTX 5090 (Blackwell, sm_120, driver 596.21) with the patch applied: 1080p H.264 High10 encode runs at ~387 fps; ffprobe reports profile=High 10, pix_fmt=yuv420p10le. The existing 8-bit H.264, HEVC, and AV1 NVENC paths are unchanged.
