### PR TITLE
libhb: aac: update supported mixdowns after FFmpeg bump.

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -2775,6 +2775,7 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_3POINT0)   ||
                     (mixdown == HB_AMIXDOWN_4POINT0)   ||
                     (mixdown == HB_AMIXDOWN_5POINT1)   ||
+                    (mixdown == HB_AMIXDOWN_6POINT1)   ||
                     (mixdown == HB_AMIXDOWN_7POINT1));
 
         case HB_ACODEC_FFAAC:
@@ -2782,7 +2783,9 @@ int hb_mixdown_has_codec_support(int mixdown, uint32_t codec)
                     (mixdown == HB_AMIXDOWN_3POINT0)   ||
                     (mixdown == HB_AMIXDOWN_4POINT0)   ||
                     (mixdown == HB_AMIXDOWN_QUAD)      ||
-                    (mixdown == HB_AMIXDOWN_5POINT1));
+                    (mixdown == HB_AMIXDOWN_5POINT1)   ||
+                    (mixdown == HB_AMIXDOWN_6POINT1)   ||
+                    (mixdown == HB_AMIXDOWN_7POINT1));
 
         case HB_ACODEC_FFALAC:
         case HB_ACODEC_FFALAC24:

--- a/libhb/encavcodecaudio.c
+++ b/libhb/encavcodecaudio.c
@@ -105,17 +105,19 @@ static int encavcodecaInit(hb_work_object_t *w, hb_job_t *job)
                     profile = AV_PROFILE_AAC_LOW;
                     break;
             }
-            // FFmpeg's libfdk-aac wrapper expects back channels for 5.1
-            // audio, and will error out unless we translate the layout
+            // FFmpeg's libfdk-aac wrapper expects back channels for 5.1, 6.1
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1_BACK);
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
             break;
 
         case HB_ACODEC_FFAAC:
             codec_name = "aac";
-            // Use 5.1 back for AAC because 5.1 side uses a
-            // not-so-universally supported feature to signal the
-            // non-standard layout
+            // use back channels for AAC otherwise the encoder will signal the
+            // layout via a PCE instead of a standard channel configuration index
+            if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1) == 0)
+                av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_6POINT1_BACK);
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1) == 0)
                 av_channel_layout_copy(&out_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_5POINT1_BACK);
             if (av_channel_layout_compare(&in_ch_layout, &(AVChannelLayout)AV_CHANNEL_LAYOUT_2_2) == 0)


### PR DESCRIPTION
**Description of Change:**

The FFmpeg 9.0 bump includes many updates to the native AAC encoder, and some updates to the libfdk wrapper as well.

Re-tested 6.1 and 7.1 (+SDDS) mixdown support using a debug build where hb_mixdown_has_codec_support() returns 1. It seems we can now enable:

- 6.1 for the native encoder (now signals layout with standard channel configuration 11)
- 7.1 for the native encoder (now signals layout with standard channel configuration 12)
- 6.1 for the FDK encoder (signals layout with standard channel configuration 11)
not sure why my previous testing determined that the FDK wrapper could not do 6.1
  - possibly my previous tests missed the mapping from 6.1 side to back in encavcodecaudio.c
  - or a wrapper update made it possible instead

7.1 (SDDS) should possibly/probably stay disabled for both encoders, as they both encode it using a PCE instead of channel configuration 7, and Core Audio has trouble parsing it properly: `Channel layout: 7.1 (C L R Ls Rs LFE Vhl Vhr)` -- while I suspect it might actually be a Core Audio bug, it might be better to avoid producing files that might be decoded incorrectly.

FDK uses a PCE to signal regular 7.1 i nstead of channel configuration 12, not sure if this is the encoder's decision or a wrapper quirk. However, since both Core Audio and libavcodec seemingly have no problem detecting the layout properly, I don't see any reason to disable it (it is currently/already allowed).

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [x] macOS 10.13+
- [ ] Ubuntu Linux

```zsh
#!/bin/zsh
()
{
	local asource
	local contfmt
	local encoder
	local mixdown
	local contfmt="mp4"
	local out="${HOME}/Downloads/test-mixdowns"
	local in1="/Volumes/dolby-channels-flac/dolby-channels-single-track"
	local in2="/Volumes/LACIE4TB/VIDEOS/audio/speakers/miscell/AV_CH_LAYOUT_7POINT1_WIDE_BACK.mkv"
	local cli="${HOME}/excluded/handbrake/wip-hb-wip/build.macos/xroot/HandBrakeCLI"
	for encoder in av_aac fdk_aac fdk_haac
	do
		for mixdown in 7point1 6point1
		do
			rm -r -f -- "${out}/${encoder}/${mixdown}"
			mkdir -p -- "${out}/${encoder}/${mixdown}"
			for asource in "${in1}/dolby-channels-flac-"*"${mixdown}"*.mkv
			do
				test -f "${asource}" || { echo "${asource} not found" 1>&2; exit 2; }
				echo "Output: ${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.${contfmt}"
				"${cli}" \
					-i "${asource}" \
					-a "1" -E "${encoder}" -6 "${mixdown}" \
					-o "${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.${contfmt}" \
					2> "${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.log"
				echo
			done
		done
		for mixdown in 7point1_sdds
		do
			rm -r -f -- "${out}/${encoder}/${mixdown}"
			mkdir -p -- "${out}/${encoder}/${mixdown}"
			for asource in "${in2}"
			do
				test -f "${asource}" || { echo "${asource} not found" 1>&2; exit 2; }
				echo "Output: ${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.${contfmt}"
				"${cli}" \
					-i "${asource}" \
					-a "1" -E "${encoder}" -6 "${mixdown}" \
					-o "${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.${contfmt}" \
					2> "${out}/${encoder}/${mixdown}/${encoder}-${mixdown}.log"
				echo
			done
		done
	done
}
```
```diff
diff --git a/libavcodec/aac/aacdec.c b/libavcodec/aac/aacdec.c
index 73e2457924..0e2abca0bc 100644
--- a/libavcodec/aac/aacdec.c
+++ b/libavcodec/aac/aacdec.c
@@ -907,6 +907,7 @@ static int decode_ga_specific_config(AACDecContext *ac, AVCodecContext *avctx,
         m4ac->object_type == AOT_ER_AAC_SCALABLE)
         skip_bits(gb, 3);     // layerNr
 
+    av_log(ac, AV_LOG_INFO, "decode_ga_specific_config: channel_config %d\n", channel_config);//debug
     if (channel_config == 0) {
         skip_bits(gb, 4);  // element_instance_tag
         tags = decode_pce(avctx, m4ac, layout_map, gb, get_bit_alignment);
@@ -2118,6 +2119,7 @@ static int parse_adts_frame_header(AACDecContext *ac, GetBitContext *gb)
             ac->warned_num_aac_frames = 1;
         }
         push_output_configuration(ac);
+        av_log(ac, AV_LOG_INFO, "parse_adts_frame_header: hdr_info.chan_config %"PRIu8"\n", hdr_info.chan_config);//debug
         if (hdr_info.chan_config) {
             ac->oc[1].m4ac.chan_config = hdr_info.chan_config;
             if ((ret = ff_aac_set_default_channel_config(ac, ac->avctx,
diff --git a/libavcodec/mpeg4audio.c b/libavcodec/mpeg4audio.c
index fbd2a8f811..7e9beb98e5 100644
--- a/libavcodec/mpeg4audio.c
+++ b/libavcodec/mpeg4audio.c
@@ -97,6 +97,7 @@ int ff_mpeg4audio_get_config_gb(MPEG4AudioConfig *c, GetBitContext *gb,
     c->object_type = get_object_type(gb);
     c->sample_rate = get_sample_rate(gb, &c->sampling_index);
     c->chan_config = get_bits(gb, 4);
+    av_log(NULL, AV_LOG_INFO, "decode_ga_specific_config: c->chan_config %d\n", c->chan_config);//debug
     if (c->chan_config < FF_ARRAY_ELEMS(ff_mpeg4audio_channels))
         c->channels = ff_mpeg4audio_channels[c->chan_config];
     else {
```
```zsh
for i in ~/Downloads/test-mixdowns/*aac/*/*mp4; do echo "$i" && ffprobe_patched -i "$i" 2>&1 | grep decode_ga_specific_config | tail -1 && ffprobe -i "$i" 2>&1 | grep Audio && afinfo "$i" | grep "Channel layout" | head -1 && echo; done
```
```txt
/Users/timothy/Downloads/test-mixdowns/av_aac/6point1/av_aac-6point1.mp4
[AAC decoder @ 0x732854000] decode_ga_specific_config: channel_config 11
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 6.1(back), fltp, 448 kb/s (default)
Channel layout: 6.1 (C L R Ls Rs Cs LFE)

/Users/timothy/Downloads/test-mixdowns/av_aac/7point1/av_aac-7point1.mp4
[AAC decoder @ 0xb70854000] decode_ga_specific_config: channel_config 12
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 7.1, fltp, 512 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs Rls Rrs LFE)

/Users/timothy/Downloads/test-mixdowns/av_aac/7point1_sdds/av_aac-7point1_sdds.mp4
[AAC decoder @ 0x858b74000] decode_ga_specific_config: channel_config 0
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 7.1(wide), fltp, 82 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs LFE Vhl Vhr)

/Users/timothy/Downloads/test-mixdowns/fdk_aac/6point1/fdk_aac-6point1.mp4
[AAC decoder @ 0x870854000] decode_ga_specific_config: channel_config 11
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 6.1(back), fltp, 448 kb/s (default)
Channel layout: 6.1 (C L R Ls Rs Cs LFE)

/Users/timothy/Downloads/test-mixdowns/fdk_aac/7point1/fdk_aac-7point1.mp4
[AAC decoder @ 0x83c854000] decode_ga_specific_config: channel_config 0
  Stream #0:1[0x2](eng): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 7.1, fltp, 512 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs Rls Rrs LFE)

/Users/timothy/Downloads/test-mixdowns/fdk_aac/7point1_sdds/fdk_aac-7point1_sdds.mp4
[AAC decoder @ 0xc76b74000] decode_ga_specific_config: channel_config 0
  Stream #0:1[0x2](und): Audio: aac (LC) (mp4a / 0x6134706D), 48000 Hz, 7.1(wide), fltp, 511 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs LFE Vhl Vhr)

/Users/timothy/Downloads/test-mixdowns/fdk_haac/6point1/fdk_haac-6point1.mp4
[AAC decoder @ 0x7f8bb0000] decode_ga_specific_config: channel_config 11
  Stream #0:1[0x2](eng): Audio: aac (HE-AAC) (mp4a / 0x6134706D), 48000 Hz, 6.1(back), fltp, 192 kb/s (default)
Channel layout: 6.1 (C L R Ls Rs Cs LFE)

/Users/timothy/Downloads/test-mixdowns/fdk_haac/7point1/fdk_haac-7point1.mp4
[AAC decoder @ 0xa46bb0000] decode_ga_specific_config: channel_config 0
  Stream #0:1[0x2](eng): Audio: aac (HE-AAC) (mp4a / 0x6134706D), 48000 Hz, 7.1, fltp, 224 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs Rls Rrs LFE)

/Users/timothy/Downloads/test-mixdowns/fdk_haac/7point1_sdds/fdk_haac-7point1_sdds.mp4
[AAC decoder @ 0x928b68000] decode_ga_specific_config: channel_config 0
  Stream #0:1[0x2](und): Audio: aac (HE-AAC) (mp4a / 0x6134706D), 48000 Hz, 7.1(wide), fltp, 224 kb/s (default)
Channel layout: 7.1 (C L R Ls Rs LFE Vhl Vhr)
```