### PR TITLE
libhb: validate PES optional header length

### DIFF
--- a/libhb/stream.c
+++ b/libhb/stream.c
@@ -3072,13 +3072,13 @@ static int parse_pes_header(
         int hdr_len = pes_info->header_len = bits_get(bb, 8);
         pes_info->header_len += bb->pos >> 3;
 
-        bitbuf_t bb_hdr;
-        bits_clone(&bb_hdr, bb, hdr_len);
-
-        if ( bits_bytes_left(&bb_hdr) < hdr_len )
+        if ( bits_bytes_left(bb) < hdr_len )
         {
             return 0;
         }
+
+        bitbuf_t bb_hdr;
+        bits_clone(&bb_hdr, bb, hdr_len);
 
         int expect = (!!has_pts) * 5 + (has_pts & 0x01) * 5 + has_escr * 6 +
                      has_esrate * 3 + has_dsm + has_copy_info + has_crc * 2 +


### PR DESCRIPTION
Reject PES packets whose declared optional header extends beyond the
available input.

Both TS and program-stream parsing reach parse_pes_header(). Its cloned bit
buffer used the declared optional-header length as its own size, so the old
check did not validate the real PES buffer. A malformed header could make
later parsing or skipping read past the packet and crash scanning or encoding.

Check the original bit buffer before creating the bounded header view.
