### PR TITLE
LinuxGui: fixed issue where changing range values wouldnt update duration in summary section

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -3352,7 +3352,6 @@ set_has_chapter_markers (gboolean markers, signal_user_data_t *ud)
         ghb_set_destination(ud);
     GtkWidget *widget = ghb_builder_widget("ChapterMarkers");
     gtk_widget_set_sensitive(widget, markers);
-    update_title_duration(ud);
 
     markers &= ghb_dict_get_int(ud->settings, "ChapterMarkers");
     ghb_dict_set_bool(dest, "ChapterMarkers", markers);
@@ -3498,9 +3497,7 @@ ptop_update_bg (int side_changed, double new_val, gpointer data)
 
     if (ghb_settings_combo_int(ud->settings, "PtoPType") == 0)
         set_has_chapter_markers (end_int > start_int, ud);
-    else if (ghb_settings_combo_int(ud->settings, "PtoPType") == 1 || 
-        ghb_settings_combo_int(ud->settings, "PtoPType") == 2)
-        update_title_duration(ud);
+    update_title_duration(ud);
 }
 
 G_MODULE_EXPORT void

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -3498,6 +3498,9 @@ ptop_update_bg (int side_changed, double new_val, gpointer data)
 
     if (ghb_settings_combo_int(ud->settings, "PtoPType") == 0)
         set_has_chapter_markers (end_int > start_int, ud);
+    else if (ghb_settings_combo_int(ud->settings, "PtoPType") == 1 || 
+        ghb_settings_combo_int(ud->settings, "PtoPType") == 2)
+        update_title_duration(ud);
 }
 
 G_MODULE_EXPORT void


### PR DESCRIPTION
**Before Posting:**

- [x] Create an issue describing the change. If an issue already exists, please use this.
  - Original issue [7893](https://github.com/HandBrake/HandBrake/issues/7893)
- [x] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!
  - Issue was tagged with "Help Welcome"


**Description of Change:**
Added a conditional in `ptop_update_bg()` in `callbacks.c` for seconds & frames so that the duration of video in the summary section updates properly on Linux devices




**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [x] Arch Linux

**Screenshots (If relevant):**
<img width="943" height="1032" alt="image" src="https://github.com/user-attachments/assets/026a4845-91ee-4343-a532-c58a04aecc01" />

**Before**
<img width="1894" height="1026" alt="image" src="https://github.com/user-attachments/assets/3e7b727a-38be-48c3-821e-70a695bb5905" />
**After**
<img width="937" height="1033" alt="image" src="https://github.com/user-attachments/assets/e5e7d1dd-3f39-4191-bbcf-3b26290b459f" />


**Log file output (If relevant):**
N/A
