### PR TITLE
contrib: update SVT-AV1 to version 4.2.0

### DIFF
--- a/contrib/svt-av1/module.defs
+++ b/contrib/svt-av1/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,SVT-AV1,svt-av1))
 $(eval $(call import.CONTRIB.defs,SVT-AV1))
 
-SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v4.1.0.tar.gz
-SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v4.1.0/SVT-AV1-v4.1.0.tar.gz
-SVT-AV1.FETCH.sha256  = 6c4c0c44ff0ba3d136d6f57f3a707f9de8e9c866f50f809c1d22a43f0d8c9583
+SVT-AV1.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/SVT-AV1-v4.2.0.tar.gz
+SVT-AV1.FETCH.url    += https://gitlab.com/AOMediaCodec/SVT-AV1/-/archive/v4.2.0/SVT-AV1-v4.2.0.tar.gz
+SVT-AV1.FETCH.sha256  = c7b13c4a84bd3751aa35fcc72be13e6875467e7c2216879251a486e5b1e4e740
 
 SVT-AV1.GCC.args.c_std =
 

--- a/libhb/encsvtav1.c
+++ b/libhb/encsvtav1.c
@@ -187,7 +187,11 @@ int encsvtInit(hb_work_object_t *w, hb_job_t *job)
         }
     }
 
-    if (job->encoder_tune != NULL && strstr(job->encoder_tune, "ms-ssim") != NULL)
+    if (job->encoder_tune != NULL && strstr(job->encoder_tune, "vmaf") != NULL)
+    {
+        param->tune = 5;
+    }
+    else if (job->encoder_tune != NULL && strstr(job->encoder_tune, "ms-ssim") != NULL)
     {
         param->tune = 4;
     }

--- a/libhb/handbrake/av1_common.h
+++ b/libhb/handbrake/av1_common.h
@@ -31,7 +31,7 @@ static const char * const hb_av1_svt_preset_names[] =
 
 static const char * const hb_av1_svt_tune_names[] =
 {
-    "vq", "psnr", "ssim", "iq", "ms-ssim", "fastdecode", NULL
+    "vq", "psnr", "ssim", "iq", "ms-ssim", "vmaf", "fastdecode", NULL
 };
 
 static const char * const hb_av1_svt_profile_names[] =


### PR DESCRIPTION
https://gitlab.com/AOMediaCodec/SVT-AV1/-/releases/v4.2.0

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux