### PR TITLE
libhb: improve scan and preview behavior

### DIFF
--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -106,7 +106,11 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     data->store_previews = store_previews;
     data->min_title_duration = min_duration;
     data->max_title_duration = max_duration;
-     
+
+    // Do at least 3 previews for any case.
+    if (data->preview_count < 3)
+        data->preview_count = 3;
+
     data->crop_threshold_frames = crop_threshold_frames;
     data->crop_threshold_pixels = crop_threshold_pixels;
     data->exclude_extensions    = hb_string_list_copy(exclude_extensions);

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -826,8 +826,7 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
 
         int packets = 0;
         vid_decoder->frame_count = 0;
-        while (vid_decoder->frame_count < PREVIEW_READ_THRESH ||
-              (!AllAudioOK(title) && packets < 10000))
+        while (vid_decoder->frame_count < PREVIEW_READ_THRESH && packets < 10000)
         {
             if ((buf = read_buf(data, stream)) == NULL)
             {

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -828,6 +828,30 @@ static int DecodePreviews( hb_scan_t * data, hb_title_t * title, int flush )
         vid_decoder->frame_count = 0;
         while (vid_decoder->frame_count < PREVIEW_READ_THRESH && packets < 10000)
         {
+            if ( *data->die )
+            {
+                if ( buf_es )
+                    hb_buffer_close( &buf_es );
+
+                hb_buffer_list_close(&list_es);
+
+                if (vid_buf == NULL)
+                {
+                    vid_buf = last_vid_buf;
+                    last_vid_buf = NULL;
+                }
+                hb_buffer_close(&last_vid_buf);
+                hb_buffer_close(&vid_buf);
+
+                free( info_list );
+                crop_record_free( crops );
+                vid_decoder->close( vid_decoder );
+                free( vid_decoder );
+                hb_stream_close(&stream);
+                hb_hwaccel_hw_device_ctx_close(&hw_device_ctx);
+                return 0;
+            }
+
             if ((buf = read_buf(data, stream)) == NULL)
             {
                 // If we reach EOF and no audio, don't continue looking for

--- a/libhb/scan.c
+++ b/libhb/scan.c
@@ -107,6 +107,10 @@ hb_thread_t * hb_scan_init( hb_handle_t * handle, volatile int * die,
     data->min_title_duration = min_duration;
     data->max_title_duration = max_duration;
 
+    // Discard previews if user disables them.
+    if (data->preview_count == 0)
+        data->store_previews = 0;
+
     // Do at least 3 previews for any case.
     if (data->preview_count < 3)
         data->preview_count = 3;


### PR DESCRIPTION
I experienced a problem with one of the versions of FFmpeg that caused scanning to stall/fail
these simple changes helped me diagnose the problem and direct them to the fix.

Part of this is related to #5841 and can be considered a further fix to that.

Also, do not let setting of `previewScanCount` to less than the required minimum of 3
cause broken behavior in the app, instead, simply reduce the number of preview frames saved afterward.

On current Handbrake, if I set `previewScanCount` to 0 and try to scan a title,
I get a bogus message "No valid source of titles found" with a list of reasons
this can happen, but not this reason.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux

**Screenshots (If relevant):**

<img width="1280" height="720" alt="handbrake-previewless" src="https://github.com/user-attachments/assets/d25e39a9-8d27-49c9-adbe-2c4ac96bf8ae" />
