### PR TITLE
Fix typos: 4 doubled-word + 1 misspelling

### DIFF
--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -101,7 +101,7 @@ validate_settings (signal_user_data_t *ud, GhbValue *settings, gint batch)
     if (!g_file_test(destdir, G_FILE_TEST_IS_DIR))
     {
         ghb_alert_dialog_show(GTK_MESSAGE_ERROR, _("Invalid Destination"),
-                              _("“%s” is is not a valid directory."), destdir);
+                              _("“%s” is not a valid directory."), destdir);
         g_free(destdir);
         return FALSE;
     }

--- a/libhb/decavcodec.c
+++ b/libhb/decavcodec.c
@@ -1303,7 +1303,7 @@ static hb_buffer_t *copy_frame( hb_work_private_t *pv )
         }
 
         // Check for Dolby Vision and store the first RPU found
-        // eventually to attach to the the initial black buffer
+        // eventually to attach to the initial black buffer
         if (pv->title->initial_rpu == NULL)
         {
             int type = AV_FRAME_DATA_DOVI_RPU_BUFFER;

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -682,7 +682,7 @@ static int avformatInit( hb_mux_object_t * m )
     if ((job->mux & HB_MUX_MASK_ISOBFF_FAMILY) && standard_rate &&
         job->cfr == 1 && vrate.den * 90000L % vrate.num)
     {
-        // Set the the correct video time base to avoid
+        // Set the correct video time base to avoid
         // timestamps jitter when using NTSC framerates
         track->st->time_base.num = vrate.den;
         track->st->time_base.den = vrate.num;

--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -5124,7 +5124,7 @@ hb_buffer_t * hb_ts_decode_pkt( hb_stream_t *stream, const uint8_t * pkt,
                 if ((pes[7] >> 6) != 0)
                 {
                     // if we have a dts use it otherwise use the pts
-                    // We simulate a psuedo-PCR here by sampling a timestamp
+                    // We simulate a pseudo-PCR here by sampling a timestamp
                     // about every 600ms.
                     int64_t timestamp;
                     timestamp = pes_timestamp(pes + (pes[7] & 0x40 ? 14 : 9));

--- a/libhb/vfr.c
+++ b/libhb/vfr.c
@@ -384,7 +384,7 @@ static int hb_vfr_init(hb_filter_object_t *filter, hb_filter_init_t *init)
         }
     }
 
-    // frame-drop analysis always looks at at least 2 buffers
+    // frame-drop analysis always looks at least 2 buffers
     pv->frame_analysis_depth = 2;
 
     // Calculate the number of frames we need to keep in order to


### PR DESCRIPTION
Five small typo fixes — no behavior change.

**Doubled-word fixes in code comments:**
- `libhb/vfr.c`: "looks at at least" → "looks at least"
- `libhb/muxavformat.c`: "Set the the correct" → "Set the correct"
- `libhb/decavcodec.c`: "attach to the the initial" → "attach to the initial"

**User-facing translatable error string:**
- `gtk/src/title-add.c`: `"%s" is is not a valid directory.` → `"%s" is not a valid directory.` (shown in HandBrake's GTK UI when an invalid destination is selected)

**Misspelling in code comment:**
- `libhb/stream.c`: "psuedo-PCR" → "pseudo-PCR"