### PR TITLE
libhb: document NVENC split_encode_mode support (no default change)

### DIFF
--- a/libhb/encavcodec.c
+++ b/libhb/encavcodec.c
@@ -627,6 +627,16 @@ int encavcodecInit( hb_work_object_t * w, hb_job_t * job )
         goto done;
     }
 
+    // NVENC HEVC/AV1 support ffmpeg's split_encode_mode option, which lets
+    // GPUs with more than one NVENC engine (e.g. RTX 4090/4080, RTX
+    // 50-series) split a single encode across engines instead of leaving
+    // extra engines idle. It is intentionally not defaulted on here: it can
+    // conflict with HandBrake's batch encode queue running multiple jobs on
+    // the same GPU concurrently, and NVIDIA advises against forcing it at
+    // lower resolutions, where it can affect quality rather than just
+    // speed. Users who want it can still set it themselves, for example
+    // -x split_encode_mode=forced (not available for H.264 NVENC).
+
     if (apply_encoder_options(job, context, &av_opts))
     {
         av_free( context );


### PR DESCRIPTION
## Summary

This originally set `split_encode_mode=forced` as a hard default for NVENC HEVC/AV1, to use both engines on GPUs with more than one NVENC chip (RTX 4090/4080 family, RTX 50-series) instead of leaving the second one idle (see #4988 and the original PR description below for the measured before/after numbers).

Per review feedback, that default is dropped. Forcing it unconditionally conflicts with HandBrake's batch encode queue, which can run multiple jobs on the same GPU concurrently and would then contend for the same physical NVENC engines. NVIDIA also advises against forcing this at lower resolutions, where it can affect quality rather than just speed. Both are good reasons not to hardcode a default.

What's left is a single comment in `encavcodecInit()`, at the point where NVENC-specific options are set up, noting that `hevc_nvenc`/`av1_nvenc` support `split_encode_mode` via `-x`/`--encopts` (this already worked before this PR, no code change was needed for that part), what it does, and why it isn't defaulted on. There's no in-repo docs source to extend (the handbrake.fr docs are built from a separate repository), and the existing `--encopts` help text in `test.c` is generic across every encoder rather than listing per-encoder options, so a comment at the point of use seemed like the most direct place to record this for whoever touches this code path next. Happy to close this instead if a comment-only change isn't worth a PR.

## Test plan

Rebuilt `HandBrakeCLI` from the updated branch and re-ran the same before/after comparison as the original PR, to confirm this change doesn't affect default behavior and that the existing advanced-options pass-through still works:

| | no `split_encode_mode` set (this PR) | `-x split_encode_mode=forced` |
|---|---|---|
| encoder utilization (`nvidia-smi`, max) | 49% | 88% |
| | matches pre-PR baseline | matches original PR's measurements (83-94%) |

- [x] Rebuilt HandBrakeCLI from the revised branch
- [x] Confirmed default behavior (no flag) is unchanged from stock HandBrake: 49% encoder utilization
- [x] Confirmed `-x split_encode_mode=forced` still reaches the same high utilization measured before
- [x] No functional/behavior change, comment only

---

<details>
<summary>Original PR description (superseded by the above)</summary>

## Summary

GPUs with more than one NVENC engine (RTX 4090/4080 family, RTX 50-series) are limited to a single encoder chip per session unless `split_encode_mode` is explicitly set. In practice this caps `nvidia-smi`-reported encoder utilization at about 50% and leaves the second (or third) NVENC engine completely idle, which matches the behavior reported in #4988.

ffmpeg has exposed `split_encode_mode` for `hevc_nvenc`/`av1_nvenc` since NVENC SDK 12.1 (ffmpeg 7.0+). HandBrake already vendors ffmpeg 9.0.1, so this capability has been available in every recent build. It was just never wired up as a default, and isn't documented anywhere as an advanced option users could set themselves via `-x`/`--encopts`.

`auto` was tried first, since today the option simply isn't set at all, so today's effective default is `disabled`. Per NVIDIA's own docs, `auto` only engages above roughly 8K resolution, so it made no measurable difference at common 4K deliverables in testing. `forced` makes the driver split whenever the GPU actually has multiple NVENC engines, independent of resolution, and is a documented no-op on single-engine GPUs.

## Test plan (original)

Built `HandBrakeCLI` (Linux, NVENC enabled, GTK disabled) and compared it against the same binary run with `-x split_encode_mode=disabled`. Hardware: RTX 4080 Super (2 NVENC engines, driver 610.57.01). Source: synthetic 4K/60fps/25s H.264 clip. Encoder: `nvenc_av1 -q 24 --encoder-preset p6`.

| | before (`split_encode_mode=disabled`) | after (forced by default) |
|---|---|---|
| encoder utilization (`nvidia-smi`, max) | 49% | 83% |
| average encode speed | 120 fps | 242 fps (about 2x) |
| wall clock | 16.14s | 9.27s |
| output size (same `-q`) | 125.75 MB | 125.64 MB |

I also validated `split_encode_mode` combined with lossless tuning directly against ffmpeg's `hevc_nvenc` (bit-exact versus an FFV1 reference decode, verified via SSIM=1.0/PSNR=inf across all sampled frames, both with splitting on and off), so splitting a frame into strips across NVENC engines is a utilization change only, not a quality or correctness trade-off in that specific test.

</details>
