### PR TITLE
contrib: update libdav1d to 1.5.4

### DIFF
--- a/contrib/libdav1d/module.defs
+++ b/contrib/libdav1d/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDAV1D,libdav1d))
 $(eval $(call import.CONTRIB.defs,LIBDAV1D))
 
-LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.5.3.tar.bz2
-LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.5.3/dav1d-1.5.3.tar.bz2
-LIBDAV1D.FETCH.sha256  = e099f53253f6c247580c554d53a13f1040638f2066edc3c740e4c2f15174ce22
+LIBDAV1D.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/dav1d-1.5.4.tar.bz2
+LIBDAV1D.FETCH.url    += https://code.videolan.org/videolan/dav1d/-/archive/1.5.4/dav1d-1.5.4.tar.bz2
+LIBDAV1D.FETCH.sha256  = 2abfb0c89212e6e4733a54e0ae509ec00a5b845a6360946f918806e14aedb011
 
 LIBDAV1D.build_dir        = build/
 LIBDAV1D.CONFIGURE.exe    = $(MESON.exe) setup


### PR DESCRIPTION
Changes for 1.5.4 'Sonic':
--------------------------
1.5.4 is a minor release of dav1d, focused on optimizations and maintenance:
 - Support for OS/2, including API exports and assembly
 - Switch to external checkasm
 - Add Armv9.3-A GCS (Guarded Control Stack) support
 - AArch64: optimize ipred_v, ipred_h and ipred_smooth_* 8bpc functions, and
   reduce .text size
 - ARM32: optimize prep_neon
 - RISC-V: ipred_(dc, h, v, pal) optimizations for 8 and 16bpc,
   generate_grain_y for 8bpc, and optimizations (prep/put_8tap, 6-tap and copy paths)
 - Portability improvements for non-POSIX systems (signal() fallback)
 - Schedule tile tasks for all passes at once, improving threading
 - Precompute the quantization matrix tables at build time
 - Move loop-invariant computations out of hot loops



**Tested on:**

- [X] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [X] Ubuntu Linux