### PR TITLE
libhb: avoid recreating the audio ch layout from mixdown each time

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5854,9 +5854,15 @@ hb_audio_t *hb_audio_copy(const hb_audio_t *src)
     {
         audio = calloc(1, sizeof(*audio));
         memcpy(audio, src, sizeof(*audio));
-        AVChannelLayout *ch_layout = calloc(1, sizeof(*ch_layout));
-        av_channel_layout_copy(ch_layout, src->config.in.ch_layout);
-        audio->config.in.ch_layout = ch_layout;
+
+        AVChannelLayout *in_ch_layout = calloc(1, sizeof(*in_ch_layout));
+        av_channel_layout_copy(in_ch_layout, src->config.in.ch_layout);
+        audio->config.in.ch_layout = in_ch_layout;
+
+        AVChannelLayout *out_ch_layout = calloc(1, sizeof(*out_ch_layout));
+        av_channel_layout_copy(out_ch_layout, src->config.in.ch_layout);
+        audio->config.out.ch_layout = out_ch_layout;
+
         if ( src->config.out.name )
         {
             audio->config.out.name = strdup(src->config.out.name);
@@ -5975,6 +5981,8 @@ void hb_audio_config_init(hb_audio_config_t * audiocfg)
     audiocfg->out.dither_method = hb_audio_dither_get_default();
     audiocfg->out.name = NULL;
     audiocfg->out.list_filter = hb_list_init();
+    audiocfg->out.ch_layout = calloc(1, sizeof(*audiocfg->out.ch_layout));
+    av_channel_layout_default(audiocfg->out.ch_layout, 0);
 }
 
 void hb_audio_config_close(hb_audio_config_t *audiocfg)
@@ -5999,6 +6007,11 @@ void hb_audio_config_close(hb_audio_config_t *audiocfg)
         {
             hb_list_rem(audiocfg->out.list_filter, filter);
             hb_filter_close(&filter);
+        }
+        if (audiocfg->out.ch_layout != NULL)
+        {
+            av_channel_layout_uninit(audiocfg->out.ch_layout);
+            free(audiocfg->out.ch_layout);
         }
         hb_list_close(&audiocfg->out.list_filter);
     }
@@ -6031,6 +6044,7 @@ int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg)
 
     /* Really shouldn't ignore the passed out track, but there is currently no
      * way to handle duplicates or out-of-order track numbers. */
+    AVChannelLayout *out_ch_layout = audio->config.out.ch_layout;
     audio->config.out = audiocfg->out;
     audio->config.out.track = hb_list_count(job->list_audio) + 1;
     if (audiocfg->out.name && *audiocfg->out.name)
@@ -6042,6 +6056,8 @@ int hb_audio_add(const hb_job_t * job, const hb_audio_config_t * audiocfg)
     {
         audio->config.out.list_filter = hb_filter_list_copy(audiocfg->out.list_filter);
     }
+
+    audio->config.out.ch_layout = out_ch_layout;
 
     hb_list_add(job->list_audio, audio);
     return 1;

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -68,12 +68,6 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     hb_ff_mixdown_xlat(audio->config.out.mixdown, &matrix_encoding);
 
-    // Templates for layout comparisons
-    AVChannelLayout ch_5point1 = AV_CHANNEL_LAYOUT_5POINT1;
-    AVChannelLayout ch_5point1_back = AV_CHANNEL_LAYOUT_5POINT1_BACK;
-    AVChannelLayout ch_6point1 = AV_CHANNEL_LAYOUT_6POINT1;
-    AVChannelLayout ch_6point1_back = AV_CHANNEL_LAYOUT_6POINT1_BACK;
-
     // default settings and options
     AVDictionary *av_opts          = NULL;
     const char *codec_name         = NULL;
@@ -113,8 +107,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             }
             // FFmpeg's libfdk-aac wrapper expects back channels for 5.1
             // audio, and will error out unless we translate the layout
-            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
-                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
             break;
 
         case HB_ACODEC_FFAAC:
@@ -122,8 +116,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             // Use 5.1 back for AAC because 5.1 side uses a
             // not-so-universally supported feature to signal the
             // non-standard layout
-            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
-                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
             break;
 
         case HB_ACODEC_FFALAC:
@@ -140,10 +134,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                     bits_per_raw_sample = 16;
                     break;
             }
-            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
-                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
-            if (av_channel_layout_compare(&in_ch_layout, &ch_6point1))
-                av_channel_layout_copy(&out_ch_layout, &ch_6point1_back);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1_BACK);
             break;
 
         case HB_ACODEC_FFFLAC:
@@ -191,8 +185,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             codec_name = "libopus";
             // FFmpeg's libopus wrapper expects back channels for 5.1
             // audio, and will error out unless we translate the layout
-            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
-                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
 
             if (out_ch_layout.nb_channels > 2)
                 av_dict_set(&av_opts, "mapping_family", "1", 0);
@@ -298,7 +292,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     int needs_resample = context->sample_fmt != AV_SAMPLE_FMT_FLT;
     int needs_remap    = av_channel_layout_compare(&in_ch_layout, &out_ch_layout) &&
-                         av_channel_layout_compare(&out_ch_layout, &ch_5point1_back);
+                         av_channel_layout_compare(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
 
     // sample_fmt or remap conversion
     if (needs_resample || needs_remap)

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -13,11 +13,9 @@
 
 struct hb_work_private_s
 {
-    hb_job_t       * job;
     AVCodecContext * context;
     AVPacket       * pkt;
 
-    int              out_discrete_channels;
     int              samples_per_frame;
     unsigned long    max_output_bytes;
     unsigned long    input_samples;
@@ -51,7 +49,6 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     hb_work_private_t *pv = calloc(1, sizeof(hb_work_private_t));
     w->private_data       = pv;
-    pv->job               = job;
     pv->list              = hb_list_init();
     pv->last_pts          = AV_NOPTS_VALUE;
     pv->pkt               = av_packet_alloc();
@@ -64,12 +61,18 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     // channel count, layout and matrix encoding
     int matrix_encoding;
-    uint64_t in_channel_layout   = hb_ff_mixdown_xlat(audio->config.out.mixdown,
-                                                      &matrix_encoding);
-    uint64_t out_channel_layout  = hb_ff_mixdown_xlat(audio->config.out.mixdown,
-                                                      &matrix_encoding);
-    pv->out_discrete_channels =
-        hb_mixdown_get_discrete_channel_count(audio->config.out.mixdown);
+    AVChannelLayout in_ch_layout, out_ch_layout;
+
+    av_channel_layout_copy(&in_ch_layout, audio->config.out.ch_layout);
+    av_channel_layout_copy(&out_ch_layout, audio->config.out.ch_layout);
+
+    hb_ff_mixdown_xlat(audio->config.out.mixdown, &matrix_encoding);
+
+    // Templates for layout comparisons
+    AVChannelLayout ch_5point1 = AV_CHANNEL_LAYOUT_5POINT1;
+    AVChannelLayout ch_5point1_back = AV_CHANNEL_LAYOUT_5POINT1_BACK;
+    AVChannelLayout ch_6point1 = AV_CHANNEL_LAYOUT_6POINT1;
+    AVChannelLayout ch_6point1_back = AV_CHANNEL_LAYOUT_6POINT1_BACK;
 
     // default settings and options
     AVDictionary *av_opts          = NULL;
@@ -110,8 +113,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             }
             // FFmpeg's libfdk-aac wrapper expects back channels for 5.1
             // audio, and will error out unless we translate the layout
-            if (in_channel_layout == AV_CH_LAYOUT_5POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
+            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
+                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
             break;
 
         case HB_ACODEC_FFAAC:
@@ -119,8 +122,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             // Use 5.1 back for AAC because 5.1 side uses a
             // not-so-universally supported feature to signal the
             // non-standard layout
-            if (in_channel_layout == AV_CH_LAYOUT_5POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
+            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
+                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
             break;
 
         case HB_ACODEC_FFALAC:
@@ -137,10 +140,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                     bits_per_raw_sample = 16;
                     break;
             }
-            if (in_channel_layout == AV_CH_LAYOUT_5POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
-            if (in_channel_layout == AV_CH_LAYOUT_6POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_6POINT1_BACK;
+            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
+                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
+            if (av_channel_layout_compare(&in_ch_layout, &ch_6point1))
+                av_channel_layout_copy(&out_ch_layout, &ch_6point1_back);
             break;
 
         case HB_ACODEC_FFFLAC:
@@ -188,12 +191,10 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             codec_name = "libopus";
             // FFmpeg's libopus wrapper expects back channels for 5.1
             // audio, and will error out unless we translate the layout
-            if (in_channel_layout == AV_CH_LAYOUT_5POINT1)
-                out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
+            if (av_channel_layout_compare(&in_ch_layout, &ch_5point1))
+                av_channel_layout_copy(&out_ch_layout, &ch_5point1_back);
 
-            AVChannelLayout ch_layout = {0};
-            av_channel_layout_from_mask(&ch_layout, out_channel_layout);
-            if (hb_layout_get_discrete_channel_count(&ch_layout) > 2)
+            if (out_ch_layout.nb_channels > 2)
                 av_dict_set(&av_opts, "mapping_family", "1", 0);
             break;
 
@@ -223,18 +224,12 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
         }
     }
 
-    AVChannelLayout in_ch_layout;
-    AVChannelLayout out_ch_layout;
-
-    av_channel_layout_from_mask(&in_ch_layout, in_channel_layout);
-    av_channel_layout_from_mask(&out_ch_layout, out_channel_layout);
-
     // allocate the context and apply the settings
     context                      = avcodec_alloc_context3(codec);
     hb_ff_set_sample_fmt(context, codec, sample_fmt);
     context->bits_per_raw_sample = bits_per_raw_sample;
     context->profile             = profile;
-    context->ch_layout           = out_ch_layout;
+    av_channel_layout_copy(&context->ch_layout, &out_ch_layout);
     context->sample_rate         = audio->config.out.samplerate;
     context->time_base           = (AVRational){1, 90000};
 
@@ -303,7 +298,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     int needs_resample = context->sample_fmt != AV_SAMPLE_FMT_FLT;
     int needs_remap    = av_channel_layout_compare(&in_ch_layout, &out_ch_layout) &&
-                          out_channel_layout != AV_CH_LAYOUT_5POINT1_BACK;
+                         av_channel_layout_compare(&out_ch_layout, &ch_5point1_back);
 
     // sample_fmt or remap conversion
     if (needs_resample || needs_remap)
@@ -472,7 +467,6 @@ static void get_packets( hb_work_object_t * w, hb_buffer_list_t * list )
 static void Encode(hb_work_object_t *w, hb_buffer_list_t *list)
 {
     hb_work_private_t * pv = w->private_data;
-    hb_audio_t        * audio = w->audio;
     uint64_t            pts, pos;
 
     while (hb_list_bytes(pv->list) >= pv->input_samples * sizeof(float))
@@ -513,8 +507,8 @@ static void Encode(hb_work_object_t *w, hb_buffer_list_t *list)
         }
 
         frame.pts = pts + (90000LL * pos / (sizeof(float) *
-                                          pv->out_discrete_channels *
-                                          audio->config.out.samplerate));
+                                            pv->context->ch_layout.nb_channels *
+                                            pv->context->sample_rate));
 
         frame.pts = av_rescale_q(frame.pts, (AVRational){1, 90000},
                                  pv->context->time_base);

--- a/libhb/encvorbis.c
+++ b/libhb/encvorbis.c
@@ -32,7 +32,6 @@ hb_work_object_t hb_encvorbis =
 struct hb_work_private_s
 {
     float     *buf;
-    hb_job_t  *job;
     hb_list_t *list;
 
     vorbis_dsp_state vd;
@@ -58,14 +57,12 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
     }
     hb_audio_t *audio = w->audio;
     w->private_data = pv;
-    pv->job = job;
 
     hb_log("encvorbis: opening libvorbis");
 
     vorbis_info_init(&pv->vi);
 
-    pv->out_discrete_channels =
-        hb_mixdown_get_discrete_channel_count(audio->config.out.mixdown);
+    pv->out_discrete_channels = audio->config.out.ch_layout->nb_channels;
 
     if (audio->config.out.bitrate > 0)
     {
@@ -133,16 +130,14 @@ int encvorbisInit(hb_work_object_t *w, hb_job_t *job)
     pv->list = hb_list_init();
 
     // channel remapping
-    AVChannelLayout out_layout, mixdown_layout;
-    hb_ff_mixdown_ch_xlat(&mixdown_layout, audio->config.out.mixdown, NULL);
-    hb_audio_remap_map_channel_layout(&hb_vorbis_chan_map, &out_layout, &mixdown_layout);
+    AVChannelLayout out_layout;
+    hb_audio_remap_map_channel_layout(&hb_vorbis_chan_map, &out_layout, audio->config.out.ch_layout);
 
     hb_audio_remap_build_table(&out_layout,
-                               &mixdown_layout,
+                               audio->config.out.ch_layout,
                                pv->remap_table);
 
     av_channel_layout_uninit(&out_layout);
-    av_channel_layout_uninit(&mixdown_layout);
 
     return 0;
 }

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -1134,6 +1134,7 @@ struct hb_audio_config_s
         int      dither_method; /* dither algorithm */
         const char * name; /* Output track name */
         hb_list_t  * list_filter; /* List of hb_filter_object_t */
+        PRIVATE hb_channel_layout_t *ch_layout; /* Output channel layout, set by the audio filter chain */
     } out;
 
     /* Input */

--- a/libhb/handbrake/hbffmpeg.h
+++ b/libhb/handbrake/hbffmpeg.h
@@ -36,7 +36,6 @@ const char* const* hb_av_preset_get_names(int encoder);
 const char* const* hb_av_tune_get_names(int encoder);
 
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode);
-int      hb_ff_mixdown_ch_xlat(AVChannelLayout *channel_layout, int hb_mixdown, int *downmix_mode);
 void     hb_ff_set_sample_fmt(AVCodecContext *, const AVCodec *, enum AVSampleFormat);
 
 int hb_sws_get_colorspace(int color_matrix);

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -739,12 +739,6 @@ hb_stereo_3d_t hb_stereo_3d_ff_to_hb(AVStereo3D stereo_3d)
     return hb_stereo_3d;
 }
 
-int hb_ff_mixdown_ch_xlat(AVChannelLayout *channel_layout, int hb_mixdown, int *downmix_mode)
-{
-    uint64_t layout = hb_ff_mixdown_xlat(hb_mixdown, downmix_mode);
-    return av_channel_layout_from_mask(channel_layout, layout);
-}
-
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
     uint64_t ff_layout = 0;

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -867,16 +867,7 @@ static int avformatInit( hb_mux_object_t * m )
             av_dict_set(&track->st->metadata, "language", lang, 0);
         }
         track->st->codecpar->sample_rate = audio->config.out.samplerate;
-        if (audio->config.out.codec & HB_ACODEC_PASS_FLAG)
-        {
-            av_channel_layout_copy(&track->st->codecpar->ch_layout, audio->config.in.ch_layout);
-        }
-        else
-        {
-            AVChannelLayout ch_layout = {0};
-            av_channel_layout_from_mask(&ch_layout, hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL));
-            track->st->codecpar->ch_layout = ch_layout;
-        }
+        av_channel_layout_copy(&track->st->codecpar->ch_layout, audio->config.out.ch_layout);
 
         // Set audio track title
         const char *name = audio->config.out.name;

--- a/libhb/platform/macosx/encca_aac.c
+++ b/libhb/platform/macosx/encca_aac.c
@@ -44,7 +44,6 @@ hb_work_object_t hb_encca_haac =
 struct hb_work_private_s
 {
     uint8_t *buf;
-    hb_job_t *job;
     hb_list_t *list;
 
     AudioConverterRef converter;
@@ -188,12 +187,10 @@ int encCoreAudioInit(hb_work_object_t *w, hb_job_t *job, enum AAC_MODE mode)
     OSStatus err;
 
     w->private_data = pv;
-    pv->job = job;
     pv->first_pts = AV_NOPTS_VALUE;
 
     // pass the number of channels used into the private work data
-    pv->nchannels =
-        hb_mixdown_get_discrete_channel_count(audio->config.out.mixdown);
+    pv->nchannels = audio->config.out.ch_layout->nb_channels;
 
     bzero(&input, sizeof(AudioStreamBasicDescription));
     input.mSampleRate = (Float64)audio->config.out.samplerate;
@@ -334,18 +331,17 @@ int encCoreAudioInit(hb_work_object_t *w, hb_job_t *job, enum AAC_MODE mode)
     audio->config.out.samples_per_frame = pv->isamples;
 
     // channel remapping
-    AVChannelLayout out_layout, mixdown_layout;
-    hb_ff_mixdown_ch_xlat(&mixdown_layout, audio->config.out.mixdown, NULL);
-    hb_audio_remap_map_channel_layout(&hb_aac_chan_map, &out_layout, &mixdown_layout);
+    AVChannelLayout out_layout;
+    hb_audio_remap_map_channel_layout(&hb_aac_chan_map, &out_layout, audio->config.out.ch_layout);
 
     pv->remap = hb_audio_remap_init(AV_SAMPLE_FMT_FLT,
                                     &out_layout,
-                                    &mixdown_layout);
+                                    audio->config.out.ch_layout);
 
     AudioChannelLayout channel_layout;
     bzero(&channel_layout, sizeof(channel_layout));
 
-    channel_layout.mChannelLayoutTag = get_aac_tag(&mixdown_layout);
+    channel_layout.mChannelLayoutTag = get_aac_tag(audio->config.out.ch_layout);
 
     if (channel_layout.mChannelLayoutTag != 0)
     {
@@ -360,7 +356,6 @@ int encCoreAudioInit(hb_work_object_t *w, hb_job_t *job, enum AAC_MODE mode)
     }
 
     av_channel_layout_uninit(&out_layout);
-    av_channel_layout_uninit(&mixdown_layout);
 
     if (pv->remap == NULL)
     {

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -2027,7 +2027,7 @@ static void do_job(hb_job_t *job)
 
             init.samplerate = audio->config.out.samplerate;
             init.sample_fmt = AV_SAMPLE_FMT_FLT;
-            av_channel_layout_copy(&init.ch_layout, audio->config.in.ch_layout);
+            av_channel_layout_copy(&init.ch_layout, audio->config.out.ch_layout);
 
             // Audio Filter Chain
             if (hb_list_count(list_filter))

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -1209,6 +1209,8 @@ static int sanitize_audio(hb_job_t *job)
             audio->config.out.samples_per_frame =
                                     audio->config.in.samples_per_frame;
             audio->config.out.samplerate = audio->config.in.samplerate;
+
+            av_channel_layout_copy(audio->config.out.ch_layout, audio->config.in.ch_layout);
             continue;
         }
 
@@ -1256,6 +1258,8 @@ static int sanitize_audio(hb_job_t *job)
                 audio->config.out.mixdown = best_mixdown;
             }
         }
+
+        av_channel_layout_from_mask(audio->config.out.ch_layout, hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL));
 
         /* sense-check the requested compression level */
         if (audio->config.out.compression_level < 0)
@@ -2016,18 +2020,18 @@ static void do_job(hb_job_t *job)
         for( i = 0; i < hb_list_count( job->list_audio ); i++ )
         {
             hb_audio_t *audio = hb_list_item( job->list_audio, i );
+            hb_list_t *list_filter = audio->config.out.list_filter;
+
+            hb_filter_init_t init;
+            memset(&init, 0, sizeof(init));
+
+            init.samplerate = audio->config.out.samplerate;
+            init.sample_fmt = AV_SAMPLE_FMT_FLT;
+            av_channel_layout_copy(&init.ch_layout, audio->config.in.ch_layout);
 
             // Audio Filter Chain
-            hb_list_t *list_filter = audio->config.out.list_filter;
             if (hb_list_count(list_filter))
             {
-                hb_filter_init_t init;
-                memset(&init, 0, sizeof(init));
-
-                init.samplerate = audio->config.out.samplerate;
-                init.sample_fmt = AV_SAMPLE_FMT_FLT;
-                av_channel_layout_from_mask(&init.ch_layout, hb_ff_mixdown_xlat(audio->config.out.mixdown, NULL));
-
                 for (int j = 0; j < hb_list_count(list_filter);)
                 {
                     hb_filter_object_t *filter = hb_list_item(list_filter, j);
@@ -2042,7 +2046,12 @@ static void do_job(hb_job_t *job)
                     }
                     j++;
                 }
+            }
 
+            av_channel_layout_copy(audio->config.out.ch_layout, &init.ch_layout);
+
+            if (hb_list_count(list_filter))
+            {
                 // Combine HB_AUDIO_FILTER_AVFILTERs that are sequential
                 hb_avfilter_audio_combine(list_filter);
 
@@ -2060,11 +2069,8 @@ static void do_job(hb_job_t *job)
                     }
                     j++;
                 }
-            }
 
-            // Set up the audio filter fifo pipeline
-            if (hb_list_count(list_filter))
-            {
+                // Set up the audio filter fifo pipeline
                 hb_fifo_t *fifo_in = audio->priv.fifo_sync;
                 for (int j = 0; j < hb_list_count(list_filter); j++)
                 {

--- a/libhb/work.c
+++ b/libhb/work.c
@@ -2049,6 +2049,7 @@ static void do_job(hb_job_t *job)
             }
 
             av_channel_layout_copy(audio->config.out.ch_layout, &init.ch_layout);
+            av_channel_layout_uninit(&init.ch_layout);
 
             if (hb_list_count(list_filter))
             {


### PR DESCRIPTION
I am not too happy about storing the channel layout in hb_audio_config_s out, but it's only the only place at the moment.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux