### PR TITLE
contrib: update libdvdread to 7.1.1

### DIFF
--- a/contrib/libdvdread/module.defs
+++ b/contrib/libdvdread/module.defs
@@ -1,9 +1,9 @@
 $(eval $(call import.MODULE.defs,LIBDVDREAD,libdvdread))
 $(eval $(call import.CONTRIB.defs,LIBDVDREAD))
 
-LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libdvdread-7.0.1.tar.bz2
-LIBDVDREAD.FETCH.url    += https://code.videolan.org/videolan/libdvdread/-/archive/7.0.1/libdvdread-7.0.1.tar.bz2
-LIBDVDREAD.FETCH.sha256  = b69f74d9ceea1ed173b579deba99f669c2cb42f3fd06d7d23b33ff222aa63763
+LIBDVDREAD.FETCH.url     = https://github.com/HandBrake/HandBrake-contribs/releases/download/contribs2/libdvdread-7.1.1.tar.bz2
+LIBDVDREAD.FETCH.url    += https://code.videolan.org/videolan/libdvdread/-/archive/7.1.1/libdvdread-7.1.1.tar.bz2
+LIBDVDREAD.FETCH.sha256  = 6dec544f502d7af70c5a8f8f19a49ffe2daca60dbd8fc0b4ffe3597fa791c24c
 
 LIBDVDREAD.build_dir             = build/
 LIBDVDREAD.CONFIGURE.exe         = $(MESON.exe) setup


### PR DESCRIPTION
**libdvdread 7.1.1**
 * reduce the number of symbols exported to avoid conflicts when linking
 * improve CI coverage
 * DVD-Audio support:
     - Allow CPRM and CSS decryption support to be available simultaneously
     - Add Audio Still Video Set (ASVS) IFO structures and readers
     - Add ASVS and SAMG support to public IFO open APIs
     - Expose ASVS IFO, backup and menu VOB files
     - Improve AOB/VOB stream type handling
     - Misc fixes on structures documentation
 * DVD-VR support:
     - Add DVD-VR IFO parsing (PGIT, PG_GI, PS_GI)
     - Add DVDOpenVideoRecording functions
     - Add ifoOpenVideoRecording support
     - Add CPRM decryption support
     - Add DVDProbeType auto-detection for DVD-Video, DVD-Audio and DVD-VR
     - Add support for user-defined cells and time maps
     - Harden parsing of missing or malformed DVD-VR metadata
 * Add DVDOpenFiles for caller-provided virtual filesystem implementations
 * Split the internal filesystem implementation into platform-specific helpers
 * Improve file and directory handling on Windows, macOS and iOS
 * Improve logger fallback behavior when no controlling terminal is available
 * Add audio and subpicture code extension enums
 * Fixes and hardening:
     - Hardened IFO parsing for oversized still video groups
     - Fix DVD-Audio ASVS/SAMG fallback handling
     - Fix DVD-VR cell entry point byte swapping
     - Fix DVDFileSeek validation for non-sector-aligned files
     - Fix partial-block size accounting
     - Fix resource leaks, null pointer checks and error paths

**Tested on:**

- [X] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [X] Ubuntu Linux