### PR TITLE
libhb: always downmix from back to side channels

### DIFF
--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -118,6 +118,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             // non-standard layout
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_2_2) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_QUAD);
             break;
 
         case HB_ACODEC_FFALAC:
@@ -138,6 +140,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1) == 0)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1_BACK);
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_7POINT1_WIDE) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_7POINT1_WIDE_BACK);
             break;
 
         case HB_ACODEC_FFFLAC:
@@ -187,7 +191,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
             // audio, and will error out unless we translate the layout
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
-
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_2_2) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_QUAD);
             if (out_ch_layout.nb_channels > 2)
                 av_dict_set(&av_opts, "mapping_family", "1", 0);
             break;
@@ -292,6 +297,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
 
     int needs_resample = context->sample_fmt != AV_SAMPLE_FMT_FLT;
     int needs_remap    = av_channel_layout_compare(&in_ch_layout, &out_ch_layout) &&
+                         av_channel_layout_compare(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_QUAD) &&
                          av_channel_layout_compare(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
 
     // sample_fmt or remap conversion
@@ -316,7 +322,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                        context->sample_rate, 0);
         av_opt_set_int(pv->swresample, "out_sample_rate",
                        context->sample_rate, 0);
-        if (hb_audio_dither_is_supported(audio->config.out.codec,
+        if (needs_resample && // not required for remap-only
+            hb_audio_dither_is_supported(audio->config.out.codec,
                                          audio->config.in.sample_bit_depth))
         {
             // dithering needs the sample rate

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -741,6 +741,16 @@ hb_stereo_3d_t hb_stereo_3d_ff_to_hb(AVStereo3D stereo_3d)
 
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
+    /*
+     * When choosing a target layout with either side or back channels,
+     * always pick the variant with side channels for downmix purposes.
+     *
+     * For some encoders, we may need to remap the layout to the back variant
+     * before sending samples to the encoder, but doing it earlier (e.g. here)
+     * could result in a sub-optimal downmix (where regular surround channels
+     * are attenuated and then mixed into the rear surround channels, instead
+     * of the reverse).
+     */
     uint64_t ff_layout = 0;
     int mode = AV_MATRIX_ENCODING_NONE;
     switch (hb_mixdown)
@@ -778,7 +788,7 @@ uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
             break;
 
         case HB_AMIXDOWN_QUAD:
-            ff_layout = AV_CH_LAYOUT_QUAD;
+            ff_layout = AV_CH_LAYOUT_2_2;
             break;
 
         case HB_AMIXDOWN_5POINT1:
@@ -794,7 +804,7 @@ uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
             break;
 
         case HB_AMIXDOWN_7POINT1_SDDS:
-            ff_layout = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
+            ff_layout = AV_CH_LAYOUT_7POINT1_WIDE;
             break;
 
         default:

--- a/libhb/platform/macosx/encca_aac.c
+++ b/libhb/platform/macosx/encca_aac.c
@@ -132,7 +132,7 @@ aac_channel_layout_map[] =
 {
     { AV_CHANNEL_LAYOUT_MONO,              kAudioChannelLayoutTag_Mono },
     { AV_CHANNEL_LAYOUT_STEREO,            kAudioChannelLayoutTag_Stereo },
-    { AV_CHANNEL_LAYOUT_QUAD,              kAudioChannelLayoutTag_AAC_Quadraphonic },
+    { AV_CHANNEL_LAYOUT_2_2,               kAudioChannelLayoutTag_AAC_Quadraphonic },
     { AV_CHANNEL_LAYOUT_OCTAGONAL,         kAudioChannelLayoutTag_AAC_Octagonal },
     { AV_CHANNEL_LAYOUT_SURROUND,          kAudioChannelLayoutTag_AAC_3_0 },
     { AV_CHANNEL_LAYOUT_4POINT0,           kAudioChannelLayoutTag_AAC_4_0 },
@@ -141,7 +141,7 @@ aac_channel_layout_map[] =
     { AV_CHANNEL_LAYOUT_6POINT0,           kAudioChannelLayoutTag_AAC_6_0 },
     { AV_CHANNEL_LAYOUT_6POINT1,           kAudioChannelLayoutTag_AAC_6_1 },
     { AV_CHANNEL_LAYOUT_7POINT0,           kAudioChannelLayoutTag_AAC_7_0 },
-    { AV_CHANNEL_LAYOUT_7POINT1_WIDE_BACK, kAudioChannelLayoutTag_AAC_7_1 },
+    { AV_CHANNEL_LAYOUT_7POINT1_WIDE,      kAudioChannelLayoutTag_AAC_7_1 },
     { AV_CHANNEL_LAYOUT_7POINT1,           kAudioChannelLayoutTag_AAC_7_1_B },
 };
 static int aac_channel_layout_map_count = sizeof(aac_channel_layout_map) / sizeof(aac_channel_layout_map[0]);


### PR DESCRIPTION
When downmixing from layouts with both side and back channels ("regular" 7.1) to layouts with only side or only back channels, swresample will use a different mix matrix depending if the target layout has side channels vs. back channels.

Basically, the channels that already exist in both input and output layout will be copied from input to output, whereas the channels being dropped will be attenuated by 3 dB and then mixed into the channels which remain in the output.

7.1 to 5.1(side)
7.1 to 5.1(back)
side resp. back channels are "copied" to the output:
```C
    for(i=0; i<FF_ARRAY_ELEMS(matrix); i++){
        if(   av_channel_layout_index_from_channel(in_ch_layout, i) >= 0
           && av_channel_layout_index_from_channel(out_ch_layout, i) >= 0)
            matrix[i][i]= 1.0;
    }
```
7.1 to 5.1(side)
input's back channels are attenuated and added to the output's side channels:
```C
    if(unaccounted & AV_CH_BACK_LEFT){
        if (av_channel_layout_index_from_channel(out_ch_layout, AV_CHAN_BACK_CENTER) >= 0) {
            matrix[BACK_CENTER][ BACK_LEFT]+= M_SQRT1_2;
            matrix[BACK_CENTER][BACK_RIGHT]+= M_SQRT1_2;
        } else if (av_channel_layout_index_from_channel(out_ch_layout, AV_CHAN_SIDE_LEFT) >= 0) {
            if (av_channel_layout_index_from_channel(in_ch_layout, AV_CHAN_SIDE_LEFT) >= 0) {
                matrix[ SIDE_LEFT][ BACK_LEFT]+= M_SQRT1_2;
                matrix[SIDE_RIGHT][BACK_RIGHT]+= M_SQRT1_2;
```
7.1 to 5.1(back)
input's side channels are attenuated and added to the output's back channels:
```C
if(unaccounted & AV_CH_SIDE_LEFT){
        if (av_channel_layout_index_from_channel(out_ch_layout, AV_CHAN_BACK_LEFT) >= 0) {
            /* if back channels do not exist in the input, just copy side
               channels to back channels, otherwise mix side into back */
            if (av_channel_layout_index_from_channel(in_ch_layout, AV_CHAN_BACK_LEFT) >= 0) {
                matrix[BACK_LEFT ][SIDE_LEFT ] += M_SQRT1_2;//side into back with attenuation
                matrix[BACK_RIGHT][SIDE_RIGHT] += M_SQRT1_2;//side into back with attenuation
```

Regular 7.1 is L R C LFE Rls Rrs Ls Rs (in libavutil order), where:
- Ls and Rs ("regular" surrounds) are assigned to the side channels
- Rls and Rrs ("rear" surrounds) are assigned to the back channels

For a "typical" downmix, you would want the "additional" channels (rear surrounds, Rls and Rrs) to be attenuated and mixed into Ls and Rs, rather than the reverse.

Rather than building our own downmix matrices, it seems easier to make sure that the target layout has side channels rather than back channels and let swresample build the suitable matrix for us.

This means that for some encoders (who either require the "back" layouts altogether or behave differently when given a "side" layout), we will need to override the layout directly in encavcodecaudio.c (and remap if necessary, e.g. AV_CH_LAYOUT_7POINT1_WIDE vs. AV_CH_LAYOUT_7POINT1_WIDE_BACK).

Before I realized the downmix matrices would be different, I wanted to try and move remapping out of encavcodecaudio, building a "smarter" hb_ff_mixdown_xlat that would accept the encoder and automatically set the final channel layout, but because of this, I have to rethink it. I still think it might be nice to do everything in a single swresample "session", but that means we need some sort of resample "context" with the initial output channel layout, the final output channel layout, and an optional remap table (for encca_aac and vorbis).

**Tested on:**
- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Testing "kit":**
https://gist.github.com/twalker314/b45b75ad49c963d5581945af437ef504
- run.zsh
run once before the patch
- chk.zsh to make sure:
libhb returned with success
ffprobe sees the correct channel layout in the output
- dmx.zsh to a before folder
- run.zsh
run again after the patch
- chk.zsh to make sure:
libhb returned with success
ffprobe sees the correct channel layout in the output (see output changes below)
- dmx.zsh to an after folder
opus and vorbis seem non-deterministic somehow
other formats except flac and pcm should have the same output before and after patch
flac and pcm converted to raw PCM should have the same output for quad
but not for 7.1(sdds) as the channel order has changed

**Input samples:**
[hb-mixes.dmg.zip](https://github.com/user-attachments/files/27608986/hb-mixes.dmg.zip)
- only need to mount the DMG above, or you can get just the two individual sample files below (need both)

[hb-amixdown---------quad.mkv.zip](https://github.com/user-attachments/files/27608993/hb-amixdown---------quad.mkv.zip)
[hb-amixdown-7point1_sdds.mkv.zip](https://github.com/user-attachments/files/27608995/hb-amixdown-7point1_sdds.mkv.zip)

**Outpout changes:**
For encoders where the channel layout is indicated via a bitwise channel mask (FLAC, PCM in MOV):
- quad now becomes quad(side)
channel order and thus decoded output to raw PCM should remain the same
- 7.1(wide) now becomes 7.1(wide-side)
channel order changes, and so does decoded output to raw PCM