### PR TITLE
Interop: Add more details when GetDefaultMixdown cannot find a result

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeEncoderHelpers.cs
@@ -582,7 +582,13 @@ namespace HandBrake.Interop.Interop
                 layoutptr = InteropUtilities.ToUtf8PtrFromString(layout);
             }
             int defaultMixdown = HBFunctions.hb_mixdown_get_default_s((uint)encoder.Id, layoutptr);
-            return Mixdowns.Single(m => m.Id == defaultMixdown);
+            var result = Mixdowns.SingleOrDefault(m => m.Id == defaultMixdown);
+            if (result == null)
+            {
+                throw new Exception($"No default mixdown found for encoder {encoder.ShortName} and layout {layout}. defaultMixdown: {defaultMixdown}, Mixdown count: {Mixdowns.Count}");
+            }
+
+            return result;
         }
 
         /// <summary>


### PR DESCRIPTION
**Description of Change:**

When it cannot find a default mixdown, it currently throws "InvalidOperationException: Sequence contains no matching element".

This throws a more detailed error.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
