### PR TITLE
Auto-Increment format for automatically naming files #7848

### DIFF
--- a/gtk/data/internal_defaults.json
+++ b/gtk/data/internal_defaults.json
@@ -115,6 +115,8 @@
         "UseM4v": false,
         "auto_name": true,
         "auto_name_template": "{source}",
+        "AutoIncrementPadding": 2,
+        "AutoIncrementNext": 1,
         "VideoQualityGranularity": "1",
         "version": "0.1",
         "PreferredLanguage": "und",

--- a/gtk/src/callbacks.c
+++ b/gtk/src/callbacks.c
@@ -426,6 +426,7 @@ static GhbBinding widget_bindings[] =
     {"VideoEncoder", "active-id", "svt_av1|svt_av1_10bit|x264|x264_10bit|x265|x265_10bit|x265_12bit|x265_16bit|mpeg4|mpeg2|VP8|VP9|VP9_10bit|qsv_av1|qsv_av1_10bit|qsv_h264|qsv_h265|qsv_h265_10bit|vce_av1|vce_av1_10bit|vce_h264|vce_h265|vce_h265_10bit|vaapi_h264|vaapi_hevc|vaapi_av1|vaapi_vp8|vaapi_vp9", "VideoOptionExtraWindow", "visible"},
     {"VideoEncoder", "active-id", "svt_av1|svt_av1_10bit|x264|x264_10bit|x265|x265_10bit|x265_12bit|x265_16bit|mpeg4|mpeg2|VP8|VP9|VP9_10bit|qsv_av1|qsv_av1_10bit|qsv_h264|qsv_h265|qsv_h265_10bit|vce_av1|vce_av1_10bit|vce_h264|vce_h265|vce_h265_10bit|vaapi_h264|vaapi_hevc|vaapi_av1|vaapi_vp8|vaapi_vp9", "VideoOptionExtraLabel", "visible"},
     {"auto_name", "active", NULL, "autoname_box", "sensitive"},
+    {"auto_name", "active", NULL, "auto_increment_box", "sensitive"},
     {"CustomTmpEnable", "active", NULL, "CustomTmpDir", "sensitive"},
     {"PresetCategory", "active-id", "new", "PresetCategoryName", "visible"},
     {"PresetCategory", "active-id", "new", "PresetCategoryEntryLabel", "visible"},
@@ -783,6 +784,26 @@ get_creation_date(const char *pattern, const char *metaValue, const char *file)
     return strdup(date);
 }
 
+#define AUTO_INCREMENT_PAD_MIN 2
+#define AUTO_INCREMENT_PAD_MAX 5
+
+static int
+auto_increment_padding (signal_user_data_t *ud)
+{
+    int padding = ghb_dict_get_int(ud->prefs, "AutoIncrementPadding");
+    return CLAMP(padding, AUTO_INCREMENT_PAD_MIN, AUTO_INCREMENT_PAD_MAX);
+}
+
+// Highest value that fits in the configured padding, e.g. 99 for 2 digits
+static int
+auto_increment_max (int padding)
+{
+    int max = 1;
+    while (padding-- > 0)
+        max *= 10;
+    return max - 1;
+}
+
 static void
 make_unique_dest(const gchar *dest_dir, GString *str, const gchar * extension)
 {
@@ -882,6 +903,8 @@ set_destination_settings(signal_user_data_t *ud, GhbValue *settings)
     {
         GString *str = g_string_new("");
         const gchar *p;
+        gboolean auto_increment_used = FALSE;
+        int auto_increment_value = 0;
 
         p = ghb_dict_get_string(ud->prefs, "auto_name_template");
         // {source-path} is only allowed as the first element of the
@@ -1064,6 +1087,23 @@ set_destination_settings(signal_user_data_t *ud, GhbValue *settings)
 
                 p += strlen("{bit-depth}");
             }
+            else if (!strncasecmp(p, "{auto-increment}", strlen("{auto-increment}")) ||
+                     !strncasecmp(p, "{auto_increment}", strlen("{auto_increment}")))
+            {
+                int padding = auto_increment_padding(ud);
+                int max     = auto_increment_max(padding);
+                int next    = ghb_dict_get_int(ud->prefs, "AutoIncrementNext");
+                // auto_increment_offset numbers the rows of the
+                // add-multiple-titles list consecutively
+                int offset  = ghb_dict_get_int(settings, "auto_increment_offset");
+
+                if (next < 1 || next > max)
+                    next = 1;
+                auto_increment_value = (next - 1 + offset) % max + 1;
+                auto_increment_used  = TRUE;
+                g_string_append_printf(str, "%0*d", padding, auto_increment_value);
+                p += strlen("{auto-increment}");
+            }
             else
             {
                 g_string_append_printf(str, "%c", *p);
@@ -1076,6 +1116,12 @@ set_destination_settings(signal_user_data_t *ud, GhbValue *settings)
         filename = g_string_free(str, FALSE);
         ghb_dict_set_string(settings, "dest_file", filename);
         g_free(filename);
+        // Remember the number used so the counter can be advanced
+        // when this name is committed to the queue
+        if (auto_increment_used)
+            ghb_dict_set_int(settings, "auto_increment_value", auto_increment_value);
+        else
+            ghb_dict_remove(settings, "auto_increment_value");
     }
 }
 
@@ -1084,6 +1130,50 @@ ghb_set_destination (signal_user_data_t *ud)
 {
     set_destination_settings(ud, ud->settings);
     ghb_ui_update("dest_file", ghb_dict_get_value(ud->settings, "dest_file"));
+}
+
+void
+ghb_update_title_destination (signal_user_data_t *ud, GhbValue *settings)
+{
+    const char *dest_file, *dest_dir;
+    char *dest;
+
+    set_destination_settings(ud, settings);
+
+    dest_file = ghb_dict_get_string(settings, "dest_file");
+    dest_dir  = ghb_dict_get_string(settings, "dest_dir");
+    dest = g_strdup_printf("%s" G_DIR_SEPARATOR_S "%s", dest_dir, dest_file);
+    ghb_dict_set_string(settings, "destination", dest);
+    GhbValue *dest_dict = ghb_get_job_dest_settings(settings);
+    ghb_dict_set_string(dest_dict, "File", dest);
+    g_free(dest);
+}
+
+// Advance the {auto-increment} counter after a job using it has been
+// committed to the queue, then refresh the displayed destination.
+// During a batch add the refresh must wait until the batch is complete,
+// otherwise pending titles would be renamed away from the names that
+// were displayed in the add-multiple list.
+void
+ghb_auto_increment_advance (signal_user_data_t *ud, GhbValue *settings,
+                            gboolean batch)
+{
+    if (!ghb_dict_get_bool(ud->prefs, "auto_name") ||
+        ghb_dict_get(settings, "auto_increment_value") == NULL)
+    {
+        return;
+    }
+
+    int used = ghb_dict_get_int(settings, "auto_increment_value");
+    int max  = auto_increment_max(auto_increment_padding(ud));
+
+    // Roll over to 1 after the highest number that fits in the padding
+    ghb_dict_set_int(ud->prefs, "AutoIncrementNext", used % max + 1);
+    ghb_pref_save(ud->prefs, "AutoIncrementNext");
+    if (!batch)
+    {
+        ghb_set_destination(ud);
+    }
 }
 
 static void
@@ -2806,17 +2896,7 @@ ghb_set_title_settings(signal_user_data_t *ud, GhbValue *settings)
         ghb_set_scale_settings(ud, settings, GHB_PIC_USE_MAX);
     }
 
-    set_destination_settings(ud, settings);
-
-    const char *dest_file, *dest_dir;
-    char *dest;
-    dest_file = ghb_dict_get_string(settings, "dest_file");
-    dest_dir = ghb_dict_get_string(settings, "dest_dir");
-    dest = g_strdup_printf("%s" G_DIR_SEPARATOR_S "%s", dest_dir, dest_file);
-    ghb_dict_set_string(settings, "destination", dest);
-    GhbValue *dest_dict = ghb_get_job_dest_settings(settings);
-    ghb_dict_set_string(dest_dict, "File", dest);
-    g_free(dest);
+    ghb_update_title_destination(ud, settings);
 
     ghb_dict_set_int(settings, "preview_frame", 2);
 }
@@ -5271,6 +5351,40 @@ log_level_changed_cb (GtkWidget *widget, gpointer data)
     pref_changed_cb(widget, ud);
     int level = ghb_dict_get_int(ud->prefs, "LoggingLevel");
     ghb_log_level_set(level);
+}
+
+G_MODULE_EXPORT void
+auto_name_template_changed_cb (GtkWidget *widget, gpointer data)
+{
+    signal_user_data_t *ud = ghb_ud();
+    GhbValue *value = ghb_widget_value(widget);
+    const char *new_template = ghb_value_get_string(value);
+    const char *old_template = ghb_dict_get_string(ud->prefs,
+                                                   "auto_name_template");
+    gboolean changed = g_strcmp0(new_template, old_template) != 0;
+    ghb_value_free(&value);
+
+    pref_changed_cb(widget, data);
+    if (changed)
+    {
+        // A new template starts a new sequence, e.g. a new TV series
+        ghb_dict_set_int(ud->prefs, "AutoIncrementNext", 1);
+        ghb_pref_set(ud->prefs, "AutoIncrementNext");
+        ghb_set_destination(ud);
+    }
+}
+
+G_MODULE_EXPORT void
+auto_increment_padding_changed_cb (GtkWidget *widget, gpointer data)
+{
+    signal_user_data_t *ud = ghb_ud();
+
+    pref_changed_cb(widget, data);
+    if (ghb_check_name_template(ud, "{auto-increment}") ||
+        ghb_check_name_template(ud, "{auto_increment}"))
+    {
+        ghb_set_destination(ud);
+    }
 }
 
 G_MODULE_EXPORT void

--- a/gtk/src/callbacks.h
+++ b/gtk/src/callbacks.h
@@ -81,6 +81,9 @@ void ghb_scale_configure(signal_user_data_t *ud, const char *name, double val,
                          int digits, gboolean inverted);
 void ghb_update_summary_info(signal_user_data_t *ud);
 void ghb_set_title_settings(signal_user_data_t *ud, GhbValue *settings);
+void ghb_update_title_destination(signal_user_data_t *ud, GhbValue *settings);
+void ghb_auto_increment_advance(signal_user_data_t *ud, GhbValue *settings,
+                                gboolean batch);
 void ghb_browse_uri(const gchar *uri);
 void ghb_file_open(GFile *file);
 void ghb_file_open_containing_folder(GFile *file);

--- a/gtk/src/title-add.c
+++ b/gtk/src/title-add.c
@@ -254,6 +254,8 @@ ghb_add_title_to_queue (signal_user_data_t *ud, GhbValue *settings, gint batch)
     ghb_update_pending(ud);
     ghb_queue_buttons_grey(ud);
 
+    ghb_auto_increment_advance(ud, settings, batch);
+
     return TRUE;
 }
 
@@ -394,6 +396,8 @@ static void title_add_check_conflicts (signal_user_data_t *ud)
     title_add_set_error_text(ud, are_conflicts);
 }
 
+static void title_add_reset_increment_offsets (signal_user_data_t *ud);
+
 static void
 add_multiple_titles (signal_user_data_t *ud)
 {
@@ -412,6 +416,7 @@ add_multiple_titles (signal_user_data_t *ud)
             break;
         }
     }
+    title_add_reset_increment_offsets(ud);
     ghb_queue_selection_init(ud);
 }
 
@@ -683,6 +688,29 @@ title_add_action_cb (GSimpleAction *action, GVariant *param,
     ghb_audio_list_refresh_all(ud);
 }
 
+// Undo the consecutive numbering applied while the add-multiple list
+// was displayed; remaining titles go back to showing the next number
+static void
+title_add_reset_increment_offsets (signal_user_data_t *ud)
+{
+    gint count, ii;
+
+    count = ghb_array_len(ud->settings_array);
+    for (ii = 0; ii < count; ii++)
+    {
+        GhbValue *settings = ghb_array_get(ud->settings_array, ii);
+        if (ghb_dict_get_int(settings, "auto_increment_offset") != 0)
+        {
+            ghb_dict_set_int(settings, "auto_increment_offset", 0);
+            ghb_update_title_destination(ud, settings);
+        }
+    }
+    if (ghb_dict_get(ud->settings, "auto_increment_value") != NULL)
+    {
+        ghb_set_destination(ud);
+    }
+}
+
 static void
 title_add_multiple_response_cb (GtkDialog *dialog, int response,
                                 signal_user_data_t *ud)
@@ -693,6 +721,7 @@ title_add_multiple_response_cb (GtkDialog *dialog, int response,
     {
         add_multiple_titles(ud);
     }
+    title_add_reset_increment_offsets(ud);
 }
 
 G_MODULE_EXPORT void
@@ -733,6 +762,12 @@ title_add_multiple_action_cb (GSimpleAction *action, GVariant *param,
         button = GHB_FILE_BUTTON(find_widget(row, "title_dir"));
 
         settings = ghb_array_get(ud->settings_array, ii);
+        if (ghb_dict_get(settings, "auto_increment_value") != NULL)
+        {
+            // Number the titles in the list consecutively
+            ghb_dict_set_int(settings, "auto_increment_offset", ii);
+            ghb_update_title_destination(ud, settings);
+        }
         if (preset != NULL)
         {
             ghb_preset_to_settings(settings, preset);

--- a/gtk/src/ui/ghb.ui
+++ b/gtk/src/ui/ghb.ui
@@ -4632,6 +4632,13 @@ Overrides all other settings.</property>
     <property name="step-increment">5</property>
     <property name="page-increment">10</property>
   </object>
+  <object class="GtkAdjustment" id="auto_increment_padding_adj">
+    <property name="lower">2</property>
+    <property name="upper">5</property>
+    <property name="value">2</property>
+    <property name="step-increment">1</property>
+    <property name="page-increment">1</property>
+  </object>
   <object class="GtkDialog" id="subtitle_defaults_dialog">
     <property name="title" translatable="yes">Subtitle Selection Behavior</property>
     <property name="transient-for">hb_window</property>
@@ -5603,14 +5610,48 @@ Each selected source track will be encoded with all selected encoders.</property
                               <object class="GtkEntry" id="auto_name_template">
                                 <property name="focusable">1</property>
                                 <property name="secondary-icon-name">help-about-symbolic</property>
-                                <property name="secondary-icon-tooltip-text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {modification-date} {modification-time} {codec} {bit-depth} {quality} {bitrate} {width} {height}</property>
+                                <property name="secondary-icon-tooltip-text" translatable="yes">Available Options: {source-path} {source} {title} {preset} {chapters} {date} {time} {creation-date} {creation-time} {modification-date} {modification-time} {codec} {bit-depth} {quality} {bitrate} {width} {height} {auto-increment}</property>
                                 <property name="activates-default">1</property>
                                 <property name="width-chars">30</property>
                                 <property name="truncate-multiline">1</property>
-                                <signal name="changed" handler="pref_changed_cb" swapped="no"/>
+                                <signal name="changed" handler="auto_name_template_changed_cb" swapped="no"/>
                                 <accessibility>
                                   <relation name="labelled-by">auto_name_template_label</relation>
                                 </accessibility>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="auto_increment_box">
+                            <property name="margin-start">18</property>
+                            <property name="margin-end">8</property>
+                            <property name="spacing">4</property>
+                            <property name="tooltip-text" translatable="yes">{auto-increment} adds an increasing number to automatically named files.
+Numbering restarts at 1 when the Auto-Name Template is changed, and rolls
+over to 1 again after the highest number that fits in the selected padding.</property>
+                            <child>
+                              <object class="GtkLabel" id="auto_increment_padding_label">
+                                <property name="halign">end</property>
+                                <property name="label" translatable="yes">Auto-Increment zero-padding is</property>
+                                <property name="use-markup">1</property>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkSpinButton" id="AutoIncrementPadding">
+                                <property name="focusable">1</property>
+                                <property name="width-chars">4</property>
+                                <property name="adjustment">auto_increment_padding_adj</property>
+                                <property name="numeric">1</property>
+                                <signal name="value-changed" handler="auto_increment_padding_changed_cb" swapped="no"/>
+                                <accessibility>
+                                  <relation name="labelled-by">auto_increment_padding_label</relation>
+                                </accessibility>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="auto_increment_padding_digits_label">
+                                <property name="label" translatable="yes">digits</property>
                               </object>
                             </child>
                           </object>

--- a/macosx/Base.lproj/Preferences.xib
+++ b/macosx/Base.lproj/Preferences.xib
@@ -13,6 +13,7 @@
                 <outlet property="excludedExtensionsControl" destination="HzZ-UL-arV" id="XwM-8E-OYr"/>
                 <outlet property="excludedExtensionsController" destination="9jP-eU-0ii" id="Aoe-oq-ifz"/>
                 <outlet property="excludedExtensionsTableView" destination="ax0-hR-WPq" id="ayQ-KO-Wc8"/>
+                <outlet property="autoIncrementPaddingField" destination="aIn-cr-Txf" id="aIn-cr-Ot1"/>
                 <outlet property="fileNameView" destination="0GP-nk-F0d" id="E56-ce-nCX"/>
                 <outlet property="formatTokenField" destination="GwY-X2-I2h" id="zv2-bk-RaK"/>
                 <outlet property="generalView" destination="233" id="Gwx-aW-6BL"/>
@@ -699,6 +700,64 @@
                                                 <binding destination="61" name="value" keyPath="values.HBAutoNamingTitleCase" id="Kee-0d-0TS"/>
                                             </connections>
                                         </button>
+                                        <stackView toolTip="Auto-Increment adds an increasing number to automatically named files. Numbering restarts at 1 when the Format is changed, and rolls over to 1 again after the highest number that fits in the selected padding." distribution="fill" orientation="horizontal" alignment="centerY" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="750" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aIn-cr-Stk">
+                                            <rect key="frame" x="0.0" y="-26" width="253" height="19"/>
+                                            <subviews>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aIn-cr-Lb1">
+                                                    <rect key="frame" x="-2" y="2" width="172" height="14"/>
+                                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Auto-Increment zero-padding is" id="aIn-cr-Lc1">
+                                                        <font key="font" metaFont="menu" size="11"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField verticalHuggingPriority="1000" verticalCompressionResistancePriority="751" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aIn-cr-Txf">
+                                                    <rect key="frame" x="174" y="0.0" width="26" height="22"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="26" id="aIn-cr-Cn1"/>
+                                                        <constraint firstAttribute="height" constant="22" id="aIn-cr-Cn2"/>
+                                                    </constraints>
+                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="right" title="2" drawsBackground="YES" id="aIn-cr-Txc">
+                                                        <font key="font" metaFont="menu" size="11"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <connections>
+                                                        <binding destination="61" name="enabled" keyPath="values.DefaultAutoNaming" id="aIn-cr-Bn1"/>
+                                                        <binding destination="61" name="value" keyPath="values.HBAutoNamingAutoIncrementPadding" id="aIn-cr-Bn2"/>
+                                                    </connections>
+                                                </textField>
+                                                <stepper horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aIn-cr-Stp">
+                                                    <rect key="frame" x="201" y="-3" width="15" height="22"/>
+                                                    <stepperCell key="cell" continuous="YES" alignment="left" controlSize="small" minValue="2" maxValue="5" doubleValue="2" id="aIn-cr-Stc"/>
+                                                    <connections>
+                                                        <accessibilityConnection property="title" destination="aIn-cr-Lb1" id="aIn-cr-Ax1"/>
+                                                        <binding destination="61" name="enabled" keyPath="values.DefaultAutoNaming" id="aIn-cr-Bn3"/>
+                                                        <binding destination="61" name="value" keyPath="values.HBAutoNamingAutoIncrementPadding" id="aIn-cr-Bn4"/>
+                                                    </connections>
+                                                </stepper>
+                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aIn-cr-Lb2">
+                                                    <rect key="frame" x="218" y="2" width="35" height="14"/>
+                                                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="digits" id="aIn-cr-Lc2">
+                                                        <font key="font" metaFont="menu" size="11"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                            </subviews>
+                                            <visibilityPriorities>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                                <integer value="1000"/>
+                                            </visibilityPriorities>
+                                            <customSpacing>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                                <real value="3.4028234663852886e+38"/>
+                                            </customSpacing>
+                                        </stackView>
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="Zvg-MF-RQF" firstAttribute="leading" secondItem="GwY-X2-I2h" secondAttribute="leading" id="RN6-xE-fhD"/>
@@ -713,8 +772,10 @@
                                         <integer value="1000"/>
                                         <integer value="1000"/>
                                         <integer value="1000"/>
+                                        <integer value="1000"/>
                                     </visibilityPriorities>
                                     <customSpacing>
+                                        <real value="3.4028234663852886e+38"/>
                                         <real value="3.4028234663852886e+38"/>
                                         <real value="3.4028234663852886e+38"/>
                                         <real value="3.4028234663852886e+38"/>

--- a/macosx/HBAppDelegate.m
+++ b/macosx/HBAppDelegate.m
@@ -14,6 +14,7 @@
 #import "HBPresetsMenuBuilder.h"
 
 #import "HBPreferencesController.h"
+#import "HBPreferencesKeys.h"
 #import "HBQueueController.h"
 #import "HBQueueDockTileController.h"
 #import "HBOutputPanelController.h"
@@ -21,6 +22,8 @@
 
 #define PRESET_FILE @"UserPresets.json"
 #define QUEUE_FILE @"Queue.hbqueue"
+
+static void *HBAppDelegateContext = &HBAppDelegateContext;
 
 @interface HBAppDelegate () <NSMenuItemValidation>
 
@@ -68,8 +71,31 @@
         _queueController.delegate = self;
         _queueDockTileController = [[HBQueueDockTileController alloc] initWithQueue:_queue dockTile:NSApplication.sharedApplication.dockTile image:NSApplication.sharedApplication.applicationIconImage];
         _mainController = [[HBController alloc] initWithDelegate:self queue:_queue presetsManager:_presetsManager];
+
+        // A new naming format starts a new {Auto-Increment} sequence,
+        // e.g. a new TV series
+        [NSUserDefaultsController.sharedUserDefaultsController addObserver:self
+                                                                forKeyPath:@"values.HBAutoNamingFormat"
+                                                                   options:0
+                                                                   context:HBAppDelegateContext];
     }
     return self;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
+{
+    if (context == HBAppDelegateContext)
+    {
+        NSUserDefaults *ud = NSUserDefaults.standardUserDefaults;
+        if ([ud integerForKey:HBAutoNamingAutoIncrementNext] != 1)
+        {
+            [ud setInteger:1 forKey:HBAutoNamingAutoIncrementNext];
+        }
+    }
+    else
+    {
+        [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    }
 }
 
 #pragma mark - NSApplicationDelegate

--- a/macosx/HBAutoNamer.m
+++ b/macosx/HBAutoNamer.m
@@ -72,6 +72,8 @@ static void *HBAutoNamerContext = &HBAutoNamerContext;
     [ud addObserver:self forKeyPath:@"values.HBAutoNamingRemovePunctuation" options:0 context:HBAutoNamerPrefsContext];
     [ud addObserver:self forKeyPath:@"values.HBAutoNamingTitleCase" options:0 context:HBAutoNamerPrefsContext];
     [ud addObserver:self forKeyPath:@"values.HBAutoNamingISODateFormat" options:0 context:HBAutoNamerPrefsContext];
+    [ud addObserver:self forKeyPath:@"values.HBAutoNamingAutoIncrementPadding" options:0 context:HBAutoNamerPrefsContext];
+    [ud addObserver:self forKeyPath:@"values.HBAutoNamingAutoIncrementNext" options:0 context:HBAutoNamerPrefsContext];
 }
 
 - (void)removePrefsObservers
@@ -82,6 +84,8 @@ static void *HBAutoNamerContext = &HBAutoNamerContext;
     [ud removeObserver:self forKeyPath:@"values.HBAutoNamingRemovePunctuation" context:HBAutoNamerPrefsContext];
     [ud removeObserver:self forKeyPath:@"values.HBAutoNamingTitleCase" context:HBAutoNamerPrefsContext];
     [ud removeObserver:self forKeyPath:@"values.HBAutoNamingISODateFormat" context:HBAutoNamerPrefsContext];
+    [ud removeObserver:self forKeyPath:@"values.HBAutoNamingAutoIncrementPadding" context:HBAutoNamerPrefsContext];
+    [ud removeObserver:self forKeyPath:@"values.HBAutoNamingAutoIncrementNext" context:HBAutoNamerPrefsContext];
 }
 
 #pragma mark - File extension

--- a/macosx/HBController.m
+++ b/macosx/HBController.m
@@ -1355,6 +1355,7 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
 - (void)doAddToQueue
 {
     [_queue addJob:[self.job copy]];
+    [HBJob advanceAutoIncrementBy:1];
 }
 
 /**
@@ -1455,7 +1456,8 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
             [job applySelectionRange:range];
             [job setDestinationFolderURL:self.destinationFolderURL
                             sameAsSource:useSourceFolderDestination];
-            job.destinationFileName = job.defaultName;
+            // Number the titles consecutively when {Auto-Increment} is in use
+            job.destinationFileName = [job defaultNameWithAutoIncrementOffset:jobs.count];
             job.title = nil;
 
             [jobs addObject:job];
@@ -1515,12 +1517,14 @@ static void *HBControllerLogLevelContext = &HBControllerLogLevelContext;
             if (returnCode == NSAlertSecondButtonReturn)
             {
                 [self->_queue addJobs:jobs];
+                [HBJob advanceAutoIncrementBy:jobs.count];
             }
         }];
     }
     else
     {
         [_queue addJobs:jobs];
+        [HBJob advanceAutoIncrementBy:jobs.count];
     }
 }
 

--- a/macosx/HBJob+HBAdditions.h
+++ b/macosx/HBJob+HBAdditions.h
@@ -10,6 +10,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+#define HB_AUTO_INCREMENT_PAD_MIN 2
+#define HB_AUTO_INCREMENT_PAD_MAX 5
+
 @interface HBJob (HBAdditions)
 
 /// Generates a file name automatically based on the inputs,
@@ -17,6 +20,19 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString *automaticName;
 @property (nonatomic, readonly) NSString *automaticExt;
 @property (nonatomic, readonly) NSString *defaultName;
+
+/// Same as defaultName, but the {Auto-Increment} token renders
+/// offset positions past the next stored counter value, so a batch
+/// of titles can be numbered consecutively
+- (NSString *)defaultNameWithAutoIncrementOffset:(NSUInteger)offset;
+
+/// Whether automatic naming is enabled and the format uses {Auto-Increment}
++ (BOOL)autoIncrementEnabled;
+
+/// Advances the stored {Auto-Increment} counter after count jobs
+/// have been committed to the queue, rolling over to 1 past the
+/// highest value that fits in the configured padding
++ (void)advanceAutoIncrementBy:(NSUInteger)count;
 
 - (void)setDestinationFolderURL:(NSURL *)destinationFolderURL sameAsSource:(BOOL)useSourceFolderDestination;
 

--- a/macosx/HBJob+HBAdditions.m
+++ b/macosx/HBJob+HBAdditions.m
@@ -13,6 +13,34 @@ static NSDateFormatter *_dateFormatter = nil;
 static NSDateFormatter *_dateISOFormatter = nil;
 static NSDateFormatter *_releaseDateFormatter = nil;
 
+static NSUInteger autoIncrementPadding(void)
+{
+    NSInteger padding = [NSUserDefaults.standardUserDefaults integerForKey:HBAutoNamingAutoIncrementPadding];
+    return MAX(HB_AUTO_INCREMENT_PAD_MIN, MIN(HB_AUTO_INCREMENT_PAD_MAX, padding));
+}
+
+// Highest value that fits in the configured padding, e.g. 99 for 2 digits
+static NSUInteger autoIncrementMax(NSUInteger padding)
+{
+    NSUInteger max = 1;
+    while (padding-- > 0)
+    {
+        max *= 10;
+    }
+    return max - 1;
+}
+
+static NSUInteger autoIncrementValue(NSUInteger offset)
+{
+    NSUInteger max = autoIncrementMax(autoIncrementPadding());
+    NSInteger next = [NSUserDefaults.standardUserDefaults integerForKey:HBAutoNamingAutoIncrementNext];
+    if (next < 1 || next > max)
+    {
+        next = 1;
+    }
+    return (next - 1 + offset) % max + 1;
+}
+
 @implementation HBJob (HBAdditions)
 
 + (void)initialize
@@ -35,7 +63,32 @@ static NSDateFormatter *_releaseDateFormatter = nil;
     }
 }
 
++ (BOOL)autoIncrementEnabled
+{
+    NSUserDefaults *ud = NSUserDefaults.standardUserDefaults;
+    return [ud boolForKey:HBDefaultAutoNaming] &&
+           [[ud arrayForKey:HBAutoNamingFormat] containsObject:@"{Auto-Increment}"];
+}
+
++ (void)advanceAutoIncrementBy:(NSUInteger)count
+{
+    if (count == 0 || ![self autoIncrementEnabled])
+    {
+        return;
+    }
+
+    NSUInteger max  = autoIncrementMax(autoIncrementPadding());
+    NSUInteger used = autoIncrementValue(count - 1);
+    [NSUserDefaults.standardUserDefaults setInteger:used % max + 1
+                                             forKey:HBAutoNamingAutoIncrementNext];
+}
+
 - (NSString *)automaticName
+{
+    return [self automaticNameWithAutoIncrementOffset:0];
+}
+
+- (NSString *)automaticNameWithAutoIncrementOffset:(NSUInteger)offset
 {
     NSUserDefaults *ud = NSUserDefaults.standardUserDefaults;
     NSMutableString *name = [[NSMutableString alloc] init];
@@ -210,6 +263,10 @@ static NSDateFormatter *_releaseDateFormatter = nil;
                 [name appendString:dateString];
             }
         }
+        else if ([formatKey isEqualToString:@"{Auto-Increment}"])
+        {
+            [name appendFormat:@"%0*lu", (int)autoIncrementPadding(), (unsigned long)autoIncrementValue(offset)];
+        }
         else if ([formatKey isEqualToString:@"{Modification-Time}"])
         {
             NSDate *modificationDate = nil;
@@ -253,12 +310,17 @@ static NSDateFormatter *_releaseDateFormatter = nil;
 
 - (NSString *)defaultName
 {
+    return [self defaultNameWithAutoIncrementOffset:0];
+}
+
+- (NSString *)defaultNameWithAutoIncrementOffset:(NSUInteger)offset
+{
     NSString *fileName = self.title.name;
 
     // Create an output filename by using the format set in the preferences
     if ([NSUserDefaults.standardUserDefaults boolForKey:HBDefaultAutoNaming])
     {
-        fileName = self.automaticName;
+        fileName = [self automaticNameWithAutoIncrementOffset:offset];
     }
 
     // Automatic name can be empty if the format is empty

--- a/macosx/HBPreferencesController.m
+++ b/macosx/HBPreferencesController.m
@@ -4,6 +4,7 @@
  */
 
 #import "HBPreferencesController.h"
+#import "HBJob+HBAdditions.h"
 
 @import HandBrakeKit.HBUtilities;
 
@@ -24,6 +25,8 @@ NSString * const HBAutoNamingRemoveUnderscore    = @"HBAutoNamingRemoveUnderscor
 NSString * const HBAutoNamingRemovePunctuation   = @"HBAutoNamingRemovePunctuation";
 NSString * const HBAutoNamingTitleCase           = @"HBAutoNamingTitleCase";
 NSString * const HBAutoNamingISODateFormat       = @"HBAutoNamingISODateFormat";
+NSString * const HBAutoNamingAutoIncrementPadding = @"HBAutoNamingAutoIncrementPadding";
+NSString * const HBAutoNamingAutoIncrementNext   = @"HBAutoNamingAutoIncrementNext";
 
 NSString * const HBDefaultMpegExtension          = @"DefaultMpegExtension";
 
@@ -148,6 +151,43 @@ static void *HBPreferencesControllerContext = &HBPreferencesControllerContext;
  * preference settings are added that cannot be handled with Cocoa bindings).
  */
 
+/**
+ * Formatter for the Auto-Increment padding field. Rejects any keystroke
+ * that would not produce an in-range digit, and clamps the committed
+ * value into range so a blank field never triggers a validation alert.
+ */
+@interface HBBoundedIntegerFormatter : NSNumberFormatter
+@end
+
+@implementation HBBoundedIntegerFormatter
+
+- (BOOL)isPartialStringValid:(NSString *)partialString newEditingString:(NSString * _Nullable *)newString errorDescription:(NSString * _Nullable *)error
+{
+    if (partialString.length == 0)
+    {
+        return YES;
+    }
+    if (partialString.length > 1)
+    {
+        return NO;
+    }
+    unichar digit = [partialString characterAtIndex:0];
+    return digit >= '0' + self.minimum.integerValue && digit <= '0' + self.maximum.integerValue;
+}
+
+- (BOOL)getObjectValue:(out id _Nullable *)obj forString:(NSString *)string errorDescription:(out NSString * _Nullable *)error
+{
+    NSInteger value = string.integerValue;
+    value = MAX(self.minimum.integerValue, MIN(self.maximum.integerValue, value));
+    if (obj)
+    {
+        *obj = @(value);
+    }
+    return YES;
+}
+
+@end
+
 @interface HBPreferencesController () <NSTokenFieldDelegate, NSToolbarDelegate, HBFileExtensionDelegate>
 
 @property (nonatomic, weak) IBOutlet NSView *generalView;
@@ -157,6 +197,7 @@ static void *HBPreferencesControllerContext = &HBPreferencesControllerContext;
 
 @property (nonatomic, weak) IBOutlet NSTokenField *formatTokenField;
 @property (nonatomic, weak) IBOutlet NSTokenField *builtInTokenField;
+@property (nonatomic, weak) IBOutlet NSTextField *autoIncrementPaddingField;
 @property (nonatomic, readonly, strong) NSArray *buildInFormatTokens;
 @property (nonatomic, strong) NSArray *matches;
 
@@ -217,6 +258,8 @@ static BOOL _hardwareDecoderSupported = NO;
         HBDefaultAutoNaming:                @NO,
         HBAutoNamingFormat:                 @[@"{Source}", @" ", @"{Title}"],
         HBAutoNamingISODateFormat:          @NO,
+        HBAutoNamingAutoIncrementPadding:   @2,
+        HBAutoNamingAutoIncrementNext:      @1,
         HBResetWhenDoneOnLaunch:            @NO,
         HBLoggingLevel:                     @1,
         HBClearOldLogs:                     @YES,
@@ -290,9 +333,15 @@ static BOOL _hardwareDecoderSupported = NO;
                              @"{Width}", @"{Height}", @"{Codec}",
                              @"{Encoder}", @"{Bit-Depth}", @"{Quality/Bitrate}", @"{Quality-Type}",
                              @"{Date}", @"{Time}", @"{Creation-Date}", @"{Creation-Time}",
-                             @"{Modification-Date}", @"{Modification-Time}"];
+                             @"{Modification-Date}", @"{Modification-Time}", @"{Auto-Increment}"];
     [self.builtInTokenField setTokenizingCharacterSet:[NSCharacterSet characterSetWithCharactersInString:@"%%"]];
     [self.builtInTokenField setStringValue:[self.buildInFormatTokens componentsJoinedByString:@"%%"]];
+
+    // Auto-Increment padding field initialization
+    HBBoundedIntegerFormatter *paddingFormatter = [[HBBoundedIntegerFormatter alloc] init];
+    paddingFormatter.minimum = @(HB_AUTO_INCREMENT_PAD_MIN);
+    paddingFormatter.maximum = @(HB_AUTO_INCREMENT_PAD_MAX);
+    self.autoIncrementPaddingField.formatter = paddingFormatter;
 
     // Excluded file extension initialization
     self.excludedExtensions = [[NSMutableArray alloc] init];
@@ -526,6 +575,10 @@ static BOOL _hardwareDecoderSupported = NO;
     else if ([tokenString isEqualToString:@"{Modification-Time}"])
     {
         return NSLocalizedString(@"Modification-Time", "Preferences -> Output Name Token");
+    }
+    else if ([tokenString isEqualToString:@"{Auto-Increment}"])
+    {
+        return NSLocalizedString(@"Auto-Increment", "Preferences -> Output Name Token");
     }
 
     return tokenString;

--- a/macosx/HBPreferencesKeys.h
+++ b/macosx/HBPreferencesKeys.h
@@ -31,6 +31,8 @@ extern NSString * const HBAutoNamingRemoveUnderscore;
 extern NSString * const HBAutoNamingRemovePunctuation;
 extern NSString * const HBAutoNamingTitleCase;
 extern NSString * const HBAutoNamingISODateFormat;
+extern NSString * const HBAutoNamingAutoIncrementPadding;
+extern NSString * const HBAutoNamingAutoIncrementNext;
 
 extern NSString * const HBDefaultMpegExtension;
 

--- a/win/CS/HandBrakeWPF/Constants.cs
+++ b/win/CS/HandBrakeWPF/Constants.cs
@@ -44,6 +44,7 @@ namespace HandBrakeWPF
         public const string EncoderDisplay = "{encoder-display}";
         public const string Encoder = "{encoder}";
         public const string Angle = "{angle}";
+        public const string AutoIncrement = "{auto-increment}";
 
         /* Auto-name Path Constants */
         public const string Source = "{source}";

--- a/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
+++ b/win/CS/HandBrakeWPF/Helpers/AutoNameHelper.cs
@@ -30,8 +30,64 @@ namespace HandBrakeWPF.Helpers
     /// </summary>
     public class AutoNameHelper
     {
+        public const int AutoIncrementPadMin = 2;
+        public const int AutoIncrementPadMax = 5;
+
         /// <summary>
-        /// Function which generates the filename and path automatically based on 
+        /// Whether automatic naming is enabled and the format uses {auto-increment}
+        /// </summary>
+        public static bool IsAutoIncrementUsed()
+        {
+            IUserSettingService userSettingService = IoCHelper.Get<IUserSettingService>();
+            if (!userSettingService.GetUserSetting<bool>(UserSettingConstants.AutoNaming))
+            {
+                return false;
+            }
+
+            string format = userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat);
+            return format != null && format.Contains(Constants.AutoIncrement);
+        }
+
+        /// <summary>
+        /// Advances the stored {auto-increment} counter after a job using it has
+        /// been committed to the queue, rolling over to 1 past the highest value
+        /// that fits in the configured padding
+        /// </summary>
+        public static void AdvanceAutoIncrement()
+        {
+            IUserSettingService userSettingService = IoCHelper.Get<IUserSettingService>();
+            int max = GetAutoIncrementMax(GetAutoIncrementPadding(userSettingService));
+            int used = GetAutoIncrementValue(userSettingService);
+            userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementNext, (used % max) + 1);
+        }
+
+        private static int GetAutoIncrementPadding(IUserSettingService userSettingService)
+        {
+            int padding = userSettingService.GetUserSetting<int>(UserSettingConstants.AutoNameAutoIncrementPadding);
+            return Math.Clamp(padding, AutoIncrementPadMin, AutoIncrementPadMax);
+        }
+
+        // Highest value that fits in the configured padding, e.g. 99 for 2 digits
+        private static int GetAutoIncrementMax(int padding)
+        {
+            int max = 1;
+            while (padding-- > 0)
+            {
+                max *= 10;
+            }
+
+            return max - 1;
+        }
+
+        private static int GetAutoIncrementValue(IUserSettingService userSettingService)
+        {
+            int max = GetAutoIncrementMax(GetAutoIncrementPadding(userSettingService));
+            int next = userSettingService.GetUserSetting<int>(UserSettingConstants.AutoNameAutoIncrementNext);
+            return (next < 1 || next > max) ? 1 : next;
+        }
+
+        /// <summary>
+        /// Function which generates the filename and path automatically based on
         /// the Source Name, DVD title and DVD Chapters
         /// </summary>
         public static string AutoName(EncodeTask task, string titleName, string sourceDisplayName, Preset presetName)
@@ -168,7 +224,8 @@ namespace HandBrakeWPF.Helpers
                         .Replace(Constants.StorageHeight, task.Height?.ToString())
                         .Replace(Constants.Codec, task.VideoEncoder?.Codec)
                         .Replace(Constants.EncoderDisplay, task.VideoEncoder?.DisplayName)
-                        .Replace(Constants.Encoder, task.VideoEncoder?.ShortName);
+                        .Replace(Constants.Encoder, task.VideoEncoder?.ShortName)
+                        .Replace(Constants.AutoIncrement, GetAutoIncrementValue(userSettingService).ToString("D" + GetAutoIncrementPadding(userSettingService)));
 
 
                 if (task.VideoEncodeRateType == VideoEncodeRateType.ConstantQuality)

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -4124,6 +4124,24 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("Options_TitleCase", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Auto-increment zero-padding is.
+        /// </summary>
+        public static string Options_AutoIncrementPadding {
+            get {
+                return ResourceManager.GetString("Options_AutoIncrementPadding", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to digits.
+        /// </summary>
+        public static string Options_AutoIncrementDigits {
+            get {
+                return ResourceManager.GetString("Options_AutoIncrementDigits", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to User Interface Behaviour.

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -1271,6 +1271,12 @@ Hint: File overwrite behaviour can be controlled in preferences. </value>
   <data name="Options_TitleCase" xml:space="preserve">
     <value>Change case to Title Case</value>
   </data>
+  <data name="Options_AutoIncrementPadding" xml:space="preserve">
+    <value>Auto-increment zero-padding is</value>
+  </data>
+  <data name="Options_AutoIncrementDigits" xml:space="preserve">
+    <value>digits</value>
+  </data>
   <data name="Options_Updates" xml:space="preserve">
     <value>Updates</value>
   </data>

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.Designer.cs
@@ -534,6 +534,15 @@ namespace HandBrakeWPF.Properties {
                 return ResourceManager.GetString("Options_RemovePunctuation", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to {auto-increment} adds an increasing number to automatically named files..
+        /// </summary>
+        public static string Options_AutoIncrementPadding {
+            get {
+                return ResourceManager.GetString("Options_AutoIncrementPadding", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to When enabled the auto name system will always use the default path. 

--- a/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
+++ b/win/CS/HandBrakeWPF/Properties/ResourcesTooltips.resx
@@ -561,6 +561,10 @@ Bitrate will vary source to source.</value>
   <data name="Options_RemovePunctuation" xml:space="preserve">
     <value>Dash (-), Period (.) and Comma (,)</value>
   </data>
+  <data name="Options_AutoIncrementPadding" xml:space="preserve">
+    <value>{auto-increment} adds an increasing number to automatically named files.
+Numbering restarts at 1 when the filename format is changed, and rolls over to 1 again after the highest number that fits in the selected padding.</value>
+  </data>
   <data name="PictureSettingsView_OptimalSize" xml:space="preserve">
     <value>Use highest resolution permitted by above settings</value>
   </data>

--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -305,6 +305,8 @@ namespace HandBrakeWPF.Services
             defaults.Add(UserSettingConstants.RemovePunctuation, false);
             defaults.Add(UserSettingConstants.FileOverwriteBehaviour, 0);
             defaults.Add(UserSettingConstants.UseM4v, 0);
+            defaults.Add(UserSettingConstants.AutoNameAutoIncrementPadding, 2);
+            defaults.Add(UserSettingConstants.AutoNameAutoIncrementNext, 1);
 
             // When Done
             defaults.Add(UserSettingConstants.SendFile, false);

--- a/win/CS/HandBrakeWPF/UserSettingConstants.cs
+++ b/win/CS/HandBrakeWPF/UserSettingConstants.cs
@@ -14,6 +14,8 @@ namespace HandBrakeWPF
     /// </summary>
     public class UserSettingConstants
     {
+        public const string AutoNameAutoIncrementNext = "AutoNameAutoIncrementNext";
+        public const string AutoNameAutoIncrementPadding = "AutoNameAutoIncrementPadding";
         public const string AutoNameFormat = "autoNameFormat";
         public const string AutoNamePath = "autoNamePath";
         public const string AutoNameRemoveUnderscore = "AutoNameRemoveUnderscore";

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1121,6 +1121,15 @@ namespace HandBrakeWPF.ViewModels
             if (!this.queueProcessor.CheckForDestinationPathDuplicates(task.Task.Destination))
             {
                 this.queueProcessor.Add(task);
+
+                if (AutoNameHelper.IsAutoIncrementUsed())
+                {
+                    // Advance the {auto-increment} counter and show the next
+                    // number in the destination. Batch adds regenerate the
+                    // destination per title, numbering them consecutively.
+                    AutoNameHelper.AdvanceAutoIncrement();
+                    this.ReGenerateAutoName();
+                }
             }
             else
             {

--- a/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/MainViewModel.cs
@@ -1124,11 +1124,11 @@ namespace HandBrakeWPF.ViewModels
 
                 if (AutoNameHelper.IsAutoIncrementUsed())
                 {
-                    // Advance the {auto-increment} counter and show the next
-                    // number in the destination. Batch adds regenerate the
-                    // destination per title, numbering them consecutively.
+                    // Advance the {auto-increment} counter. The destination is
+                    // refreshed to show the next number by the setting changed
+                    // handler. Batch adds regenerate the destination per title,
+                    // numbering them consecutively.
                     AutoNameHelper.AdvanceAutoIncrement();
-                    this.ReGenerateAutoName();
                 }
             }
             else
@@ -2577,6 +2577,19 @@ namespace HandBrakeWPF.ViewModels
                     this.NotifyOfPropertyChange(() => this.ShowAddSelectionToQueue);
                     this.NotifyOfPropertyChange(() => this.ShowAddAllMenuName);
                     this.NotifyOfPropertyChange(() => this.ShowAddSelectionMenuName);
+                    break;
+
+                case UserSettingConstants.AutoNameAutoIncrementNext:
+                case UserSettingConstants.AutoNameAutoIncrementPadding:
+                    // Show the current number in the destination, e.g. after a new
+                    // naming format has restarted the sequence, or a queued job has
+                    // advanced it. Without this, the first job queued after the token
+                    // is added to the format would keep the previous destination.
+                    if (AutoNameHelper.IsAutoIncrementUsed())
+                    {
+                        this.ReGenerateAutoName();
+                    }
+
                     break;
 
                 case UserSettingConstants.PresetUiType:

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -54,6 +54,7 @@ namespace HandBrakeWPF.ViewModels
         private string autoNameDefaultPath;
         private bool automaticallyNameFiles;
         private string autonameFormat;
+        private int autoIncrementPadding;
         private bool changeToTitleCase;
         private bool checkForUpdates;
         private UpdateCheck checkForUpdatesFrequency;
@@ -543,6 +544,23 @@ namespace HandBrakeWPF.ViewModels
             }
         }
 
+        public int AutoIncrementPadding
+        {
+            get => this.autoIncrementPadding;
+
+            set
+            {
+                value = Math.Clamp(value, AutoNameHelper.AutoIncrementPadMin, AutoNameHelper.AutoIncrementPadMax);
+                if (value == this.autoIncrementPadding)
+                {
+                    return;
+                }
+
+                this.autoIncrementPadding = value;
+                this.NotifyOfPropertyChange(() => this.AutoIncrementPadding);
+            }
+        }
+
         public bool ChangeToTitleCase
         {
             get => this.changeToTitleCase;
@@ -683,6 +701,7 @@ namespace HandBrakeWPF.ViewModels
                     new PlaceHolderBucket { Name = Constants.StorageHeight },
                     new PlaceHolderBucket { Name = Constants.Codec },
                     new PlaceHolderBucket { Name = Constants.Encoder },
+                    new PlaceHolderBucket { Name = Constants.AutoIncrement },
                 };
             }
         }
@@ -1583,6 +1602,9 @@ namespace HandBrakeWPF.ViewModels
             string anf = this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat) ?? string.Empty;
             this.AutonameFormat = this.IsValidAutonameFormat(anf, true) ? anf : "{source}-{title}";
 
+            // Auto-increment zero-padding
+            this.AutoIncrementPadding = this.userSettingService.GetUserSetting<int>(UserSettingConstants.AutoNameAutoIncrementPadding);
+
             // Use iPod/iTunes friendly .m4v extension for MP4 files.
             this.SelectedMp4Extension = (Mp4Behaviour)this.userSettingService.GetUserSetting<int>(UserSettingConstants.UseM4v);
 
@@ -1849,7 +1871,16 @@ namespace HandBrakeWPF.ViewModels
 
             /* Output Files */
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNaming, this.AutomaticallyNameFiles);
+
+            // A new naming format starts a new {auto-increment} sequence, e.g. a new TV series
+            string previousAutonameFormat = this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat);
+            if (!string.Equals(previousAutonameFormat, this.AutonameFormat, StringComparison.Ordinal))
+            {
+                this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementNext, 1);
+            }
+
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameFormat, this.AutonameFormat);
+            this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementPadding, this.AutoIncrementPadding);
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNamePath, this.AutoNameDefaultPath);
             this.userSettingService.SetUserSetting(UserSettingConstants.UseM4v, (int)this.SelectedMp4Extension);
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameRemoveUnderscore, this.RemoveUnderscores);

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -1872,15 +1872,24 @@ namespace HandBrakeWPF.ViewModels
             /* Output Files */
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNaming, this.AutomaticallyNameFiles);
 
-            // A new naming format starts a new {auto-increment} sequence, e.g. a new TV series
             string previousAutonameFormat = this.userSettingService.GetUserSetting<string>(UserSettingConstants.AutoNameFormat);
+            int previousAutoIncrementPadding = this.userSettingService.GetUserSetting<int>(UserSettingConstants.AutoNameAutoIncrementPadding);
+
+            // Store the format before the counter below, so that the main window regenerates the destination against the new format.
+            this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameFormat, this.AutonameFormat);
+
+            // A new naming format starts a new {auto-increment} sequence, e.g. a new TV series
             if (!string.Equals(previousAutonameFormat, this.AutonameFormat, StringComparison.Ordinal))
             {
                 this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementNext, 1);
             }
 
-            this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameFormat, this.AutonameFormat);
-            this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementPadding, this.AutoIncrementPadding);
+            // Only store the padding when it changes, so that saving the options doesn't discard a manually entered destination.
+            if (this.AutoIncrementPadding != previousAutoIncrementPadding)
+            {
+                this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameAutoIncrementPadding, this.AutoIncrementPadding);
+            }
+
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNamePath, this.AutoNameDefaultPath);
             this.userSettingService.SetUserSetting(UserSettingConstants.UseM4v, (int)this.SelectedMp4Extension);
             this.userSettingService.SetUserSetting(UserSettingConstants.AutoNameRemoveUnderscore, this.RemoveUnderscores);

--- a/win/CS/HandBrakeWPF/Views/Options/OptionsOutput.xaml
+++ b/win/CS/HandBrakeWPF/Views/Options/OptionsOutput.xaml
@@ -129,6 +129,15 @@
 
                     <CheckBox Content="{x:Static Properties:Resources.OptionsView_IsoDateFormat}" Grid.Column="1" Grid.Row="8" IsChecked="{Binding UseIsoDateFormat}" />
 
+                    <StackPanel Orientation="Horizontal" Grid.Column="1" Grid.Row="9" Margin="0,5,0,0"
+                                ToolTip="{x:Static Properties:ResourcesTooltips.Options_AutoIncrementPadding}">
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static Properties:Resources.Options_AutoIncrementPadding}" />
+                        <TextBox Name="autoIncrementPadding" Width="30" MaxLength="1" HorizontalContentAlignment="Right"
+                                 Text="{Binding AutoIncrementPadding, UpdateSourceTrigger=PropertyChanged}"
+                                 PreviewTextInput="AutoIncrementPadding_OnPreviewTextInput" />
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static Properties:Resources.Options_AutoIncrementDigits}" Margin="5,0,0,0" />
+                    </StackPanel>
+
                 </Grid>
 
                 <StackPanel Orientation="Horizontal" Margin="0,15,0,0">

--- a/win/CS/HandBrakeWPF/Views/Options/OptionsOutput.xaml.cs
+++ b/win/CS/HandBrakeWPF/Views/Options/OptionsOutput.xaml.cs
@@ -36,6 +36,20 @@ namespace HandBrakeWPF.Views.Options
             e.Effects = DragDropEffects.Copy;
         }
 
+        private void AutoIncrementPadding_OnPreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            // Only digits reach the auto-increment padding box; the view model
+            // clamps the committed value into the supported range.
+            foreach (char c in e.Text)
+            {
+                if (!char.IsDigit(c))
+                {
+                    e.Handled = true;
+                    return;
+                }
+            }
+        }
+
         private void AutoNameOutputPath_OnDragEnter(object sender, DragEventArgs e)
         {
             e.Effects = DragDropEffects.Copy;

--- a/win/CS/HandBrakeWPF/packages.lock.json
+++ b/win/CS/HandBrakeWPF/packages.lock.json
@@ -30,7 +30,15 @@
         "type": "Direct",
         "requested": "[10.0.0, )",
         "resolved": "10.0.0",
-        "contentHash": "LE3rDZoPzulou78Tsq+3ALhUs4vatQ03v2QWbYVIenVPneUH/+LTUmHyyl098OxIFLQI6sNkZs8YHbUnT/sm3A=="
+        "contentHash": "LE3rDZoPzulou78Tsq+3ALhUs4vatQ03v2QWbYVIenVPneUH/+LTUmHyyl098OxIFLQI6sNkZs8YHbUnT/sm3A==",
+        "dependencies": {
+          "System.CodeDom": "10.0.0"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "QWERdKi/tQAx+MbrPxTGcpchqMANnVXNiv2r2tILBBB38E74buD+fABSUhozZ1G9kjbadFB0m+HPFMkhJPeFvA=="
       },
       "handbrake.app.core": {
         "type": "Project",
@@ -45,6 +53,17 @@
         "type": "Project",
         "dependencies": {
           "HandBrake.Interop": "[1.11.0, )"
+        }
+      }
+    },
+    "net10.0-windows10.0.17763/win-x64": {
+      "System.Management": {
+        "type": "Direct",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "LE3rDZoPzulou78Tsq+3ALhUs4vatQ03v2QWbYVIenVPneUH/+LTUmHyyl098OxIFLQI6sNkZs8YHbUnT/sm3A==",
+        "dependencies": {
+          "System.CodeDom": "10.0.0"
         }
       }
     }


### PR DESCRIPTION
**Description of Change:**

This PR implements the `Auto-Increment` format (file naming) and supports configuring how many digits of precision to use for numeric padding. See my comment on https://github.com/HandBrake/HandBrake/issues/7848#issuecomment-4876654378 for specifications of this change.

Support for macOS, Ubuntu Linux, and Windows is included.

This PR was created in collaboration with Claude Fable.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots:**

macOS 
<img width="577" height="486" alt="image" src="https://github.com/user-attachments/assets/0684914a-d200-47b7-b76b-24a2344f6fe7" />

Ubuntu Linux 
<img width="647" height="687" alt="image" src="https://github.com/user-attachments/assets/8a2f0cb1-8aeb-4f77-903e-8ce3d99f4aee" />

Windows 
<img width="1136" height="851" alt="image" src="https://github.com/user-attachments/assets/de604dff-520a-4726-87b5-6f0b9520e990" />
