### PR TITLE
CLI: miscellaneous help fixes.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2671,6 +2671,10 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
     if (mixdown == HB_AMIXDOWN_NONE)
         return 0;
 
+    // Not an actual audio encoder
+    if (codec == HB_ACODEC_NONE)
+        return 0;
+
     /*
      * for clarity: explicitly list/test every mixdown above 2 channels
      *              list all encoders separately in alphabetical order

--- a/test/test.c
+++ b/test/test.c
@@ -1570,7 +1570,7 @@ static void ShowHelp(void)
 "                           tracks, default: first one).\n"
 "                           Multiple output tracks can be used for one input.\n"
 "   -E, --aencoder <string> Select audio encoder(s):\n" );
-    encoder = NULL;
+    encoder = hb_audio_encoder_get_next(NULL); // skip HB_ACODEC_NONE
     while ((encoder = hb_audio_encoder_get_next(encoder)) != NULL)
     {
         fprintf(out, "                               %s\n", encoder->short_name);
@@ -1585,7 +1585,7 @@ static void ShowHelp(void)
 "                           \"copy\" audio encoder option is specified\n"
 "                           (" );
     i       = 0;
-    encoder = NULL;
+    encoder = hb_audio_encoder_get_next(NULL); // skip HB_ACODEC_NONE
     while ((encoder = hb_audio_encoder_get_next(encoder)) != NULL)
     {
         if ((encoder->codec &  HB_ACODEC_PASS_FLAG) &&
@@ -1667,7 +1667,7 @@ static void ShowHelp(void)
     fprintf(out,
 "                           Separate tracks by commas.\n"
 "                           Supported by encoder(s):\n");
-    encoder = NULL;
+    encoder = hb_audio_encoder_get_next(NULL); // skip HB_ACODEC_NONE
     while ((encoder = hb_audio_encoder_get_next(encoder)) != NULL)
     {
         if (hb_audio_dither_is_supported(encoder->codec, 0))

--- a/test/test.c
+++ b/test/test.c
@@ -1580,16 +1580,6 @@ static void ShowHelp(void)
 "                           corresponding audio track without modification\n"
 "                           if passthru is supported for the audio type.\n"
 "                           Separate tracks by commas.\n"
-"                           Defaults:\n");
-    container = NULL;
-    while ((container = hb_container_get_next(container)) != NULL)
-    {
-        int audio_encoder = hb_audio_encoder_get_default(container->format);
-        fprintf(out, "                               %-8s %s\n",
-                container->short_name,
-                hb_audio_encoder_get_short_name(audio_encoder));
-    }
-    fprintf(out,
 "       --audio-copy-mask <string>\n"
 "                           Set audio codecs that are permitted when the\n"
 "                           \"copy\" audio encoder option is specified\n"
@@ -1634,20 +1624,6 @@ static void ShowHelp(void)
     }
     fprintf(out,
 "                           Separate tracks by commas.\n"
-"                           Defaults:\n");
-    encoder = NULL;
-    while((encoder = hb_audio_encoder_get_next(encoder)) != NULL)
-    {
-        if (!(encoder->codec & HB_ACODEC_PASS_FLAG))
-        {
-            // layout: 7.1 should work with all supported mixdowns
-            int mixdown = hb_mixdown_get_default_s(encoder->codec, "7.1");
-            // assumes that the encoder short name is <= 16 characters long
-            fprintf(out, "                               %-16s up to %s\n",
-                    encoder->short_name, hb_mixdown_get_short_name(mixdown));
-        }
-    }
-    fprintf(out,
 "       --normalize-mix     Normalize audio mix levels to prevent clipping.\n"
 "              <string>     Separate tracks by commas.\n"
 "                           0 = Disable Normalization (default)\n"


### PR DESCRIPTION
**Description of Change:**

Mostly self-explanatory as per the commit messages.

In the olden days (< 1.0.x), when no audio encoder (resp. audio mixdown, also audio bitrate) was passed to HandBrakeCLI, said CLI would leave the job fields set to their default (invalid) value, and rely on libhb to sanitize them to a valid one using hb_get_default_audio_encoder (later hb_audio_encoder_get_default), hb_mixdown_get_default and hb_audio_bitrate_get_default.

When the CLI became ~self-aware~ preset-aware, every such job field came set to a valid value from the start, and the aforementioned sanitizing/fallback to a global default value no longer happens.

hb_audio_encoder_get_default() is still used in cases where the container gets changed and the preset's audio encoder(s) is/are not compatible with the new container, but that's really a different mechanism which IMO does not need to be explicitly documented in --help

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

**Log file output (If relevant):**

https://gist.github.com/twalker314/e90f532c229a5aa0b4dd537404e7fcdb