### PR TITLE
1.11.x: backport/adapt e168fea9bd11ad3310aea91b59cbab2937cf24f6 (#7870)

### DIFF
--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -141,7 +141,7 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                 out_channel_layout  = AV_CH_LAYOUT_5POINT1_BACK;
             if (in_channel_layout == AV_CH_LAYOUT_6POINT1)
                 out_channel_layout  = AV_CH_LAYOUT_6POINT1_BACK;
-            if (in_channel_layout == AV_CH_LAYOUT_7POINT1)
+            if (in_channel_layout == AV_CH_LAYOUT_7POINT1_WIDE)
                 out_channel_layout  = AV_CH_LAYOUT_7POINT1_WIDE_BACK;
             break;
 
@@ -329,7 +329,8 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                        context->sample_rate, 0);
         av_opt_set_int(pv->swresample, "out_sample_rate",
                        context->sample_rate, 0);
-        if (hb_audio_dither_is_supported(audio->config.out.codec,
+        if (needs_resample && // not required for remap-only
+            hb_audio_dither_is_supported(audio->config.out.codec,
                                          audio->config.in.sample_bit_depth))
         {
             // dithering needs the sample rate

--- a/libhb/hbffmpeg.c
+++ b/libhb/hbffmpeg.c
@@ -679,6 +679,16 @@ int hb_ff_mixdown_ch_xlat(AVChannelLayout *channel_layout, int hb_mixdown, int *
 
 uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
 {
+    /*
+     * When choosing a target layout with either side or back channels,
+     * always pick the variant with side channels for downmix purposes.
+     *
+     * For some encoders, we may need to remap the layout to the back variant
+     * before sending samples to the encoder, but doing it earlier (e.g. here)
+     * could result in a sub-optimal downmix (where regular surround channels
+     * are attenuated and then mixed into the rear surround channels, instead
+     * of the reverse).
+     */
     uint64_t ff_layout = 0;
     int mode = AV_MATRIX_ENCODING_NONE;
     switch (hb_mixdown)
@@ -720,9 +730,7 @@ uint64_t hb_ff_mixdown_xlat(int hb_mixdown, int *downmix_mode)
             break;
 
         case HB_AMIXDOWN_5_2_LFE:
-            ff_layout = (AV_CH_LAYOUT_5POINT1_BACK|
-                         AV_CH_FRONT_LEFT_OF_CENTER|
-                         AV_CH_FRONT_RIGHT_OF_CENTER);
+            ff_layout = AV_CH_LAYOUT_7POINT1_WIDE;
             break;
 
         default:

--- a/libhb/platform/macosx/encca_aac.c
+++ b/libhb/platform/macosx/encca_aac.c
@@ -142,7 +142,7 @@ aac_channel_layout_map[] =
     { AV_CHANNEL_LAYOUT_6POINT0,           kAudioChannelLayoutTag_AAC_6_0 },
     { AV_CHANNEL_LAYOUT_6POINT1,           kAudioChannelLayoutTag_AAC_6_1 },
     { AV_CHANNEL_LAYOUT_7POINT0,           kAudioChannelLayoutTag_AAC_7_0 },
-    { AV_CHANNEL_LAYOUT_7POINT1_WIDE_BACK, kAudioChannelLayoutTag_AAC_7_1 },
+    { AV_CHANNEL_LAYOUT_7POINT1_WIDE,      kAudioChannelLayoutTag_AAC_7_1 },
     { AV_CHANNEL_LAYOUT_7POINT1,           kAudioChannelLayoutTag_AAC_7_1_B },
 };
 static int aac_channel_layout_map_count = sizeof(aac_channel_layout_map) / sizeof(aac_channel_layout_map[0]);


### PR DESCRIPTION
**Description of Change:**

See #7870

This:

- explicitly disables dithering when we are not converting sample_fmt to something other than float
before, audio->config.out.codec would end up disabling dithering anyway in case of remap-only
(codecs that don't need sample_fmt conversion return 0 in hb_audio_dither_is_supported)
but at least it's more obvious now

- uses AV_CHANNEL_LAYOUT_7POINT1_WIDE instead
of AV_CHANNEL_LAYOUT_7POINT1_WIDE_BACK for 7.1 SDDS == 5F/2R/LFE

- map WIDE to WIDE_BACK in encavcodecaudio for ALAC 7.1 SDDS
other libavcodec-based encoders including fdk-aac and av-aac have 7.1 SDDS disabled as
per the results of testing made for #7805

- encca_aac has its own automatic building of remap tables based on the AV_CHANNEL_LAYOUT

As with #7870, for PCM and FLAC encoders, output layout and mask changes from 7.1(wide) to 7.1(wide-side)

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux