### PR TITLE
libhb: allow downmixing 5.1(side) to quad

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2804,9 +2804,10 @@ int hb_mixdown_has_remix_support(int mixdown, hb_channel_layout_t *ch_layout)
         case HB_AMIXDOWN_4POINT0:
                 return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_4POINT0) == AV_CH_LAYOUT_4POINT0);
 
-        // stereo + back stereo
+        // stereo + side or back stereo
         case HB_AMIXDOWN_QUAD:
-                return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD);
+                return (av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_2_2) == AV_CH_LAYOUT_2_2 ||
+                        av_channel_layout_subset(ch_layout, AV_CH_LAYOUT_QUAD) == AV_CH_LAYOUT_QUAD);
 
         // stereo + front center
         case HB_AMIXDOWN_3POINT0:


### PR DESCRIPTION
**Description of Change:**

Also allow remixing of quad(side) to quad

Incidentally, because lavc:
- encodes quadraphonic AC-3 to AC3_CHMODE_2F2R (acmod == '110')
regardless of whether input is quad or quad(side)
(because there's only one AC-3 channel mode for quadraphonic)

- and decodes AC3_CHMODE_2F2R to AV_CH_LAYOUT_2_2
i.e. quad(side)

…this allows HandBrake to re-encode its own output without having to downmix.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux