### PR TITLE
contrib: update libass to 0.17.5

### DIFF
--- a/contrib/libass/module.defs
+++ b/contrib/libass/module.defs
@@ -7,9 +7,9 @@ endif
 $(eval $(call import.MODULE.defs,LIBASS,libass,$(__deps__)))
 $(eval $(call import.CONTRIB.defs,LIBASS))
 
-LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libass-0.17.4.tar.gz
-LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.17.4/libass-0.17.4.tar.gz
-LIBASS.FETCH.sha256  = a886b3b80867f437bc55cff3280a652bfa0d37b43d2aff39ddf3c4f288b8c5a8
+LIBASS.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libass-0.17.5.tar.gz
+LIBASS.FETCH.url    += https://github.com/libass/libass/releases/download/0.17.5/libass-0.17.5.tar.gz
+LIBASS.FETCH.sha256  = caab4b993dd7be6187c55623b789ed75dddefea6e65938af134637c732fe094a
 
 LIBASS.GCC.args.c_std =
 


### PR DESCRIPTION
Detailed changes:
- Fix limited OOB read and write in `wrap_lines_measure` (GHSA-pjjp-65r7-ppgm; CVE pending)
- Fix OOB bit clears for negative Matroska ReadOrder fields (GHSA-5gf7-wjfm-vmvm; CVE pending)
- Fix \fay with glyph clusters
- Fix small alpha changes not always splitting runs when combined with fade
- Fix compilation with MSVC-mode clang
- Fades are now applied to BorderStyle=4 boxes too
- Fonts using legacy arabic Windows charmaps are now supported
- `ass_render_frame` no longer returns fully transparent images
- Avoid MSVC’s subpar code generation for isnan to bring performance closer to other compilers
- Avoid SSE instructions if compiler baseline already includes AVX

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux