### PR TITLE
WinGui: Expose AMF hardware decode preference

### DIFF
--- a/win/CS/HandBrake.Interop/Interop/HandBrakeHardwareEncoderHelper.cs
+++ b/win/CS/HandBrake.Interop/Interop/HandBrakeHardwareEncoderHelper.cs
@@ -21,8 +21,6 @@ namespace HandBrake.Interop.Interop
         private static bool? isNvencH265Available;
         private static bool? isNVDecAvailable;
 
-        private static bool? isVcnH264Available;
-
         private static int? qsvHardwareGeneration;
         private static bool? isQsvAvailable;
 
@@ -261,14 +259,7 @@ namespace HandBrake.Interop.Interop
             {
                 try
                 {
-                    if (isVcnH264Available != null)
-                    {
-                        return isVcnH264Available.Value;
-                    }
-
-                    isVcnH264Available = HBFunctions.hb_vce_h264_available() > 0;
-
-                    return isVcnH264Available.Value;
+                    return HBFunctions.hb_vce_h264_available() > 0;
                 }
                 catch (Exception)
                 {
@@ -289,6 +280,38 @@ namespace HandBrake.Interop.Interop
                 catch (Exception)
                 {
                     // Silent failure. Typically this means the dll hasn't been built with --enable-qsv
+                    return false;
+                }
+            }
+        }
+
+        public static bool IsVceAV1Available
+        {
+            get
+            {
+                try
+                {
+                    return HBFunctions.hb_vce_av1_available() > 0;
+                }
+                catch (Exception)
+                {
+                    // Silent failure. Typically this means the dll hasn't been built with --enable-vce
+                    return false;
+                }
+            }
+        }
+
+        public static bool IsAMFDecAvailable
+        {
+            get
+            {
+                try
+                {
+                    return HBFunctions.hb_check_amfdec_available() > 0;
+                }
+                catch (Exception)
+                {
+                    // Silent failure. Typically this means the dll hasn't been built with --enable-amfdec
                     return false;
                 }
             }

--- a/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/HbFunctions.cs
@@ -265,6 +265,12 @@ namespace HandBrake.Interop.Interop.HbLib
         [DllImport("hb", EntryPoint = "hb_vce_h265_available", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_vce_h265_available();
 
+        [DllImport("hb", EntryPoint = "hb_vce_av1_available", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_vce_av1_available();
+
+        [DllImport("hb", EntryPoint = "hb_check_amfdec_available", CallingConvention = CallingConvention.Cdecl)]
+        public static extern int hb_check_amfdec_available();
+
         [DllImport("hb", EntryPoint = "hb_nvenc_h264_available", CallingConvention = CallingConvention.Cdecl)]
         public static extern int hb_nvenc_h264_available();
 

--- a/win/CS/HandBrake.Interop/Interop/HbLib/NativeConstants.cs
+++ b/win/CS/HandBrake.Interop/Interop/HbLib/NativeConstants.cs
@@ -80,8 +80,9 @@ namespace HandBrake.Interop.Interop.HbLib
         public const uint HB_DECODE_NVDEC = 0x04;
         public const uint HB_DECODE_VIDEOTOOLBOX = 0x08;
         public const uint HB_DECODE_MF = 0x10;
+        public const uint HB_DECODE_AMFDEC = 0x20;
 
-        public const uint HB_DECODE_HWACCEL = (HB_DECODE_NVDEC | HB_DECODE_VIDEOTOOLBOX | HB_DECODE_QSV | HB_DECODE_MF);
+        public const uint HB_DECODE_HWACCEL = (HB_DECODE_NVDEC | HB_DECODE_VIDEOTOOLBOX | HB_DECODE_QSV | HB_DECODE_MF | HB_DECODE_AMFDEC);
         public const uint HB_DECODE_FORCE_HW = 0x80000000;
 
     }

--- a/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
+++ b/win/CS/HandBrakeWPF/Properties/Resources.Designer.cs
@@ -4550,6 +4550,15 @@ namespace HandBrakeWPF.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Prefer use of AMD AMFDec for decoding video when using the AMFEnc encoder and the hardware is available for use..
+        /// </summary>
+        public static string OptionsView_EnableAmfDecSupport {
+            get {
+                return ResourceManager.GetString("OptionsView_EnableAmfDecSupport", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Allow use of DirectX Decoding.
         /// </summary>
         public static string OptionsView_EnableDirectXDecoding {

--- a/win/CS/HandBrakeWPF/Properties/Resources.resx
+++ b/win/CS/HandBrakeWPF/Properties/Resources.resx
@@ -2667,6 +2667,9 @@ This may be due to limitations of the file container you have selected. Please s
   <data name="OptionsView_EnableNvDecSupport" xml:space="preserve">
     <value>Prefer use of Nvidia NVDec for decoding video when using the NVEnc encoder and the hardware is available for use.</value>
   </data>
+  <data name="OptionsView_EnableAmfDecSupport" xml:space="preserve">
+    <value>Prefer use of AMF AMFDec for decoding video when using the AMFEnc encoder and the hardware is available for use.</value>
+  </data>
   <data name="Options_Hardware" xml:space="preserve">
     <value>Hardware Support</value>
   </data>

--- a/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
+++ b/win/CS/HandBrakeWPF/Services/Encode/Factories/EncodeTaskFactory.cs
@@ -118,6 +118,7 @@ namespace HandBrakeWPF.Services.Encode.Factories
             }
 
             bool nvdec = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableNvDecSupport);
+            bool amfdec = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableAmfDecSupport);
             bool directx = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding);
 
             int hwDecode = 0;
@@ -125,8 +126,11 @@ namespace HandBrakeWPF.Services.Encode.Factories
             {
                 hwDecode = (int)NativeConstants.HB_DECODE_NVDEC;
             }
-
-            if (directx && HandBrakeHardwareEncoderHelper.IsDirectXAvailable)
+            if (amfdec && HandBrakeHardwareEncoderHelper.IsAMFDecAvailable)
+            {
+                hwDecode = (int)NativeConstants.HB_DECODE_AMFDEC;
+            }
+            else if (directx && HandBrakeHardwareEncoderHelper.IsDirectXAvailable)
             {
                 hwDecode = (int)NativeConstants.HB_DECODE_MF;
             }
@@ -321,7 +325,12 @@ namespace HandBrakeWPF.Services.Encode.Factories
                 video.HardwareDecode = NativeConstants.HB_DECODE_NVDEC;
             }
 
-            if (HandBrakeHardwareEncoderHelper.IsDirectXAvailable && this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding))
+            //use AMFDec to scan and detect format
+            if (this.isEncodePath && HandBrakeHardwareEncoderHelper.IsAMFDecAvailable && this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableAmfDecSupport) && job.VideoEncoder.IsVCN)
+            {
+                video.HardwareDecode = NativeConstants.HB_DECODE_AMFDEC | NativeConstants.HB_DECODE_FORCE_HW;
+            }
+            else if (HandBrakeHardwareEncoderHelper.IsDirectXAvailable && this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding))
             {
                 video.HardwareDecode = NativeConstants.HB_DECODE_MF | NativeConstants.HB_DECODE_FORCE_HW;
             }

--- a/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
+++ b/win/CS/HandBrakeWPF/Services/Scan/LibScan.cs
@@ -278,6 +278,7 @@ namespace HandBrakeWPF.Services.Scan
                 List<string> excludedExtensions = this.userSettingService.GetUserSetting<List<string>>(UserSettingConstants.ExcludedExtensions);
 
                 bool nvdec = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableNvDecSupport);
+                bool amfdec = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableAmfDecSupport);
                 bool directx = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding);
 
                 int hwDecode = 0;
@@ -285,7 +286,11 @@ namespace HandBrakeWPF.Services.Scan
                 {
                     hwDecode = (int)NativeConstants.HB_DECODE_NVDEC;
                 }
-                if (directx && HandBrakeHardwareEncoderHelper.IsDirectXAvailable)
+                if (amfdec && HandBrakeHardwareEncoderHelper.IsAMFDecAvailable)
+                {
+                    hwDecode = (int)NativeConstants.HB_DECODE_AMFDEC;
+                }
+                else if (directx && HandBrakeHardwareEncoderHelper.IsDirectXAvailable)
                 {
                     hwDecode = (int)NativeConstants.HB_DECODE_MF;
                 }

--- a/win/CS/HandBrakeWPF/Services/UserSettingService.cs
+++ b/win/CS/HandBrakeWPF/Services/UserSettingService.cs
@@ -317,11 +317,13 @@ namespace HandBrakeWPF.Services
             // Video
             bool intelDefaultSetting = HandBrakeHardwareEncoderHelper.IsQsvAvailable;
             bool nvidiaDefaultSetting = HandBrakeHardwareEncoderHelper.IsNVEncH264Available;
+            bool amfDefaultSetting = HandBrakeHardwareEncoderHelper.IsAMFDecAvailable;
 
             defaults.Add(UserSettingConstants.EnableQuickSyncDecoding, intelDefaultSetting);
             defaults.Add(UserSettingConstants.EnableQuickSyncHyperEncode, false);
             defaults.Add(UserSettingConstants.UseQSVDecodeForNonQSVEnc, false);
             defaults.Add(UserSettingConstants.EnableNvDecSupport, nvidiaDefaultSetting);
+            defaults.Add(UserSettingConstants.EnableAmfDecSupport, amfDefaultSetting);
             defaults.Add(UserSettingConstants.EnableQuickSyncLowPower, true);
             defaults.Add(UserSettingConstants.EnableDirectXDecoding, SystemInfo.IsArmDevice);
 

--- a/win/CS/HandBrakeWPF/UserSettingConstants.cs
+++ b/win/CS/HandBrakeWPF/UserSettingConstants.cs
@@ -90,6 +90,7 @@ namespace HandBrakeWPF
         public const string ForceDisableHardwareSupport = "ForceDisableHardwareSupport";
         public const string IsUpdateAvailableBuild = "IsUpdateAvailableBuild";
         public const string EnableNvDecSupport = "EnableNvDecSupport";
+        public const string EnableAmfDecSupport = "EnableAmfDecSupport";
         public const string UseIsoDateFormat = "UseIsoDateFormat";
         public const string ExtendedQueueDisplay = "ExtendedQueueDisplay";
         public const string HardwareDetectTimeoutSeconds = "HardwareDetectTimeoutSeconds";

--- a/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
+++ b/win/CS/HandBrakeWPF/ViewModels/OptionsViewModel.cs
@@ -118,6 +118,7 @@ namespace HandBrakeWPF.ViewModels
         private int simultaneousEncodes;
         private bool enableQuickSyncHyperEncode;
         private bool enableNvDecSupport;
+        private bool enableAmfDecSupport;
         private bool useIsoDateFormat;
         private BindingList<string> excludedFileExtensions;
         private bool recursiveFolderScan;
@@ -1154,6 +1155,8 @@ namespace HandBrakeWPF.ViewModels
 
         public bool IsNvdecAvailable => HandBrakeHardwareEncoderHelper.IsNVDecAvailable;
 
+        public bool IsAmfdecAvailable { get; } = HandBrakeHardwareEncoderHelper.IsAMFDecAvailable;
+
         public bool UseQSVDecodeForNonQSVEnc
         {
             get => this.useQsvDecodeForNonQsvEnc;
@@ -1191,6 +1194,16 @@ namespace HandBrakeWPF.ViewModels
             }
         }
 
+        public bool EnableAmfDecSupport
+        {
+            get => this.enableAmfDecSupport;
+            set
+            {
+                if (value == this.enableAmfDecSupport) return;
+                this.enableAmfDecSupport = value;
+                this.NotifyOfPropertyChange(() => this.EnableAmfDecSupport);
+            }
+        }
         /* About HandBrake */
 
         public string Version { get; } = string.Format("{0}", HandBrakeVersionHelper.GetVersion());
@@ -1624,6 +1637,7 @@ namespace HandBrakeWPF.ViewModels
             this.EnableQuickSyncLowPower = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncLowPower);
             this.EnableQuickSyncHyperEncode = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableQuickSyncHyperEncode);
             this.EnableNvDecSupport = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableNvDecSupport);
+            this.EnableAmfDecSupport = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableAmfDecSupport);
             this.EnableDirectXDecoding = this.userSettingService.GetUserSetting<bool>(UserSettingConstants.EnableDirectXDecoding);
 
             // #############################
@@ -1870,6 +1884,7 @@ namespace HandBrakeWPF.ViewModels
             this.userSettingService.SetUserSetting(UserSettingConstants.UseQSVDecodeForNonQSVEnc, this.UseQSVDecodeForNonQSVEnc);
             this.userSettingService.SetUserSetting(UserSettingConstants.EnableQuickSyncHyperEncode, this.EnableQuickSyncHyperEncode);
             this.userSettingService.SetUserSetting(UserSettingConstants.EnableNvDecSupport, this.EnableNvDecSupport);
+            this.userSettingService.SetUserSetting(UserSettingConstants.EnableAmfDecSupport, this.EnableAmfDecSupport);
             this.userSettingService.SetUserSetting(UserSettingConstants.EnableDirectXDecoding, this.EnableDirectXDecoding);
             this.userSettingService.SetUserSetting(UserSettingConstants.EnableQuickSyncLowPower, this.EnableQuickSyncLowPower);
 

--- a/win/CS/HandBrakeWPF/Views/Options/OptionsHardware.xaml
+++ b/win/CS/HandBrakeWPF/Views/Options/OptionsHardware.xaml
@@ -127,6 +127,10 @@
                 <StackPanel Orientation="Vertical" Visibility="{Binding IsVceAvailable, Converter={StaticResource boolToVisConverter}}">
                     <TextBlock Text="AMD VCN" Style="{StaticResource subHeader}" Margin="0,15,0,0" />
                     <TextBlock Text="{x:Static Properties:Resources.OptionsView_Available}" Margin="25,5,0,0" />
+
+                    <CheckBox Content="{x:Static Properties:Resources.OptionsView_EnableAmfDecSupport}" Margin="25,5,0,0" IsEnabled="{Binding IsVceAvailable}"
+                              Visibility="{Binding IsAmfdecAvailable, Converter={StaticResource boolToVisConverter}}" IsChecked="{Binding EnableAmfDecSupport}" />
+
                 </StackPanel>
                 <StackPanel Orientation="Vertical" Visibility="{Binding IsVceAvailable, Converter={StaticResource boolToVisConverter}, ConverterParameter=true}">
                     <TextBlock Text="AMD VCN" Style="{StaticResource subHeader}" Margin="0,15,0,0" />


### PR DESCRIPTION
This patch builds on the work introduced in #7698 (Enable AMF Decoder, HWContext AMF, vpp_amf filter) by exposing the AMF decoder option in the Windows GUI.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [ ] Ubuntu Linux
