### PR TITLE
libhb: always sanitize pv->frame->color_range

### DIFF
--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1393,7 +1393,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     if (pix_fmt            == pv->frame->format  &&
         orig_width         == pv->frame->width   &&
         orig_height        == pv->frame->height  &&
-        color_range        == pv->frame->color_range &&
+        color_range        == hb_get_color_range(pv->frame->color_range) &&
         HB_ROTATION_0      == pv->title->rotation)
     {
         // No filtering required.
@@ -1404,7 +1404,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     if (pv->video_filters.graph       != NULL              &&
         pv->video_filters.width       == pv->frame->width  &&
         pv->video_filters.height      == pv->frame->height &&
-        pv->video_filters.color_range == pv->frame->color_range &&
+        pv->video_filters.color_range == hb_get_color_range(pv->frame->color_range) &&
         pv->video_filters.pix_fmt     == pv->frame->format)
     {
         // Current filter settings are good
@@ -1413,7 +1413,7 @@ int reinit_video_filters(hb_work_private_t * pv)
 
     pv->video_filters.width       = pv->frame->width;
     pv->video_filters.height      = pv->frame->height;
-    pv->video_filters.color_range = pv->frame->color_range;
+    pv->video_filters.color_range = hb_get_color_range(pv->frame->color_range);
     pv->video_filters.pix_fmt     = pv->frame->format;
 
     // New filter required, create filter graph
@@ -1430,7 +1430,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     if (pix_fmt            != pv->frame->format ||
         orig_width         != pv->frame->width  ||
         orig_height        != pv->frame->height ||
-        color_range        != pv->frame->color_range)
+        color_range        != hb_get_color_range(pv->frame->color_range))
     {
         settings = hb_dict_init();
 #if HB_PROJECT_FEATURE_QSV && (defined( _WIN32 ) || defined( __MINGW32__ ))
@@ -1446,7 +1446,7 @@ int reinit_video_filters(hb_work_private_t * pv)
 #endif
         if (pv->frame->hw_frames_ctx && pv->job->hw_pix_fmt == AV_PIX_FMT_CUDA)
         {
-            if (color_range != pv->frame->color_range)
+            if (color_range != hb_get_color_range(pv->frame->color_range))
             {
                 hb_dict_set_int(settings, "range", color_range);
                 hb_avfilter_append_dict(filters, "colorspace_cuda", settings);
@@ -1485,7 +1485,7 @@ int reinit_video_filters(hb_work_private_t * pv)
             hb_dict_set(settings, "w", hb_value_int(orig_width));
             hb_dict_set(settings, "h", hb_value_int(orig_height));
             hb_dict_set(settings, "flags", hb_value_string("lanczos+accurate_rnd"));
-            hb_dict_set_int(settings, "in_range", pv->frame->color_range);
+            hb_dict_set_int(settings, "in_range", hb_get_color_range(pv->frame->color_range));
             hb_dict_set_int(settings, "out_range", color_range);
             hb_avfilter_append_dict(filters, "scale", settings);
 
@@ -1593,7 +1593,7 @@ int reinit_video_filters(hb_work_private_t * pv)
     filter_init.geometry.par.num  = pv->frame->sample_aspect_ratio.num;
     filter_init.geometry.par.den  = pv->frame->sample_aspect_ratio.den;
     filter_init.color_matrix      = color_matrix;
-    filter_init.color_range       = pv->frame->color_range;
+    filter_init.color_range       = hb_get_color_range(pv->frame->color_range);
     filter_init.time_base.num     = 1;
     filter_init.time_base.den     = 1;
     filter_init.vrate.num         = vrate.num;

--- a/libhb/hbavfilter.c
+++ b/libhb/hbavfilter.c
@@ -145,6 +145,9 @@ hb_avfilter_graph_init(hb_value_t * settings, hb_filter_init_t * init)
                  graph->settings);
         goto fail;
     }
+    hb_deep_log(3,
+                "hb_avfilter_graph_init: avfilter_graph_parse2 (%s)",
+                graph->settings);
 
     result = avfilter_link(graph->input, 0, in->filter_ctx, 0);
     if (result != 0)


### PR DESCRIPTION
Currently, we sanitize the input colorimetry at the end of the scan pass (scan .c):

```C
        title->color_range = hb_get_color_range(vid_info.color_range);
```
And during the encode, we forcibly restore the sanitized color range for each frame (decavcodec.c):
```C
static void filter_video(hb_work_private_t *pv)
{
    // Make sure every frame is tagged
    if (pv->job)
    {
        pv->frame->color_primaries = pv->title->color_prim;
        pv->frame->color_trc       = pv->title->color_transfer;
        pv->frame->colorspace      = pv->title->color_matrix;
        pv->frame->color_range     = pv->title->color_range; // here
    }
```

Among other things, this means we enforce a static colorimetry (including color range) throughout a source; this might theoretically be subject to change in the future.

By mapping/sanitizing the input color_range (via hb_get_color_range) whenever we check pv->frame->color_range, we ensure we'll always be using the same mapping even if we later start supporting input where colorimetry changes at some point (I don't have any samples, but presumably there would be an MPEG-PS or two somewhere where this might happen).

This is a WIP; I guess we should maybe look into using hb_get_color_transfer, hb_get_color_prim and hb_get_color_matrix in pv->frame comparisons (but the latter two rely on the video geometry in cases where guessing is required), and there is some additional logic in scan.c we might want to think about exporting somewhere:

```C
        // DVD-Video have no defined color info, but some mostly wrong
        // values could be read from the mpeg-2 bitstream. Override those here.
        if (data->dvd)
        {
            title->color_prim     = hb_get_color_prim(HB_COLR_PRI_UNSET, vid_info.geometry, vid_info.rate);
            title->color_transfer = HB_COLR_TRA_BT709;
            title->color_matrix   = HB_COLR_MAT_SMPTE170M;
        }
        else if ((title->color_prim     != HB_COLR_PRI_UNDEF &&
                  title->color_prim     != HB_COLR_PRI_UNSET) ||
                 (title->color_transfer != HB_COLR_TRA_UNDEF &&
                  title->color_transfer != HB_COLR_TRA_UNSET) ||
                 (title->color_matrix   != HB_COLR_MAT_UNDEF &&
                  title->color_matrix != HB_COLR_MAT_UNSET))
        {
            title->color_prim     = hb_get_color_prim(title->color_prim, vid_info.geometry, vid_info.rate);
            title->color_transfer = hb_get_color_transfer(title->color_transfer);
            title->color_matrix   = hb_get_color_matrix(title->color_matrix, vid_info.geometry);
        }
        else if ((title->dovi.dv_profile == 5 ||
                 (title->dovi.dv_profile == 10 && title->dovi.dv_bl_signal_compatibility_id == 0)) &&
                 (title->color_prim == HB_COLR_PRI_UNDEF     ||
                  title->color_transfer == HB_COLR_TRA_UNDEF ||
                  title->color_matrix   == HB_COLR_MAT_UNDEF))
        {
            title->color_prim     = HB_COLR_PRI_BT2020;
            title->color_transfer = HB_COLR_TRA_SMPTEST2084;
            title->color_matrix   = HB_COLR_MAT_IPT_C2;
        }
        else
        {
            title->color_prim     = hb_get_color_prim(vid_info.color_prim, vid_info.geometry, vid_info.rate);
            title->color_transfer = hb_get_color_transfer(vid_info.color_transfer);
            title->color_matrix   = hb_get_color_matrix(vid_info.color_matrix, vid_info.geometry);
        }
```

An additional commit also logs all AVFilterGraphs we initialize/parse which may help catch cases where we unnecessarily insert a filter just to do AVCOL_RANGE_UNSPECIFIED -> AVCOL_RANGE_MPEG (which should have no effect besides wasting a touch of CPU time).

This was e.g. the case before the "Make sure every frame is tagged" code was added; where we would insert an AVFilter do convert unspecified color range to TV range even when no crop/scale was otherwise required.

Sample with an unspecified color range coming in next comment.

Thoughts?

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux