### PR TITLE
configure: Disable VAAPI encoder by default.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -38,4 +38,4 @@ jobs:
 
     - name: Build HandBrake Linux
       run: |
-         ./configure --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --launch-jobs=0 --launch
+         ./configure --enable-qsv --enable-vce --enable-nvenc --enable-nvdec --enable-vaapi --launch-jobs=0 --launch

--- a/make/configure.py
+++ b/make/configure.py
@@ -1445,7 +1445,7 @@ def createCLI( cross = None ):
     grp.add_argument( '--disable-nvdec', dest="enable_nvdec", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = 'VAAPI video encoder/decoder' if vaapi_supported else argparse.SUPPRESS
-    grp.add_argument( '--enable-vaapi', dest="enable_vaapi", default=True, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
+    grp.add_argument( '--enable-vaapi', dest="enable_vaapi", default=False, action='store_true', help=(( 'enable %s' %h ) if h != argparse.SUPPRESS else h) )
     grp.add_argument( '--disable-vaapi', dest="enable_vaapi", action='store_false', help=(( 'disable %s' %h ) if h != argparse.SUPPRESS else h) )
 
     h = 'Intel QSV video encoder/decoder' if qsv_supported else argparse.SUPPRESS


### PR DESCRIPTION
Still buggy and requires additional dependencies `libva-dev` and `libdrm-dev` like Intel QSV. Disable it for vanilla `configure` without `--enable-vaapi` for now, but keep it enabled in CI for development snapshots.

**Tested on:**

- [x] Ubuntu Linux