### PR TITLE
libhb: silence pointer offset warning

### DIFF
--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -1501,6 +1501,8 @@ size_t hb_getline(char ** lineptr, size_t * n, FILE * fp)
         if ((p - bufptr) >= (size - 1))
         {
             char * tmp;
+            size_t offset = p - bufptr;
+
             size = size + 128;
             tmp = realloc(bufptr, size);
             if (tmp == NULL)
@@ -1508,7 +1510,7 @@ size_t hb_getline(char ** lineptr, size_t * n, FILE * fp)
                 free(bufptr);
                 return -1;
             }
-            p = tmp + (p - bufptr);
+            p = tmp + offset;
             bufptr = tmp;
         }
         *p++ = c;


### PR DESCRIPTION
The compiler gives a warning regarding pointer usage after freeing for memory rebase:
  : ../libhb/ports.c:1511:26: warning: pointer 'bufptr' may be used after 'realloc' [-Wuse-after-free]

To fix this, use another harmless variable as an intermediary to store the offset.



**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

