### PR TITLE
avcodec: set frame SAR for FFV1 encoding

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -1418,6 +1418,7 @@ static void Encode( hb_work_object_t *w, hb_buffer_t **buf_in,
     // Convert the hb_buffer_t to avframe
     // This will consume the hb_buffer_t and make it NULL
     hb_video_buffer_to_avframe(&frame, buf_in);
+    frame.sample_aspect_ratio = pv->context->sample_aspect_ratio;
     frame.pts = pv->frameno_in++;
     frame.duration = 0;
 


### PR DESCRIPTION
**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this.

Yes, issue 7931: https://github.com/HandBrake/HandBrake/issues/7931

- [X] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

Done, they asked if a PR also existed, which I'm creating now.


**Description of Change:**

I've been processing a few NTSC DVDs that need IVTC, some 4:3 and some 16:9 using FFV1 for output. And then I'll use those output files for further processing by a script using ffmpeg. I think the 16:9 ones are working without issue, but the 4:3 ones make ffmpeg spam the console with messages like these:

[ffv1 @ 000002538926e080] ignoring invalid SAR: 0/0
[ffv1 @ 000002538c507c00] ignoring invalid SAR: 0/0
[ffv1 @ 000002538b4e8a80] ignoring invalid SAR: 0/0

Thousands and thousands of them, over and over, making it impossible to actually see the usual console output since it is just constantly scrolling these messages. Since the issue does not seem to crop up with 16:9 content I assume this is being set properly for that stuff, but for 4:3 stuff something isn't quite right. Codex gave me this line in my fork, which seems to solve it:

diff --git a/libhb/encavcodec.c b/libhb/encavcodec.c
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -1418,6 +1418,7 @@ static void Encode( hb_work_object_t *w, hb_buffer_t **buf_in,
// Convert the hb_buffer_t to avframe
// This will consume the hb_buffer_t and make it NULL
hb_video_buffer_to_avframe(&frame, buf_in);

frame.sample_aspect_ratio = pv->context->sample_aspect_ratio;
frame.pts = pv->frameno_in++;
frame.duration = 0;
I checked out 1.11.2 from git and tested both HandBrakeCLI.exe and the official GUI release with the hb.dll replaced and it seems to work fine. Files encoded with the CLI or GUI versions no longer make ffmpeg spam the console with those messages, and the result is the normal console output remains viewable.

https://github.com/ShortyCM/HandBrake/pull/1



**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
HandBrake 1.11.2 (2026060700)
OS: Microsoft Windows NT 10.0.26200.0
CPU: 12th Gen Intel(R) Core(TM) i9-12900KS
Ram: 65392 MB, 
GPU Information:
  NVIDIA GeForce RTX 3080 Ti - 32.0.15.9636
Screen: 3440x1440
Temp Dir: c:\temp\
Install Dir: C:\Program Files\HandBrake\
Data Dir: C:\Users\Clay\AppData\Roaming\HandBrake

-------------------------------------------

 # Starting Encode ...

[04:05:43] base preset: Fast 1080p30 (Modified)
[04:05:43] Remote Process started with Process ID: 9848 using port: 8037. Max Allowed Instances: 1
[04:05:43] Worker: Starting HandBrake Engine ...
[04:05:43] Worker: Parent Process Id 20316
[04:05:43] Worker: Starting Web Server on port 8037 ...
[04:05:43] Worker: Starting Listener: 1
[04:05:43] Worker: Server Started
[04:05:43] Worker: Disconnected worker monitoring enabled!
[04:05:43] Compile-time hardening features are enabled
[04:05:43] nvenc: version 13.0 is available
[04:05:43] nvdec: is available
[04:05:43] CUDA Version: 8.6
[04:05:43] vcn: not available on this system
[04:05:43] qsv: not available on this system
[04:05:43] hb_init: starting libhb thread

[04:05:43] Starting work at: Sat Jun 20 04:05:43 2026
[04:05:43] 1 job(s) to process
[04:05:43] json job:
{
  "Audio": {
    "AudioList": [
      {
        "DRC": 0,
        "Encoder": "copy:ac3",
        "Gain": 0,
        "Mixdown": -1,
        "NormalizeMixLevel": false,
        "Samplerate": 0,
        "Track": 0,
        "DitherMethod": 0
      },
      {
        "DRC": 0,
        "Encoder": "copy:ac3",
        "Gain": 0,
        "Mixdown": -1,
        "NormalizeMixLevel": false,
        "Samplerate": 0,
        "Name": "Surround 5.1",
        "Track": 1,
        "DitherMethod": 0
      },
      {
        "DRC": 0,
        "Encoder": "copy:dts",
        "Gain": 0,
        "Mixdown": -1,
        "NormalizeMixLevel": false,
        "Samplerate": 0,
        "Name": "Surround 5.1",
        "Track": 2,
        "DitherMethod": 0
      }
    ],
    "CopyMask": [
      "copy:aac"
    ],
    "FallbackEncoder": "av_aac"
  },
  "Destination": {
    "ChapterList": [
      {
        "Name": "Chapter 1"
      },
      {
        "Name": "Chapter 2"
      },
      {
        "Name": "Chapter 3"
      },
      {
        "Name": "Chapter 4"
      },
      {
        "Name": "Chapter 5"
      },
      {
        "Name": "Chapter 6"
      },
      {
        "Name": "Chapter 7"
      },
      {
        "Name": "Chapter 8"
      },
      {
        "Name": "Chapter 9"
      },
      {
        "Name": "Chapter 10"
      },
      {
        "Name": "Chapter 11"
      },
      {
        "Name": "Chapter 12"
      },
      {
        "Name": "Chapter 13"
      },
      {
        "Name": "Chapter 14"
      },
      {
        "Name": "Chapter 15"
      },
      {
        "Name": "Chapter 16"
      }
    ],
    "ChapterMarkers": true,
    "AlignAVStart": false,
    "File": "T:\\IVTC\\vanhalen-IVTC.mkv",
    "Options": {
      "IpodAtom": false,
      "Optimize": false
    },
    "Mux": "av_mkv"
  },
  "Filters": {
    "FilterList": [
      {
        "ID": 3,
        "Settings": {}
      },
      {
        "ID": 6,
        "Settings": {
          "mode": "7"
        }
      },
      {
        "ID": 4,
        "Settings": {
          "block-height": "16",
          "block-thresh": "40",
          "block-width": "16",
          "filter-mode": "2",
          "mode": "3",
          "motion-thresh": "1",
          "spatial-metric": "2",
          "spatial-thresh": "1"
        }
      },
      {
        "ID": 20,
        "Settings": {
          "crop-bottom": "0",
          "crop-left": "0",
          "crop-right": "0",
          "crop-top": "0",
          "height": "480",
          "width": "720"
        }
      },
      {
        "ID": 11,
        "Settings": {
          "mode": "1",
          "rate": "27000000/1126125"
        }
      }
    ]
  },
  "PAR": {
    "Num": 8,
    "Den": 9
  },
  "Metadata": {
    "CreationTime": "2025-07-12T17:15:36.000000Z"
  },
  "CoverArts": [],
  "SequenceID": 0,
  "Source": {
    "Angle": 1,
    "Range": {
      "Type": "chapter",
      "Start": 1,
      "End": 16
    },
    "Title": 1,
    "Path": "T:\\IVTC\\vanhalen.mkv",
    "HWDecode": 4,
    "KeepDuplicateTitles": false
  },
  "Subtitle": {
    "Search": {
      "Burn": false,
      "Default": false,
      "Enable": false,
      "Forced": false
    },
    "SubtitleList": []
  },
  "Video": {
    "Encoder": "ffv1",
    "Level": "auto",
    "MultiPass": false,
    "Turbo": true,
    "ColorRange": 1,
    "ColorMatrixCode": 0,
    "Options": "",
    "Preset": "default",
    "Profile": "auto",
    "Quality": 0,
    "HardwareDecode": 0
  }
}
[04:05:43] OS: Windows 10.0 (26200)
[04:05:43] CPU: 12th Gen Intel(R) Core(TM) i9-12900KS
[04:05:43]  - Intel microarchitecture Alder Lake performance hybrid architecture
[04:05:43]  - logical processor count: 24
[04:05:43] Intel Quick Sync Video support: no
[04:05:43] hb_scan: path=T:\IVTC\vanhalen.mkv, title_index=1
Input #0, matroska,webm, from 'T:\IVTC\vanhalen.mkv':
  Metadata:
    encoder         : libmakemkv v1.18.1 (1.3.10/1.5.2) win(x64-release)
    creation_time   : 2025-07-12T17:15:36.000000Z
  Duration: 01:32:25.97, start: 0.000000, bitrate: 8566 kb/s
  Chapters:
    Chapter #0:0: start 0.000000, end 37.337300
      Metadata:
        title           : Chapter 01
    Chapter #0:1: start 37.337300, end 337.603933
      Metadata:
        title           : Chapter 02
    Chapter #0:2: start 337.603933, end 713.145767
      Metadata:
        title           : Chapter 03
    Chapter #0:3: start 713.145767, end 1010.642967
      Metadata:
        title           : Chapter 04
    Chapter #0:4: start 1010.642967, end 1329.628300
      Metadata:
        title           : Chapter 05
    Chapter #0:5: start 1329.628300, end 1783.515067
      Metadata:
        title           : Chapter 06
    Chapter #0:6: start 1783.515067, end 2577.608367
      Metadata:
        title           : Chapter 07
    Chapter #0:7: start 2577.608367, end 2910.440867
      Metadata:
        title           : Chapter 08
    Chapter #0:8: start 2910.440867, end 3190.787600
      Metadata:
        title           : Chapter 09
    Chapter #0:9: start 3190.787600, end 3561.391167
      Metadata:
        title           : Chapter 10
    Chapter #0:10: start 3561.391167, end 4282.478200
      Metadata:
        title           : Chapter 11
    Chapter #0:11: start 4282.478200, end 4547.309433
      Metadata:
        title           : Chapter 12
    Chapter #0:12: start 4547.309433, end 4778.874100
      Metadata:
        title           : Chapter 13
    Chapter #0:13: start 4778.874100, end 5092.720967
      Metadata:
        title           : Chapter 14
    Chapter #0:14: start 5092.720967, end 5406.567833
      Metadata:
        title           : Chapter 15
    Chapter #0:15: start 5406.567833, end 5545.973767
      Metadata:
        title           : Chapter 16
  Stream #0:0(eng): Video: mpeg2video (Main), yuv420p(tv, top first), 720x480 [SAR 8:9 DAR 4:3], 29.97 fps, 29.97 tbr, 1k tbn
    Metadata:
      BPS-eng         : 7164561
      DURATION-eng    : 01:32:25.973766666
      NUMBER_OF_FRAMES-eng: 166213
      NUMBER_OF_BYTES-eng: 4966807879
      SOURCE_ID-eng   : 0100E0
      _STATISTICS_WRITING_APP-eng: MakeMKV v1.18.1 win(x64-release)
      _STATISTICS_WRITING_DATE_UTC-eng: 2025-07-12 17:15:36
      _STATISTICS_TAGS-eng: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES SOURCE_ID
    Side data:
      cpb: bitrate max/min/avg: 9800000/0/0 buffer size: 1835008 vbv_delay: N/A
  Stream #0:1(eng): Audio: ac3, 48000 Hz, stereo, fltp, 192 kb/s (default)
    Metadata:
      title           : Stereo
      BPS-eng         : 192000
      DURATION-eng    : 01:32:25.952000000
      NUMBER_OF_FRAMES-eng: 173311
      NUMBER_OF_BYTES-eng: 133102848
      SOURCE_ID-eng   : 0180BD
      _STATISTICS_WRITING_APP-eng: MakeMKV v1.18.1 win(x64-release)
      _STATISTICS_WRITING_DATE_UTC-eng: 2025-07-12 17:15:36
      _STATISTICS_TAGS-eng: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES SOURCE_ID
  Stream #0:2(eng): Audio: ac3, 48000 Hz, 5.1(side), fltp, 448 kb/s
    Metadata:
      title           : Surround 5.1
      BPS-eng         : 448000
      DURATION-eng    : 01:32:25.952000000
      NUMBER_OF_FRAMES-eng: 173311
      NUMBER_OF_BYTES-eng: 310573312
      SOURCE_ID-eng   : 0181BD
      _STATISTICS_WRITING_APP-eng: MakeMKV v1.18.1 win(x64-release)
      _STATISTICS_WRITING_DATE_UTC-eng: 2025-07-12 17:15:36
      _STATISTICS_TAGS-eng: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES SOURCE_ID
  Stream #0:3(eng): Audio: dts (dca) (DTS), 48000 Hz, 5.1(side), fltp, 768 kb/s
    Metadata:
      title           : Surround 5.1
      BPS-eng         : 754500
      DURATION-eng    : 01:32:25.973333333
      NUMBER_OF_FRAMES-eng: 519935
      NUMBER_OF_BYTES-eng: 523054610
      SOURCE_ID-eng   : 018ABD
      _STATISTICS_WRITING_APP-eng: MakeMKV v1.18.1 win(x64-release)
      _STATISTICS_WRITING_DATE_UTC-eng: 2025-07-12 17:15:36
      _STATISTICS_TAGS-eng: BPS DURATION NUMBER_OF_FRAMES NUMBER_OF_BYTES SOURCE_ID
[04:05:43] scan: decoding previews for title 1
[04:05:43] scan: audio 0x1: ac3, rate=48000Hz, bitrate=192000 English (AC3, 2.0 ch, 192 kbps)
[04:05:43] scan: audio 0x2: ac3, rate=48000Hz, bitrate=448000 English (AC3, 5.1 ch, 448 kbps)
[04:05:43] scan: audio 0x3: dca, rate=48000Hz, bitrate=768000 English (DTS, 5.1 ch, 768 kbps)
[04:05:43] using bitstream PAR 8:9
[04:05:43] scan: 10 previews, 720x480, 29.970 fps, autocrop = 0/0/8/10, aspect 4:3, PAR 8:9, color profile: 6-1-6, chroma location: left
[04:05:43] scan: supported video decoders: avcodec hwaccel
[04:05:43] libhb: scan thread found 1 valid title(s)
[04:05:43] Starting Task: Encoding Pass
[04:05:43] work: skipping crop/scale filter
[04:05:43] job configuration:
[04:05:43]  * source
[04:05:43]    + T:\IVTC\vanhalen.mkv
[04:05:43]    + title 1, chapter(s) 1 to 16
[04:05:43]    + container: matroska,webm
[04:05:43]    + data rate: 8566 kbps
[04:05:43]  * destination
[04:05:43]    + T:\IVTC\vanhalen-IVTC.mkv
[04:05:43]    + container: Matroska (libavformat)
[04:05:43]      + chapter markers
[04:05:43]  * video track
[04:05:43]    + decoder: mpeg2video 8-bit (yuv420p)
[04:05:43]    + filters
[04:05:43]      + Detelecine (pullup) ()
[04:05:43]      + Comb Detect (mode=3:spatial-metric=2:motion-thresh=1:spatial-thresh=1:filter-mode=2:block-thresh=40:block-width=16:block-height=16)
[04:05:43]      + Decomb (mode=39)
[04:05:43]      + Framerate Shaper (mode=1:rate=27000000/1126125)
[04:05:43]        + frame rate: 29.970 fps -> constant 23.976 fps
[04:05:43]    + Output geometry
[04:05:43]      + storage dimensions: 720 x 480
[04:05:43]      + pixel aspect ratio: 8 : 9
[04:05:43]      + display dimensions: 640 x 480
[04:05:43]    + encoder: FFV1 (libavcodec)
[04:05:43]      + preset:  default
[04:05:43]      + profile: auto
[04:05:43]      + level:   auto
[04:05:43]      + quality: 0.00 (QP)
[04:05:43]      + color profile: 6-1-6
[04:05:43]      + color range: tv
[04:05:43]      + chroma location: left
[04:05:43]  * audio track 1
[04:05:43]    + decoder: English (AC3, 2.0 ch, 192 kbps) (track 1, id 0x1)
[04:05:43]      + bitrate: 192 kbps, samplerate: 48000 Hz
[04:05:43]    + AC3 Passthru
[04:05:43]  * audio track 2
[04:05:43]    + name: Surround 5.1
[04:05:43]    + decoder: English (AC3, 5.1 ch, 448 kbps) (track 2, id 0x2)
[04:05:43]      + bitrate: 448 kbps, samplerate: 48000 Hz
[04:05:43]    + AC3 Passthru
[04:05:43]  * audio track 3
[04:05:43]    + name: Surround 5.1
[04:05:43]    + decoder: English (DTS, 5.1 ch, 768 kbps) (track 3, id 0x3)
[04:05:43]      + bitrate: 768 kbps, samplerate: 48000 Hz
[04:05:43]    + DTS Passthru
[04:05:43] sync: expecting 166212 video frames
[04:05:43] encavcodecInit: FFV1 (libavcodec)
[04:05:43] encavcodec: encoding at constant quantizer 0
[04:05:43] encavcodec: encoding with stored aspect 8/9
[04:05:43] sync: first pts video is 0
[04:05:43] sync: "Chapter 1" (1) at frame 1 time 0
[04:05:43] sync: first pts audio 0x1 is 0
[04:05:43] sync: first pts audio 0x2 is 0
[04:05:43] sync: first pts audio 0x3 is 0
[04:05:44] sync: "Chapter 2" (2) at frame 1122 time 3366363
[04:05:51] sync: "Chapter 3" (3) at frame 10119 time 30384354
[04:05:59] sync: "Chapter 4" (4) at frame 21374 time 64183119
[04:06:06] sync: "Chapter 5" (5) at frame 30290 time 90957867
[04:06:14] sync: "Chapter 6" (6) at frame 39852 time 119672553
[04:06:25] sync: "Chapter 7" (7) at frame 53455 time 160522362
[04:06:44] sync: "Chapter 8" (8) at frame 77254 time 231990759
[04:06:52] sync: "Chapter 9" (9) at frame 87227 time 261939678
[04:06:59] sync: "Chapter 10" (10) at frame 95629 time 287170884
[04:07:07] sync: "Chapter 11" (11) at frame 106738 time 320531211
[04:07:24] sync: "Chapter 12" (12) at frame 128349 time 385429044
[04:07:30] sync: "Chapter 13" (13) at frame 136287 time 409266858
[04:07:36] sync: "Chapter 14" (14) at frame 143227 time 430107678
[04:07:43] sync: "Chapter 15" (15) at frame 152630 time 458344887
[04:07:52] sync: "Chapter 16" (16) at frame 162036 time 486591105
[04:07:56] reader: done. 1 scr changes
[04:07:56] work: average encoding speed for job is 1258.811035 fps
[04:07:56] comb detect: heavy 44699 | light 33955 | uncombed 55307 | total 133961
[04:07:56] decomb: deinterlaced 44699 | blended 33955 | unfiltered 55307 | total 133961
[04:07:56] vfr: 132971 frames output, 1145 dropped and 155 duped for CFR/PFR
[04:07:56] vfr: lost time: 96858762 (0 frames)
[04:07:56] vfr: gained time: 96858762 (128992 frames) (0 not accounted for)
[04:07:56] ac3-decoder done: 173311 frames, 0 decoder errors
[04:07:56] ac3-decoder done: 173311 frames, 0 decoder errors
[04:07:56] dca-decoder done: 519935 frames, 0 decoder errors
[04:07:56] mpeg2video-decoder done: 166213 frames, 0 decoder errors
[04:07:56] sync: got 166213 frames, 166212 expected
[04:07:56] sync: framerate min 29.970 fps, max 29.970 fps, avg 29.970 fps
[04:07:56] mux: track 0, 132971 frames, 19418329368 bytes, 28010.37 kbps, fifo 512
[04:07:56] mux: track 1, 173311 frames, 133102848 bytes, 192.00 kbps, fifo 512
[04:07:56] mux: track 2, 173311 frames, 310573312 bytes, 447.99 kbps, fifo 512
[04:07:56] mux: track 3, 519935 frames, 523054610 bytes, 754.49 kbps, fifo 2048
[04:07:56] Finished work at: Sat Jun 20 04:07:56 2026
[04:07:56] libhb: work result = 0

 # Job Completed!