### PR TITLE
BugFix: High memory usage when previewing with SVT AV1

### DIFF
--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -44,6 +44,9 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -807,6 +810,11 @@ ghb_application_activate (GApplication *app)
     textview = GTK_TEXT_VIEW(ghb_builder_widget("MetaLongDescription"));
     buffer = gtk_text_view_get_buffer(textview);
     g_signal_connect(buffer, "changed", G_CALLBACK(plot_changed_cb), ud);
+
+#ifdef __GLIBC__
+    mallopt(M_MMAP_THRESHOLD, 1024 * 1024);
+    mallopt(M_TRIM_THRESHOLD, 1024 * 1024);
+#endif
 
     // Initialize HB internal tables etc.
     hb_global_init();

--- a/gtk/src/application.c
+++ b/gtk/src/application.c
@@ -44,9 +44,6 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
-#ifdef __GLIBC__
-#include <malloc.h>
-#endif
 
 #ifdef _WIN32
 #include <windows.h>
@@ -810,11 +807,6 @@ ghb_application_activate (GApplication *app)
     textview = GTK_TEXT_VIEW(ghb_builder_widget("MetaLongDescription"));
     buffer = gtk_text_view_get_buffer(textview);
     g_signal_connect(buffer, "changed", G_CALLBACK(plot_changed_cb), ud);
-
-#ifdef __GLIBC__
-    mallopt(M_MMAP_THRESHOLD, 1024 * 1024);
-    mallopt(M_TRIM_THRESHOLD, 1024 * 1024);
-#endif
 
     // Initialize HB internal tables etc.
     hb_global_init();

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -42,6 +42,9 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 
 #if defined( __FreeBSD__ ) || defined(__OpenBSD__)
 #include <sys/socket.h>
@@ -4751,6 +4754,11 @@ ghb_backend_events(signal_user_data_t *ud)
         ghb_queue_progress_set_fraction(ud, index, 1.0);
 
         ghb_clear_queue_state(GHB_STATE_WORKDONE);
+
+#ifdef __GLIBC__
+        malloc_trim(0);
+#endif
+
         if (ud->job_activity_log)
             g_io_channel_unref(ud->job_activity_log);
         ud->job_activity_log = NULL;

--- a/gtk/src/preview.c
+++ b/gtk/src/preview.c
@@ -29,6 +29,9 @@
 #include "values.h"
 
 #include <unistd.h>
+#ifdef __GLIBC__
+#include <malloc.h>
+#endif
 
 enum {
     PREVIEW_STATE_STOPPED = 0,
@@ -480,6 +483,10 @@ ghb_live_encode_done(signal_user_data_t *ud, gboolean success)
         ud->preview->encoded[ud->preview->encode_frame] = FALSE;
         live_preview_set_state(PREVIEW_STATE_STOPPED);
     }
+
+#ifdef __GLIBC__
+    malloc_trim(0);
+#endif
 }
 
 G_MODULE_EXPORT gboolean


### PR DESCRIPTION
**Original Thread** 
https://github.com/HandBrake/HandBrake/issues/7815

**Description of Change:**
Used mallopt to pin glibc's mmap threshold and malloc_trim to return freed memory to the OS after each encode, so repeated encodes no longer make glibc hoard its memory.  

This stops handbrake from lagging out my machine. The numbers I got were before my patch handbrake would use about 5.8 GB of memory after about 5 previews (memory usage would go up after every encode). After my patch, it was about 218 MB after 5 previews. 



**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
- [X] Arch Linux

**Screenshots (If relevant):**


**Log file output (If relevant):**
Before 
```
09:04:35 RSS_kB=259260
09:04:37 RSS_kB=259260
09:04:39 RSS_kB=259260
09:04:41 RSS_kB=259260
09:04:43 RSS_kB=259260
09:04:45 RSS_kB=259260
09:04:47 RSS_kB=259260
09:04:49 RSS_kB=259260
09:04:51 RSS_kB=1102592
09:04:53 RSS_kB=1866992
09:04:55 RSS_kB=2039232
09:04:57 RSS_kB=2052976
09:04:59 RSS_kB=2057176
09:05:01 RSS_kB=2158936
09:05:03 RSS_kB=2170372
09:05:05 RSS_kB=2181020
09:05:07 RSS_kB=2187064
09:05:09 RSS_kB=2210564
09:05:11 RSS_kB=2227576
09:05:13 RSS_kB=1828280
09:05:15 RSS_kB=1837232
09:05:17 RSS_kB=1857936
09:05:19 RSS_kB=1857936
09:05:21 RSS_kB=2993476
09:05:23 RSS_kB=3540048
09:05:25 RSS_kB=3636156
09:05:27 RSS_kB=3652684
09:05:29 RSS_kB=3674924
09:05:31 RSS_kB=3753088
09:05:33 RSS_kB=3763260
09:05:35 RSS_kB=3770820
09:05:37 RSS_kB=3776304
09:05:39 RSS_kB=3801608
09:05:41 RSS_kB=3818956
09:05:43 RSS_kB=3337040
09:05:45 RSS_kB=3337068
09:05:47 RSS_kB=3337064
09:05:49 RSS_kB=3340940
09:05:51 RSS_kB=4326164
09:05:53 RSS_kB=4840968
09:05:55 RSS_kB=4979044
09:05:57 RSS_kB=4995128
09:05:59 RSS_kB=5002016
09:06:01 RSS_kB=5079004
09:06:03 RSS_kB=5084412
09:06:05 RSS_kB=5088456
09:06:07 RSS_kB=5091960
09:06:09 RSS_kB=5135436
09:06:11 RSS_kB=5118648
09:06:13 RSS_kB=4782444
09:06:15 RSS_kB=4809472
09:06:19 RSS_kB=5835344
09:08:07 RSS_kB=5936220
09:12:50 RSS_kB=
09:12:52 process exited
```
After
```
12:14:46 RSS_kB=138036
12:14:48 RSS_kB=138036
12:14:50 RSS_kB=138036
12:14:52 RSS_kB=138036
12:14:54 RSS_kB=138036
12:14:56 RSS_kB=138036
12:14:58 RSS_kB=138036
12:15:00 RSS_kB=138036
12:15:02 RSS_kB=138036
12:15:04 RSS_kB=138036
12:15:06 RSS_kB=138036
12:15:08 RSS_kB=138036
12:15:10 RSS_kB=138036
12:15:12 RSS_kB=138036
12:15:14 RSS_kB=138036
12:15:16 RSS_kB=138036
12:15:18 RSS_kB=138036
12:15:20 RSS_kB=138036
12:15:22 RSS_kB=138036
12:15:24 RSS_kB=138036
12:15:26 RSS_kB=138036
12:15:28 RSS_kB=138036
12:15:30 RSS_kB=138368
12:15:32 RSS_kB=149516
12:15:34 RSS_kB=187800
12:15:36 RSS_kB=187800
12:15:38 RSS_kB=187928
12:15:40 RSS_kB=188776
12:15:42 RSS_kB=190932
12:15:44 RSS_kB=1437028
12:15:46 RSS_kB=1871336
12:15:48 RSS_kB=1936136
12:15:50 RSS_kB=1951428
12:15:52 RSS_kB=2024768
12:15:54 RSS_kB=2042616
12:15:56 RSS_kB=2052560
12:15:58 RSS_kB=2060452
12:16:00 RSS_kB=2064028
12:16:02 RSS_kB=2059360
12:16:04 RSS_kB=2076592
12:16:06 RSS_kB=212160
12:16:08 RSS_kB=211828
12:16:10 RSS_kB=211828
12:16:12 RSS_kB=211664
12:16:14 RSS_kB=1159740
12:16:16 RSS_kB=1791996
12:16:19 RSS_kB=1953176
12:16:21 RSS_kB=1973056
12:16:23 RSS_kB=1981188
12:16:25 RSS_kB=2063896
12:16:27 RSS_kB=2074424
12:16:29 RSS_kB=2084980
12:16:31 RSS_kB=2091260
12:16:33 RSS_kB=2066836
12:16:35 RSS_kB=2084672
12:16:37 RSS_kB=216780
12:16:39 RSS_kB=216780
12:16:41 RSS_kB=216780
12:16:43 RSS_kB=230576
12:16:45 RSS_kB=1597224
12:16:47 RSS_kB=1953076
12:16:49 RSS_kB=1991068
12:16:51 RSS_kB=2005336
12:16:53 RSS_kB=2081944
12:16:55 RSS_kB=2097160
12:16:57 RSS_kB=2107592
12:16:59 RSS_kB=2116756
12:17:01 RSS_kB=2120612
12:17:03 RSS_kB=2110392
12:17:05 RSS_kB=2104136
12:17:07 RSS_kB=218844
12:17:09 RSS_kB=1330548
12:17:11 RSS_kB=1864480
12:17:13 RSS_kB=2026844
12:17:15 RSS_kB=2037304
12:17:17 RSS_kB=2049164
12:17:19 RSS_kB=2055680
12:17:21 RSS_kB=2063604
12:17:23 RSS_kB=2073496
12:17:25 RSS_kB=2130380
12:17:27 RSS_kB=2112928
12:17:29 RSS_kB=2122096
12:17:31 RSS_kB=2130768
12:17:33 RSS_kB=2136664
12:17:35 RSS_kB=2115312
12:17:37 RSS_kB=223660
12:17:39 RSS_kB=223660
12:17:41 RSS_kB=223660
12:17:43 RSS_kB=223660
12:17:45 RSS_kB=223660
12:17:47 RSS_kB=223660
12:17:49 RSS_kB=223660
12:17:51 RSS_kB=223660
12:17:53 RSS_kB=223324
12:17:55 RSS_kB=223324
12:17:57 RSS_kB=223324
12:17:59 RSS_kB=223324
12:18:01 RSS_kB=223324
12:18:03 RSS_kB=223324
12:18:05 RSS_kB=223324
12:18:07 RSS_kB=223324
12:18:09 RSS_kB=223324
12:18:11 RSS_kB=223324
12:18:13 RSS_kB=223324
12:18:15 RSS_kB=223324
12:18:17 RSS_kB=223324
12:18:19 RSS_kB=223324
12:18:21 RSS_kB=223324
12:18:23 RSS_kB=223324
12:18:25 RSS_kB=223324
12:18:27 RSS_kB=223324
12:18:29 RSS_kB=223324
12:18:31 RSS_kB=223324
12:18:33 RSS_kB=223324
12:18:35 RSS_kB=223324
12:18:37 RSS_kB=223324
12:18:39 RSS_kB=223324
12:18:41 RSS_kB=223324
12:18:43 RSS_kB=223324
12:18:45 RSS_kB=223324
12:18:47 RSS_kB=223324
12:18:49 RSS_kB=223324
12:18:51 RSS_kB=223324
12:18:53 RSS_kB=223324
12:18:55 RSS_kB=223324
12:18:57 RSS_kB=223320
12:18:59 RSS_kB=237484
12:19:01 RSS_kB=1437704
12:19:03 RSS_kB=1974544
12:19:05 RSS_kB=2035468
12:19:07 RSS_kB=2046124
12:19:09 RSS_kB=2054980
12:19:11 RSS_kB=2060688
12:19:13 RSS_kB=2062016
12:19:15 RSS_kB=2080656
12:19:17 RSS_kB=2098096
12:19:19 RSS_kB=2160156
12:19:21 RSS_kB=2171452
12:19:24 RSS_kB=2180104
12:19:26 RSS_kB=2186840
12:19:28 RSS_kB=2189404
12:19:30 RSS_kB=1070172
12:19:32 RSS_kB=223580
12:19:34 RSS_kB=223580
12:19:36 RSS_kB=223568
12:19:38 RSS_kB=223696
12:19:40 process exited
```