### PR TITLE
configure: Enable MediaFoundation encoder by default for Windows ARM.

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         export PATH="/home/runner/work/HandBrake/HandBrake/toolchains/llvm-mingw-20251216-ucrt-ubuntu-22.04-x86_64/bin:${PATH}"
         export PATH=/usr/bin:$PATH
-        ./configure --cross=aarch64-w64-mingw32 --enable-mf --launch-jobs=0 --launch
+        ./configure --cross=aarch64-w64-mingw32 --launch-jobs=0 --launch
         cd build
         make pkg.create.zip
         cd libhb

--- a/make/configure.py
+++ b/make/configure.py
@@ -1433,7 +1433,7 @@ def createCLI( cross = None ):
     grp.add_argument( '--disable-ffmpeg-prores', dest="enable_ffmpeg_prores", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = 'MediaFoundation video encoder' if mf_supported else argparse.SUPPRESS
-    grp.add_argument( '--enable-mf', dest="enable_mf", default=False, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
+    grp.add_argument( '--enable-mf', dest="enable_mf", default=IfHost(True, "aarch64-w64-mingw32*", none=False).value, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-mf', dest="enable_mf", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = 'Nvidia NVENC video encoder' if nvenc_supported else argparse.SUPPRESS


### PR DESCRIPTION
It's literally the feature that got us building for Windows ARM.

**Tested on:**

- [x] Windows 10+ (via MinGW)
- [x] Ubuntu Linux