### PR TITLE
contrib: update NVENC to 13.1.15.0

### DIFF
--- a/contrib/nvenc/module.defs
+++ b/contrib/nvenc/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,NVENC,nvenc))
 $(eval $(call import.CONTRIB.defs,NVENC))
 
-NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/nv-codec-headers-13.0.19.0.tar.gz
-NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n13.0.19.0/nv-codec-headers-13.0.19.0.tar.gz
-NVENC.FETCH.sha256   = 13da39edb3a40ed9713ae390ca89faa2f1202c9dda869ef306a8d4383e242bee
+NVENC.FETCH.url      = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/nv-codec-headers-13.1.15.0.tar.gz
+NVENC.FETCH.url     += https://github.com/FFmpeg/nv-codec-headers/releases/download/n13.1.15.0/nv-codec-headers-13.1.15.0.tar.gz
+NVENC.FETCH.sha256   = 52532ceade3d5c1af62624986f13cf01b63c910576b08c0c278756c5e4b41ad0
 
 NVENC.CONFIGURE = $(TOUCH.exe) $@
 NVENC.BUILD.extra = PREFIX="$(NVENC.CONFIGURE.prefix)"


### PR DESCRIPTION
**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux