### PR TITLE
libhb: use snprintf for Linux paths

### DIFF
--- a/libhb/ports.c
+++ b/libhb/ports.c
@@ -643,17 +643,12 @@ void hb_get_user_config_directory( char path[512] )
 
     if ((p = getenv("XDG_CONFIG_HOME")) != NULL)
     {
-        strncpy(path, p, 511);
-        path[511] = 0;
+        snprintf(path, 512, "%s", p);
         return;
     }
     else if ((p = getenv("HOME")) != NULL)
     {
-        strncpy(path, p, 511);
-        path[511] = 0;
-        int len = strlen(path);
-        strncpy(path + len, "/.config", 511 - len - 1);
-        path[511] = 0;
+        snprintf(path, 512, "%s/.config", p);
         return;
     }
 #elif defined( __APPLE__ )


### PR DESCRIPTION
**Before Posting:**

- [ ] Create an issue describing the change. If an issue already exists, please use this.
- [ ] Discuss the issue with the HandBrake team to ensure that the idea has been accepted. (An open enhancement request does not equal acceptance). This will avoid any time wasted on features that are outside the project scope!


**Description of Change:**

Simplifies how the path strings are copied for Linux by using `snprintf` instead of manually terminating the string or calculating the appended string length.


**Tested on:**

- [ ] Windows 10+  (via MinGW)
- [ ] macOS 10.13+
- [x] Ubuntu Linux

**Screenshots (If relevant):**
N/A

**Log file output (If relevant):**
N/A
