### PR TITLE
libhb: update hb_audio_dither_is_supported

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2532,14 +2532,30 @@ int hb_audio_dither_get_default_method()
     return SWR_DITHER_TRIANGULAR;
 }
 
-int hb_audio_dither_is_supported(uint32_t codec, int depth)
+int hb_audio_dither_is_supported(uint32_t codec, int source_depth)
 {
-    // Since dithering is performed by swresample, all codecs are supported
+    /*
+     * Enable/allow for encoder(s) taking 16-bit integers as input,
+     * but only in cases where the source is > 16-bit (or unknown).
+     *
+     * Lossy encoders are not exempt, as the rounding/truncation errors
+     * which dithering is meant to rectify happen while downsampling to
+     * 16bit; whether the encoder uses a higher/variable internal depth
+     * does not eliminate the need to dither following the >16 to 16bit
+     * conversion performed to create the input samples to said encoder.
+     */
     switch (codec)
     {
+        case HB_ACODEC_FDK_AAC:
+        case HB_ACODEC_FDK_HAAC:
+        case HB_ACODEC_FFALAC:
         case HB_ACODEC_FFFLAC:
-            if (depth == 0 || depth > 16)
+        case HB_ACODEC_FFPCM16:
+            if (source_depth == 0 || source_depth > 16)
                 return 1;
+        // fall through
+        default:
+            break;
     }
     return 0;
 }

--- a/libhb/handbrake/common.h
+++ b/libhb/handbrake/common.h
@@ -568,7 +568,7 @@ float hb_audio_compression_get_default(uint32_t codec);
 
 int                hb_audio_dither_get_default(void);
 int                hb_audio_dither_get_default_method(void); // default method, if enabled && supported
-int                hb_audio_dither_is_supported(uint32_t codec, int depth);
+int                hb_audio_dither_is_supported(uint32_t codec, int source_depth);
 int                hb_audio_dither_get_from_name(const char *name);
 const char*        hb_audio_dither_get_description(int method);
 const hb_dither_t* hb_audio_dither_get_next(const hb_dither_t *last);


### PR DESCRIPTION
**Description of Change:**

Two new 16-bit encoders were added since it was last updated (16-bit ALAC, 16-bit PCM).

Also, as far as I can understand, the possible audio artifacts for which dithering is required/recommended are a direct result of the conversion of audio samples from >16 to 16-bit; so for any encoder which takes s16 samples as input, the artifacts will exist in the samples fed to the encoder, and whatever processing the encoder then does won't remove them. Thus I enable dithering for FDK-AAC as well (as was already the case _before_ https://github.com/HandBrake/HandBrake/commit/d444faf), and added a comment so this is not forgotten like it was in https://github.com/HandBrake/HandBrake/commit/d3ea0cb.

Also renamed a variable name to make its purpose a little clearer, used _source_ rather than _input_ as the latter could be mistaken as the encoder's input bit depth (rather than the decoder's output bit depth from the source audio).

In theory, we should maybe allow users to manually-enable dithering anyway:
- removing hb_audio_dither_is_supported() 
- introducing hb_audio_dither_should_enable(uint32_t codec, int source_depth, int dither_method)

Where the latter enables dither based on encoder and source depth when dither_method is (SWR_DITHER_NONE - 1) a.k.a. "auto" but unconditionally when a specific method is specified (i.e. by the user).

But that's a behavior change that would also require documentation updates, CLI help changes etc. rather than a simple bugfix.

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux
