### PR TITLE
AMF: Enable VP9 hardware decoding on Windows

### DIFF
--- a/libhb/hwaccel.c
+++ b/libhb/hwaccel.c
@@ -198,6 +198,10 @@ int hb_hwaccel_is_available(hb_hwaccel_t *hwaccel, int codec_id)
     }
 
     const AVCodec *codec = hwaccel->find_decoder(codec_id);
+    if (codec == NULL)
+    {
+        return 0;
+    }
     const AVCodecHWConfig *config = get_hw_config(codec, hwaccel->type);
 
     return config != NULL;

--- a/libhb/vce_common.c
+++ b/libhb/vce_common.c
@@ -366,22 +366,27 @@ static const char * hb_vce_decode_get_codec_name(enum AVCodecID codec_id)
         case AV_CODEC_ID_AV1:
             return "av1_amf";
 
+#if defined(_WIN32)
+        case AV_CODEC_ID_VP9:
+            return "vp9_amf";
+#endif
         default:
             return NULL;
     }
-    return NULL;
-#else
-    return NULL;
 #endif
+    return NULL;
 }
 
 static void * find_decoder(int codec_param)
 {
+#if HB_PROJECT_FEATURE_AMFDEC
     if (!hb_check_amfdec_available())
         return NULL;
 
     const char *codec_name = hb_vce_decode_get_codec_name(codec_param);
-    return (void *)avcodec_find_decoder_by_name(codec_name);
+    return codec_name != NULL ? (void *)avcodec_find_decoder_by_name(codec_name) : NULL;
+#endif
+    return NULL;
 }
 
 static const int vce_encoders[] =


### PR DESCRIPTION
Enable VP9 hardware decoding via AMF on Windows.
VP9 decoding is supported by the AMF decoder on Windows, but was not previously enabled in HandBrake.
Linux is excluded for now, as VP9 decoding is not currently supported by the AMF Vulkan decoder.
Fixes #8062.

**Tested on:**

- [x] Windows 10+  (via MinGW)
- [x] Ubuntu Linux

