### PR TITLE
libhb: Fix double-pointer read and write

### DIFF
--- a/libhb/common.c
+++ b/libhb/common.c
@@ -5138,7 +5138,7 @@ void hb_job_close( hb_job_t ** _j )
     {
         job_clean(*_j);
         free( *_j );
-        _j = NULL;
+        *_j = NULL;
     }
 }
 

--- a/libhb/muxavformat.c
+++ b/libhb/muxavformat.c
@@ -233,7 +233,7 @@ static int set_extradata(hb_data_t *extradata, uint8_t **priv_data, int *priv_si
         // So allocate extra bytes
         *priv_size = extradata->size;
         *priv_data = av_mallocz(extradata->size + AV_INPUT_BUFFER_PADDING_SIZE);
-        if (priv_data == NULL)
+        if (*priv_data == NULL)
         {
             hb_error("extradata: malloc failure");
             return 1;


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

I'm pretty sure my PR fixes 2 cases of misuse of double-pointers.
(see details in my own code review)

**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**
N/A

**Log file output (If relevant):**
N/A