### PR TITLE
LinuxGui: Improvement/move duration count next to range to match windows and mac os builds

### DIFF
--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -1177,19 +1177,17 @@ update_title_duration(signal_user_data_t *ud)
     gint hh, mm, ss;
     gint64 duration;
     gchar *text;
-    GtkWidget *widget;
     int title_id, titleindex;
     const hb_title_t *title;
 
     title_id = ghb_dict_get_int(ud->settings, "title");
     title = ghb_lookup_title(title_id, &titleindex);
-    widget = ghb_builder_widget("title_duration");
 
     duration = title_range_get_duration(ud->settings, title);
     ghb_break_duration(duration, &hh, &mm, &ss);
 
     text = g_strdup_printf("%02d:%02d:%02d", hh, mm, ss);
-    gtk_label_set_text(GTK_LABEL(widget), text);
+    gtk_label_set_text(GTK_LABEL(ghb_builder_widget("title_duration_inline")), text);
     g_free(text);
 }
 

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -1637,6 +1637,24 @@ This is often the feature title of a DVD.</property>
                         <signal name="input" handler="ptop_read_value_cb" swapped="no"/>
                       </object>
                     </child>
+                    <child>
+                      <object class="GtkLabel" id="duration_label">
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <property name="use-markup">1</property>
+                        <property name="margin-start">6</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Duration:&lt;/b&gt;</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="title_duration_inline">
+                        <property name="halign">start</property>
+                        <property name="valign">center</property>
+                        <property name="margin-start">6</property>
+                        <property name="width-chars">8</property>
+                        <property name="label" translatable="yes">hh:mm:ss</property>
+                      </object>
+                    </child>
                     <layout>
                       <property name="row">1</property>
                       <property name="column">1</property>
@@ -1840,35 +1858,6 @@ sync for broken players that do not honor MP4 edit lists.</property>
                               <object class="GtkGrid" id="summary_table">
                                 <property name="row-spacing">2</property>
                                 <property name="column-spacing">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="label6">
-                                    <property name="xalign">0</property>
-                                    <property name="yalign">0</property>
-                                    <property name="halign">start</property>
-                                    <property name="use-markup">1</property>
-                                    <property name="margin-top">12</property>
-                                    <property name="label" translatable="yes">Duration:</property>
-                                    <layout>
-                                      <property name="row">5</property>
-                                      <property name="column">0</property>
-                                    </layout>
-                                  </object>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="title_duration">
-                                    <property name="halign">start</property>
-                                    <property name="xalign">0</property>
-                                    <property name="yalign">0</property>
-                                    <property name="hexpand">0</property>
-                                    <property name="label" translatable="yes">hh:mm:ss</property>
-                                    <property name="margin-top">12</property>
-                                    <property name="width-chars">8</property>
-                                    <layout>
-                                      <property name="row">5</property>
-                                      <property name="column">1</property>
-                                    </layout>
-                                  </object>
-                                </child>
                                 <child>
                                   <object class="GtkLabel" id="tracks_summary_label">
                                     <property name="label" translatable="yes">Tracks:</property>


### PR DESCRIPTION
**Before Posting:**

- [X] Create an issue describing the change. If an issue already exists, please use this.
- [X] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!

Both these were discussed here: https://github.com/HandBrake/HandBrake/pull/7933

**Description of Change:**
Removed duration count from summary and moved it to be on the same line as title & range as well as set title drop down width to match the preset drop down. They now match the windows and macos builds




**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [X] Arch Linux 

**Screenshots (If relevant):**
Before 
<img width="1919" height="1015" alt="image" src="https://github.com/user-attachments/assets/2440d82d-3874-4fa9-9385-32ecb9476b35" />

After
<img width="1919" height="1054" alt="image" src="https://github.com/user-attachments/assets/24667585-5f35-4124-9002-a77cd5474475" />

Windows ref image 
<img width="1362" height="866" alt="image" src="https://github.com/user-attachments/assets/960ef91f-7873-49df-bdb1-fcbe82cf404b" />


**Log file output (If relevant):**
